### PR TITLE
Switch CI from Temurin to Liberica

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: '17'
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
       - run: mvn -V -B license:check
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
       - name: OWASP dependency check
@@ -46,7 +46,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: ${{ matrix.jvm }}
           cache: 'maven'
       - name: Install Maven Daemon

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 17
       - name: Cache SonarCloud packages
         uses: actions/cache@v4


### PR DESCRIPTION
Use the same JDK vendor in 7.x.x as eXist-db eXist-db [4.x.x](https://github.com/eXist-db/exist/pull/5468), [5.x.x](https://github.com/eXist-db/exist/pull/5467), and [6.x.x](https://github.com/eXist-db/exist/pull/5466).

NOTE: There is no Temurin JDK 8 on macOS available in CI. So we are switching to Liberica which does support that.