### PR TITLE
Bump jetty from 9.4.50.v20221201 to 9.4.54.v20240208

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -112,7 +112,7 @@
         <jansi.version>2.4.1</jansi.version>
         <jaxb.api.version>3.0.1</jaxb.api.version>
         <jaxb.impl.version>3.0.2</jaxb.impl.version>
-        <jetty.version>9.4.50.v20221201</jetty.version>
+        <jetty.version>9.4.54.v20240208</jetty.version>
         <log4j.version>2.22.1</log4j.version>
         <lucene.version>4.10.4</lucene.version>
         <milton.version>1.8.1.3</milton.version>


### PR DESCRIPTION
### Description:

Update to latest jetty release compatible with exist-db 6

### Reference:

### Type of tests:
