### PR TITLE
[Feature] Make WebDAV document size reporting more configurable

### DIFF
--- a/exist-distribution/src/main/config/webdav.properties
+++ b/exist-distribution/src/main/config/webdav.properties
@@ -23,11 +23,50 @@
 ## XML Serialization options for the WevDAV
 ## The file is read from EXIST_HOME/etc
 ## Be careful changing the default values !
-#indent=yes
-#expand-xincludes=no
-#process-xsl-pi=no
 #encoding=UTF-8
+#expand-xincludes=no
+#indent=yes
+#omit-original-xml-declaration=no
 #omit-xml-declaration=no
 #output-doctype=yes
-#omit-xml-declaration=yes
-#omit-original-xml-declaration=no
+#process-xsl-pi=no
+
+## Due to the way eXist-db stores XML, the exact size of an XML document when
+## it is serialized (e.g., sent to a WebDAV client) may vary depending upon
+## serialization parameters.
+##
+## For performance reasons, eXist by default only reports an approximate file size
+## for XML documents. (eXist reports accurate sizes for binary documents,
+## which aren't subject to serialization parameters.)
+##
+## The approximate size is a good indication of the size of document
+## but some WebDAV clients, in particular the macOS Finder version, can
+## not deal with this estimate, resulting in incomplete or overcomplete
+## documents.
+##
+## To address these various possibilities, two system variables can be set
+## to change the way the size is calculated.
+##
+## Supported values are APPROXIMATE, EXACT, NULL
+##
+## PROPFIND:
+## Unfortunately both NULL and APPROXIMATE do not work for
+## macOS Finder. The default behaviour for the Finder 'user-agent' is
+## exact, for the others it is approximate.
+##
+## GET:
+## The NULL value seems to be working well for macOS too.
+##
+## The system properties are:
+## -Dorg.exist.webdav.PROPFIND_METHOD_XML_SIZE=..  (used for listing documents in collection)
+## -Dorg.exist.webdav.GET_METHOD_XML_SIZE=...      (used during download of one document)
+##
+## Supported values are:
+## NULL         - document sizes are NOT reported
+## EXACT        - document sizes are reported using document pre-serialization [Slow]
+## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)
+##
+## Depending on the WebDAV client needs, one or both properties can be set.
+#
+# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
+# org.exist.webdav.GET_METHOD_XML_SIZE=NULL

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
@@ -55,7 +55,7 @@ public class ExistResourceFactory implements ResourceFactory {
     /**
      * XML serialization options
      */
-    private Properties webDavOptions = new Properties();
+    private final Properties webDavOptions = new Properties();
 
     /**
      * Default constructor. Get access to instance of exist-db broker pool.
@@ -173,7 +173,7 @@ public class ExistResourceFactory implements ResourceFactory {
 
         // MacOsX finder specific files
         String documentSeqment = xmldbUri.lastSegment().toString();
-        if (documentSeqment.startsWith("._") || documentSeqment.equals(".DS_Store")) {
+        if (documentSeqment.startsWith("._") || ".DS_Store".equals(documentSeqment)) {
             //LOG.debug(String.format("Ignoring MacOSX file '%s'", xmldbUri.lastSegment().toString()));
             //return ResourceType.IGNORABLE;
         }

--- a/extensions/webdav/src/main/java/org/exist/webdav/MiltonCollection.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/MiltonCollection.java
@@ -52,7 +52,7 @@ public class MiltonCollection extends MiltonResource
         DeletableResource, MakeCollectionableResource, PutableResource, LockingCollectionResource 
         /*, DigestResource */, MoveableResource, CopyableResource, LockNullResource {
 
-    private ExistCollection existCollection;
+    private final ExistCollection existCollection;
 
     /**
      * Constructor of representation of a Collection in the Milton framework, without subject information.

--- a/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
@@ -131,7 +131,7 @@ public class MiltonDocument extends MiltonResource
 
                 } catch (IllegalArgumentException ex) {
                     LOG.debug(ex.getMessage());
-                    // Set preffered default
+                    // Set preferred default
                     propfindSizeMethod = SIZE_METHOD.APPROXIMATE;
                 }
             }
@@ -207,31 +207,47 @@ public class MiltonDocument extends MiltonResource
     @Override
     public Long getContentLength() {
 
-
-        // Note
-        // Whilst for non-XML documents the exact size of the documents can
-        // be determined by checking the administration, this is not possible
-        // for XML documents.
-        //
-        // For XML documents by default the 'approximate' size is available
-        // which can be sufficient (pagesize * nr of pages). Exact size
-        // is dependant on many factors, the serialization parameters.
-        //
-        // The approximate size is a good indication of the size of document
-        // but some WebDAV client, mainly the MacOsX Finder version, can
-        // not deal with this guesstimate, resulting in incomplete or overcomplete
-        // documents.
-        //
-        // Special for this, two system variables can be set to change the
-        // way the size is calculated. Supported values are
-        // NULL, EXACT, APPROXIMATE
-        //
-        // PROPFIND: Unfortunately both NULL and APPROXIMATE do not work for
-        // MacOsX Finder. The default behaviour for the Finder 'user-agent' is
-        // exact, for the others it is approximate.
-        // This behaviour is swiched by the system properties.
-        //
-        // GET: the NULL value seems to be working well for macosx too.
+        /*
+            ## Whilst for non-XML documents the exact size of the documents can
+            ## be determined by checking the blob store metadata, this is not possible
+            ## for XML documents.
+            ##
+            ## For XML documents by default the 'approximate' size is available
+            ## which can be sufficient (pagesize * number of pages). Exact size
+            ## is dependent on factors like the serialization parameters.
+            ##
+            ## The approximate size is a good indication of the size of document
+            ## but some WebDAV clients, in particular the macOS Finder version, can
+            ## not deal with this estimate, resulting in incomplete or overcomplete
+            ## documents.
+            ##
+            ## To address these various possibilities, two system variables can be set
+            ## to change the way the size is calculated.
+            ##
+            ## Supported values are NULL, EXACT, APPROXIMATE
+            ##
+            ## PROPFIND:
+            ## Unfortunately both NULL and APPROXIMATE do not work for
+            ## macOS Finder. The default behaviour for the Finder 'user-agent' is
+            ## exact, for the others it is approximate.
+            ##
+            ## GET:
+            ## The NULL value seems to be working well for macOS too.
+            ##
+            ## The system properties are:
+            ## -Dorg.exist.webdav.PROPFIND_METHOD_XML_SIZE=..  (used for listing documents in collection)
+            ## -Dorg.exist.webdav.GET_METHOD_XML_SIZE=...      (used during download of one document)
+            ##
+            ## Supported values are:
+            ## NULL         - document sizes are NOT reported                              [Alternative]
+            ## EXACT        - document sizes are reported using document pre-serialization [Slow]
+            ## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)  [Default]
+            ##
+            ## Depending on the WebDAV client needs, one or both properties can be set.
+            #
+            # org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
+            # org.exist.webdav.GET_METHOD_XML_SIZE=APPROXIMATE
+         */
 
         Long size = null;
 

--- a/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
@@ -61,7 +61,7 @@ public class MiltonDocument extends MiltonResource
     private static SIZE_METHOD getSizeMethod = null;
 
     private static UserAgentHelper userAgentHelper = null;
-    private ExistDocument existDocument;
+    private final ExistDocument existDocument;
 
     // Only for PROPFIND the estimate size for an XML document must be shown
     private boolean isPropFind = false;
@@ -114,52 +114,63 @@ public class MiltonDocument extends MiltonResource
             existDocument.initMetadata();
         }
 
-
         // PROPFIND method
         if (propfindSizeMethod == null) {
-            // get user supplied preferred size determination approach
+            LOG.info("Try read {} from System Property", PROPFIND_METHOD_XML_SIZE);
             String systemProp = System.getProperty(PROPFIND_METHOD_XML_SIZE);
+            propfindSizeMethod = getSizeMethod(systemProp);
+        }
 
-            if (systemProp == null) {
-                // Default method is approximate
-                propfindSizeMethod = SIZE_METHOD.APPROXIMATE;
+        if (propfindSizeMethod == null) {
+            LOG.info("Try read {} from properties file", PROPFIND_METHOD_XML_SIZE);
+            String fileProp = configuration.getProperty(PROPFIND_METHOD_XML_SIZE);
+            propfindSizeMethod = getSizeMethod(fileProp);
+        }
 
-            } else {
-                // Try to parse from environment property
-                try {
-                    propfindSizeMethod = SIZE_METHOD.valueOf(systemProp.toUpperCase());
-
-                } catch (IllegalArgumentException ex) {
-                    LOG.debug(ex.getMessage());
-                    // Set preferred default
-                    propfindSizeMethod = SIZE_METHOD.APPROXIMATE;
-                }
-            }
+        if (propfindSizeMethod == null) {
+            LOG.info("Use default value {}", SIZE_METHOD.APPROXIMATE);
+            propfindSizeMethod = SIZE_METHOD.APPROXIMATE;
         }
 
         // GET method
         if (getSizeMethod == null) {
-            // get user supplied preferred size determination approach
+            LOG.info("Try read {} from System Property", GET_METHOD_XML_SIZE);
             String systemProp = System.getProperty(GET_METHOD_XML_SIZE);
-
-            if (systemProp == null) {
-                // Default method is NULL
-                getSizeMethod = SIZE_METHOD.NULL;
-
-            } else {
-                // Try to parse from environment property
-                try {
-                    getSizeMethod = SIZE_METHOD.valueOf(systemProp.toUpperCase());
-
-                } catch (IllegalArgumentException ex) {
-                    LOG.debug(ex.getMessage());
-                    // Set preffered default
-                    getSizeMethod = SIZE_METHOD.APPROXIMATE;
-                }
-            }
+            getSizeMethod = getSizeMethod(systemProp);
         }
 
+        if (getSizeMethod == null) {
+            LOG.info("Try read {} from properties file", GET_METHOD_XML_SIZE);
+            String fileProp = configuration.getProperty(GET_METHOD_XML_SIZE);
+            getSizeMethod = getSizeMethod(fileProp);
+        }
 
+        if (getSizeMethod == null) {
+            LOG.info("Use default value {}", SIZE_METHOD.NULL);
+            getSizeMethod = SIZE_METHOD.NULL;
+        }
+
+    }
+
+    /**
+     * Determine what size methodology shall be applied.
+     *
+     * @param value Properties value
+     * @return Corresponding SIZE_METHOD, or else NULL.
+     */
+    SIZE_METHOD getSizeMethod(String value) {
+        if (value == null || value.strip().isEmpty()) {
+            return null;
+        }
+
+        try {
+            final SIZE_METHOD sizeMethod = SIZE_METHOD.valueOf(value.toUpperCase());
+            LOG.info("Found value {}", sizeMethod);
+            return sizeMethod;
+        } catch (IllegalArgumentException ex) {
+            LOG.debug(ex.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
@@ -208,13 +208,13 @@ public class MiltonDocument extends MiltonResource
     public Long getContentLength() {
 
         /*
-            ## Whilst for non-XML documents the exact size of the documents can
-            ## be determined by checking the blob store metadata, this is not possible
-            ## for XML documents.
+            ## Due to the way eXist-db stores XML, the exact size of an XML document when
+            ## it is serialized (e.g., sent to a WebDAV client) may vary depending upon
+            ## serialization parameters.
             ##
-            ## For XML documents by default the 'approximate' size is available
-            ## which can be sufficient (pagesize * number of pages). Exact size
-            ## is dependent on factors like the serialization parameters.
+            ## For performance reasons, eXist by default only reports an approximate file size
+            ## for XML documents. (eXist reports accurate sizes for binary documents,
+            ## which aren't subject to serialization parameters.)
             ##
             ## The approximate size is a good indication of the size of document
             ## but some WebDAV clients, in particular the macOS Finder version, can

--- a/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/MiltonDocument.java
@@ -116,13 +116,13 @@ public class MiltonDocument extends MiltonResource
 
         // PROPFIND method
         if (propfindSizeMethod == null) {
-            LOG.info("Try read {} from System Property", PROPFIND_METHOD_XML_SIZE);
+            LOG.info("Try to obtain {} from System Property", PROPFIND_METHOD_XML_SIZE);
             String systemProp = System.getProperty(PROPFIND_METHOD_XML_SIZE);
             propfindSizeMethod = getSizeMethod(systemProp);
         }
 
         if (propfindSizeMethod == null) {
-            LOG.info("Try read {} from properties file", PROPFIND_METHOD_XML_SIZE);
+            LOG.info("Alternatively try to obtain {} from properties file", PROPFIND_METHOD_XML_SIZE);
             String fileProp = configuration.getProperty(PROPFIND_METHOD_XML_SIZE);
             propfindSizeMethod = getSizeMethod(fileProp);
         }
@@ -134,13 +134,13 @@ public class MiltonDocument extends MiltonResource
 
         // GET method
         if (getSizeMethod == null) {
-            LOG.info("Try read {} from System Property", GET_METHOD_XML_SIZE);
+            LOG.info("Try to obtain {} from System Property", GET_METHOD_XML_SIZE);
             String systemProp = System.getProperty(GET_METHOD_XML_SIZE);
             getSizeMethod = getSizeMethod(systemProp);
         }
 
         if (getSizeMethod == null) {
-            LOG.info("Try read {} from properties file", GET_METHOD_XML_SIZE);
+            LOG.info("Alternatively try to obtain {} from properties file", GET_METHOD_XML_SIZE);
             String fileProp = configuration.getProperty(GET_METHOD_XML_SIZE);
             getSizeMethod = getSizeMethod(fileProp);
         }
@@ -235,7 +235,7 @@ public class MiltonDocument extends MiltonResource
             ## To address these various possibilities, two system variables can be set
             ## to change the way the size is calculated.
             ##
-            ## Supported values are NULL, EXACT, APPROXIMATE
+            ## Supported values are APPROXIMATE, EXACT, NULL
             ##
             ## PROPFIND:
             ## Unfortunately both NULL and APPROXIMATE do not work for
@@ -250,15 +250,15 @@ public class MiltonDocument extends MiltonResource
             ## -Dorg.exist.webdav.GET_METHOD_XML_SIZE=...      (used during download of one document)
             ##
             ## Supported values are:
-            ## NULL         - document sizes are NOT reported                              [Alternative]
+            ## NULL         - document sizes are NOT reported
             ## EXACT        - document sizes are reported using document pre-serialization [Slow]
-            ## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)  [Default]
+            ## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)
             ##
             ## Depending on the WebDAV client needs, one or both properties can be set.
             #
             # org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-            # org.exist.webdav.GET_METHOD_XML_SIZE=APPROXIMATE
-         */
+            # org.exist.webdav.GET_METHOD_XML_SIZE=NULL
+        */
 
         Long size = null;
 

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -23,13 +23,13 @@
 ## XML Serialization options for the WevDAV
 ## The file is read from the classpath
 ## Be careful changing the default values !
-#indent=yes
-#expand-xincludes=no
-#process-xsl-pi=no
 #encoding=UTF-8
-omit-xml-declaration=yes
-omit-original-xml-declaration=no
-output-doctype=yes
+#expand-xincludes=no
+#indent=yes
+#omit-original-xml-declaration=no
+#omit-xml-declaration=no
+#output-doctype=yes
+#process-xsl-pi=no
 
 ## Due to the way eXist-db stores XML, the exact size of an XML document when
 ## it is serialized (e.g., sent to a WebDAV client) may vary depending upon
@@ -62,9 +62,9 @@ output-doctype=yes
 ## -Dorg.exist.webdav.GET_METHOD_XML_SIZE=...      (used during download of one document)
 ##
 ## Supported values are:
-## NULL         - document sizes are NOT reported                              [Alternative]
+## NULL         - document sizes are NOT reported
 ## EXACT        - document sizes are reported using document pre-serialization [Slow]
-## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)  [Default]
+## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)
 ##
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -30,3 +30,43 @@
 omit-xml-declaration=yes
 omit-original-xml-declaration=no
 output-doctype=yes
+
+## Whilst for non-XML documents the exact size of the documents can
+## be determined by checking the blob store metadata, this is not possible
+## for XML documents.
+##
+## For XML documents by default the 'approximate' size is available
+## which can be sufficient (pagesize * number of pages). Exact size
+## is dependent on factors like the serialization parameters.
+##
+## The approximate size is a good indication of the size of document
+## but some WebDAV clients, in particular the macOS Finder version, can
+## not deal with this estimate, resulting in incomplete or overcomplete
+## documents.
+##
+## To address these various possibilities, two system variables can be set
+## to change the way the size is calculated.
+##
+## Supported values are NULL, EXACT, APPROXIMATE
+##
+## PROPFIND:
+## Unfortunately both NULL and APPROXIMATE do not work for
+## macOS Finder. The default behaviour for the Finder 'user-agent' is
+## exact, for the others it is approximate.
+##
+## GET:
+## The NULL value seems to be working well for macOS too.
+##
+## The system properties are:
+## -Dorg.exist.webdav.PROPFIND_METHOD_XML_SIZE=..  (used for listing documents in collection)
+## -Dorg.exist.webdav.GET_METHOD_XML_SIZE=...      (used during download of one document)
+##
+## Supported values are:
+## NULL         - document sizes are NOT reported                              [Alternative]
+## EXACT        - document sizes are reported using document pre-serialization [Slow]
+## APPROXIMATE  - document sizes are reported as (pagesize * number of pages)  [Default]
+##
+## Depending on the WebDAV client needs, one or both properties can be set.
+#
+# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
+# org.exist.webdav.GET_METHOD_XML_SIZE=APPROXIMATE

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -31,13 +31,13 @@ omit-xml-declaration=yes
 omit-original-xml-declaration=no
 output-doctype=yes
 
-## Whilst for non-XML documents the exact size of the documents can
-## be determined by checking the blob store metadata, this is not possible
-## for XML documents.
+## Due to the way eXist-db stores XML, the exact size of an XML document when
+## it is serialized (e.g., sent to a WebDAV client) may vary depending upon
+## serialization parameters.
 ##
-## For XML documents by default the 'approximate' size is available
-## which can be sufficient (pagesize * number of pages). Exact size
-## is dependent on factors like the serialization parameters.
+## For performance reasons, eXist by default only reports an approximate file size
+## for XML documents. (eXist reports accurate sizes for binary documents,
+## which aren't subject to serialization parameters.)
 ##
 ## The approximate size is a good indication of the size of document
 ## but some WebDAV clients, in particular the macOS Finder version, can

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -26,9 +26,9 @@
 #encoding=UTF-8
 #expand-xincludes=no
 #indent=yes
-#omit-original-xml-declaration=no
-#omit-xml-declaration=no
-#output-doctype=yes
+omit-original-xml-declaration=no
+omit-xml-declaration=yes
+output-doctype=yes
 #process-xsl-pi=no
 
 ## Due to the way eXist-db stores XML, the exact size of an XML document when

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -47,7 +47,7 @@ output-doctype=yes
 ## To address these various possibilities, two system variables can be set
 ## to change the way the size is calculated.
 ##
-## Supported values are NULL, EXACT, APPROXIMATE
+## Supported values are APPROXIMATE, EXACT, NULL
 ##
 ## PROPFIND:
 ## Unfortunately both NULL and APPROXIMATE do not work for
@@ -69,4 +69,4 @@ output-doctype=yes
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #
 # org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-# org.exist.webdav.GET_METHOD_XML_SIZE=APPROXIMATE
+# org.exist.webdav.GET_METHOD_XML_SIZE=NULL


### PR DESCRIPTION
This PR...
- allows configuration of the  "size report method' via webdav.properties
- updates relevant in-code documentation
- simplifies code
- makes the webdav.properties file in sync again