### PR TITLE
Fix NPE in NativeBroker

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -3033,7 +3033,7 @@ public class NativeBroker extends DBBroker {
                 }
             }.run();
             // create a copy of the old doc to copy the nodes into it
-            final DocumentImpl tempDoc = new DocumentImpl(null, null, doc.getCollection(), doc.getDocId(), doc.getFileURI());
+            final DocumentImpl tempDoc = new DocumentImpl(null, pool, doc.getCollection(), doc.getDocId(), doc.getFileURI());
             tempDoc.copyOf(this, doc, doc);
             final StreamListener listener = getIndexController().getStreamListener(doc, ReindexMode.STORE);
             // copy the nodes

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -715,6 +715,18 @@
                 <configuration>
                     <showfiles>true</showfiles>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.11.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-utils</artifactId>
+                        <version>1.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>autodeploy-expath-pkgs-for-appassembler</id>


### PR DESCRIPTION
### Description:

Frequent updates on any XML resource stored in the database will cause a NullPointerException when it hits the fragmentation limit.

This will have dire consequences on the consistency of the stored data:

1. the document is effectively removed from the database
2. the document is no longer present in the index

### Reference:

fixes #5273 

### Type of tests:

TBD