### PR TITLE
[bugfix] Address vulnerabilities as indicated by OWASP/NVD.

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.77</version>
+            <version>1.78.1</version>
         </dependency>
 
         <dependency>
@@ -338,7 +338,13 @@
         <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.2</version> <!-- needed an compile time for various dependencies -->
+            <version>2.7.3</version> <!-- needed an compile time for various dependencies -->
+        </dependency>
+
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>serializer</artifactId>
+            <version>2.7.3</version>
         </dependency>
 
         <dependency>
@@ -565,7 +571,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <!--
@@ -955,6 +961,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                 <ignoredUnusedDeclaredDependency>org.fusesource.jansi:jansi:jar:${jansi.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>net.sourceforge.nekohtml:nekohtml:jar:1.9.22</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>xml-resolver:xml-resolver:jar:1.2</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>xalan:serializer:jar:2.7.3</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.xmlresolver:xmlresolver:jar:${xmlresolver.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.exist-db.thirdparty.org.eclipse.wst.xml:xpath2:jar:1.2.0</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>edu.princeton.cup:java-cup:jar:10k</ignoredUnusedDeclaredDependency>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -118,7 +118,7 @@
         <milton.version>1.8.1.3</milton.version>
         <saxon.version>9.9.1-8</saxon.version>
         <xmlresolver.version>4.6.4</xmlresolver.version>
-        <xmlunit.version>2.9.1</xmlunit.version>
+        <xmlunit.version>2.10.0</xmlunit.version>
         <junit.version>4.13.2</junit.version>
         <junit.platform.version>1.10.2</junit.platform.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>


### PR DESCRIPTION
PR #5386 repairs the NVD scan;

This PR addresses some of the scanned vulnerabilities.

to discuss:
- nekohtml => 2.0.2 requires changes in conf.xml (textual)
- com.ibm.icu:icu4j:59.1 =? not sure about compatibility of newer versions

exclude
- quartz => unmaintained
- xpath2 => needed/embedded in latest Xerces?

for best build first pull-in #5385 and #5386 