### PR TITLE
[bugfix] fix errors on update operations

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -3172,7 +3172,7 @@ public class NativeBroker implements DBBroker {
                 }
             }.run();
             // create a copy of the old doc to copy the nodes into it
-            final DocumentImpl tempDoc = new DocumentImpl(null, pool, doc.getCollection(), doc.getDocId(), doc.getFileURI());
+            final DocumentImpl tempDoc = new DocumentImpl(null, doc.getDocId(), doc);
             tempDoc.copyOf(this, doc, doc);
             final StreamListener listener = getIndexController().getStreamListener(doc, ReindexMode.STORE);
             // copy the nodes

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -3172,7 +3172,7 @@ public class NativeBroker implements DBBroker {
                 }
             }.run();
             // create a copy of the old doc to copy the nodes into it
-            final DocumentImpl tempDoc = new DocumentImpl(null, null, doc.getCollection(), doc.getDocId(), doc.getFileURI());
+            final DocumentImpl tempDoc = new DocumentImpl(null, pool, doc.getCollection(), doc.getDocId(), doc.getFileURI());
             tempDoc.copyOf(this, doc, doc);
             final StreamListener listener = getIndexController().getStreamListener(doc, ReindexMode.STORE);
             // copy the nodes

--- a/exist-core/src/main/java/org/exist/test/ExistXmldbEmbeddedServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistXmldbEmbeddedServer.java
@@ -42,6 +42,7 @@ import javax.xml.transform.OutputKeys;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -95,6 +96,17 @@ public class ExistXmldbEmbeddedServer extends ExternalResource {
      */
     public ExistXmldbEmbeddedServer(final boolean asGuest, final boolean disableAutoDeploy, final boolean useTemporaryStorage, @Nullable final Path configFile) {
         this.existEmbeddedServer = new ExistEmbeddedServer(null, configFile, null, disableAutoDeploy, useTemporaryStorage);
+        this.asGuest = asGuest;
+    }
+
+    /**
+     * @param asGuest Use the guest account, default is the admin account
+     * @param disableAutoDeploy Whether auto-deployment of XARs should be disabled
+     * @param useTemporaryStorage Whether the data and journal folder should use temporary storage
+     * @param settings set properties
+     */
+    public ExistXmldbEmbeddedServer(final boolean asGuest, final boolean disableAutoDeploy, final boolean useTemporaryStorage, final Properties settings) {
+        this.existEmbeddedServer = new ExistEmbeddedServer(null, null, settings, disableAutoDeploy, useTemporaryStorage);
         this.asGuest = asGuest;
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/update/UpdateInsertTriggersDefrag.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/UpdateInsertTriggersDefrag.java
@@ -1,0 +1,87 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.test.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XPathQueryService;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
+import static org.junit.Assert.assertEquals;
+
+public class UpdateInsertTriggersDefrag {
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer exist = new ExistXmldbEmbeddedServer(false, true, true, propertiesBuilder().put(DBBroker.PROPERTY_XUPDATE_FRAGMENTATION_FACTOR, -1).build());
+    final String path = TestConstants.TEST_COLLECTION_URI + "/" + TestConstants.TEST_XML_URI.toString();
+    final String xml = "<list><item>initial</item></list>";
+    Collection testCollection;
+    XQueryService queryService;
+    CollectionManagementService collectionService;
+
+    /**
+     * stores XML String and get Query Service
+     *
+     * @param documentName to be stored in the DB
+     * @param content      to be stored in the DB
+     * @throws XMLDBException if an error occurs storing the document
+     */
+    private void storeXML(final String documentName, final String content) throws XMLDBException {
+        final XMLResource doc = testCollection.createResource(documentName, XMLResource.class);
+        doc.setContent(content);
+        testCollection.storeResource(doc);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        collectionService = exist.getRoot().getService(CollectionManagementService.class);
+        testCollection = collectionService.createCollection(TestConstants.TEST_COLLECTION_URI.toString());
+        queryService = (XQueryService) testCollection.getService(XPathQueryService.class);
+        storeXML(TestConstants.TEST_XML_URI.toString(), xml);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        collectionService.removeCollection(testCollection.getName());
+    }
+
+    @Test
+    public void triggerDefragAfterUpdate() throws Exception {
+        final String update = "update insert <item>new node</item> into doc('" + path + "')//list";
+        final ResourceSet updateResult = queryService.queryResource(TestConstants.TEST_XML_URI.toString(), update);
+        assertEquals("Update expression returns an empty sequence", 0, updateResult.getSize());
+
+        final ResourceSet itemResult = queryService.queryResource(TestConstants.TEST_XML_URI.toString(), "//item");
+        assertEquals("Both items are returned", 2, itemResult.getSize());
+    }
+
+}


### PR DESCRIPTION
### Description:

By setting the allowed-fragmentation attribute value to `-1` any modification will trigger the defragmentation of the dom.dbx (AKA BTree pages).

This setting triggers the NPE described in #5273 on the very first call to

```xquery
update (replace|insert) $nodeA (with|into) $nodeB
```

Unfortunately, it also triggers a totally different class of NPEs in XQueryTrigger and other subsystems of the database.

<details>
  <summary>Failures before d145f29857be1cf7be5ab15226f8239b5e5aac3d</summary>

```
[ERROR] Failures:
[ERROR]   TriggerConfigTest.removeDocument:137 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.removeDocument:137 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.removeDocument:137 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.storeDocument:114 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.storeDocument:114 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.storeDocument:114 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.updateTriggers:183 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.updateTriggers:183 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TriggerConfigTest.updateTriggers:183 Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.collectionCreate:522 expected:<1> but was:<0>
[ERROR]   XQueryTriggerTest.collectionMove:626 expected:<1> but was:<0>
[ERROR]   XQueryTriggerTest.documentBinaryDelete:475 expected:<1> but was:<0>
[ERROR]   XQueryTriggerTest.documentDelete:381 expected:<1> but was:<0>
[ERROR]   RESTServiceTest.xUpdate:642 Server returned response code 500 expected:<200> but was:<500>
[ERROR]   IndexIntegrationTest.insertElement Multiple Failures (2 failures)
	org.xmldb.api.base.XMLDBException: Failed to store collection configuration: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
	java.lang.IllegalStateException: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
[ERROR]   IndexIntegrationTest.removeAttribute Multiple Failures (2 failures)
	org.xmldb.api.base.XMLDBException: Failed to store collection configuration: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
	java.lang.IllegalStateException: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
[ERROR]   IndexIntegrationTest.updateAttribute:134->run:81->lambda$updateAttribute$3:173->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119
  Unexpected method call IndexWorker.setDocument(/db/test/pathNs2.xml - <test>):
    IndexWorker.flush(): expected: 2, actual: 2
[ERROR] Errors:
[ERROR]   XQueryTrigger2Test.collectionCopy:476 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.collectionCreate:448 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.collectionDelete:559 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.collectionMove:519 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.documentBinaryCreate:384 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.documentBinaryDelete:413 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.documentCreate:284 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.documentDelete:346 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTrigger2Test.documentUpdate:309 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.collectionCopy:550 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.collectionDelete:678 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.documentBinaryCreate:423 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.documentCreate:283 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTriggerTest.documentUpdate:317 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   AppendTest>AbstractUpdateTest.update:78->doUpdate:67 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   RangeIndexUpdateTest.updates:118 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   RemoveTest>AbstractUpdateTest.update:78->doUpdate:77 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   RenameTest>AbstractUpdateTest.update:78->doUpdate:72 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ReplaceTest>AbstractUpdateTest.update:78->doUpdate:69 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateAttributeTest>AbstractUpdateTest.update:78->doUpdate:70 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateRecoverTest.storeAndRead:88->store:153 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateRecoverTest.storeAndReadXmldb:100->xmldbStore:336 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateTest>AbstractUpdateTest.update:78->doUpdate:71 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   SerializationTest.xqueryUpdateNsTest:154 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   SerializationTest.xqueryUpdateNsTest:154 » XMLDB Failed to invoke method queryPT in class org.exist.xmlrpc.RpcConnection: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ComplexUpdateTest>ConcurrentTestBase.concurrent:139 » Execution java.lang.NullPointerException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ConcurrentAttrUpdateTest>ConcurrentTestBase.concurrent:139 » Execution java.lang.NullPointerException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ConcurrentQueryUpdateTest>ConcurrentTestBase.concurrent:139 » Execution org.xmldb.api.base.XMLDBException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ConcurrentXUpdateTest>ConcurrentTestBase.concurrent:139 » Execution java.lang.NullPointerException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   TextUpdateTest>ConcurrentTestBase.concurrent:139 » Execution java.lang.NullPointerException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ValueIndexUpdateTest>ConcurrentTestBase.concurrent:139 » Execution java.lang.NullPointerException: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   DocumentUpdateTest.update:110->execQuery:156 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   DocumentUpdateTest.updateAttribute:149->execQuery:156 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   NamespaceUpdateTest.updateAttribute:64 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   QueryPoolTest.differentQueries:54 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ValueIndexByQNameTest>ValueIndexTest.updates:360 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ValueIndexByQNameTest>ValueIndexTest.updatesQName:392 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ValueIndexTest.updates:360 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   ValueIndexTest.updatesQName:392 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XPathQueryTest.ids_persistent:1617->queryResource:2279->queryResource:2296 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XPathQueryTest.ids_persistent:1617->queryResource:2279->queryResource:2296 » XMLDB Failed to invoke method queryPT in class org.exist.xmlrpc.RpcConnection: Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryTest.attribute_1691177:1788 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.appendAttributes:105->append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.appendCDATA:432 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.attrUpdate:413 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.insertAfter:221 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.insertAttrib:462 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.insertBefore:167 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.remove:315->append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.rename:335->append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.replace:364->append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQueryUpdateTest.update:263->append:81 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateInsertTest.insertInMemoryDocument:102->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateInsertTest.insertNamespacedAttribute:46->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateInsertTest.insertPrecedingAttribute:83->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateReplaceTest.replaceFirstChildWhereParentHasAttribute:157 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateReplaceTest.replaceFirstChildWhereParentHasNoAttributes:89 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateReplaceTest.replaceOnlyChildWhereParentHasAttribute:123 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateReplaceTest.replaceOnlyChildWhereParentHasNoAttributes:55 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateValueTest.updateAttributeInNamespacedElement:54->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   UpdateValueTest.updateNamespacedAttribute:42->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119 » XMLDB Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   RemoveAppendTest.appendRemove:91->append:116 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   StressTest.stressTest:73->insertTags:98 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XUpdateTest.xupdate:132->updateDocument:185 » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   CoreTests » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
[ERROR]   XQuery3Tests » NullPointer Cannot invoke "org.exist.storage.BrokerPool.getSecurityManager()" because "pool" is null
```
</details>
<details>
  <summary>Failures after adding the fix for #5273</summary>

```
[ERROR]   IndexIntegrationTest.insertElement Multiple Failures (2 failures)
	org.xmldb.api.base.XMLDBException: Failed to store collection configuration: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
	java.lang.IllegalStateException: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
[ERROR]   IndexIntegrationTest.removeAttribute Multiple Failures (2 failures)
	org.xmldb.api.base.XMLDBException: Failed to store collection configuration: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
	java.lang.IllegalStateException: missing behavior definition for the preceding method call:
IndexWorker.getListener()
Usage is: expect(a.foo()).andXXX()
[ERROR]   IndexIntegrationTest.updateAttribute:134->run:81->lambda$updateAttribute$3:173->AbstractTestUpdate.queryResource:105->AbstractTestUpdate.queryResource:119
  Unexpected method call IndexWorker.setDocument(/db/test/pathNs2.xml - <test>):
    IndexWorker.flush(): expected: 2, actual: 2
[ERROR] Errors:
[ERROR]   XQueryTriggerTest.collectionCopy:550 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.collectionCreate:513 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.collectionDelete:675 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.collectionMove:614 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.documentBinaryCreate:423 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.documentBinaryDelete:463 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.documentCreate:283 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.documentDelete:369 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.documentUpdate:317 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
[ERROR]   XQueryTriggerTest.storeDocumentInvalidTriggerForPrepare:719 » NullPointer Cannot invoke "org.exist.storage.btree.Value.data()" because "oldVal" is null
```
</details>

-- UPDATE --

The first attempt to fix modifying files did surface a new issue. A non-DBA user triggering the defragmentation of an XML resource would lead to a PermissionDeniedException. The patch was updated to copy the documents permissions instead of applying the DB's default permissions (see 1ca99018758d6ae32fa68f725a1643119927630a).