### PR TITLE
[6.x.x] Adds in memory cache for RPC query results

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '8'
@@ -21,7 +21,7 @@ jobs:
         with:
           install: true
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: deploy-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.DEV_JDK }}
@@ -23,12 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
-      - run: mvn -V -B dependency-check:check
+      - name: OWASP dependency check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: mvn -V -B dependency-check:check
         timeout-minutes: 60
   test:
     name: ${{ matrix.os }} Test
@@ -40,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.DEV_JDK }}
@@ -72,7 +75,7 @@ jobs:
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B jacoco:report coveralls:report
       - name: Archive build logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-build-logs
           retention-days: 5

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '8'
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: xqts-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -29,7 +29,7 @@ jobs:
         run: find exist-xqts/target -name exist-xqts-runner.sh -exec {} --xqts-version HEAD --output-dir /tmp/xqts-output --exclude-test-case RangeExpr-411d,RangeExpr-409d,RangeExpr-408d,RangeExpr-409c,RangeExpr-408c,GenCompEq-21 \;
       - name: Check for HeapDump
         id: check_heapdump
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@v3
         with:
           files: "/tmp/*.hprof"
       - name: Compress HeapDump
@@ -37,14 +37,14 @@ jobs:
         run: zstd --rm -9 --progress -T0 /tmp/*.hprof
       - name: Attach HeapDump artifact
         if: steps.check_heapdump.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: exist-xqts-runner-hprof
           retention-days: 1
           path: /tmp/*.hprof.zst
       - name: Archive XQTS Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xqts-logs
           retention-days: 14

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -515,6 +515,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/exist-core/src/main/java/org/exist/util/io/MemoryContentsInputStream.java
+++ b/exist-core/src/main/java/org/exist/util/io/MemoryContentsInputStream.java
@@ -26,7 +26,6 @@ import static java.lang.Math.min;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
@@ -84,7 +83,7 @@ final class MemoryContentsInputStream extends InputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         boolean success = false;
         int read = 0;
-        while (!success) {
+        while (!success && len > 0) {
             long positionBefore = POSITION_UPDATER.get(this);
             read = this.memoryContents.read(b, positionBefore, off, len);
             if (read < 1) {
@@ -115,13 +114,4 @@ final class MemoryContentsInputStream extends InputStream {
         }
         return skipped;
     }
-
-    // Java 9 method, has to compile under Java 1.7 so no @Override
-    public long transferTo(OutputStream out) throws IOException {
-        long positionBefore = POSITION_UPDATER.get(this);
-        long written = this.memoryContents.transferTo(out, positionBefore);
-        POSITION_UPDATER.set(this, this.memoryContents.size());
-        return written;
-    }
-
 }

--- a/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
+++ b/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
@@ -52,6 +52,10 @@ public final class VirtualTempPath implements ContentFile {
     @GuardedBy("lock")
     private Path contentFile;
 
+    public VirtualTempPath(TemporaryFileManager tempFileManager) {
+        this(DEFAULT_IN_MEMORY_SIZE, tempFileManager);
+    }
+
     public VirtualTempPath(int inMemorySize, TemporaryFileManager tempFileManager) {
         this.inMemorySize = inMemorySize;
         this.lock = new StampedLock();
@@ -97,6 +101,7 @@ public final class VirtualTempPath implements ContentFile {
         }
     }
 
+    @Override
     public InputStream newInputStream() throws IOException {
         long stamp = lock.readLock();
         try {
@@ -129,6 +134,7 @@ public final class VirtualTempPath implements ContentFile {
         }
     }
 
+    @Override
     public long size() {
         long stamp = lock.readLock();
         try {
@@ -141,6 +147,7 @@ public final class VirtualTempPath implements ContentFile {
         }
     }
 
+    @Override
     public byte[] getBytes() {
         long stamp = lock.readLock();
         try {

--- a/exist-core/src/main/java/org/exist/xmlrpc/CachedContentFile.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/CachedContentFile.java
@@ -23,15 +23,19 @@ package org.exist.xmlrpc;
 
 import org.exist.util.io.ContentFile;
 
+import java.util.function.Consumer;
+
 /**
  * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
  */
