### PR TITLE
[6.x.x] Switch CI from Temurin to Liberica

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: '8'
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
       - run: mvn -V -B license:check
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
       - name: OWASP dependency check
@@ -40,19 +40,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         jvm: ['8']
-        exclude:
-          - os: macOS-latest
-            jvm: '8'
-        include:
-          - os: macOS-latest
-            jvm: '11'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ matrix.jvm }}
           cache: 'maven'
       - name: Install Maven Daemon

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: '8'
       - name: Cache Maven packages
         uses: actions/cache@v4


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/pull/5304

Liberica should still provide JDK 8 on macOS