### PR TITLE
Test that Function References should be able to have postfix expressions

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -815,6 +815,7 @@
                                 <exclude>src/test/xquery/xqsuite/xqsuite-assertions-dynamic.xqm</exclude>
                                 <exclude>src/test/xquery/xqsuite/xqsuite-assertions-inline.xqm</exclude>
                                 <exclude>src/test/xquery/xqsuite/xqsuite-assertions.resources.xqm.ignore</exclude>
+                                <exclude>src/test/xquery/xquery3/function-reference.xqm</exclude>
                                 <exclude>src/test/xquery/xquery3/postfix-expr.xqm</exclude>
 
                                 <!--
@@ -978,6 +979,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/xquery/xqsuite/xqsuite-assertions-dynamic.xqm</include>
                                 <include>src/test/xquery/xqsuite/xqsuite-assertions-inline.xqm</include>
                                 <include>src/test/xquery/xqsuite/xqsuite-assertions.resources.xqm.ignore</include>
+                                <include>src/test/xquery/xquery3/function-reference.xqm</include>
                                 <include>src/test/xquery/xquery3/postfix-expr.xqm</include>
                             </includes>
 

--- a/exist-core/src/test/xquery/xquery3/function-reference.xqm
+++ b/exist-core/src/test/xquery/xquery3/function-reference.xqm
@@ -1,0 +1,54 @@
+(:
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This file was originally ported from FusionDB to eXist-db by
+ : Evolved Binary, for the benefit of the eXist-db Open Source community.
+ : Only the ported code as it appears in this file, at the time that
+ : it was contributed to eXist-db, was re-licensed under The GNU
+ : Lesser General Public License v2.1 only for use in eXist-db.
+ :
+ : This license grant applies only to a snapshot of the code as it
+ : appeared when ported, it does not offer or infer any rights to either
+ : updates of this source code or access to the original source code.
+ :
+ : The GNU Lesser General Public License v2.1 only license follows.
+ :
+ : ---------------------------------------------------------------------
+ :
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace fr = "http://exist-db.org/xquery/test/function-reference";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertExists
+function fr:function-reference() {
+  fr:test-identity#1
+};
+
+declare
+    %test:args("adam")
+    %test:assertEquals("adam")
+function fr:function-reference-eval($arg) {
+  fr:test-identity#1($arg)
+};
+
+declare function fr:test-identity($x) {
+  $x
+};


### PR DESCRIPTION
Just adding a simple missing test for function references with postfix expressions