### PR TITLE
Fix PermissionDeniedException  in NativeBroker.defragXMLresource

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -3171,9 +3171,9 @@ public class NativeBroker implements DBBroker {
                     return null;
                 }
             }.run();
-            // create a copy of the old doc to copy the nodes into it
+            // Create a copy of the old document to copy the nodes into it.
+            // tempDoc serves as a storage container for the child nodes.
             final DocumentImpl tempDoc = new DocumentImpl(null, doc.getDocId(), doc);
-            tempDoc.copyOf(this, doc, doc);
             final StreamListener listener = getIndexController().getStreamListener(doc, ReindexMode.STORE);
             // copy the nodes
             final NodeList nodes = doc.getChildNodes();
@@ -3198,15 +3198,17 @@ public class NativeBroker implements DBBroker {
                     return null;
                 }
             }.run();
+            // assign new child nodes from the temporary document
             doc.copyChildren(tempDoc);
             doc.setSplitCount(0);
             doc.setPageCount(tempDoc.getPageCount());
+            // store defragmented document
             storeXMLResource(transaction, doc);
             closeDocument();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Defragmentation took {} ms.", (System.currentTimeMillis() - start));
             }
-        } catch(final PermissionDeniedException | IOException e) {
+        } catch(final IOException e) {
             LOG.error(e);
         }
     }


### PR DESCRIPTION
### Description:

Additional bugfix for NativeBroker.defragXMLresource where in specific setups with modules and collections with set group ID set a PermissionDeniedException is thrown when the modified XML resource is defragmented.

### Reference:

refs #5276

### Type of tests:

Code review was addressed in UpdateInsertTriggersDefrag.java 