### PR TITLE
[Bugfix] Address two old jdom-1 jars on class path 

### DIFF
--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -75,6 +75,22 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt2-main</artifactId>
             <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdom</groupId>
+                    <artifactId>jdom</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+            <version>1.1.3</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -177,6 +193,7 @@
                                 <ignoredUnusedDeclaredDependency>java3d:vecmath:jar:1.3.1</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.media:jai_core:jar:1.1.3</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.junit.vintage:junit-vintage-engine:jar</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.jdom:jdom:jar:1.1.3</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -55,6 +55,19 @@
         <dependency>
             <groupId>org.exist-db.thirdparty.com.ettrema</groupId>
             <artifactId>milton-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdom</groupId>
+                    <artifactId>jdom</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+            <version>1.1.3</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -173,6 +186,7 @@
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.junit.vintage:junit-vintage-engine:jar</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.jdom:jdom:jar:1.1.3</ignoredUnusedDeclaredDependency>
 
                                 <!-- needed for running tests that depend on eXist-db Jetty server -->
                                 <ignoredUnusedDeclaredDependency>${project.groupId}:exist-jetty-config:jar:${project.version}</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Make sure the latest jdom(1) jar is used, i.s.o. 2 different older versions

fixes #5392