### PR TITLE
[bugfix] Fixes izPack schema issues

### DIFF
--- a/exist-installer/src/main/izpack/UnixShortcutSpec.xml
+++ b/exist-installer/src/main/izpack/UnixShortcutSpec.xml
@@ -22,12 +22,14 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<izpack:shortcuts xmlns:izpack="http://izpack.org/schema/shortcuts" version="5.0">
+<izpack:shortcuts version="5.0"
+                  xmlns:izpack="http://izpack.org/schema/shortcuts"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://izpack.org/schema/shortcuts http://izpack.org/schema/5.0/izpack-shortcuts-5.0.xsd">
     <programGroup defaultName="eXist-db XML Database" location="applications"/>
 
     <shortcut
             name="eXist-db Database"
-            genericName="eXist-db"
             description="eXist-db XML Database Launcher"
             type="Application"
             encoding="UTF-8"

--- a/exist-installer/src/main/izpack/custom.eng.xml
+++ b/exist-installer/src/main/izpack/custom.eng.xml
@@ -25,7 +25,10 @@
 
 <!-- The English langpack -->
 
-<izpack:langpack xmlns:izpack="http://izpack.org/schema/langpack" version="5.0">
+<izpack:langpack version="5.0"
+                 xmlns:izpack="http://izpack.org/schema/langpack"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
 
     <!-- Heading messages START -->
     <str id="CheckedHelloPanel.headline" txt="Welcome"/>

--- a/exist-installer/src/main/izpack/install.xml
+++ b/exist-installer/src/main/izpack/install.xml
@@ -22,8 +22,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<izpack:installation xmlns:izpack="http://izpack.org/schema/installation"
-        version="5.0">
+<izpack:installation version="5.0"
+                     xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
 
     <logging>
         <log-file mkdirs="true" pattern="$INSTALL_PATH/logs/izpack-install-%u.log"/>

--- a/exist-installer/src/main/izpack/jobs.xml
+++ b/exist-installer/src/main/izpack/jobs.xml
@@ -25,7 +25,7 @@
 <izpack:processing version="5.0"
                   xmlns:izpack="http://izpack.org/schema/processing"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://izpack.org/schema/processing http://izpack.org/schema/5.0/izpack-processing-5.0.xsd"
+                  xsi:schemaLocation="http://izpack.org/schema/processing http://izpack.org/schema/5.0/izpack-processing-5.0.xsd">
 
     <logfiledir>$INSTALL_PATH${FILE_SEPARATOR}logs</logfiledir>
 

--- a/exist-installer/src/main/izpack/jobs.xml
+++ b/exist-installer/src/main/izpack/jobs.xml
@@ -22,7 +22,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<izpack:processing xmlns:izpack="http://izpack.org/schema/processing" version="5.0">
+<izpack:processing version="5.0"
+                  xmlns:izpack="http://izpack.org/schema/processing"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://izpack.org/schema/processing http://izpack.org/schema/5.0/izpack-processing-5.0.xsd"
 
     <logfiledir>$INSTALL_PATH${FILE_SEPARATOR}logs</logfiledir>
 

--- a/exist-installer/src/main/izpack/shortcutSpec.xml
+++ b/exist-installer/src/main/izpack/shortcutSpec.xml
@@ -22,11 +22,13 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<izpack:shortcuts xmlns:izpack="http://izpack.org/schema/shortcuts" version="5.0">
+<izpack:shortcuts version="5.0"
+                  xmlns:izpack="http://izpack.org/schema/shortcuts"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://izpack.org/schema/shortcuts http://izpack.org/schema/5.0/izpack-shortcuts-5.0.xsd">
     <programGroup defaultName="eXist-db XML Database" location="applications"/>
     <shortcut
             name="eXist-db Database"
-            genericName="eXist-db"
             description="eXist-db XML Database Launcher"
             type="Application"
             encoding="UTF-8"

--- a/exist-installer/src/main/izpack/userInput.xml
+++ b/exist-installer/src/main/izpack/userInput.xml
@@ -25,7 +25,7 @@
 <izpack:userinput version="5.0"
                   xmlns:izpack="http://izpack.org/schema/userinput"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd"
+                  xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd">
     <panel id="DataDirPanel">
         <field size="1.33" bold="false" txt="Set Data Directory" align="left"
             type="title"/>

--- a/exist-installer/src/main/izpack/userInput.xml
+++ b/exist-installer/src/main/izpack/userInput.xml
@@ -22,7 +22,10 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<izpack:userinput xmlns:izpack="http://izpack.org/schema/userinput" version="5.0">
+<izpack:userinput version="5.0"
+                  xmlns:izpack="http://izpack.org/schema/userinput"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://izpack.org/schema/userinput http://izpack.org/schema/5.0/izpack-userinput-5.0.xsd"
     <panel id="DataDirPanel">
         <field size="1.33" bold="false" txt="Set Data Directory" align="left"
             type="title"/>


### PR DESCRIPTION
Addes correct izPack 5 schema headers and fixes resulting schema errors within shortcut panel specs.

This fix is a precondiiton in order for the #5213 to be accepted.