### PR TITLE
Feat-multi-arch-containers

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -5,6 +5,7 @@ jobs:
     name: Build and Test Images
     runs-on: ubuntu-latest
     # NOTE (DP): Publish on develop and master, test on PRs against these
+    # TODO(DP) Reinstate CRONed release builds to update stock apps regularly
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.base_ref ==  'develop' || github.base_ref ==  'master'
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +16,10 @@ jobs:
         with:
           distribution: liberica
           java-version: '17'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64 
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v3
         id: buildx

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -60,12 +60,12 @@ jobs:
         run: mvn -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
-      # - name: Publish experimental images
-      #   if: github.base_ref == 'develop'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      #   run: mvn -q -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
-      #   working-directory: ./exist-docker  
+      - name: Publish experimental images
+        if: github.base_ref == 'develop'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: mvn -q -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+        working-directory: ./exist-docker  
       

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -69,12 +69,12 @@ jobs:
         run: mvn -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
-      - name: Publish experimental images
-        if: github.base_ref == 'develop'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: mvn -q -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
-        working-directory: ./exist-docker  
+      # - name: Publish experimental images
+      #   if: github.base_ref == 'develop'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      #   run: mvn -q -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+      #   working-directory: ./exist-docker  
       

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -32,7 +32,11 @@ jobs:
           key: deploy-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: deploy-${{ runner.os }}-maven
       - name: Install bats
-        run: sudo apt-get install bats    
+        run: sudo apt-get install bats
+        # Hack around #5450
+      - name: pull base image
+        run: |
+          docker pull --platform linux/amd64 --platform linux/arm64 gcr.io/distroless/java17-debian12:latest      
       - name: Build images
         run: mvn -V -B -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package
       - name: Check local images

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -22,7 +22,9 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,14 +44,15 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <assemble.dir>${project.build.directory}/exist-docker-${project.version}-docker-dir</assemble.dir>
         <exist.uber.jar.filename>exist.uber.jar</exist.uber.jar.filename>
         <docker.tag>latest</docker.tag>
         <docker.debug.tag>debug</docker.debug.tag>
+        <docker.platforms>linux/amd64, linux/arm64</docker.platforms>
     </properties>
 
     <dependencies>
@@ -106,7 +109,9 @@
                         <configuration>
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
-                                <ignoredUnusedDeclaredDependency>${project.groupId}:exist-distribution:pom:${project.version}</ignoredUnusedDeclaredDependency>  <!-- needed at runtime to support lucene query syntax -->
+                                <ignoredUnusedDeclaredDependency>
+                                    ${project.groupId}:exist-distribution:pom:${project.version}</ignoredUnusedDeclaredDependency>  <!--
+                                needed at runtime to support lucene query syntax -->
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
@@ -124,7 +129,8 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <archiveBaseDirectory>${project.basedir}/../exist-distribution/target/exist-distribution-${project.version}-dir</archiveBaseDirectory>
+                            <archiveBaseDirectory>
+                                ${project.basedir}/../exist-distribution/target/exist-distribution-${project.version}-dir</archiveBaseDirectory>
                             <attach>false</attach>
                             <descriptors>
                                 <descriptor>src/assembly/dist-assembly-docker.xml</descriptor>
@@ -183,18 +189,24 @@
                                 </filter>
                             </filters>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
                                     <addHeader>false</addHeader>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/mailcap</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/mailcap.default</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
@@ -210,12 +222,18 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.45.1</version>
                 <configuration>
-                  <verbose>true</verbose>
+                    <verbose>true</verbose>
+                    <pushRegistry>registry.hub.docker.com</pushRegistry>
                     <images>
                         <image>
                             <name>existdb/existdb:%v</name>
                             <alias>exist</alias>
                             <build>
+                                <buildx>
+                                    <platforms>
+                                        <platform>${docker.platforms}</platform>
+                                    </platforms>
+                                </buildx>
                                 <tags>
                                     <tag>${docker.tag}</tag>
                                 </tags>
@@ -227,6 +245,11 @@
                             <name>existdb/existdb:%v-DEBUG</name>
                             <alias>exist-debug</alias>
                             <build>
+                                <buildx>
+                                    <platforms>
+                                        <platform>${docker.platforms}</platform>
+                                    </platforms>
+                                </buildx>
                                 <tags>
                                     <tag>${docker.debug.tag}</tag>
                                 </tags>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -227,6 +227,7 @@
                     <images>
                         <image>
                             <name>existdb/existdb:%v</name>
+                            <registry>registry.hub.docker.com</registry>
                             <alias>exist</alias>
                             <build>
                                 <buildx>
@@ -243,6 +244,7 @@
                         </image>
                         <image>
                             <name>existdb/existdb:%v-DEBUG</name>
