### PR TITLE
[bugfix] reenable builds by switching to a different nexus

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -58,7 +58,7 @@ jobs:
           file-version-suffix: ''
           cache: 'true'
       - name: Maven Build
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -59,7 +59,7 @@ jobs:
           cache: 'true'
       - name: Maven Build
         timeout-minutes: 30
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -U -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1126,6 +1126,17 @@
             </snapshots>
         </repository>
         <repository>
+            <id>exist-db-maven-central-mirror</id>
+            <name>exist-db.org - eXist-db Releases</name>
+            <url>https://repo.exist-db.org/repository/maven-central/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>evolvedbinary-snapshots</id>
             <name>Evolved Binary - eXist-db Snapshots</name>
             <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1105,6 +1105,28 @@
     <repositories>
         <repository>
             <id>exist-db-snapshots</id>
+            <name>exist-db.org - eXist-db Snapshots</name>
+            <url>https://repo.exist-db.org/repository/exist-db-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>exist-db</id>
+            <name>exist-db.org - eXist-db Releases</name>
+            <url>https://repo.exist-db.org/repository/exist-db/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>evolvedbinary-snapshots</id>
             <name>Evolved Binary - eXist-db Snapshots</name>
             <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
             <releases>
@@ -1115,7 +1137,7 @@
             </snapshots>
         </repository>
         <repository>
-            <id>exist-db</id>
+            <id>evolvedbinary-releases</id>
             <name>Evolved Binary - eXist-db Releases</name>
             <url>https://repo.evolvedbinary.com/repository/exist-db/</url>
             <releases>
@@ -1134,6 +1156,39 @@
         </pluginRepository>
         <pluginRepository>
             <id>exist-db</id>
+            <name>exist-db.org - eXist-db Releases</name>
+            <url>https://repo.exist-db.org/repository/exist-db/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>exist-db-maven-central-mirror</id>
+            <name>exist-db.org - eXist-db Releases</name>
+            <url>https://repo.exist-db.org/repository/maven-central/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>exist-db-snapshots</id>
+            <name>exist-db.org - eXist-db Snapshots</name>
+            <url>https://repo.exist-db.org/repository/exist-db-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>evolvedbinary-releases</id>
             <name>Evolved Binary - eXist-db Releases</name>
             <url>https://repo.evolvedbinary.com/repository/exist-db/</url>
             <releases>
@@ -1144,7 +1199,7 @@
             </snapshots>
         </pluginRepository>
         <pluginRepository>
-            <id>exist-db-snapshots</id>
+            <id>evolvedbinary-snapshots</id>
             <name>Evolved Binary - eXist-db Snapshots</name>
             <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
             <releases>
@@ -1159,8 +1214,8 @@
     <distributionManagement>
         <snapshotRepository>
             <id>exist-db-snapshots</id>
-            <name>Evolved Binary - eXist-db Snapshots</name>
-            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+            <name>exist-db.org - eXist-db Snapshots</name>
+            <url>https://repo.exist-db.org/repository/exist-db-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>


### PR DESCRIPTION
This is an attempt to re-enable builds of exist-db-6.x.x by switching to a different Nexus server.

https://repo.exist-db.org

The existing Nexus was kept in the parent-pom.