### PR TITLE
[ci] Repair 6.x.x build for macOs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -39,6 +39,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        jvm: ['8']
+        exclude:
+          - os: macOS-latest
+            version: '8'
+        include:
+          - os: macOS-latest
+            version: '11'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +53,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ env.DEV_JDK }}
+          java-version: ${{ matrix.jvm }}
           cache: 'maven'
       - name: Install Maven Daemon
         id: install-mvnd

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -42,10 +42,10 @@ jobs:
         jvm: ['8']
         exclude:
           - os: macOS-latest
-            version: '8'
+            jvm: '8'
         include:
           - os: macOS-latest
-            version: '11'
+            jvm: '11'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Java8 on macOS seems really impossible to find in GHA. Spending more time is IMO not worth the effort.

Personally I do not expect OpenJDK8 on macOS to be really used, it is a corner case, Apple ditched Java8 support ages ago.

Whilst OpenJDK11 might be a bit slower [not sure if this is true] , keeping Java8 support on this OS is IMHO not worth the effort of the eXist-db contributors.

More valuable is to have green builds again.
OpenJDK works just fine as reported by end-users.

It is up to the community (monday eve) to decide and agree.

