### PR TITLE
[6.x.x] Removed finalize() methods

### DIFF
--- a/exist-core/src/main/java/org/exist/util/GZIPInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/GZIPInputSource.java
@@ -145,15 +145,6 @@ public final class GZIPInputSource extends EXistInputSource {
 	}
 
 	@Override
-	protected void finalize() throws Throwable {
-		try {
-			close();
-		} finally {
-			super.finalize();
-		}
-	}
-
-	@Override
 	public void close() {
 		if(!isClosed()) {
 			try {

--- a/exist-core/src/main/java/org/exist/xmldb/AbstractRemoteResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/AbstractRemoteResource.java
@@ -566,13 +566,4 @@ public abstract class AbstractRemoteResource extends AbstractRemote
     public final void freeResources() {
         close();
     }
-
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
 }

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
@@ -304,15 +304,6 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
         }
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
-
     class NewResourceIterator implements ResourceIterator {
         long pos = 0;
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/AbstractCachedResult.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/AbstractCachedResult.java
@@ -128,14 +128,4 @@ public abstract class AbstractCachedResult implements Closeable {
     public final void free() {
         close();
     }
-
-    @Override
-    protected void finalize() throws Throwable {
-        // Calling free to reclaim pinned resources
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
 }


### PR DESCRIPTION
Removed all finalize() methods for the following classes:
- exist-core/src/main/java/org/exist/util/GZIPInputSource.java
- exist-core/src/main/java/org/exist/xmldb/AbstractRemoteResource.java
- exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
- exist-core/src/main/java/org/exist/xmlrpc/AbstractCachedResult.java

Remplaced finalize() method with shutdown hook:
- exist-core/src/main/java/org/exist/util/io/TemporaryFileManager.java

### Description:
Fixes a SAXParseException that occured in heavy use denoting that the document does missing a needed ending tag or having a premature end of file.