### PR TITLE
[feature] gh package snapshots...

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Publish Container
 on: [push, pull_request]
 jobs:
   build:
-    name: Build and Test Images
+    name: Test and Publish Container Images
     runs-on: ubuntu-latest
     # NOTE (DP): Publish on develop and master, test on PRs against these
     # TODO(DP) Reinstate CRONed release builds to update stock apps regularly
@@ -77,4 +77,4 @@ jobs:
       #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       #   run: mvn -q -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
       #   working-directory: ./exist-docker  
-      
+

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -1,0 +1,30 @@
+name: Publish Snaphots to Github Packages
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  publish-snapshots:
+    name: Deploy Snapshots
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: '17'
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: deploy-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: deploy-${{ runner.os }}-maven
+      - name: Deploy SNAPSHOT maven artefacts
+        run: mvn -V -B -q -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean deploy

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1177,17 +1177,28 @@
     </reporting>
 
     <repositories>
-        <repository>
-            <id>exist-db-snapshots</id>
-            <name>Evolved Binary - eXist-db Snapshots</name>
-            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
+            <repository>
+                <id>github</id>
+                <name>GitHub Registry for Snapshots</name>
+                <url>https://maven.pkg.github.com/eXist-db/exist</url>
+                <releases>
+                    <enabled>false</enabled>
+                </releases>
+                <snapshots>
+                    <enabled>true</enabled>
+                </snapshots>
+            </repository>
+<!--        <repository>-->
+<!--            <id>exist-db-snapshots</id>-->
+<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
+<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
+<!--            <releases>-->
+<!--                <enabled>false</enabled>-->
+<!--            </releases>-->
+<!--            <snapshots>-->
+<!--                <enabled>true</enabled>-->
+<!--            </snapshots>-->
+<!--        </repository>-->
         <repository>
             <id>exist-db</id>
             <name>Evolved Binary - eXist-db Releases</name>
@@ -1217,10 +1228,21 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+<!--        <pluginRepository>-->
+<!--            <id>exist-db-snapshots</id>-->
+<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
+<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
+<!--            <releases>-->
+<!--                <enabled>false</enabled>-->
+<!--            </releases>-->
+<!--            <snapshots>-->
+<!--                <enabled>true</enabled>-->
+<!--            </snapshots>-->
+<!--        </pluginRepository>-->
         <pluginRepository>
-            <id>exist-db-snapshots</id>
-            <name>Evolved Binary - eXist-db Snapshots</name>
-            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <id>github</id>
+            <name>GitHub Registry for Snapshots</name>
+            <url>https://maven.pkg.github.com/eXist-db/exist</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -1232,10 +1254,15 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>exist-db-snapshots</id>
-            <name>Evolved Binary - eXist-db Snapshots</name>
-            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <id>github</id>
+            <name>GitHub Registry for Snapshots</name>
+            <url>https://maven.pkg.github.com/eXist-db/exist</url>
         </snapshotRepository>
+<!--        <snapshotRepository>-->
+<!--            <id>exist-db-snapshots</id>-->
+<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
+<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
+<!--        </snapshotRepository>-->
         <repository>
             <id>sonatype-nexus-staging</id>
             <name>Nexus Release Repository</name>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1188,17 +1188,17 @@
                     <enabled>true</enabled>
                 </snapshots>
             </repository>
-<!--        <repository>-->
-<!--            <id>exist-db-snapshots</id>-->
-<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
-<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
-<!--            <releases>-->
-<!--                <enabled>false</enabled>-->
-<!--            </releases>-->
-<!--            <snapshots>-->
-<!--                <enabled>true</enabled>-->
-<!--            </snapshots>-->
-<!--        </repository>-->
+        <repository>
+            <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
+            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>exist-db</id>
             <name>Evolved Binary - eXist-db Releases</name>
@@ -1228,17 +1228,17 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
-<!--        <pluginRepository>-->
-<!--            <id>exist-db-snapshots</id>-->
-<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
-<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
-<!--            <releases>-->
-<!--                <enabled>false</enabled>-->
-<!--            </releases>-->
-<!--            <snapshots>-->
-<!--                <enabled>true</enabled>-->
-<!--            </snapshots>-->
-<!--        </pluginRepository>-->
+        <pluginRepository>
+            <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
+            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
         <pluginRepository>
             <id>github</id>
             <name>GitHub Registry for Snapshots</name>
@@ -1258,11 +1258,6 @@
             <name>GitHub Registry for Snapshots</name>
             <url>https://maven.pkg.github.com/eXist-db/exist</url>
         </snapshotRepository>
-<!--        <snapshotRepository>-->
-<!--            <id>exist-db-snapshots</id>-->
-<!--            <name>Evolved Binary - eXist-db Snapshots</name>-->
-<!--            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>-->
-<!--        </snapshotRepository>-->
         <repository>
             <id>sonatype-nexus-staging</id>
             <name>Nexus Release Repository</name>


### PR DESCRIPTION
from CI (hopefully)

The previous SNAPSHOT repo hasn't seen any traffic for over a year. This automates release snapshots to GitHub on push events on develop. 

We could make the step, run only after tests have passed (as they should always be green on develop anyway) but that would mean that every time the OWASP dependency check times out, we won't publish artefacts. So I decided against it. What do others think?

This will also not publish artefacts from PRs by design, but this could be adjusted. 


<img width="1120" alt="Screenshot 2025-01-02 at 12 00 20" src="https://github.com/user-attachments/assets/4f095d0f-ed7f-4cac-99f9-2e5a71aeee5f" />

close #5592