### PR TITLE
[ignore] reduce build warnings

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1085,6 +1085,26 @@ The BaseX Team. The original license statement is also included below.]]></pream
             </plugin>
 
             <plugin>
+                <groupId>software.xdev</groupId>
+                <artifactId>find-and-replace-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-underscore-with-hyphen</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>file-contents</goal>
+                        </goals>
+                        <configuration>
+                            <baseDir>target/generated-sources/antlr/org/exist/xquery/parser/</baseDir>
+                            <fileMask>XQueryLexer.java</fileMask>
+                            <findRegex>new Integer</findRegex>
+                            <replaceValue>Integer.valueOf</replaceValue>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>

--- a/exist-core/src/main/java/org/exist/collections/triggers/FilteringTrigger.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/FilteringTrigger.java
@@ -29,6 +29,7 @@ package org.exist.collections.triggers;
  * 
  * @deprecated use SAXTrigger
  */
+@Deprecated
 public abstract class FilteringTrigger extends SAXTrigger {
 
 }

--- a/exist-core/src/main/java/org/exist/scheduler/UserXQueryJob.java
+++ b/exist-core/src/main/java/org/exist/scheduler/UserXQueryJob.java
@@ -117,6 +117,7 @@ public class UserXQueryJob extends UserJob {
      * @return  The User for this Job
      * @deprecated use getCurrentSubject method
      */
+    @Deprecated
     public Subject getUser() {
         return subject;
     }

--- a/exist-core/src/main/java/org/exist/security/User.java
+++ b/exist-core/src/main/java/org/exist/security/User.java
@@ -103,6 +103,7 @@ public interface User extends Principal {
      * @return The users password
      * @deprecated
      */
+    @Deprecated
     String getPassword();
 
     @Deprecated

--- a/exist-core/src/main/java/org/exist/security/internal/AccountImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/AccountImpl.java
@@ -241,7 +241,7 @@ public class AccountImpl extends AbstractAccount {
      * @return Description of the Return Value
      * @deprecated
      */
-    @Override
+    @Override @Deprecated
     public final String getPassword() {
         return password;
     }

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -843,6 +843,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
      * @deprecated use countActiveBrokers
      */
     //TODO : rename as getActiveBrokers ?
+    @Deprecated
     public int active() {
         return activeBrokers.size();
     }

--- a/exist-core/src/main/java/org/exist/util/ByteConversion.java
+++ b/exist-core/src/main/java/org/exist/util/ByteConversion.java
@@ -42,6 +42,7 @@ public class ByteConversion {
      * @deprecated reads the lowest byte first. will be replaced with
      *     {@link #byteToIntH(byte[], int)} for consistency.
      */
+    @Deprecated
     public final static int byteToInt(final byte[] data, final int start ) {
         return ( data[start] & 0xff ) |
             ( ( data[start + 1] & 0xff ) << 8 ) |
@@ -144,6 +145,7 @@ public class ByteConversion {
      *
      * @return the short integer
      */
+    @Deprecated
     public final static short byteToShort( final byte[] data, final int start ) {
         return (short) ( ( ( data[start + 1] & 0xff ) << 8 ) |
             ( data[start] & 0xff ) );
@@ -190,6 +192,7 @@ public class ByteConversion {
      * @param  start  the offset
      * @return   the byte array
      */
+    @Deprecated
     public final static byte[] intToByte( final int v, final byte[] data, final int start ) {
         data[start] = (byte) ( ( v >>> 0 ) & 0xff );
         data[start + 1] = (byte) ( ( v >>> 8 ) & 0xff );
@@ -302,6 +305,7 @@ public class ByteConversion {
      * @param  start  the offset
      * @return   the byte array
      */
+    @Deprecated
     public final static byte[] shortToByte( final short v, final byte[] data, final int start ) {
         data[start] = (byte) ( ( v >>> 0 ) & 0xff );
         data[start + 1] = (byte) ( ( v >>> 8 ) & 0xff );

--- a/exist-core/src/main/java/org/exist/util/NamedThreadFactory.java
+++ b/exist-core/src/main/java/org/exist/util/NamedThreadFactory.java
@@ -68,6 +68,7 @@ public class NamedThreadFactory implements ThreadFactory {
      *
      * @deprecated use {@link #NamedThreadFactory(Database, String)}.
      */
+    @Deprecated
     public NamedThreadFactory(final Database database, final String nameBase) {
         this(database.getThreadGroup(), database.getId(), nameBase);
     }

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteXMLResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteXMLResource.java
@@ -110,6 +110,7 @@ public class RemoteXMLResource
      * @throws XMLDBException if an error occurs during construction
      * @deprecated Use {@link #RemoteXMLResource(RemoteCollection, int, int, XmldbURI, Optional, Optional)}.
      */
+    @Deprecated
     public RemoteXMLResource(final RemoteCollection parent, final XmldbURI docId, final Optional<String> id, final Optional<String> type)
             throws XMLDBException {
         this(parent, -1, -1, docId, id, type);

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -618,6 +618,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>software.xdev</groupId>
+                    <artifactId>find-and-replace-maven-plugin</artifactId>
+                    <version>1.0.2</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>3.4.0</version>
@@ -979,6 +984,11 @@
                                 <exclude>FDB-backport-LGPL-21-ONLY-license.xml.template.txt</exclude>
                                 <exclude>LGPL-21-license.template.txt</exclude>                    
                                 <exclude>LGPL-21-license.txt</exclude>
+                                <exclude>LGPL-21-license.template.txt</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>**/README</exclude>
+                                <exclude>**/LICENSE</exclude>
+                                <exclude>**/*.xar</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>
@@ -1006,13 +1016,6 @@
                         <email>${contact.email}</email>
                         <url>${project.organization.url}</url>
                     </properties>
-                    <excludes>
-                        <exclude>LGPL-21-license.template.txt</exclude>
-                        <exclude>**/README.md</exclude>
-                        <exclude>**/README</exclude>
-                        <exclude>**/LICENSE</exclude>
-                        <exclude>**/*.xar</exclude>
-                    </excludes>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
                 <executions>
@@ -1041,6 +1044,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
- postprocess 'slower' new Integer(int) to cached Integer.valueOf() in generated antlr code as hinted by the build
- add @Deprecated to remaining methods