+                            <registry>registry.hub.docker.com</registry>
                             <alias>exist-debug</alias>
                             <build>
                                 <buildx>

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -48,10 +48,10 @@ ARG CACHE_MEM
 ARG MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
 
-ENV EXIST_HOME "/exist"
+ENV EXIST_HOME=/exist
 ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
 
-ENV JAVA_TOOL_OPTIONS \
+ENV JAVA_TOOL_OPTIONS="\
   -Dfile.encoding=UTF8 \
   -Dsun.jnu.encoding=UTF-8 \
   -Djava.awt.headless=true \
@@ -67,7 +67,7 @@ ENV JAVA_TOOL_OPTIONS \
   -XX:+UseStringDeduplication \
   -XX:+UseContainerSupport \
   -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
-  -XX:+ExitOnOutOfMemoryError
+  -XX:+ExitOnOutOfMemoryError"
 
 HEALTHCHECK CMD [ "java", \
     "org.exist.start.Main", "client", \

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -20,25 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-# Use Debian Bullseye (which is the base of gcr.io/distroless/java:17) for additional library dependencies that we need
-# FROM debian:bullseye-slim as debian-slim
-# RUN apt-get update && apt-get -y dist-upgrade
-# RUN apt-get install -y openjdk-17-jre-headless
-# RUN apt-get install -y expat fontconfig     # Install tools required by FOP
-
 FROM gcr.io/distroless/java17:latest
-
-# Copy over dependencies for Apache FOP, missing from GCR's JRE
-# COPY --from=debian-slim /usr/lib/x86_64-linux-gnu/libfreetype.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6
-# COPY --from=debian-slim /usr/lib/x86_64-linux-gnu/liblcms2.so.2 /usr/lib/x86_64-linux-gnu/liblcms2.so.2
-# COPY --from=debian-slim /usr/lib/x86_64-linux-gnu/libpng16.so.16 /usr/lib/x86_64-linux-gnu/libpng16.so.16
-# COPY --from=debian-slim /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 /usr/lib/x86_64-linux-gnu/libfontconfig.so.1
-
-# Copy dependencies for Apache Batik (used by Apache FOP to handle SVG rendering)
-# COPY --from=debian-slim /etc/fonts /etc/fonts
-# COPY --from=debian-slim /lib/x86_64-linux-gnu/libexpat.so.1 /lib/x86_64-linux-gnu/libexpat.so.1
-# COPY --from=debian-slim /usr/share/fontconfig /usr/share/fontconfig
-# COPY --from=debian-slim /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/dejavu
 
 # Copy eXist-db
 COPY LICENSE /exist/LICENSE

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-FROM gcr.io/distroless/java17:latest
+FROM gcr.io/distroless/java17-debian12:latest
 
 # Copy eXist-db
 COPY LICENSE /exist/LICENSE

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-# Use JDK 17 in Debian Bullseye (as our production image gcr.io/distroless/java:17 is based on Debian Bullseye with just a JRE)
+# Use JDK 17 in Debian as our production image gcr.io/distroless/java is based on Debian with just a JRE)
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y openjdk-17-jdk-headless

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -52,10 +52,10 @@ ARG MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
 ARG JVM_JDWP_SUSPEND
 
-ENV EXIST_HOME "/exist"
+ENV EXIST_HOME=/exist
 ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
 
-ENV JAVA_TOOL_OPTIONS \
+ENV JAVA_TOOL_OPTIONS="\
   -Dfile.encoding=UTF8 \
   -Dsun.jnu.encoding=UTF-8 \
   -Djava.awt.headless=true \
@@ -72,7 +72,7 @@ ENV JAVA_TOOL_OPTIONS \
   -XX:+UseContainerSupport \
   -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
   -XX:+ExitOnOutOfMemoryError \
-  -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND:-n},address=5005
+  -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND:-n},address=5005"
 
 HEALTHCHECK CMD [ "java", \
     "org.exist.start.Main", "client", \

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -21,7 +21,7 @@
 #
 
 # Use JDK 17 in Debian Bullseye (as our production image gcr.io/distroless/java:17 is based on Debian Bullseye with just a JRE)
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y openjdk-17-jdk-headless
 RUN apt-get install -y expat fontconfig     # Install tools required by FOP


### PR DESCRIPTION
enables a long overdue feature: multi-arch containers for `existdb/existdb` 
backport will remove a release blocker for 6.3.1

sidessteps docker maven plugin bug, `deploy` is green again.
see fabric8io/docker-maven-plugin#1835

fixes outdated JRE patches, bumps base image to Debian 12 
see #5450
close #4151
close #5532
close #4153
