### PR TITLE
Fix ForClause PositionalVar empty sequence handling

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ForExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ForExpr.java
@@ -229,7 +229,8 @@ public class ForExpr extends BindingExpression {
         context.proceed(this);
         context.setContextSequencePosition(p, in);
         if (positionalVariable != null) {
-            at.setValue(new IntegerValue(this, p + 1));
+            final int position = contextItem == AtomicValue.EMPTY_VALUE ? 0 : p + 1;
+            at.setValue(new IntegerValue(this, position));
         }
         final Sequence contextSequence = contextItem.toSequence();
         // set variable value to current item

--- a/exist-core/src/test/xquery/xquery3/flwor.xql
+++ b/exist-core/src/test/xquery/xquery3/flwor.xql
@@ -156,3 +156,32 @@ function flwor:allowing-empty($n as xs:integer) {
     return concat("[", $x, "]")
 };
 
+declare
+    %test:args(4)
+    %test:assertEquals(":0")
+    %test:args(2)
+    %test:assertEquals("b:1")
+    %test:args(1)
+    %test:assertEquals("a:1")
+    %test:args(5)
+    %test:assertEquals(":0")
+function flwor:allowing-empty-fix($n as xs:integer) {
+    let $sequence := ("a", "b", "c")[$n]
+    for $x allowing empty at $y in $sequence
+    return $x || ":" || $y
+};
+
+declare
+    %test:args(4)
+    %test:assertEquals("")
+    %test:args(2)
+    %test:assertEquals("b:1")
+function flwor:no-allow-empty($n as xs:integer) {
+    let $sequence := ("a", "b", "c")[$n]
+    return
+        if (empty($sequence)) then
+            ""
+        else
+            for $x at $y in $sequence
+            return $x || ":" || $y
+};


### PR DESCRIPTION
### Description:  
Resolved an issue where ForClause's PositionalVar incorrectly returned values when faced with an empty sequence while allowing emptiness. This adjustment ensures accurate handling of edge cases in sequence evaluations, aligning behavior with expected standards.


### Reference: 
https://github.com/eXist-db/exist/issues/5235

### Tests: 
Added tests which verifies the same
