### PR TITLE
[6.x.x] Fix CI Windows stream corruption

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,6 +20,7 @@ jobs:
         timeout-minutes: 60
   dependencies:
     name: Dependency checks
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +67,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
       - name: Maven Code Coverage (Develop branch on Linux only)
-        if: ${{ github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest' }}
         env:
           CI_NAME: github
           BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 permissions:
   contents: read
 env:
-  MAVEN_OPTS: -XX:StartFlightRecording=maxsize=5g,disk=true,dumponexit=true,settings=default,filename=./ -DtrimStackTrace=false -D'maven.resolver.transport=wagon'
+  MAVEN_OPTS: -DtrimStackTrace=false -D'maven.resolver.transport=wagon'
   DEV_JDK: '8'
 jobs:
   license:
@@ -81,6 +81,5 @@ jobs:
           name: ${{ runner.os }}-build-logs
           retention-days: 5
           path: |
-            **/*.jfr
             **/hs_err_pid*.log
             **/target/surefire-reports/*

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1133,18 +1133,17 @@ The BaseX Team. The original license statement is also included below.]]></pream
     <profiles>
         <profile>
             <!--
-            Disable parallel tests on Windows.
-            When running multiple tests in parallel, Quartz seems to stop eXist-db from shutting down
-            on AppVeyor Windows CI, see: https://github.com/quartz-scheduler/quartz/issues/448
+            Disable parallel tests on Windows in CI, seems to cause an occasional issue with
+            Surefire that produces the Maven error: 'Corrupted channel by directly writing to native stream in forked JVM'.
             -->
-            <id>windows-disable-parallel-testing</id>
+            <id>windows-disable-parallel-ci-testing</id>
             <activation>
                 <os>
                     <family>windows</family>
                 </os>
                 <property>
-                    <name>env.APPVEYOR</name>
-                    <value>True</value>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
                 </property>
             </activation>
             <build>
@@ -1173,7 +1172,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
                             <forkCount>1C</forkCount>
                             <reuseForks>false</reuseForks>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                             <systemPropertyVariables>
                                 <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                                 <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
@@ -1181,8 +1180,8 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                 <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                             </systemPropertyVariables>
                             <excludes>
-                                <!-- NOTE: this test fails on AppVeyor Windows CI with Oracle JDK 11,
-                                 but not on some other windows systems :-/ -->
+                                <!-- NOTE: this test occasionally fails on Windows CI
+                                 but not on some other Windows systems :-/ -->
                                 <exclude>org.exist.storage.lock.CollectionLocksTest</exclude>
 
                                 <!-- NOTE: these can still exhibit deadlocks -->

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -778,7 +778,7 @@
                               However it can make it hard to diagnose problems if tests leak state; If you experience
                               such a problem you may want to set it to `false` whilst debugging -->
                         <reuseForks>true</reuseForks>
-                        <argLine>@{jacocoArgLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED -XX:StartFlightRecording=maxsize=5g,disk=true,dumponexit=true,settings=default,filename=${project.build.directory}/ -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        <argLine>@{jacocoArgLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                         <systemPropertyVariables>
                             <user.country>UK</user.country>
                             <user.language>en</user.language>


### PR DESCRIPTION
* Remove JFR from CI
* Use Windows specific CI profile for testing in CI