-public final class CachedContentFile extends AbstractCachedResult {
+final class CachedContentFile extends AbstractCachedResult {
     private final ContentFile result;
+    private final Consumer<ContentFile> poolConsumer;
 
-    public CachedContentFile(final ContentFile result) {
+    CachedContentFile(final ContentFile result, final Consumer<ContentFile> poolConsumer) {
         super(0);
         this.result = result;
+        this.poolConsumer = poolConsumer;
     }
 
     @Override
@@ -42,6 +46,7 @@ public final class CachedContentFile extends AbstractCachedResult {
     @Override
     protected void doClose() {
         if (result != null) {
+            poolConsumer.accept(result);
             result.close();
         }
     }

--- a/exist-core/src/main/java/org/exist/xmlrpc/CachedContentFile.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/CachedContentFile.java
@@ -21,37 +21,28 @@
  */
 package org.exist.xmlrpc;
 
-import org.exist.util.io.TemporaryFileManager;
-
-import java.nio.file.Path;
+import org.exist.util.io.ContentFile;
 
 /**
- * Simple container for the results of a query. Used to cache
- * query results that may be retrieved later by the client.
- *
- * @author jmfernandez
+ * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
  */
-public class SerializedResult extends AbstractCachedResult {
-    protected Path result;
+public final class CachedContentFile extends AbstractCachedResult {
+    private final ContentFile result;
 
-    public SerializedResult(final Path result) {
+    public CachedContentFile(final ContentFile result) {
         super(0);
         this.result = result;
     }
 
-    /**
-     * @return Returns the result.
-     */
     @Override
-    public Path getResult() {
+    public ContentFile getResult() {
         return result;
     }
 
     @Override
     protected void doClose() {
         if (result != null) {
-            TemporaryFileManager.getInstance().returnTemporaryFile(result);
-            result = null;
+            result.close();
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xmlrpc/QueryResultCache.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/QueryResultCache.java
@@ -51,9 +51,9 @@ public class QueryResultCache {
                 .expireAfterAccess(TIMEOUT, TimeUnit.MILLISECONDS)
                 .removalListener((key, value, cause) -> {
                     final AbstractCachedResult qr = (AbstractCachedResult)value;
-                    qr.free();  // must free associated resources
+                    qr.close();  // must close associated resources
                     if(LOG.isDebugEnabled()) {
-                        LOG.debug("Removing cached result set: {}", new Date(qr.getTimestamp()).toString());
+                        LOG.debug("Removing cached result set: {}", new Date(qr.getTimestamp()));
                     }
                 }).build();
     }

--- a/exist-core/src/main/java/org/exist/xmlrpc/QueryResultCache.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/QueryResultCache.java
@@ -81,6 +81,11 @@ public class QueryResultCache {
         return (acr != null && acr instanceof SerializedResult) ? (SerializedResult) acr : null;
     }
 
+    public CachedContentFile getCachedContentFile(final int cacheId) {
+        final AbstractCachedResult acr = get(cacheId);
+        return (acr != null && acr instanceof CachedContentFile) ? (CachedContentFile) acr : null;
+    }
+
     public void remove(final int cacheId) {
         if (cacheId < 0 || cacheId >= cacheIdCounter.get()) {
             return; // out of scope

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
@@ -112,7 +112,7 @@ public interface RpcAPI {
     /**
      * Retrieve document by name. XML content is indented if prettyPrint is set
      * to &gt;=0. Use supplied encoding for output.
-     *
+     * <p>
      * This method is provided to retrieve a document with encodings other than
      * UTF-8. Since the data is handled as binary data, character encodings are
      * preserved. byte[]-values are automatically BASE64-encoded by the XMLRPC
@@ -132,7 +132,7 @@ public interface RpcAPI {
      * Retrieve document by name. XML content is indented if prettyPrint is set
      * to &gt;=0. Use supplied encoding for output and apply the specified
      * stylesheet.
-     *
+     * <p>
      * This method is provided to retrieve a document with encodings other than
      * UTF-8. Since the data is handled as binary data, character encodings are
      * preserved. byte[]-values are automatically BASE64-encoded by the XMLRPC
@@ -152,7 +152,7 @@ public interface RpcAPI {
     /**
      * Retrieve document by name. All optional output parameters are passed as
      * key/value pairs int the <code>parameters</code>.
-     *
+     * <p>
      * Valid keys may either be taken from
      * {@link javax.xml.transform.OutputKeys} or
      * {@link org.exist.storage.serializers.EXistOutputKeys}. For example, the
@@ -247,10 +247,10 @@ public interface RpcAPI {
     List<String> getDocumentListing(String collection)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
-    Map<String, List> listDocumentPermissions(String name)
+    Map<String, List<Object>> listDocumentPermissions(String name)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
-    Map<XmldbURI, List> listCollectionPermissions(String name)
+    Map<String, List<Object>> listCollectionPermissions(String name)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     /**
@@ -497,6 +497,7 @@ public interface RpcAPI {
      * @throws PermissionDeniedException If the current user is not allowed to perform this action
      * @deprecated use List query() or int executeQuery() instead
      */
+    @Deprecated
     Map<String, Object> querySummary(String xquery)
             throws EXistException, PermissionDeniedException;
 
@@ -612,7 +613,7 @@ public interface RpcAPI {
 
     /**
      * Parse a file previously uploaded with upload.
-     *
+     * <p>
      * The temporary file will be removed.
      *
      * @param localFile temporary file name
@@ -749,6 +750,7 @@ public interface RpcAPI {
      *
      * @deprecated Use {@link #executeT(String, Map)} instead.
      */
+    @Deprecated
     Map<String, Object> executeT(String path, Map<String, Object> parameters)
             throws EXistException, PermissionDeniedException;
 
@@ -926,7 +928,7 @@ public interface RpcAPI {
 
     List<String> getGroups() throws EXistException, PermissionDeniedException;
 
-    List<List> getIndexedElements(String collectionName, boolean inclusive)
+    List<List<Object>> getIndexedElements(String collectionName, boolean inclusive)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     boolean releaseQueryResult(int handle);

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -131,10 +131,11 @@ import static java.nio.file.StandardOpenOption.*;
  */
 public class RpcConnection implements RpcAPI {
 
-    private final static Logger LOG = LogManager.getLogger(RpcConnection.class);
+    private static final Logger LOG = LogManager.getLogger(RpcConnection.class);
 
-    public final static int MAX_DOWNLOAD_CHUNK_SIZE = 1024 * 1024;  // 1 MB
-    private final static Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
+    public static final int MAX_DOWNLOAD_CHUNK_SIZE = 1024 * 1024;  // 1 MB
+    private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
+    private static final String EXIST_RESULT_XMLNS_EXIST = "<exist:result xmlns:exist=\"";
 
     private final XmldbRequestProcessorFactory factory;
     private final ContentFilePool filePool;
@@ -1608,7 +1609,7 @@ public class RpcConnection implements RpcAPI {
             if (opt == null || opt.equalsIgnoreCase("no")) {
                 buf.append("<?xml version=\"1.0\"?>\n");
             }
-            buf.append("<exist:result xmlns:exist=\"").append(Namespaces.EXIST_NS).append("\" ");
+            buf.append(EXIST_RESULT_XMLNS_EXIST).append(Namespaces.EXIST_NS).append("\" ");
             buf.append("hitCount=\"0\"/>");
             return buf.toString();
         }
@@ -1621,7 +1622,7 @@ public class RpcConnection implements RpcAPI {
         }
 
         final StringWriter writer = new StringWriter();
-        writer.write("<exist:result xmlns:exist=\"");
+        writer.write(EXIST_RESULT_XMLNS_EXIST);
         writer.write(Namespaces.EXIST_NS);
         writer.write("\" hits=\"");
         writer.write(Integer.toString(resultSet.getItemCount()));
@@ -1684,7 +1685,7 @@ public class RpcConnection implements RpcAPI {
                 final QueryResult qr = this.<QueryResult>compileQuery(broker, transaction, source, parameters).apply(compiled -> doQuery(broker, compiled, null, parameters));
                 if (qr == null) {
                     return "<?xml version=\"1.0\"?>\n"
-                            + "<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" "
+                            + EXIST_RESULT_XMLNS_EXIST + Namespaces.EXIST_NS + "\" "
                             + "hitCount=\"0\"/>";
                 }
                 try {
@@ -1730,6 +1731,7 @@ public class RpcConnection implements RpcAPI {
      * @throws EXistException if an internal error occurs
      * @throws PermissionDeniedException If the current user is not allowed to perform this action
      */
+    @Deprecated
     private Map<String, Object> queryP(final String xpath, final XmldbURI docUri,
                                        final String s_id, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -72,7 +72,9 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.*;
 import org.exist.util.crypto.digest.DigestType;
 import org.exist.util.crypto.digest.MessageDigest;
+import org.exist.util.io.ContentFile;
 import org.exist.util.io.TemporaryFileManager;
+import org.exist.util.io.VirtualTempPath;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
 import org.exist.validation.ValidationReport;
@@ -163,6 +165,14 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
+    private TemporaryFileManager temporaryFileManager() {
+        return TemporaryFileManager.getInstance();
+    }
+
+    private VirtualTempPath createVirtualTempPath() {
+        return new VirtualTempPath(temporaryFileManager());
+    }
+
     private boolean createCollection(final XmldbURI collUri, final Date created) throws PermissionDeniedException, EXistException {
         withDb((broker, transaction) -> {
             Collection current = broker.getCollection(collUri);
@@ -216,22 +226,11 @@ public class RpcConnection implements RpcAPI {
 
     private String createId(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         return this.<String>readCollection(collUri).apply((collection, broker, transaction) -> {
-            XmldbURI id;
             final Random rand = new Random();
-            boolean ok;
+            XmldbURI id;
             do {
-                ok = true;
                 id = XmldbURI.create(Integer.toHexString(rand.nextInt()) + ".xml");
-                // check if this id does already exist
-                if (collection.hasDocument(broker, id)) {
-                    ok = false;
-                }
-
-                if (collection.hasChildCollection(broker, id)) {
-                    ok = false;
-                }
-
-            } while (!ok);
+            } while (collection.hasDocument(broker, id) || collection.hasChildCollection(broker, id));
             return id.toString();
         });
     }
@@ -320,7 +319,7 @@ public class RpcConnection implements RpcAPI {
             context.setModuleLoadPath(moduleLoadPath);
         }
         final Map<String, String> namespaces = (Map<String, String>) parameters.get(RpcAPI.NAMESPACES);
-        if (namespaces != null && namespaces.size() > 0) {
+        if (namespaces != null && !namespaces.isEmpty()) {
             context.declareNamespaces(namespaces);
         }
         //  declare static variables
@@ -406,7 +405,7 @@ public class RpcConnection implements RpcAPI {
     public int executeQuery(final byte[] xpath, final String encoding, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         final Charset charset = Optional.ofNullable(encoding).map(Charset::forName).orElse(DEFAULT_ENCODING);
         final String xpathString = new String(xpath, charset);
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
             LOG.debug("query: {}", xpathString);
         }
         return executeQuery(xpathString, parameters);
@@ -565,10 +564,10 @@ public class RpcConnection implements RpcAPI {
 
     /**
      * The method <code>describeCollection</code>
-     *
+     * <p>
      * Returns details of a collection - collections (list of sub-collections) -
      * name - created - owner - group - permissions - acl
-     *
+     * <p>
      * If you do not have read access on the collection, the list of
      * sub-collections will be empty, an exception will not be thrown!
      *
@@ -705,15 +704,15 @@ public class RpcConnection implements RpcAPI {
 
             // A tweak for very large resources, VirtualTempFile
             final Map<String, Object> result = new HashMap<>();
-            final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
-            final Path tempFile = temporaryFileManager.getTemporaryFile();
+            final VirtualTempPath tempFile = createVirtualTempPath();
 
             if (document.getResourceType() == DocumentImpl.XML_FILE) {
-                try (final Writer writer = Files.newBufferedWriter(tempFile, encoding)) {
+                try (final OutputStream out = tempFile.newOutputStream();
+                     final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, encoding))) {
                     serialize(broker, toProperties(parameters), saxSerializer -> saxSerializer.toSAX(document), writer);
                 }
             } else {
-                try (final OutputStream os = new BufferedOutputStream(Files.newOutputStream(tempFile))) {
+                try (final OutputStream os = new BufferedOutputStream(tempFile.newOutputStream())) {
                     broker.readBinaryResource(transaction, (BinaryDocument) document, os);
                 }
             }
@@ -722,14 +721,14 @@ public class RpcConnection implements RpcAPI {
 
             result.put("data", firstChunk);
             int offset = 0;
-            if (Files.size(tempFile) > MAX_DOWNLOAD_CHUNK_SIZE) {
+            if (tempFile.size() > MAX_DOWNLOAD_CHUNK_SIZE) {
                 offset = firstChunk.length;
 
-                final int handle = factory.resultSets.add(new SerializedResult(tempFile));
+                final int handle = factory.resultSets.add(new CachedContentFile(tempFile));
                 result.put("handle", Integer.toString(handle));
                 result.put("supports-long-offset", Boolean.TRUE);
             } else {
-                temporaryFileManager.returnTemporaryFile(tempFile);
+                tempFile.close();
             }
             result.put("offset", offset);
 
@@ -737,16 +736,19 @@ public class RpcConnection implements RpcAPI {
         });
     }
 
-    private byte[] getChunk(final Path file, final int offset) throws IOException {
-        final long available = Files.size(file);
+    private byte[] getChunk(final ContentFile file, final int offset) throws IOException {
+        final long available = file.size();
         final int len = (int)Math.min(Math.min(available - offset, MAX_DOWNLOAD_CHUNK_SIZE), Integer.MAX_VALUE);
 
         final byte[] chunk = new byte[len];
-        try (final InputStream is = Files.newInputStream(file)) {
-            is.skip(offset);
+        try (final InputStream is = file.newInputStream()) {
+            long remainingSkipped = offset;
+            do {
+                remainingSkipped -=  is.skip(remainingSkipped);
+            } while (remainingSkipped > 0);
             final int read = is.read(chunk);
             if(read != len) {
-                throw new IOException("Unable to read full chunk at offset: " + offset + ", from file: " + file.toAbsolutePath().toString());
+                throw new IOException("Unable to read full chunk at offset: " + offset + ", from file: " + file);
             }
         }
         return chunk;
@@ -757,16 +759,16 @@ public class RpcConnection implements RpcAPI {
             throws EXistException, PermissionDeniedException {
         try {
             final int resultId = Integer.parseInt(handle);
-            final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
+            final CachedContentFile sr = factory.resultSets.getCachedContentFile(resultId);
 
             if (sr == null) {
                 throw new EXistException("Invalid handle specified");
             }
             // This will keep the serialized result in the cache
             sr.touch();
-            final Path tempFile = sr.result;
+            final ContentFile tempFile = sr.getResult();
 
-            if (offset <= 0 || offset > Files.size(tempFile)) {
+            if (offset <= 0 || offset > tempFile.size()) {
                 factory.resultSets.remove(resultId);
                 throw new EXistException("No more data available");
             }
@@ -776,7 +778,7 @@ public class RpcConnection implements RpcAPI {
             final Map<String, Object> result = new HashMap<>();
             result.put("data", chunk);
             result.put("handle", handle);
-            if (nextChunk > (long) Integer.MAX_VALUE || nextChunk >= Files.size(tempFile)) {
+            if (nextChunk > Integer.MAX_VALUE || nextChunk >= tempFile.size()) {
                 factory.resultSets.remove(resultId);
                 result.put("offset", 0);
             } else {
@@ -793,17 +795,17 @@ public class RpcConnection implements RpcAPI {
             throws EXistException, PermissionDeniedException {
         try {
             final int resultId = Integer.parseInt(handle);
-            final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
+            final CachedContentFile sr = factory.resultSets.getCachedContentFile(resultId);
 
             if (sr == null) {
                 throw new EXistException("Invalid handle specified");
             }
             // This will keep the serialized result in the cache
             sr.touch();
-            final Path tempFile = sr.result;
+            final ContentFile tempFile = sr.getResult();
 
             final long longOffset = Long.parseLong(offset);
-            if (longOffset < 0 || longOffset > Files.size(tempFile)) {
+            if (longOffset < 0 || longOffset > tempFile.size()) {
                 factory.resultSets.remove(resultId);
                 throw new EXistException("No more data available");
             }
@@ -813,7 +815,7 @@ public class RpcConnection implements RpcAPI {
             final Map<String, Object> result = new HashMap<>();
             result.put("data", chunk);
             result.put("handle", handle);
-            if (nextChunk >= Files.size(tempFile)) {
+            if (nextChunk >= tempFile.size()) {
                 factory.resultSets.remove(resultId);
                 result.put("offset", Long.toString(0));
             } else {
@@ -869,10 +871,10 @@ public class RpcConnection implements RpcAPI {
 
     private int xupdate(final XmldbURI collUri, final String xupdate) throws PermissionDeniedException, EXistException {
         return withDb((broker, transaction) -> {
-            final Collection collectionRef = this.<Collection>readCollection(collUri).apply((collection, broker1, transaction1) -> collection);
-            //TODO : register a lock (which one ?) in the transaction ?
-            final DocumentSet docs = collectionRef.allDocs(broker, new DefaultDocumentSet(), true);
-            try(final Reader reader = new StringReader(xupdate)) {
+            try (final Collection collectionRef = this.<Collection>readCollection(collUri).apply((collection, broker1, transaction1) -> collection);
+                 final Reader reader = new StringReader(xupdate)) {
+                //TODO : register a lock (which one ?) in the transaction ?
+                final DocumentSet  docs = collectionRef.allDocs(broker, new DefaultDocumentSet(), true);
                 final XUpdateProcessor processor = new XUpdateProcessor(broker, docs);
                 final Modification modifications[] = processor.parse(new InputSource(reader));
                 long mods = 0;
@@ -1015,7 +1017,7 @@ public class RpcConnection implements RpcAPI {
     /**
      * Creates a unique name for a database resource Uniqueness is only
      * guaranteed within the eXist instance
-     *
+     * <p>
      * The name is based on a hex encoded string of a random integer and will
      * have the format xxxxxxxx.xml where x is in the range 0 to 9 and a to f
      *
@@ -1124,14 +1126,14 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public Map<String, List> listDocumentPermissions(final String name)
+    public Map<String, List<Object>> listDocumentPermissions(final String name)
             throws EXistException, PermissionDeniedException, URISyntaxException {
         return listDocumentPermissions(XmldbURI.xmldbUriFor(name));
     }
 
-    private Map<String, List> listDocumentPermissions(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
-        return this.<Map<String, List>>readCollection(collUri).apply((collection, broker, transaction) -> {
-            final Map<String, List> result = new HashMap<>(collection.getDocumentCount(broker));
+    private Map<String, List<Object>> listDocumentPermissions(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
+        return this.<Map<String, List<Object>>>readCollection(collUri).apply((collection, broker, transaction) -> {
+            final Map<String, List<Object>> result = new HashMap<>(collection.getDocumentCount(broker));
             for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 final DocumentImpl doc = i.next();
 
@@ -1145,21 +1147,21 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public Map<XmldbURI, List> listCollectionPermissions(final String name)
+    public Map<String, List<Object>> listCollectionPermissions(final String name)
             throws EXistException, PermissionDeniedException, URISyntaxException {
         return listCollectionPermissions(XmldbURI.xmldbUriFor(name));
     }
 
-    private Map<XmldbURI, List> listCollectionPermissions(final XmldbURI collUri)
+    private Map<String, List<Object>> listCollectionPermissions(final XmldbURI collUri)
             throws EXistException, PermissionDeniedException {
-        return this.<Map<XmldbURI, List>>readCollection(collUri).apply((collection, broker, transaction) -> {
-            final Map<XmldbURI, List> result = new HashMap<>(collection.getChildCollectionCount(broker));
+        return this.<Map<String, List<Object>>>readCollection(collUri).apply((collection, broker, transaction) -> {
+            final Map<String, List<Object>> result = new HashMap<>(collection.getChildCollectionCount(broker));
             for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
                 final XmldbURI child = i.next();
                 final XmldbURI path = collUri.append(child);
                 final Collection childColl = broker.getCollection(path);
                 final Permission perm = childColl.getPermissionsNoLock();  // NOTE: we already have a READ lock on childColl implicitly
-                result.put(child, toList(perm));
+                result.put(child.toString(), toList(perm));
             }
             return result;
         });
@@ -1385,7 +1387,7 @@ public class RpcConnection implements RpcAPI {
 
     /**
      * Parse a file previously uploaded with upload.
-     *
+     * <p>
      * The temporary file will be removed.
      *
      * @param localFile the name of the temporary, uploaded file
@@ -1405,7 +1407,7 @@ public class RpcConnection implements RpcAPI {
     /**
      * Parse a file previously uploaded with upload, forcing it to XML or
      * Binary.
-     *
+     * <p>
      * The temporary file will be removed.
      *
      * @param localFile the name of the temporary, uploaded file
@@ -1514,12 +1516,6 @@ public class RpcConnection implements RpcAPI {
         return storeBinary(data, documentPath, mimeType, overwrite, null, null);
     }
 
-    @SuppressWarnings("unused")
-    private boolean storeBinary(final byte[] data, final XmldbURI docUri, final String mimeType,
-                                final int overwrite) throws EXistException, PermissionDeniedException {
-        return storeBinary(data, docUri, mimeType, overwrite, null, null);
-    }
-
     public boolean storeBinary(final byte[] data, final String documentPath, final String mimeType,
                                final int overwrite, final Date created, final Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
         return storeBinary(data, XmldbURI.xmldbUriFor(documentPath), mimeType, overwrite, created, modified);
@@ -1562,12 +1558,12 @@ public class RpcConnection implements RpcAPI {
             throws EXistException, IOException {
         final OpenOption[] openOptions;
         final Path tempFile;
-        if (fileName == null || fileName.length() == 0) {
+        if (fileName == null || fileName.isEmpty()) {
             // no fileName, so new file
             openOptions = new OpenOption[] { CREATE, TRUNCATE_EXISTING, WRITE };
 
             // create temporary file
-            tempFile = TemporaryFileManager.getInstance().getTemporaryFile();
+            tempFile = temporaryFileManager().getTemporaryFile();
             final int handle = factory.resultSets.add(new SerializedResult(tempFile));
             fileName = Integer.toString(handle);
         } else {
@@ -1693,11 +1689,14 @@ public class RpcConnection implements RpcAPI {
                             + "<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" "
                             + "hitCount=\"0\"/>";
                 }
-                if (qr.hasErrors()) {
-                    throw qr.getException();
+                try {
+                    if (qr.hasErrors()) {
+                        throw qr.getException();
+                    }
+                    return printAll(broker, qr.result, howmany, start, parameters, (System.currentTimeMillis() - startTime));
+                } finally {
+                    qr.close();
                 }
-
-                return printAll(broker, qr.result, howmany, start, parameters, (System.currentTimeMillis() - startTime));
             } catch (final XPathException e) {
                 throw new EXistException(e);
             }
@@ -1715,6 +1714,7 @@ public class RpcConnection implements RpcAPI {
      * @throws EXistException if an internal error occurs
      * @throws PermissionDeniedException If the current user is not allowed to perform this action
      */
+    @Deprecated
     public Map<String, Object> queryP(final String xpath, final String documentPath,
                                       final String s_id, final Map<String, Object> parameters) throws URISyntaxException, EXistException, PermissionDeniedException {
         return queryP(xpath,
@@ -1750,7 +1750,7 @@ public class RpcConnection implements RpcAPI {
                     docs[0] = docUri.toString();
                     parameters.put(RpcAPI.STATIC_DOCUMENTS, docs);
 
-                    if (s_id.length() > 0) {
+                    if (!s_id.isEmpty()) {
                         final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(s_id);
                         final NodeProxy node = new NodeProxy(null, document, nodeId);
                         final NodeSet nodeSet = new ExtArrayNodeSet(1);
@@ -1823,15 +1823,11 @@ public class RpcConnection implements RpcAPI {
                         result.add(next.getStringValue());
                     }
                 }
-            } else {
-                if(LOG.isDebugEnabled()) {
-                    LOG.debug("sequence iterator is null. Should not");
-                }
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("sequence iterator is null. Should not");
             }
-        } else {
-            if(LOG.isDebugEnabled()) {
-                LOG.debug("result sequence is null. Skipping it...");
-            }
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("result sequence is null. Skipping it...");
         }
 
         queryResult.result = resultSeq;
@@ -1871,7 +1867,7 @@ public class RpcConnection implements RpcAPI {
                     docs[0] = docUri.toString();
                     parameters.put(RpcAPI.STATIC_DOCUMENTS, docs);
 
-                    if (s_id.length() > 0) {
+                    if (!s_id.isEmpty()) {
                         final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(s_id);
                         final NodeProxy node = new NodeProxy(null, document, nodeId);
                         final NodeSet nodeSet = new ExtArrayNodeSet(1);
@@ -1940,15 +1936,11 @@ public class RpcConnection implements RpcAPI {
                         result.add(entry);
                     }
                 }
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("sequence iterator is null. Should not");
-                }
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("sequence iterator is null. Should not");
             }
-        } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("result sequence is null. Skipping it...");
-            }
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("result sequence is null. Skipping it...");
         }
 
         queryResult.result = resultSeq;
@@ -1963,7 +1955,7 @@ public class RpcConnection implements RpcAPI {
     private @Nullable Map<String, String> nodeMap(final Item item) {
         final Map<String, String> result;
 
-        if(item instanceof NodeValue &&
+        if (item instanceof NodeValue &&
                 ((NodeValue)item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
             final NodeProxy p = (NodeProxy) item;
 
@@ -2057,7 +2049,7 @@ public class RpcConnection implements RpcAPI {
     @Override
     public boolean releaseQueryResult(final int handle) {
         factory.resultSets.remove(handle);
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
             LOG.debug("removed query result with handle {}", handle);
         }
         return true;
@@ -2066,7 +2058,7 @@ public class RpcConnection implements RpcAPI {
     @Override
     public boolean releaseQueryResult(final int handle, final int hash) {
         factory.resultSets.remove(handle, hash);
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
             LOG.debug("removed query result with handle {}", handle);
         }
         return true;
@@ -2188,16 +2180,15 @@ public class RpcConnection implements RpcAPI {
             final NodeProxy node = new NodeProxy(null, document, nodeId);
 
             final Map<String, Object> result = new HashMap<>();
-            final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
-            final Path tempFile = temporaryFileManager.getTemporaryFile();
+            final VirtualTempPath tempFile = createVirtualTempPath();
 
             if (compression && LOG.isDebugEnabled()) {
                 LOG.debug("retrieveFirstChunk with compression");
             }
 
             try (final OutputStream os = compression
-                    ? new DeflaterOutputStream(new BufferedOutputStream(Files.newOutputStream(tempFile)))
-                    : new BufferedOutputStream(Files.newOutputStream(tempFile));
+                    ? new DeflaterOutputStream(new BufferedOutputStream(tempFile.newOutputStream()))
+                    : new BufferedOutputStream(tempFile.newOutputStream());
                     final Writer writer = new OutputStreamWriter(os, getEncoding(parameters))) {
                 serialize(broker, toProperties(parameters), saxSerializer -> saxSerializer.toSAX(node), writer);
             }
@@ -2205,14 +2196,14 @@ public class RpcConnection implements RpcAPI {
             final byte[] firstChunk = getChunk(tempFile, 0);
             result.put("data", firstChunk);
             int offset = 0;
-            if (Files.size(tempFile) > MAX_DOWNLOAD_CHUNK_SIZE) {
+            if (tempFile.size() > MAX_DOWNLOAD_CHUNK_SIZE) {
                 offset = firstChunk.length;
 
-                final int handle = factory.resultSets.add(new SerializedResult(tempFile));
+                final int handle = factory.resultSets.add(new CachedContentFile(tempFile));
                 result.put("handle", Integer.toString(handle));
                 result.put("supports-long-offset", Boolean.TRUE);
             } else {
-                temporaryFileManager.returnTemporaryFile(tempFile);
+                tempFile.close();
             }
             result.put("offset", offset);
             return result;
@@ -2292,16 +2283,15 @@ public class RpcConnection implements RpcAPI {
             }
 
             final Map<String, Object> result = new HashMap<>();
-            final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
-            final Path tempFile = temporaryFileManager.getTemporaryFile();
+            final VirtualTempPath tempFile = createVirtualTempPath();
 
             if (compression && LOG.isDebugEnabled()) {
                 LOG.debug("retrieveFirstChunk with compression");
             }
 
             try (final OutputStream os = compression
-                    ? new DeflaterOutputStream(new BufferedOutputStream(Files.newOutputStream(tempFile)))
-                    : new BufferedOutputStream(Files.newOutputStream(tempFile));
+                    ? new DeflaterOutputStream(new BufferedOutputStream(tempFile.newOutputStream()))
+                    : new BufferedOutputStream(tempFile.newOutputStream());
                     final Writer writer = new OutputStreamWriter(os, getEncoding(parameters))) {
                 if (Type.subTypeOf(item.getType(), Type.NODE)) {
                     final NodeValue nodeValue = (NodeValue) item;
@@ -2319,14 +2309,14 @@ public class RpcConnection implements RpcAPI {
             final byte[] firstChunk = getChunk(tempFile, 0);
             result.put("data", firstChunk);
             int offset = 0;
-            if (Files.size(tempFile) > MAX_DOWNLOAD_CHUNK_SIZE) {
+            if (tempFile.size() > MAX_DOWNLOAD_CHUNK_SIZE) {
                 offset = firstChunk.length;
 
-                final int handle = factory.resultSets.add(new SerializedResult(tempFile));
+                final int handle = factory.resultSets.add(new CachedContentFile(tempFile));
                 result.put("handle", Integer.toString(handle));
                 result.put("supports-long-offset", Boolean.TRUE);
             } else {
-                temporaryFileManager.returnTemporaryFile(tempFile);
+                tempFile.close();
             }
             result.put("offset", offset);
             return result;
@@ -2410,16 +2400,15 @@ public class RpcConnection implements RpcAPI {
             try {
 
                 final Map<String, Object> result = new HashMap<>();
-                final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
-                final Path tempFile = temporaryFileManager.getTemporaryFile();
+                final VirtualTempPath tempFile = createVirtualTempPath();
 
                 if (compression && LOG.isDebugEnabled()) {
                     LOG.debug("retrieveAllFirstChunk with compression");
                 }
 
                 try (final OutputStream os = compression
-                        ? new DeflaterOutputStream(new BufferedOutputStream(Files.newOutputStream(tempFile)))
-                        : new BufferedOutputStream(Files.newOutputStream(tempFile));
+                        ? new DeflaterOutputStream(new BufferedOutputStream(tempFile.newOutputStream()))
+                        : new BufferedOutputStream(tempFile.newOutputStream());
                      final Writer writer = new OutputStreamWriter(os, getEncoding(parameters))) {
                     handler.setOutput(writer, toProperties(parameters));
 
@@ -2462,14 +2451,14 @@ public class RpcConnection implements RpcAPI {
                 final byte[] firstChunk = getChunk(tempFile, 0);
                 result.put("data", firstChunk);
                 int offset = 0;
-                if (Files.size(tempFile) > MAX_DOWNLOAD_CHUNK_SIZE) {
+                if (tempFile.size() > MAX_DOWNLOAD_CHUNK_SIZE) {
                     offset = firstChunk.length;
 
-                    final int handle = factory.resultSets.add(new SerializedResult(tempFile));
+                    final int handle = factory.resultSets.add(new CachedContentFile(tempFile));
                     result.put("handle", Integer.toString(handle));
                     result.put("supports-long-offset", Boolean.TRUE);
                 } else {
-                    temporaryFileManager.returnTemporaryFile(tempFile);
+                    tempFile.close();
                 }
                 result.put("offset", offset);
                 return result;
@@ -2557,7 +2546,7 @@ public class RpcConnection implements RpcAPI {
     @Override
     public boolean addAccount(final String name, String passwd, final String passwdDigest, final List<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
 
-        if (passwd.length() == 0) {
+        if (passwd.isEmpty()) {
             passwd = null;
         }
 
@@ -2611,7 +2600,7 @@ public class RpcConnection implements RpcAPI {
 
     @Override
     public boolean updateAccount(final String name, String passwd, final String passwdDigest, final List<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
-        if (passwd.length() == 0) {
+        if (passwd.isEmpty()) {
             passwd = null;
         }
 
@@ -2787,11 +2776,11 @@ public class RpcConnection implements RpcAPI {
 
     /**
      * Added by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
-     *
+     * <p>
      * modified by Chris Tomlinson based on above updateAccount - it appears
      * that this code can rely on the SecurityManager to enforce policy about
      * whether user is or is not permitted to update the Account with name.
-     *
+     * <p>
      * This is called via RemoteUserManagementService.addUserGroup(Account)
      *
      * @param name user name to update
@@ -2831,11 +2820,11 @@ public class RpcConnection implements RpcAPI {
 
     /**
      * Added by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
-     *
+     * <p>
      * modified by Chris Tomlinson based on above updateAccount - it appears
      * that this code can rely on the SecurityManager to enforce policy about
      * whether user is or is not permitted to update the Account with name.
-     *
+     * <p>
      * This is called via RemoteUserManagementService.removeGroup(Account,
      * String)
      *
@@ -2945,16 +2934,18 @@ public class RpcConnection implements RpcAPI {
                 if (qr == null) {
                     return new HashMap<>();
                 }
-                if (qr.hasErrors()) {
-                    throw qr.getException();
+                try {
+                    if (qr.hasErrors()) {
+                        throw qr.getException();
+                    }
+                    if (qr.result == null) {
+                        return summaryToMap(qr.queryTime, null, null, null);
+                    }
+                    final Tuple2<java.util.Collection<NodeCount>, java.util.Collection<DoctypeCount>> summary = summarise(qr.result);
+                    return summaryToMap(System.currentTimeMillis() - startTime, qr.result, summary._1, summary._2);
+                } finally {
+                    qr.close();
                 }
-                if (qr.result == null) {
-                    return summaryToMap(qr.queryTime, null, null, null);
-                }
-
-                final Tuple2<java.util.Collection<NodeCount>, java.util.Collection<DoctypeCount>> summary = summarise(qr.result);
-                return summaryToMap(System.currentTimeMillis() - startTime, qr.result, summary._1, summary._2);
-
             } catch (final XPathException e) {
                 throw new EXistException(e);
             }
@@ -3048,31 +3039,32 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public List<List> getIndexedElements(final String collectionName,
+    public List<List<Object>> getIndexedElements(final String collectionName,
                                          final boolean inclusive) throws EXistException, PermissionDeniedException, URISyntaxException {
         return getIndexedElements(XmldbURI.xmldbUriFor(collectionName), inclusive);
     }
 
-    private List<List> getIndexedElements(final XmldbURI collUri,
+    private List<List<Object>> getIndexedElements(final XmldbURI collUri,
                                           final boolean inclusive) throws EXistException, PermissionDeniedException {
-        return this.<List<List>>readCollection(collUri).apply((collection, broker, transaction) -> {
-            final Occurrences occurrences[] = broker.getElementIndex().scanIndexedElements(collection,
-                    inclusive);
-            final List<List> result = new ArrayList<>(occurrences.length);
-            for (final Occurrences occurrence : occurrences) {
-                final QName qname = (QName) occurrence.getTerm();
-                final List temp = new ArrayList(4);
-                temp.add(qname.getLocalPart());
-                temp.add(qname.getNamespaceURI());
-                temp.add(qname.getPrefix() == null ? "" : qname.getPrefix());
-                temp.add(occurrence.getOccurrences());
-                result.add(temp);
+        return this.<List<List<Object>>>readCollection(collUri).apply((collection, broker, transaction) -> {
+            final ElementIndex elementIndex = broker.getElementIndex();
+            if (elementIndex != null) {
+                final Occurrences occurrences[] = elementIndex.scanIndexedElements(collection, inclusive);
+                final List<List<Object>> result = new ArrayList<>(occurrences.length);
+                for (final Occurrences occurrence : occurrences) {
+                    final QName qname = (QName) occurrence.getTerm();
+                    final List<Object> temp = new ArrayList<>(4);
+                    temp.add(qname.getLocalPart());
+                    temp.add(qname.getNamespaceURI());
+                    temp.add(qname.getPrefix() == null ? "" : qname.getPrefix());
+                    temp.add(occurrence.getOccurrences());
+                    result.add(temp);
+                }
+                return result;
+            } else {
+                return Collections.emptyList();
             }
-            return result;
         });
-    }
-
-    public void synchronize() {
     }
 
     private Properties toProperties(final Map<String, Object> parameters) {
@@ -3383,8 +3375,7 @@ public class RpcConnection implements RpcAPI {
     @Override
     public List<String> getDocumentChunk(final String name, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException, IOException {
         final List<String> result = new ArrayList<>(2);
-        final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
-        final Path file = temporaryFileManager.getTemporaryFile();
+        final Path file = temporaryFileManager().getTemporaryFile();
         try (final OutputStream os = new BufferedOutputStream(Files.newOutputStream(file))) {
             os.write(getDocument(name, parameters));
         }
@@ -3654,7 +3645,7 @@ public class RpcConnection implements RpcAPI {
                 return null;
 
             } finally {
-                TemporaryFileManager.getInstance().returnTemporaryFile(backupFile);
+                temporaryFileManager().returnTemporaryFile(backupFile);
             }
         });
 
@@ -3745,7 +3736,7 @@ public class RpcConnection implements RpcAPI {
         }
 
         private void add(final RestoreTaskEvent restoreTaskEvent, @Nullable final String value) {
-            final String event = "" + restoreTaskEvent.getCode() + (value == null ? "" : value);
+            final String event = restoreTaskEvent.getCode() + (value == null ? "" : value);
             queueLock.lock();
             try {
                 queue.add(event);
@@ -4018,7 +4009,7 @@ public class RpcConnection implements RpcAPI {
     /**
      * Higher-order-function for performing an XMLDB operation on
      * the database.
-     *
+     * <p>
      * Performs the operation as the current user of the RpcConnection
      *
      * @param dbOperation The operation to perform on the database

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -3049,7 +3049,7 @@ public class RpcConnection implements RpcAPI {
         return this.<List<List<Object>>>readCollection(collUri).apply((collection, broker, transaction) -> {
             final ElementIndex elementIndex = broker.getElementIndex();
             if (elementIndex != null) {
-                final Occurrences occurrences[] = elementIndex.scanIndexedElements(collection, inclusive);
+                final Occurrences[] occurrences = elementIndex.scanIndexedElements(collection, inclusive);
                 final List<List<Object>> result = new ArrayList<>(occurrences.length);
                 for (final Occurrences occurrence : occurrences) {
                     final QName qname = (QName) occurrence.getTerm();

--- a/exist-core/src/test/java/org/exist/util/io/ContentFilePoolTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/ContentFilePoolTest.java
@@ -55,7 +55,7 @@ class ContentFilePoolTest {
         configuration = new Configuration();
         configuration.setProperty(PROPERTY_POOL_SIZE, 1);
         configuration.setProperty(PROPERTY_IN_MEMORY_SIZE, 10);
-        pool = new ContentFilePool(temporaryFileManager, configuration);
+        pool = new ContentFilePool(temporaryFileManager, null, configuration);
         replay(contentFile, temporaryFileManager);
     }
 

--- a/exist-core/src/test/java/org/exist/util/io/MemoryContentsInputStreamTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/MemoryContentsInputStreamTest.java
@@ -26,9 +26,7 @@ import org.easymock.IArgumentMatcher;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 
 import static org.easymock.EasyMock.aryEq;
 import static org.easymock.EasyMock.createMock;
@@ -95,6 +93,7 @@ public class MemoryContentsInputStreamTest {
         assertEquals(9, inputStream.read(buf, 1, 10));
         assertEquals(0, inputStream.read(buf, 2, 9));
         assertEquals(-1, inputStream.read(buf, 3, 8));
+        assertEquals(0, inputStream.read(buf, 3, 0));
 
         verify(memoryContents);
     }
@@ -108,20 +107,6 @@ public class MemoryContentsInputStreamTest {
 
         assertEquals(10, inputStream.skip(20));
         assertEquals(20, inputStream.skip(20));
-
-        verify(memoryContents);
-    }
-
-    @Test
-    public void transferTo​() throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        expect(memoryContents.size()).andReturn(123L);
-        expect(memoryContents.transferTo(out, 0L)).andReturn(123L);
-
-        replay(memoryContents);
-
-        assertEquals(123L, inputStream.transferTo(out));
 
         verify(memoryContents);
     }

--- a/exist-core/src/test/java/org/exist/util/io/VirtualTempPathTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/VirtualTempPathTest.java
@@ -26,7 +26,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,6 +34,7 @@ import java.io.OutputStream;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
@@ -79,7 +79,9 @@ public class VirtualTempPathTest {
     public void newInputStreamUseEmptyInputStreamIfNotAlreadyWritten() throws IOException {
         InputStream in = virtualTempPath.newInputStream();
 
-        assertEquals(ByteArrayInputStream.class, in.getClass());
+        assertNotNull(in);
+        assertEquals(0, in.available());
+        assertEquals(-1, in.read());
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/xmlrpc/CachedContentFileTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/CachedContentFileTest.java
@@ -1,0 +1,71 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmlrpc;
+
+import org.easymock.EasyMockExtension;
+import org.easymock.Mock;
+import org.exist.util.io.ContentFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
+ */
+@ExtendWith(EasyMockExtension.class)
+class CachedContentFileTest {
+    @Mock
+    ContentFile contentFile;
+    CachedContentFile cachedContentFile;
+    CachedContentFile cachedContentFileNoContent;
+
+    @BeforeEach
+    void prepare() {
+        cachedContentFile = new CachedContentFile(contentFile);
+        cachedContentFileNoContent= new CachedContentFile(null);
+    }
+
+    @AfterEach
+    void verifyMocks() {
+        verify(contentFile);
+    }
+
+    @Test
+    void testGetResult() {
+        replay(contentFile);
+        assertThat(cachedContentFile.getResult()).isEqualTo(contentFile);
+        assertThat(cachedContentFileNoContent.getResult()).isNull();
+    }
+
+    @Test
+    void testDoClose() {
+        contentFile.close();
+        replay(contentFile);
+        assertThatNoException().isThrownBy(cachedContentFile::doClose);
+        assertThatNoException().isThrownBy(cachedContentFileNoContent::doClose);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xmlrpc/CachedContentFileTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/CachedContentFileTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.function.Consumer;
+
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.assertj.core.api.Assertions.*;
@@ -40,23 +42,26 @@ import static org.assertj.core.api.Assertions.*;
 class CachedContentFileTest {
     @Mock
     ContentFile contentFile;
+    @Mock
+    Consumer<ContentFile> contentFileConsumer;
+
     CachedContentFile cachedContentFile;
     CachedContentFile cachedContentFileNoContent;
 
     @BeforeEach
     void prepare() {
-        cachedContentFile = new CachedContentFile(contentFile);
-        cachedContentFileNoContent= new CachedContentFile(null);
+        cachedContentFile = new CachedContentFile(contentFile, contentFileConsumer);
+        cachedContentFileNoContent= new CachedContentFile(null, contentFileConsumer);
     }
 
     @AfterEach
     void verifyMocks() {
-        verify(contentFile);
+        verify(contentFile, contentFileConsumer);
     }
 
     @Test
     void testGetResult() {
-        replay(contentFile);
+        replay(contentFile, contentFileConsumer);
         assertThat(cachedContentFile.getResult()).isEqualTo(contentFile);
         assertThat(cachedContentFileNoContent.getResult()).isNull();
     }
@@ -64,7 +69,8 @@ class CachedContentFileTest {
     @Test
     void testDoClose() {
         contentFile.close();
-        replay(contentFile);
+        contentFileConsumer.accept(contentFile);
+        replay(contentFile, contentFileConsumer);
         assertThatNoException().isThrownBy(cachedContentFile::doClose);
         assertThatNoException().isThrownBy(cachedContentFileNoContent::doClose);
     }

--- a/exist-core/src/test/java/org/exist/xmlrpc/QueryResultCacheTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/QueryResultCacheTest.java
@@ -24,7 +24,9 @@ package org.exist.xmlrpc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
 
 /**
  * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
@@ -71,8 +73,8 @@ class QueryResultCacheTest {
     void testRemove() throws InterruptedException {
         assertThatNoException().isThrownBy(() ->  cache.remove(-1));
         assertThatNoException().isThrownBy(() ->  cache.remove(0));
-        Thread.sleep(400);
-        assertThat(cachedResult.getResult()).isOne();
+
+        await().atMost(1, SECONDS).untilAsserted(() -> assertThat(cachedResult.getResult()).isOne());
         assertThatNoException().isThrownBy(() ->  cache.remove(1));
     }
 
@@ -82,8 +84,8 @@ class QueryResultCacheTest {
         assertThatNoException().isThrownBy(() ->  cache.remove(0, 0));
         assertThat(cachedResult.getResult()).isZero();
         assertThatNoException().isThrownBy(() ->  cache.remove(0, 42));
-        Thread.sleep(400);
-        assertThat(cachedResult.getResult()).isOne();
+
+        await().atMost(1, SECONDS).untilAsserted(() -> assertThat(cachedResult.getResult()).isOne());
         assertThatNoException().isThrownBy(() ->  cache.remove(1, 0));
     }
 

--- a/exist-core/src/test/java/org/exist/xmlrpc/QueryResultCacheTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/QueryResultCacheTest.java
@@ -1,0 +1,108 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmlrpc;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author <a href="mailto:patrick@reini.net">Patrick Reinhart</a>
+ */
+class QueryResultCacheTest {
+    QueryResultCache cache = new QueryResultCache();
+    TestCachedResult cachedResult = new TestCachedResult();
+
+    @BeforeEach
+    void prepare() {
+        assertThat(cache.add(cachedResult)).isZero();
+        assertThat(cachedResult.getResult()).isZero();
+    }
+
+    @Test
+    void testGet() {
+        assertThat(cache.get(-1)).isNull();
+        assertThat(cache.get(0)).isSameAs(cachedResult);
+        assertThat(cache.get(1)).isNull();
+    }
+
+    @Test
+    void testGetResult() {
+        assertThat(cache.getResult(-1)).isNull();
+        assertThat(cache.getResult(0)).isNull();
+        assertThat(cache.getResult(1)).isNull();
+    }
+
+    @Test
+    void testGetSerializedResult() {
+        assertThat(cache.getSerializedResult(-1)).isNull();
+        assertThat(cache.getSerializedResult(0)).isNull();
+        assertThat(cache.getSerializedResult(1)).isNull();
+    }
+
+    @Test
+    void testGetCachedContentFile() {
+        assertThat(cache.getCachedContentFile(-1)).isNull();
+        assertThat(cache.getCachedContentFile(0)).isNull();
+        assertThat(cache.getCachedContentFile(1)).isNull();
+    }
+
+    @Test
+    void testRemove() throws InterruptedException {
+        assertThatNoException().isThrownBy(() ->  cache.remove(-1));
+        assertThatNoException().isThrownBy(() ->  cache.remove(0));
+        Thread.sleep(400);
+        assertThat(cachedResult.getResult()).isOne();
+        assertThatNoException().isThrownBy(() ->  cache.remove(1));
+    }
+
+    @Test
+    void testRemoveWithHashCode() throws InterruptedException {
+        assertThatNoException().isThrownBy(() ->  cache.remove(-1, 0));
+        assertThatNoException().isThrownBy(() ->  cache.remove(0, 0));
+        assertThat(cachedResult.getResult()).isZero();
+        assertThatNoException().isThrownBy(() ->  cache.remove(0, 42));
+        Thread.sleep(400);
+        assertThat(cachedResult.getResult()).isOne();
+        assertThatNoException().isThrownBy(() ->  cache.remove(1, 0));
+    }
+
+    static class TestCachedResult extends AbstractCachedResult {
+        private int closeCount;
+
+        @Override
+        public Integer getResult() {
+            return Integer.valueOf(closeCount);
+        }
+
+        @Override
+        protected void doClose() {
+            closeCount++;
+        }
+
+        @Override
+        public int hashCode() {
+            return 42;
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xmlrpc;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import org.apache.xmlrpc.XmlRpcException;
@@ -34,12 +33,14 @@ import org.exist.test.ExistWebServer;
 import org.exist.test.TestConstants;
 import org.exist.util.Compressor;
 import org.exist.util.MimeType;
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.exist.test.TestConstants.TEST_XML_URI;
@@ -129,15 +130,14 @@ public class XmlRpcTest {
 
     @After
     public void tearDown() throws XmlRpcException, MalformedURLException {
-        XmlRpcClient xmlrpc = getClient();
+        final XmlRpcClient xmlrpc = getClient();
         assertThat(xmlrpc.execute("removeCollection", asList(TARGET_COLLECTION.toString()))).isInstanceOf(Boolean.class);
     }
 
     @Test
     public void testStoreAndRetrieve() throws XmlRpcException, IOException {
-        XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+        final List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(TARGET_RESOURCE.toString());
         params.add(0);
@@ -190,7 +190,7 @@ public class XmlRpcTest {
         params.add(emptyMap());
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
             int offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -213,15 +213,14 @@ public class XmlRpcTest {
     }
 
     private XmlRpcClient createCollection(XmldbURI collection) throws XmlRpcException, MalformedURLException {
-        XmlRpcClient xmlrpc = getClient();
+        final XmlRpcClient xmlrpc = getClient();
         assertThat(xmlrpc.execute("createCollection", asList(collection.toString()))).isEqualTo(TRUE);
         return xmlrpc;
     }
 
     private XmlRpcClient storeData() throws XmlRpcException, MalformedURLException {
-        XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+        final List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(TARGET_RESOURCE.toString());
         params.add(1);
@@ -244,8 +243,7 @@ public class XmlRpcTest {
     @Test
     public void getDocumentDataChunked_nextChunk() throws IOException, XmlRpcException {
         final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         final String generatedXml = generateXml((int) (MAX_DOWNLOAD_CHUNK_SIZE * 1.5));
         params.add(generatedXml);
         params.add(TARGET_RESOURCE.toString());
@@ -260,7 +258,7 @@ public class XmlRpcTest {
         params.add(parameters);
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
             int offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -281,8 +279,7 @@ public class XmlRpcTest {
     @Test
     public void getDocumentDataChunked_nextExtendedChunk() throws IOException, XmlRpcException {
         final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         final String generatedXml = generateXml((int) (MAX_DOWNLOAD_CHUNK_SIZE * 1.75));
         params.add(generatedXml);
         params.add(TARGET_RESOURCE.toString());
@@ -297,7 +294,7 @@ public class XmlRpcTest {
         params.add(parameters);
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
             long offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -324,7 +321,7 @@ public class XmlRpcTest {
 
         // 1) upload
         String uploadedFileName = null;
-        try (final InputStream is = new ByteArrayInputStream(binary)) {
+        try (final InputStream is = new UnsynchronizedByteArrayInputStream(binary)) {
             final byte[] chunk = new byte[MAX_UPLOAD_CHUNK];
             int len;
             while ((len = is.read(chunk)) > -1) {
@@ -356,7 +353,7 @@ public class XmlRpcTest {
         params.add(resURI);
         params.add(emptyMap());
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
             long offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -378,8 +375,7 @@ public class XmlRpcTest {
     @Test
     public void testRemoveCollection() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List params = new ArrayList(1);
+        final List params = new ArrayList(1);
         params.add(TARGET_COLLECTION.toString());
         assertThat(xmlrpc.execute("hasCollection", params)).isEqualTo(TRUE);
         assertThat(xmlrpc.execute("removeCollection", params)).isEqualTo(TRUE);
@@ -389,8 +385,7 @@ public class XmlRpcTest {
     @Test
     public void testRemoveDoc() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List params = new ArrayList(1);
+        final List params = new ArrayList(1);
         params.add(TARGET_RESOURCE.toString());
         assertThat(xmlrpc.execute("hasDocument", params)).isEqualTo(TRUE);
         assertThat(xmlrpc.execute("remove", params)).isEqualTo(TRUE);
@@ -400,14 +395,13 @@ public class XmlRpcTest {
     @Test
     public void testRetrieveDoc() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        Map<String, String> options = new HashMap<>();
+        final Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
         options.put("encoding", StandardCharsets.UTF_8.name());
         options.put("expand-xincludes", "yes");
         options.put("process-xsl-pi", "no");
 
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_RESOURCE.toString());
         params.add(options);
 
@@ -421,8 +415,8 @@ public class XmlRpcTest {
     @Test
     public void testCharEncoding() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-        List<Object> params = new ArrayList<>();
-        String query = "distinct-values(//para)";
+        final List<Object> params = new ArrayList<>();
+        final String query = "distinct-values(//para)";
         params.add(query.getBytes(UTF_8));
         params.add(emptyMap());
 
@@ -437,9 +431,8 @@ public class XmlRpcTest {
     @Test
     public void testQuery() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
-        String query = "(::pragma exist:serialize indent=no::) //para";
+        final List<Object> params = new ArrayList<>();
+        final String query = "(::pragma exist:serialize indent=no::) //para";
         params.add(query.getBytes(UTF_8));
         params.add(10);
         params.add(1);
@@ -451,8 +444,7 @@ public class XmlRpcTest {
     @Test
     public void testQuerySummary() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("//para");
 
         assertThat((Map<String, Object>) xmlrpc.execute("querySummary", params)).isNotEmpty();
@@ -461,13 +453,12 @@ public class XmlRpcTest {
     @Test
     public void testQueryWithStylesheet() throws XmlRpcException, MalformedURLException, SAXException, IOException {
         final XmlRpcClient xmlrpc = storeData();
-
-        Map<String, String> options = new HashMap<>();
+        final Map<String, String> options = new HashMap<>();
         options.put(EXistOutputKeys.STYLESHEET, "test.xsl");
         options.put(EXistOutputKeys.STYLESHEET_PARAM + ".testparam", "Test");
         options.put(OutputKeys.OMIT_XML_DECLARATION, "no");
         //TODO : check the number of resources before !
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         String query = "//para[1]";
         params.add(query.getBytes(UTF_8));
         params.add(options);
@@ -496,9 +487,8 @@ public class XmlRpcTest {
     @Test
     public void testCompile() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
-        String query = "<a>Invalid<a>";
+        final List<Object> params = new ArrayList<>();
+        final String query = "<a>Invalid<a>";
         params.add(query.getBytes(UTF_8));
         params.add(emptyMap());
 
@@ -511,10 +501,9 @@ public class XmlRpcTest {
     public void testAccount() throws MalformedURLException, XmlRpcException {
         final String user = "rudi";
         final String passwd = "pass";
-        String simpleMd5 = MessageDigester.md5(passwd, true);
-        String digest = MessageDigester.md5(user + ":exist:" + passwd, false);
-
-        List<Object> params = new ArrayList<>(12);
+        final String simpleMd5 = MessageDigester.md5(passwd, true);
+        final String digest = MessageDigester.md5(user + ":exist:" + passwd, false);
+        final List<Object> params = new ArrayList<>(12);
         params.add(user);
         params.add(simpleMd5);
         params.add(digest);
@@ -538,9 +527,9 @@ public class XmlRpcTest {
         XmlRpcClientConfigImpl config = (XmlRpcClientConfigImpl) xmlrpc.getClientConfig();
         config.setBasicUserName("admin");
         config.setBasicPassword("");
-        assertThat(xmlrpc.execute("sync", asList())).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("sync", emptyList())).isEqualTo(TRUE);
 
-        Object[] accounts = (Object[]) xmlrpc.execute("getAccounts", asList());
+        Object[] accounts = (Object[]) xmlrpc.execute("getAccounts", emptyList());
         assertThat(accounts).hasSize(5);
 
         for (Object account : accounts) {
@@ -579,7 +568,7 @@ public class XmlRpcTest {
     public void testGroups() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = getClient();
 
-        assertThat((Object[]) xmlrpc.execute("getGroups", asList()))
+        assertThat((Object[]) xmlrpc.execute("getGroups", emptyList()))
                 .containsExactlyInAnyOrder("dba", "guest", "nogroup")
                 .allSatisfy(groupName -> {
                     assertThat((Map<String, Object>) xmlrpc.execute("getGroup", asList(groupName)))
@@ -587,7 +576,7 @@ public class XmlRpcTest {
                 });
 
         assertThat(xmlrpc.execute("addGroup", asList("testGroup", emptyMap()))).isEqualTo(TRUE);
-        assertThat((Object[]) xmlrpc.execute("getGroups", asList()))
+        assertThat((Object[]) xmlrpc.execute("getGroups", emptyList()))
                 .containsExactlyInAnyOrder("dba", "guest", "nogroup", "testGroup");
 
         assertThat(xmlrpc.execute("updateGroup", asList("testGroup", asList("admin"), emptyMap()))).isEqualTo(TRUE);
@@ -600,8 +589,7 @@ public class XmlRpcTest {
     @Test
     public void testExecuteQuery() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         String query = "distinct-values(//para)";
         params.add(query.getBytes(UTF_8));
         params.add(emptyMap());
@@ -628,18 +616,17 @@ public class XmlRpcTest {
     @Test
     public void testQueryModuleExternalVar() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(QUERY_MODULE_DATA.getBytes(UTF_8));
 
-        Map<String, Object> qp = new HashMap<>();
+        final Map<String, Object> qp = new HashMap<>();
 
-        Map<String, Object> namespaceDecls = new HashMap<>();
+        final Map<String, Object> namespaceDecls = new HashMap<>();
         namespaceDecls.put("tm", "http://exist-db.org/test/module");
         namespaceDecls.put("tm-query", "http://exist-db.org/test/module/query");
         qp.put(RpcAPI.NAMESPACES, namespaceDecls);
 
-        Map<String, Object> variableDecls = new HashMap<>();
+        final Map<String, Object> variableDecls = new HashMap<>();
         variableDecls.put("tm:imported-external-string", "imported-string-value");
         variableDecls.put("tm-query:local-external-string", "local-string-value");
         qp.put(RpcAPI.VARIABLES, variableDecls);
@@ -654,8 +641,7 @@ public class XmlRpcTest {
     @Test
     public void testCollectionWithAccentsAndSpaces() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = createCollection(SPECIAL_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(SPECIAL_RESOURCE.toString());
         params.add(1);
@@ -678,7 +664,7 @@ public class XmlRpcTest {
         }
         assertThat(foundMatch).withFailMessage("added collection not found").isTrue();
 
-        Map<String, String> options = new HashMap<>();
+        final Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
         options.put("encoding", StandardCharsets.UTF_8.name());
         options.put("expand-xincludes", "yes");
@@ -694,15 +680,14 @@ public class XmlRpcTest {
 
     @Test
     public void testGetVersion() throws XmlRpcException, MalformedURLException {
-        XmlRpcClient xmlrpc = getClient();
-        assertThat(xmlrpc.execute("getVersion", asList())).isEqualTo(Version.getVersion());
+        final XmlRpcClient xmlrpc = getClient();
+        assertThat(xmlrpc.execute("getVersion", emptyList())).isEqualTo(Version.getVersion());
     }
 
     @Test
     public void testConfigureCollection() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         params.add("<configuration/>");
         assertThat(xmlrpc.execute("configureCollection", params)).isEqualTo(TRUE);
@@ -711,8 +696,7 @@ public class XmlRpcTest {
     @Test
     public void testCreateId() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((String) xmlrpc.execute("createId", params)).endsWith(".xml");
     }
@@ -720,8 +704,7 @@ public class XmlRpcTest {
     @Test
     public void testCreateResourceId() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((String) xmlrpc.execute("createResourceId", params)).endsWith(".xml");
     }
@@ -729,8 +712,7 @@ public class XmlRpcTest {
     @Test
     public void testGetCollectionDesc() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         Map<String, Object> response = (Map<String, Object>) xmlrpc.execute("getCollectionDesc", params);
         assertThat(response).isNotEmpty();
@@ -739,8 +721,7 @@ public class XmlRpcTest {
     @Test
     public void testExistsAndCanOpenCollection() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat(xmlrpc.execute("existsAndCanOpenCollection", params)).isEqualTo(TRUE);
     }
@@ -748,8 +729,7 @@ public class XmlRpcTest {
     @Test
     public void testDescribeResource() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_RESOURCE.toString());
         Map<String, Object> result = (Map<String, Object>) xmlrpc.execute("describeResource", params);
         assertThat(result).isNotEmpty();
@@ -758,8 +738,7 @@ public class XmlRpcTest {
     @Test
     public void testGetContentDigest() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(MODULE_RESOURCE.toString());
         params.add("SHA-256");
         Map<String, Object> result = (Map<String, Object>) xmlrpc.execute("getContentDigest", params);
@@ -770,9 +749,9 @@ public class XmlRpcTest {
     public void testDocumentListing() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
 
-        assertThat((Object[]) xmlrpc.execute("getDocumentListing", asList())).isNotEmpty();
+        assertThat((Object[]) xmlrpc.execute("getDocumentListing", emptyList())).isNotEmpty();
 
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((Object[]) xmlrpc.execute("getDocumentListing", params)).isNotEmpty();
     }
@@ -780,8 +759,7 @@ public class XmlRpcTest {
     @Test
     public void testGetCollectionListing() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("/db");
         Object[] result = (Object[]) xmlrpc.execute("getCollectionListing", params);
         assertThat(result).isNotEmpty();
@@ -790,8 +768,7 @@ public class XmlRpcTest {
     @Test
     public void testGetResourceCount() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((Integer) xmlrpc.execute("getResourceCount", params)).isEqualTo(3);
     }
@@ -799,8 +776,7 @@ public class XmlRpcTest {
     @Test
     public void testPermissions() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((Map<String, Object>) xmlrpc.execute("getPermissions", params)).isNotEmpty();
 
@@ -837,15 +813,14 @@ public class XmlRpcTest {
         params.add("admin");
         params.add("dba");
         params.add(755);
-        params.add(asList());
+        params.add(emptyList());
         assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
     }
 
     @Test
     public void testChgrp() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(MODULE_RESOURCE.toString());
         params.add("guest");
         assertThat(xmlrpc.execute("chgrp", params)).isEqualTo(TRUE);
@@ -854,8 +829,7 @@ public class XmlRpcTest {
     @Test
     public void testChown() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(MODULE_RESOURCE.toString());
         params.add("anoymous");
         assertThat(xmlrpc.execute("chown", params)).isEqualTo(TRUE);
@@ -867,8 +841,7 @@ public class XmlRpcTest {
     @Test
     public void testGetBinaryResource() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(MODULE_RESOURCE.toString());
         assertThat((byte[]) xmlrpc.execute("getBinaryResource", params)).isNotEmpty();
     }
@@ -876,8 +849,7 @@ public class XmlRpcTest {
     @Test
     public void testListDocumentPermissions() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((Map<String, List>) xmlrpc.execute("listDocumentPermissions", params)).isNotEmpty();
     }
@@ -885,8 +857,7 @@ public class XmlRpcTest {
     @Test
     public void testListCollectionPermissions() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("/db");
         assertThat((Map<String, List>) xmlrpc.execute("listCollectionPermissions", params)).isNotEmpty();
     }
@@ -894,8 +865,7 @@ public class XmlRpcTest {
     @Test
     public void testGetSubCollectionPermissions() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("/db");
         params.add("xmlrpc");
         assertThat((Map<String, List>) xmlrpc.execute("getSubCollectionPermissions", params)).isNotEmpty();
@@ -904,8 +874,7 @@ public class XmlRpcTest {
     @Test
     public void testGetSubCollectionCreationTime() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("/db");
         params.add("xmlrpc");
         assertThat((Long)xmlrpc.execute("getSubCollectionCreationTime", params)).isPositive();
@@ -914,8 +883,7 @@ public class XmlRpcTest {
     @Test
     public void testGetSubResourcePermissions() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         params.add(TEST_XML_URI.toString());
         assertThat((Map<String, List>) xmlrpc.execute("getSubResourcePermissions", params)).isNotEmpty();
@@ -924,8 +892,7 @@ public class XmlRpcTest {
     @Test
     public void testGetCreationDate() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_COLLECTION.toString());
         assertThat((Date) xmlrpc.execute("getCreationDate", params)).isNotNull();
     }
@@ -933,8 +900,7 @@ public class XmlRpcTest {
     @Test
     public void testGetTimestamps() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(TARGET_RESOURCE.toString());
         assertThat((Object[]) xmlrpc.execute("getTimestamps", params)).isNotEmpty();
     }
@@ -942,8 +908,7 @@ public class XmlRpcTest {
     @Test
     public void testPrintDiagnostics() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add(QUERY_MODULE_DATA);
         params.add(emptyMap());
         assertThat((String) xmlrpc.execute("printDiagnostics", params))
@@ -953,8 +918,7 @@ public class XmlRpcTest {
     @Test
     public void testQueryP() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("//test");
         params.add(TARGET_RESOURCE.toString());
         params.add("1");
@@ -968,8 +932,7 @@ public class XmlRpcTest {
     @Test
     public void testQueryPT() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = storeData();
-
-        List<Object> params = new ArrayList<>();
+        final List<Object> params = new ArrayList<>();
         params.add("//test".getBytes());
         params.add(emptyMap());
         assertThat((Map<String, Object>) xmlrpc.execute("queryPT", params)).isNotEmpty();

--- a/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
@@ -612,9 +612,7 @@ public class XmlRpcTest {
         params.clear();
         params.add(handle);
         Integer hits = (Integer) xmlrpc.execute("getHits", params);
-        assertThat(hits).isNotNull();
-
-        assertThat(hits).isEqualTo(2);
+        assertThat(hits).isNotNull().isEqualTo(2);
 
         params.add(0);
         params.add(new HashMap());
@@ -910,7 +908,7 @@ public class XmlRpcTest {
         List<Object> params = new ArrayList<>();
         params.add("/db");
         params.add("xmlrpc");
-        assertThat((Long)xmlrpc.execute("getSubCollectionCreationTime", params)).isGreaterThan(0);
+        assertThat((Long)xmlrpc.execute("getSubCollectionCreationTime", params)).isPositive();
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
@@ -21,20 +21,28 @@
  */
 package org.exist.xmlrpc;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
 import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+import org.exist.Version;
 import org.exist.security.MessageDigester;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.test.ExistWebServer;
 import org.exist.test.TestConstants;
 import org.exist.util.Compressor;
 import org.exist.util.MimeType;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
-import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.exist.test.TestConstants.TEST_XML_URI;
 import static org.exist.xmldb.RemoteCollection.MAX_UPLOAD_CHUNK;
 import static org.exist.xmlrpc.RpcConnection.MAX_DOWNLOAD_CHUNK_SIZE;
 
@@ -47,12 +55,18 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+
 import org.exist.security.Permission;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 import org.junit.After;
 import org.xml.sax.SAXException;
@@ -74,7 +88,7 @@ public class XmlRpcTest {
 
     private final static XmldbURI TARGET_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("xmlrpc");
 
-    private final static XmldbURI TARGET_RESOURCE = TARGET_COLLECTION.append(TestConstants.TEST_XML_URI);
+    private final static XmldbURI TARGET_RESOURCE = TARGET_COLLECTION.append(TEST_XML_URI);
 
     public final static XmldbURI MODULE_RESOURCE = TARGET_COLLECTION.append(TestConstants.TEST_MODULE_URI);
 
@@ -116,58 +130,69 @@ public class XmlRpcTest {
     @After
     public void tearDown() throws XmlRpcException, MalformedURLException {
         XmlRpcClient xmlrpc = getClient();
-        List<String> params = new ArrayList<>(1);
-        params.add(TARGET_COLLECTION.toString());
-        @SuppressWarnings("unused")
-        Boolean b = (Boolean) xmlrpc.execute("removeCollection", params);
+        assertThat(xmlrpc.execute("removeCollection", asList(TARGET_COLLECTION.toString()))).isInstanceOf(Boolean.class);
     }
 
     @Test
     public void testStoreAndRetrieve() throws XmlRpcException, IOException {
-        XmlRpcClient xmlrpc = getClient();
-        List<Object> params = new ArrayList<>();
-        params.add(TARGET_COLLECTION.toString());
-        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
-        assertTrue(result);
+        XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
 
-        params.clear();
+        List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(TARGET_RESOURCE.toString());
+        params.add(0);
+
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(XML_DATA.getBytes());
+        params.add(TARGET_RESOURCE.toString());
+        params.add("application/xml");
         params.add(1);
 
-        result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
-        Map<String, String> options = new HashMap<>();
+        params.clear();
+        params.add(XML_DATA.getBytes());
+        params.add(TARGET_RESOURCE.toString());
+        params.add(1);
+        params.add(new Date(10_0000));
+        params.add(new Date(20_0000));
+
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
+
         params.clear();
         params.add(TARGET_RESOURCE.toString());
-        params.add(options);
+        params.add(emptyMap());
 
-        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
-        assertNotNull(data);
+        assertThat((byte[])xmlrpc.execute("getDocument", params)).isNotEmpty();
 
         params.clear();
         params.add(TARGET_RESOURCE.toString());
         params.add(StandardCharsets.UTF_8.name());
         params.add(0);
 
-        data = (byte[]) xmlrpc.execute("getDocument", params);
-        assertNotNull(data);
+        assertThat((byte[])xmlrpc.execute("getDocument", params)).isNotEmpty();
 
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(singletonMap(EXistOutputKeys.COMPRESS_OUTPUT, "yes"));
+
+        assertThat((byte[])xmlrpc.execute("getDocument", params)).isNotEmpty();
         params.clear();
         params.add(TARGET_RESOURCE.toString());
         params.add(0);
-        String sdata = (String) xmlrpc.execute("getDocumentAsString", params);
-        assertNotNull(data);
+
+        assertThat(xmlrpc.execute("getDocumentAsString", params)).isInstanceOf(String.class);
 
         params.clear();
         params.add(TARGET_RESOURCE.toString());
-        params.add(options);
+        params.add(emptyMap());
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             int offset = (int) table.get("offset");
-            data = (byte[]) table.get("data");
+            byte[] data = (byte[]) table.get("data");
             os.write(data);
             while (offset > 0) {
                 params.clear();
@@ -179,58 +204,53 @@ public class XmlRpcTest {
                 os.write(data);
             }
             data = os.toByteArray();
-            assertTrue(data.length > 0);
+            assertThat(data).isNotEmpty();
         }
 
         params.clear();
         params.add(TARGET_RESOURCE.toString());
-        Boolean b = (Boolean) xmlrpc.execute("hasDocument", params);
-        assertTrue(b);
+        assertThat(xmlrpc.execute("hasDocument", params)).isEqualTo(TRUE);
     }
 
-    private void storeData() throws XmlRpcException, MalformedURLException {
+    private XmlRpcClient createCollection(XmldbURI collection) throws XmlRpcException, MalformedURLException {
         XmlRpcClient xmlrpc = getClient();
-        List<Object> params = new ArrayList<>();
-        params.add(TARGET_COLLECTION.toString());
-        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("createCollection", asList(collection.toString()))).isEqualTo(TRUE);
+        return xmlrpc;
+    }
 
-        params.clear();
+    private XmlRpcClient storeData() throws XmlRpcException, MalformedURLException {
+        XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+
+        List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(TARGET_RESOURCE.toString());
         params.add(1);
 
-        result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
         params.set(0, XSL_DATA);
         params.set(1, TARGET_COLLECTION.append("test.xsl").toString());
-        result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
         params.set(0, MODULE_DATA.getBytes(UTF_8));
         params.set(1, MODULE_RESOURCE.toString());
         params.set(2, MimeType.XQUERY_TYPE.getName());
-        params.add(Boolean.TRUE);
-        result = (Boolean) xmlrpc.execute("storeBinary", params);
-        assertTrue(result);
+        params.add(TRUE);
+        assertThat(xmlrpc.execute("storeBinary", params)).isEqualTo(TRUE);
+
+        return xmlrpc;
     }
 
     @Test
     public void getDocumentDataChunked_nextChunk() throws IOException, XmlRpcException {
-        final XmlRpcClient xmlrpc = getClient();
-        List<Object> params = new ArrayList<>();
-        params.add(TARGET_COLLECTION.toString());
-        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
-        assertTrue(result);
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
 
-        params.clear();
-        final String generatedXml = generateXml((int)(MAX_DOWNLOAD_CHUNK_SIZE * 1.5));
+        List<Object> params = new ArrayList<>();
+        final String generatedXml = generateXml((int) (MAX_DOWNLOAD_CHUNK_SIZE * 1.5));
         params.add(generatedXml);
         params.add(TARGET_RESOURCE.toString());
         params.add(1);
-        result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
         params.clear();
         final Map<String, Object> parameters = new HashMap<>();
@@ -240,7 +260,7 @@ public class XmlRpcTest {
         params.add(parameters);
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             int offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -249,30 +269,25 @@ public class XmlRpcTest {
                 params.add(table.get("handle"));
                 params.add(offset);
                 table = (Map<?, ?>) xmlrpc.execute("getNextChunk", params);
-                offset = (int)table.get("offset");
+                offset = (int) table.get("offset");
                 data = (byte[]) table.get("data");
                 os.write(data);
             }
             data = os.toByteArray();
-            assertEquals(generatedXml, new String(data));
+            assertThat(generatedXml).isEqualTo(new String(data));
         }
     }
 
     @Test
     public void getDocumentDataChunked_nextExtendedChunk() throws IOException, XmlRpcException {
-        final XmlRpcClient xmlrpc = getClient();
-        List<Object> params = new ArrayList<>();
-        params.add(TARGET_COLLECTION.toString());
-        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
-        assertTrue(result);
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
 
-        params.clear();
-        final String generatedXml = generateXml((int)(MAX_DOWNLOAD_CHUNK_SIZE * 1.75));
+        List<Object> params = new ArrayList<>();
+        final String generatedXml = generateXml((int) (MAX_DOWNLOAD_CHUNK_SIZE * 1.75));
         params.add(generatedXml);
         params.add(TARGET_RESOURCE.toString());
         params.add(1);
-        result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
         params.clear();
         final Map<String, Object> parameters = new HashMap<>();
@@ -282,7 +297,7 @@ public class XmlRpcTest {
         params.add(parameters);
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             long offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -296,7 +311,7 @@ public class XmlRpcTest {
                 os.write(data);
             }
             data = os.toByteArray();
-            assertEquals(generatedXml, new String(data));
+            assertThat(generatedXml).isEqualTo(new String(data));
         }
     }
 
@@ -305,11 +320,11 @@ public class XmlRpcTest {
         final XmlRpcClient xmlrpc = getClient();
         final String resURI = XmldbURI.ROOT_COLLECTION_URI.append("test.bin").toString();
         final Date now = new Date(System.currentTimeMillis());
-        final byte[] binary = generateBinary((int)(MAX_UPLOAD_CHUNK * 1.5));
+        final byte[] binary = generateBinary((int) (MAX_UPLOAD_CHUNK * 1.5));
 
         // 1) upload
         String uploadedFileName = null;
-        try (final InputStream is = new UnsynchronizedByteArrayInputStream(binary)) {
+        try (final InputStream is = new ByteArrayInputStream(binary)) {
             final byte[] chunk = new byte[MAX_UPLOAD_CHUNK];
             int len;
             while ((len = is.read(chunk)) > -1) {
@@ -328,9 +343,9 @@ public class XmlRpcTest {
         final List<Object> paramsEx = new ArrayList<>();
         paramsEx.add(uploadedFileName);
         paramsEx.add(resURI);
-        paramsEx.add(Boolean.TRUE);
+        paramsEx.add(TRUE);
         paramsEx.add("application/octet-stream");
-        paramsEx.add(Boolean.FALSE);
+        paramsEx.add(FALSE);
         paramsEx.add(now);
         paramsEx.add(now);
         xmlrpc.execute("parseLocalExt", paramsEx);
@@ -339,9 +354,9 @@ public class XmlRpcTest {
         // 2) download
         final List<Object> params = new ArrayList<>();
         params.add(resURI);
-        params.add(Collections.emptyMap());
+        params.add(emptyMap());
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
-        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             long offset = (int) table.get("offset");
             byte[] data = (byte[]) table.get("data");
             os.write(data);
@@ -356,46 +371,36 @@ public class XmlRpcTest {
             }
 
             data = os.toByteArray();
-            assertArrayEquals(binary, data);
+            assertThat(binary).isEqualTo(data);
         }
     }
 
     @Test
     public void testRemoveCollection() throws XmlRpcException, MalformedURLException {
-        storeData();
-        XmlRpcClient xmlrpc = getClient();
+        final XmlRpcClient xmlrpc = storeData();
+
         List params = new ArrayList(1);
         params.add(TARGET_COLLECTION.toString());
-        Boolean b = (Boolean) xmlrpc.execute("hasCollection", params);
-        assertTrue(b);
-
-        b = (Boolean) xmlrpc.execute("removeCollection", params);
-        assertTrue(b);
-
-        b = (Boolean) xmlrpc.execute("hasCollection", params);
-        assertFalse(b);
+        assertThat(xmlrpc.execute("hasCollection", params)).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("removeCollection", params)).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("hasCollection", params)).isEqualTo(FALSE);
     }
 
     @Test
     public void testRemoveDoc() throws XmlRpcException, MalformedURLException {
-        storeData();
-        XmlRpcClient xmlrpc = getClient();
+        final XmlRpcClient xmlrpc = storeData();
+
         List params = new ArrayList(1);
         params.add(TARGET_RESOURCE.toString());
-        Boolean b = (Boolean) xmlrpc.execute("hasDocument", params);
-
-        assertTrue(b);
-
-        b = (Boolean) xmlrpc.execute("remove", params);
-        assertTrue(b);
-
-        b = (Boolean) xmlrpc.execute("hasDocument", params);
-        assertFalse(b);
+        assertThat(xmlrpc.execute("hasDocument", params)).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("remove", params)).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("hasDocument", params)).isEqualTo(FALSE);
     }
 
     @Test
     public void testRetrieveDoc() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
         options.put("encoding", StandardCharsets.UTF_8.name());
@@ -407,50 +412,56 @@ public class XmlRpcTest {
         params.add(options);
 
         // execute the call
-        XmlRpcClient xmlrpc = getClient();
-        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
+        assertThat(xmlrpc.execute("getDocument", params)).isInstanceOf(byte[].class);
 
         options.put("stylesheet", "test.xsl");
-        data = (byte[]) xmlrpc.execute("getDocument", params);
+        assertThat(xmlrpc.execute("getDocument", params)).isInstanceOf(byte[].class);
     }
 
     @Test
     public void testCharEncoding() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
         List<Object> params = new ArrayList<>();
         String query = "distinct-values(//para)";
         params.add(query.getBytes(UTF_8));
-        params.add(new HashMap<>());
-        XmlRpcClient xmlrpc = getClient();
+        params.add(emptyMap());
+
         HashMap<?, ?> result = (HashMap<?, ?>) xmlrpc.execute("queryP", params);
         Object[] resources = (Object[]) result.get("results");
         //TODO : check the number of resources before !
-        assertEquals(2, resources.length);
-        String value = (String) resources[0];
-        assertEquals("\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF", value);
-        value = (String) resources[1];
-        assertEquals("\uC5F4\uB2E8\uACC4", value);
+        assertThat(resources).containsExactly(
+                "\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF",
+                "\uC5F4\uB2E8\uACC4");
     }
 
     @Test
     public void testQuery() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         List<Object> params = new ArrayList<>();
-        String query
-                = "(::pragma exist:serialize indent=no::) //para";
+        String query = "(::pragma exist:serialize indent=no::) //para";
         params.add(query.getBytes(UTF_8));
         params.add(10);
         params.add(1);
-        params.add(new HashMap());
-        XmlRpcClient xmlrpc = getClient();
-        byte[] result = (byte[]) xmlrpc.execute("query", params);
-        assertNotNull(result);
-        assertTrue(result.length > 0);
+        params.add(singletonMap(RpcAPI.PROTECTED_MODE, "/db"));
+
+        assertThat((byte[]) xmlrpc.execute("query", params)).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    public void testQuerySummary() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("//para");
+
+        assertThat((Map<String, Object>) xmlrpc.execute("querySummary", params)).isNotEmpty();
     }
 
     @Test
     public void testQueryWithStylesheet() throws XmlRpcException, MalformedURLException, SAXException, IOException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         Map<String, String> options = new HashMap<>();
         options.put(EXistOutputKeys.STYLESHEET, "test.xsl");
         options.put(EXistOutputKeys.STYLESHEET_PARAM + ".testparam", "Test");
@@ -460,17 +471,16 @@ public class XmlRpcTest {
         String query = "//para[1]";
         params.add(query.getBytes(UTF_8));
         params.add(options);
-        XmlRpcClient xmlrpc = getClient();
+
         Integer handle = (Integer) xmlrpc.execute("executeQuery", params);
-        assertNotNull(handle);
+        assertThat(handle).isNotNull();
 
         params.clear();
         params.add(handle);
         params.add(0);
         params.add(options);
         byte[] item = (byte[]) xmlrpc.execute("retrieve", params);
-        assertNotNull(item);
-        assertTrue(item.length > 0);
+        assertThat(item).isNotNull().isNotEmpty();
         String out = new String(item, UTF_8);
 
         final Source expected = Input.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<p>Test: \u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</p>").build();
@@ -480,78 +490,147 @@ public class XmlRpcTest {
                 .withTest(actual)
                 .checkForSimilar()
                 .build();
-        assertFalse(diff.toString(), diff.hasDifferences());
+        assertThat(diff.hasDifferences()).withFailMessage(diff.toString()).isFalse();
     }
 
     @Test
     public void testCompile() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         List<Object> params = new ArrayList<>();
         String query = "<a>Invalid<a>";
         params.add(query.getBytes(UTF_8));
-        params.add(new HashMap<>());
-        XmlRpcClient xmlrpc = getClient();
+        params.add(emptyMap());
+
         Map stats = (Map) xmlrpc.execute("compile", params);
-        assertNotNull(stats);
-        assertNotNull(stats.get("error"));
+        assertThat(stats).isNotNull();
+        assertThat(stats.get("error")).isNotNull();
     }
 
     @Test
-    public void testAddAccount() throws MalformedURLException, XmlRpcException {
-        String user = "rudi";
-        String passwd = "pass";
+    public void testAccount() throws MalformedURLException, XmlRpcException {
+        final String user = "rudi";
+        final String passwd = "pass";
         String simpleMd5 = MessageDigester.md5(passwd, true);
         String digest = MessageDigester.md5(user + ":exist:" + passwd, false);
+
         List<Object> params = new ArrayList<>(12);
-        params.add("rudi");
+        params.add(user);
         params.add(simpleMd5);
         params.add(digest);
         params.add(new String[]{"guest"});
         params.add(true);
         params.add(Permission.DEFAULT_UMASK);
-        params.add(new HashMap<>());
+        params.add(emptyMap());
 
-        XmlRpcClient xmlrpc = getClient();
-        xmlrpc.execute("addAccount", params);
+        final XmlRpcClient xmlrpc = getClient();
+        assertThat(xmlrpc.execute("addAccount", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(user);
+        params.add(simpleMd5);
+        params.add(digest);
+        params.add(new String[]{"guest"});
+        assertThat(xmlrpc.execute("updateAccount", params)).isEqualTo(TRUE);
+
+        assertThat(xmlrpc.execute("setUserPrimaryGroup", asList(user, "guest"))).isEqualTo(TRUE);
 
         XmlRpcClientConfigImpl config = (XmlRpcClientConfigImpl) xmlrpc.getClientConfig();
         config.setBasicUserName("admin");
         config.setBasicPassword("");
-        xmlrpc.execute("sync", Collections.EMPTY_LIST);
+        assertThat(xmlrpc.execute("sync", asList())).isEqualTo(TRUE);
+
+        Object[] accounts = (Object[]) xmlrpc.execute("getAccounts", asList());
+        assertThat(accounts).hasSize(5);
+
+        for (Object account : accounts) {
+            Map<String, Object> accountInfo = (Map<String, Object>) account;
+            assertThat(accountInfo).hasSize(9);
+            String name = (String) accountInfo.get("name");
+            assertThat((Map<String, Object>) xmlrpc.execute("getAccount", asList(name)))
+                    .containsExactlyEntriesOf(accountInfo);
+        }
+
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("dba")))
+                .containsExactlyInAnyOrder("SYSTEM", "admin");
+        xmlrpc.execute("addAccountToGroup", asList(user, "dba"));
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("dba")))
+                .containsExactlyInAnyOrder("SYSTEM", "admin", user);
+
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("nogroup")))
+                .containsExactlyInAnyOrder("nobody");
+
+        assertThat(xmlrpc.execute("updateAccount", asList(user, asList("nogroup")))).isEqualTo(TRUE);
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("nogroup")))
+                .containsExactlyInAnyOrder("nobody", user);
+
+        xmlrpc.execute("removeGroupMember", asList("nogroup", user));
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("nogroup")))
+                .containsExactlyInAnyOrder("nobody");
+
+        assertThat(xmlrpc.execute("updateAccount", asList(user, asList("guest", "dba"), "dba"))).isEqualTo(TRUE);
+        assertThat((Object[]) xmlrpc.execute("getGroupMembers", asList("dba")))
+                .containsExactlyInAnyOrder("SYSTEM", "admin");
+
+        assertThat(xmlrpc.execute("removeAccount", asList(user))).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testGroups() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = getClient();
+
+        assertThat((Object[]) xmlrpc.execute("getGroups", asList()))
+                .containsExactlyInAnyOrder("dba", "guest", "nogroup")
+                .allSatisfy(groupName -> {
+                    assertThat((Map<String, Object>) xmlrpc.execute("getGroup", asList(groupName)))
+                            .hasSize(5).containsEntry("name", groupName);
+                });
+
+        assertThat(xmlrpc.execute("addGroup", asList("testGroup", emptyMap()))).isEqualTo(TRUE);
+        assertThat((Object[]) xmlrpc.execute("getGroups", asList()))
+                .containsExactlyInAnyOrder("dba", "guest", "nogroup", "testGroup");
+
+        assertThat(xmlrpc.execute("updateGroup", asList("testGroup", asList("admin"), emptyMap()))).isEqualTo(TRUE);
+
+        xmlrpc.execute("removeGroupManager", asList("testGroup", "admin"));
+        xmlrpc.execute("addGroupManager", asList("admin", "testGroup"));
+        xmlrpc.execute("removeGroup", asList("testGroup"));
     }
 
     @Test
     public void testExecuteQuery() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         List<Object> params = new ArrayList<>();
         String query = "distinct-values(//para)";
         params.add(query.getBytes(UTF_8));
-        params.add(new HashMap<>());
-        XmlRpcClient xmlrpc = getClient();
+        params.add(emptyMap());
+
         Integer handle = (Integer) xmlrpc.execute("executeQuery", params);
-        assertNotNull(handle);
+        assertThat(handle).isNotNull();
 
         params.clear();
         params.add(handle);
         Integer hits = (Integer) xmlrpc.execute("getHits", params);
-        assertNotNull(hits);
+        assertThat(hits).isNotNull();
 
-        assertEquals(2, hits.intValue());
+        assertThat(hits).isEqualTo(2);
 
         params.add(0);
         params.add(new HashMap());
-        byte[] item = (byte[]) xmlrpc.execute("retrieve", params);
+        assertThat(xmlrpc.execute("retrieve", params)).isInstanceOf(byte[].class);
 
         params.clear();
         params.add(handle);
         params.add(1);
         params.add(new HashMap());
-        item = (byte[]) xmlrpc.execute("retrieve", params);
+        assertThat(xmlrpc.execute("retrieve", params)).isInstanceOf(byte[].class);
     }
 
     @Test
     public void testQueryModuleExternalVar() throws XmlRpcException, MalformedURLException {
-        storeData();
+        final XmlRpcClient xmlrpc = storeData();
+
         List<Object> params = new ArrayList<>();
         params.add(QUERY_MODULE_DATA.getBytes(UTF_8));
 
@@ -569,31 +648,21 @@ public class XmlRpcTest {
 
         params.add(qp);
 
-        XmlRpcClient xmlrpc = getClient();
         Map<String, Object[]> result = (Map<String, Object[]>) xmlrpc.execute("queryP", params);
         Object[] resources = (Object[]) result.get("results");
-        assertEquals(2, resources.length);
-        String value = (String) resources[0];
-        assertEquals("imported-string-value", value);
-        value = (String) resources[1];
-        assertEquals("local-string-value", value);
+        assertThat(resources).containsExactly("imported-string-value", "local-string-value");
     }
 
     @Test
     public void testCollectionWithAccentsAndSpaces() throws XmlRpcException, MalformedURLException {
-        storeData();
-        List<Object> params = new ArrayList<>();
-        params.add(SPECIAL_COLLECTION.toString());
-        XmlRpcClient xmlrpc = getClient();
-        xmlrpc.execute("createCollection", params);
+        final XmlRpcClient xmlrpc = createCollection(SPECIAL_COLLECTION);
 
-        params.clear();
+        List<Object> params = new ArrayList<>();
         params.add(XML_DATA);
         params.add(SPECIAL_RESOURCE.toString());
         params.add(1);
 
-        Boolean result = (Boolean) xmlrpc.execute("parse", params);
-        assertTrue(result);
+        assertThat(xmlrpc.execute("parse", params)).isEqualTo(TRUE);
 
         params.clear();
         params.add(SPECIAL_COLLECTION.removeLastSegment().toString());
@@ -609,7 +678,7 @@ public class XmlRpcTest {
                 break;
             }
         }
-        assertTrue("added collection not found", foundMatch);
+        assertThat(foundMatch).withFailMessage("added collection not found").isTrue();
 
         Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
@@ -622,7 +691,331 @@ public class XmlRpcTest {
         params.add(options);
 
         // execute the call
-        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
+        assertThat(xmlrpc.execute("getDocument", params)).isInstanceOf(byte[].class);
+    }
+
+    @Test
+    public void testGetVersion() throws XmlRpcException, MalformedURLException {
+        XmlRpcClient xmlrpc = getClient();
+        assertThat(xmlrpc.execute("getVersion", asList())).isEqualTo(Version.getVersion());
+    }
+
+    @Test
+    public void testConfigureCollection() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        params.add("<configuration/>");
+        assertThat(xmlrpc.execute("configureCollection", params)).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testCreateId() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((String) xmlrpc.execute("createId", params)).endsWith(".xml");
+    }
+
+    @Test
+    public void testCreateResourceId() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = createCollection(TARGET_COLLECTION);
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((String) xmlrpc.execute("createResourceId", params)).endsWith(".xml");
+    }
+
+    @Test
+    public void testGetCollectionDesc() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        Map<String, Object> response = (Map<String, Object>) xmlrpc.execute("getCollectionDesc", params);
+        assertThat(response).isNotEmpty();
+    }
+
+    @Test
+    public void testExistsAndCanOpenCollection() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat(xmlrpc.execute("existsAndCanOpenCollection", params)).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testDescribeResource() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_RESOURCE.toString());
+        Map<String, Object> result = (Map<String, Object>) xmlrpc.execute("describeResource", params);
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    public void testGetContentDigest() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(MODULE_RESOURCE.toString());
+        params.add("SHA-256");
+        Map<String, Object> result = (Map<String, Object>) xmlrpc.execute("getContentDigest", params);
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    public void testDocumentListing() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        assertThat((Object[]) xmlrpc.execute("getDocumentListing", asList())).isNotEmpty();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((Object[]) xmlrpc.execute("getDocumentListing", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testGetCollectionListing() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("/db");
+        Object[] result = (Object[]) xmlrpc.execute("getCollectionListing", params);
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    public void testGetResourceCount() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((Integer) xmlrpc.execute("getResourceCount", params)).isEqualTo(3);
+    }
+
+    @Test
+    public void testPermissions() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((Map<String, Object>) xmlrpc.execute("getPermissions", params)).isNotEmpty();
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        assertThat((Map<String, Object>) xmlrpc.execute("getPermissions", params)).isNotEmpty();
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(755);
+        assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add("rw-rw-rw-");
+        assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add("admin");
+        params.add("dba");
+        params.add(755);
+        assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add("admin");
+        params.add("dba");
+        params.add("rw-rw-rw-");
+        assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add("admin");
+        params.add("dba");
+        params.add(755);
+        params.add(asList());
+        assertThat(xmlrpc.execute("setPermissions", params)).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testChgrp() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(MODULE_RESOURCE.toString());
+        params.add("guest");
+        assertThat(xmlrpc.execute("chgrp", params)).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testChown() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(MODULE_RESOURCE.toString());
+        params.add("anoymous");
+        assertThat(xmlrpc.execute("chown", params)).isEqualTo(TRUE);
+
+        params.add("guest");
+        assertThat(xmlrpc.execute("chown", params)).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testGetBinaryResource() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(MODULE_RESOURCE.toString());
+        assertThat((byte[]) xmlrpc.execute("getBinaryResource", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testListDocumentPermissions() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((Map<String, List>) xmlrpc.execute("listDocumentPermissions", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testListCollectionPermissions() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("/db");
+        assertThat((Map<String, List>) xmlrpc.execute("listCollectionPermissions", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testGetSubCollectionPermissions() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("/db");
+        params.add("xmlrpc");
+        assertThat((Map<String, List>) xmlrpc.execute("getSubCollectionPermissions", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testGetSubCollectionCreationTime() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("/db");
+        params.add("xmlrpc");
+        assertThat((Long)xmlrpc.execute("getSubCollectionCreationTime", params)).isGreaterThan(0);
+    }
+
+    @Test
+    public void testGetSubResourcePermissions() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        params.add(TEST_XML_URI.toString());
+        assertThat((Map<String, List>) xmlrpc.execute("getSubResourcePermissions", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testGetCreationDate() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        assertThat((Date) xmlrpc.execute("getCreationDate", params)).isNotNull();
+    }
+
+    @Test
+    public void testGetTimestamps() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_RESOURCE.toString());
+        assertThat((Object[]) xmlrpc.execute("getTimestamps", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testPrintDiagnostics() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add(QUERY_MODULE_DATA);
+        params.add(emptyMap());
+        assertThat((String) xmlrpc.execute("printDiagnostics", params))
+                .contains("$tm:imported-external-string, $tm-query:local-external-string");
+    }
+
+    @Test
+    public void testQueryP() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("//test");
+        params.add(TARGET_RESOURCE.toString());
+        params.add("1");
+        params.add(emptyMap());
+        assertThat((Map<String, Object>) xmlrpc.execute("queryP", params)).isNotEmpty();
+
+        params.set(0, "//test".getBytes());
+        assertThat((Map<String, Object>) xmlrpc.execute("queryP", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testQueryPT() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        List<Object> params = new ArrayList<>();
+        params.add("//test".getBytes());
+        params.add(emptyMap());
+        assertThat((Map<String, Object>) xmlrpc.execute("queryPT", params)).isNotEmpty();
+
+        params.clear();
+        params.add("//test".getBytes());
+        params.add(TARGET_RESOURCE.toString());
+        params.add("1");
+        params.add(emptyMap());
+        assertThat((Map<String, Object>) xmlrpc.execute("queryPT", params)).isNotEmpty();
+    }
+
+    @Test
+    public void testLockUnlockResources() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        assertThat(xmlrpc.execute("hasUserLock", asList(TARGET_RESOURCE.toString()))).isEqualTo("");
+        assertThat(xmlrpc.execute("lockResource", asList(TARGET_RESOURCE.toString(), "admin"))).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("hasUserLock", asList(TARGET_RESOURCE.toString()))).isEqualTo("admin");
+        assertThat(xmlrpc.execute("unlockResource", asList(TARGET_RESOURCE.toString()))).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("hasUserLock", asList(TARGET_RESOURCE.toString()))).isEqualTo("");
+    }
+
+    @Test
+    public void testIndexedElements() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        assertThat((Object[])xmlrpc.execute("getIndexedElements", asList(TARGET_COLLECTION.toString(), true))).isEmpty();
+        assertThat(xmlrpc.execute("reindexCollection", asList(TARGET_COLLECTION.toString()))).isEqualTo(TRUE);
+        assertThat(xmlrpc.execute("reindexDocument", asList(TARGET_RESOURCE.toString()))).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testLastModified() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        assertThat(xmlrpc.execute("setLastModified", asList(TARGET_RESOURCE.toString(), 5000L))).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void testGetDocType() throws XmlRpcException, MalformedURLException {
+        final XmlRpcClient xmlrpc = storeData();
+
+        assertThat((Object[])xmlrpc.execute("getDocType", asList(TARGET_RESOURCE.toString()))).isNotEmpty();
     }
 
     private String generateXml(final int minBytes) {

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -816,7 +816,7 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no" output-doctype="yes" enable-xinclude="yes"
-                enable-xsl="no" indent="yes" match-tagging-attributes="no"
+                enable-xsl="no" indent="yes" match-tagging-attributes="no" 
                 match-tagging-elements="no">
         <!--
             You may add as many custom-filters as you want, they will be executed
@@ -1121,6 +1121,6 @@
         - max-idle:
           Defines the maximum amount of idle pool entries that will not be removed for later reuse.
         -->
-        <content-file-pool size="-1" max-idle="5"/>
+        <content-file-pool size="10" max-idle="5"/>
     </rpc-server>
 </exist>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -572,6 +572,7 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>9.0.9</version>
                     <configuration>
+                        <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
                         <!-- The OSS Index Server (https://ossindex.sonatype.org) can sometimes be flaky -->
                         <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -125,6 +125,7 @@
         <easymock.version>5.2.0</easymock.version>
         <objenesis.version>3.3</objenesis.version>
         <assertj.version>3.25.3</assertj.version>
+        <awaitility.version>4.2.0</awaitility.version>
         <junit.toolbox.version>2.4</junit.toolbox.version>
         <hamcrest.version>2.2</hamcrest.version>
 
@@ -529,6 +530,12 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/5188.

Enables in-memory query result values less than 4 MB instead of writing them to a temporary file.

By using the in-memory-buffer no potential virus scanner is trigger either on the server as on the client side. This almost doubled the performance on our productive systems, when using this change.