### PR TITLE
Bump jackson-core from 2.13.4 to 2.15.2

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.4</version>
+            <version>2.15.2</version>
         </dependency>
 
         <!-- dependency>


### PR DESCRIPTION
This aligns the jackson-core version with the one that tika depends on.

While exist-db 6 declares a dependency on jackson-core v2.13.4 the recently updated tika library depends on 2.15.2. In my testing this lead to problems with a Java extension [oad](https://github.com/eeditiones/oad) that also depends on jackson-core (2.15.2).

Interesting to note here is that this works fine when the tika library is not updated as oad comes packaged with the correct version.  Only after that update the extension did not work anymore because the older version of jackson-core was used.

Thanks to @dizzzz for helping me find the issue in yesterdays community call.

