### PR TITLE
[ci] remove -U mvn flag again

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -59,7 +59,7 @@ jobs:
           cache: 'true'
       - name: Maven Build
         timeout-minutes: 30
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -U -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'


### PR DESCRIPTION
as discussed on the community call:
Now that we know that our Nexus has all necessary dependencies we can drop the -U flag from the build step.

```
-U --update-snapshots Forces a check for updated releases and snapshots on remote repositories
```