### PR TITLE
[BUG] fix #5685 NPE on nested anonymous functions

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
@@ -170,16 +170,14 @@ public class FunctionSignature {
         this.description = description;
     }
 
-    public void addMetadata(final String key, String value) {
+    public void addMetadata(final String key, final String value) {
         if(metadata == null) {
             metadata = new HashMap<>(5);
         }
         final String old = metadata.get(key);
-        if (old != null) {
-            // if the key exists, simply append the new value
-            value = old + ", " + value;
-        }
-        metadata.put(key, value);
+        // if the key exists, append the new value
+        final String newValue = old == null ? value : old + ", " + value;
+        metadata.put(key, newValue);
     }
 
     public String getMetadata(final String key) {
@@ -232,7 +230,7 @@ public class FunctionSignature {
         buf.append(name.getStringValue());
         buf.append('(');
         if(arguments != null) {
-            final char var = 'a';
+            final char ANON_VAR = 'a';
             for(int i = 0; i < arguments.length; i++) {
                 if(i > 0) {
                     buf.append(", ");
@@ -241,7 +239,7 @@ public class FunctionSignature {
                 if(arguments[i] instanceof FunctionParameterSequenceType) {
                     buf.append(((FunctionParameterSequenceType)arguments[i]).getAttributeName());
                 } else {
-                    buf.append((char)(var + i));
+                    buf.append((char)(ANON_VAR + i));
                 }
                 buf.append(" as ");
                 buf.append(arguments[i].toString());
@@ -251,7 +249,7 @@ public class FunctionSignature {
                 buf.append(", ...");
             }
         }
-        buf.append(") ");
+        buf.append(") as ");
         buf.append(returnType.toString());
         
         return buf.toString();
@@ -259,7 +257,7 @@ public class FunctionSignature {
 
     @Override
     public boolean equals(final Object obj) {
-        if(obj == null || !(obj instanceof FunctionSignature)) {
+        if (!(obj instanceof FunctionSignature)) {
             return false;
         }
         // quick comparison by object identity
@@ -275,11 +273,8 @@ public class FunctionSignature {
             return false;
         }
 
-        if (name.equals(other.name)) {
-            return getArgumentCount() == other.getArgumentCount();
-        }
-        
-        return false;
+        // compare by QName and arity
+        return (name.equals(other.name) && getArgumentCount() == other.getArgumentCount());
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
@@ -262,16 +262,20 @@ public class FunctionSignature {
         if(obj == null || !(obj instanceof FunctionSignature)) {
             return false;
         }
-        
-        final FunctionSignature other = (FunctionSignature)obj;
-        if(name == null) {
-            if(other.name != null) {
-                return false;
-            }    
-            return getArgumentCount() == other.getArgumentCount();
+        // quick comparison by object identity
+        if (this == obj) { return true; }
+
+        // anonymous functions cannot be compared by name and argument count
+        final FunctionSignature other = (FunctionSignature) obj;
+        if (
+                name == null || other.name == null ||
+                name.getLocalPart().equals("") ||
+                other.name.getLocalPart().equals("")
+        ) {
+            return false;
         }
-        
-        if(name.equals(other.name)) {
+
+        if (name.equals(other.name)) {
             return getArgumentCount() == other.getArgumentCount();
         }
         

--- a/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
@@ -166,40 +166,47 @@ public class UserDefinedFunction extends Function implements Cloneable {
             context.stackLeave(this);
 //            context.expressionEnd(this);
         }
-	}
-	
-	/* (non-Javadoc)
-     * @see org.exist.xquery.Function#dump(org.exist.xquery.util.ExpressionDumper)
-     */
+    }
+
+    @Override
     public void dump(ExpressionDumper dumper) {
         final FunctionSignature signature = getSignature();
-        if (signature.getName() != null)
-        	{dumper.display(signature.getName());}
+        if (signature.getName() != null) {
+            dumper.display(signature.getName());
+        }
         dumper.display('(');
-        for(int i = 0; i < signature.getArgumentTypes().length; i++) {
-			if(i > 0)
-				{dumper.display(", ");}
-			dumper.display(signature.getArgumentTypes()[i]);
-		}
-		dumper.display(") ");
+        for (int i = 0; i < signature.getArgumentTypes().length; i++) {
+            if (i > 0) {
+                dumper.display(", ");
+            }
+            dumper.display('$');
+            dumper.display(getParameters().get(i));
+            dumper.display(" as ");
+            dumper.display(signature.getArgumentTypes()[i]);
+        }
+        dumper.display(") as ");
         dumper.display(signature.getReturnType().toString());
     }
-    
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
+
+    @Override
     public String toString() {
         final FunctionSignature signature = getSignature();
         final StringBuilder buf = new StringBuilder();
-        if (signature.getName() != null)
-        	{buf.append(signature.getName());}
+        if (signature.getName() != null) {
+            buf.append(signature.getName());
+        }
         buf.append('(');
-        for(int i = 0; i < signature.getArgumentTypes().length; i++) {
-			if(i > 0)
-				{buf.append(", ");}
-			buf.append(signature.getArgumentTypes()[i]);
-		}
-        buf.append(')');
+        for (int i = 0; i < signature.getArgumentTypes().length; i++) {
+            if (i > 0) {
+                buf.append(", ");
+            }
+            buf.append('$');
+            buf.append(getParameters().get(i));
+            buf.append(" as ");
+            buf.append(signature.getArgumentTypes()[i]);
+        }
+        buf.append(") as ");
+        buf.append(signature.getReturnType());
         return buf.toString();
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
@@ -35,133 +35,127 @@ import java.util.List;
  */
 public class UserDefinedFunction extends Function implements Cloneable {
 
-	private Expression body;
-	
-	private List<QName> parameters = new ArrayList<>(5);
-	
-	private Sequence[] currentArguments = null;
-
-    private DocumentSet[] contextDocs = null;
-    
-    private boolean bodyAnalyzed = false;
-    
-    private FunctionCall call;
-    
-    private boolean hasBeenReset = false;
-
+    private final List<QName> parameters = new ArrayList<>(5);
     protected boolean visited = false;
-
+    private Expression body;
+    private Sequence[] currentArguments = null;
+    private DocumentSet[] contextDocs = null;
+    private boolean bodyAnalyzed = false;
+    private FunctionCall call;
+    private boolean hasBeenReset = false;
     private List<ClosureVariable> closureVariables = null;
-    
-	public UserDefinedFunction(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
-	
-	public void setFunctionBody(Expression body) {
-		this.body = body.simplify();
-	}
+
+    public UserDefinedFunction(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
+    }
 
     public Expression getFunctionBody() {
         return body;
     }
-    
-    public void addVariable(final String varName) throws XPathException {
-		try {
-			final QName qname = QName.parse(context, varName, null);
-			addVariable(qname);
-		} catch (final QName.IllegalQNameException e) {
-			throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + varName);
-		}
-	}
-	
-    public void addVariable(QName varName) throws XPathException {
-    	if (parameters.contains(varName))
-			{throw new XPathException(this, "XQST0039: function " + getName() + " is already have parameter with the name "+varName);}
 
-		parameters.add(varName);
+    public void setFunctionBody(Expression body) {
+        this.body = body.simplify();
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Function#setArguments(java.util.List)
-	 */
-	public void setArguments(Sequence[] args, DocumentSet[] contextDocs) throws XPathException {
-		this.currentArguments = args;
+
+    public void addVariable(final String varName) throws XPathException {
+        try {
+            final QName qname = QName.parse(context, varName, null);
+            addVariable(qname);
+        } catch (final QName.IllegalQNameException e) {
+            throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + varName);
+        }
+    }
+
+    public void addVariable(QName varName) throws XPathException {
+        if (parameters.contains(varName)) {
+            throw new XPathException(this, ErrorCodes.XQST0039, "function " + getName() + " already has a parameter with the name " + varName);
+        }
+
+        parameters.add(varName);
+    }
+
+    public void setArguments(Sequence[] args, DocumentSet[] contextDocs) throws XPathException {
+        this.currentArguments = args;
         this.contextDocs = contextDocs;
     }
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Function#analyze(org.exist.xquery.AnalyzeContextInfo)
-	 */
-	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-		hasBeenReset = false;
-		
-		if(call != null && !call.isRecursive()) {
-			// Save the local variable stack
-			final LocalVariable mark = context.markLocalVariables(true);
-			if (closureVariables != null)
-				// if this is a inline function, context variables are known
-	        	{context.restoreStack(closureVariables);}
-			try {
-				LocalVariable var;
-				for(final QName varName : parameters) {
-					var = new LocalVariable(varName);
-					context.declareVariableBinding(var);
-				}
 
-				final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
-				newContextInfo.setParent(this);
-				if (!bodyAnalyzed) {
-					if(body != null) {
-						body.analyze(newContextInfo);
-					}
-					bodyAnalyzed = true;
-				}
-			} finally {
-				// restore the local variable stack
-				context.popLocalVariables(mark);
-			}
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-	 */
-	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+        hasBeenReset = false;
+
+        if (call != null && !call.isRecursive()) {
+            // Save the local variable stack
+            final LocalVariable mark = context.markLocalVariables(true);
+            if (closureVariables != null) {
+                // if this is a inline function, context variables are known
+                context.restoreStack(closureVariables);
+            }
+            try {
+                LocalVariable var;
+                for (final QName varName : parameters) {
+                    var = new LocalVariable(varName);
+                    context.declareVariableBinding(var);
+                }
+
+                final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
+                newContextInfo.setParent(this);
+                if (!bodyAnalyzed) {
+                    if (body != null) {
+                        body.analyze(newContextInfo);
+                    }
+                    bodyAnalyzed = true;
+                }
+            } finally {
+                // restore the local variable stack
+                context.popLocalVariables(mark);
+            }
+        }
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
 //        context.expressionStart(this);
         context.stackEnter(this);
         // make sure reset state is called after query has finished
-	    hasBeenReset = false;
+        hasBeenReset = false;
         // Save the local variable stack
         final LocalVariable mark = context.markLocalVariables(true);
-        if (closureVariables != null)
-        	{context.restoreStack(closureVariables);}
+        if (closureVariables != null) {
+            context.restoreStack(closureVariables);
+        }
         Sequence result = null;
-		try {
-			QName varName;
-			LocalVariable var;
-			int j = 0;
-			for (int i = 0; i < parameters.size(); i++, j++) {
-				varName = parameters.get(i);
-				var = new LocalVariable(varName);
-				var.setValue(currentArguments[j]);
-				if (contextDocs != null)
-					{var.setContextDocs(contextDocs[i]);}
-				context.declareVariableBinding(var);
-				
-				Cardinality actualCardinality;
-				if (currentArguments[j].isEmpty()) {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
-				else if (currentArguments[j].hasMany()) {actualCardinality = Cardinality._MANY;}
-				else {actualCardinality = Cardinality.EXACTLY_ONE;}
-				
-				if (!getSignature().getArgumentTypes()[j].getCardinality().isSuperCardinalityOrEqualOf(actualCardinality))
-					{throw new XPathException(this, ErrorCodes.XPTY0004, "Invalid cardinality for parameter $" + varName +  
- 						". Expected " + getSignature().getArgumentTypes()[j].getCardinality().getHumanDescription() +
- 						", got " + currentArguments[j].getItemCount());}
-			}
-			result = body.eval(null, null);
-			return result;
-		} finally {
-			// restore the local variable stack
+        try {
+            QName varName;
+            LocalVariable var;
+            int j = 0;
+            for (int i = 0; i < parameters.size(); i++, j++) {
+                varName = parameters.get(i);
+                var = new LocalVariable(varName);
+                var.setValue(currentArguments[j]);
+                if (contextDocs != null) {
+                    var.setContextDocs(contextDocs[i]);
+                }
+                context.declareVariableBinding(var);
+
+                Cardinality actualCardinality;
+                if (currentArguments[j].isEmpty()) {
+                    actualCardinality = Cardinality.EMPTY_SEQUENCE;
+                } else if (currentArguments[j].hasMany()) {
+                    actualCardinality = Cardinality._MANY;
+                } else {
+                    actualCardinality = Cardinality.EXACTLY_ONE;
+                }
+
+                if (!getSignature().getArgumentTypes()[j].getCardinality().isSuperCardinalityOrEqualOf(actualCardinality)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004, "Invalid cardinality for parameter $" + varName +
+                            ". Expected " + getSignature().getArgumentTypes()[j].getCardinality().getHumanDescription() +
+                            ", got " + currentArguments[j].getItemCount());
+                }
+            }
+            result = body.eval(null, null);
+            return result;
+        } finally {
+            // restore the local variable stack
             context.popLocalVariables(mark, result);
             context.stackLeave(this);
 //            context.expressionEnd(this);
@@ -209,31 +203,27 @@ public class UserDefinedFunction extends Function implements Cloneable {
         buf.append(signature.getReturnType());
         return buf.toString();
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.functions.Function#getDependencies()
-	 */
-	public int getDependencies() {
-		return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM
-			+ Dependency.CONTEXT_POSITION;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.PathExpr#resetState()
-	 */
-	public void resetState(boolean postOptimization) {
-		if (hasBeenReset) {
+
+    @Override
+    public int getDependencies() {
+        return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM
+                + Dependency.CONTEXT_POSITION;
+    }
+
+    @Override
+    public void resetState(boolean postOptimization) {
+        if (hasBeenReset) {
             return;
         }
-		hasBeenReset = true;
-		
-		super.resetState(postOptimization);
+        hasBeenReset = true;
+
+        super.resetState(postOptimization);
         // Question: understand this test. Why not reset even is not in recursion ?
-		// Answer: would lead to an infinite loop if the function is recursive.
+        // Answer: would lead to an infinite loop if the function is recursive.
         bodyAnalyzed = false;
-        if(body != null) {
-			body.resetState(postOptimization);
-		}
+        if (body != null) {
+            body.resetState(postOptimization);
+        }
 
         if (!postOptimization) {
             currentArguments = null;
@@ -241,57 +231,59 @@ public class UserDefinedFunction extends Function implements Cloneable {
         }
     }
 
+    @Override
     public void accept(ExpressionVisitor visitor) {
-        if (visited)
-            {return;}
+        if (visited) {
+            return;
+        }
         visited = true;
         visitor.visitUserFunction(this);
     }
-    
+
     /**
      * Return the functions parameters list
-     * 
+     *
      * @return List of function parameters
      */
-    public List<QName> getParameters()
-    {
-    	return parameters;
+    public List<QName> getParameters() {
+        return parameters;
     }
 
+    @Override
     public synchronized Object clone() {
-    	try {
-    		final UserDefinedFunction clone = (UserDefinedFunction) super.clone();
-    		
-    		clone.currentArguments = null;
-    		clone.contextDocs = null;
-    		
-    		clone.body = this.body; // so body will be analyzed and optimized for all calls of such functions in recursion.  
-    	    
-    	    return clone;
-    	} catch (final CloneNotSupportedException e) {
-    	    // this shouldn't happen, since we are Cloneable
-    	    throw new InternalError();
-    	}
+        try {
+            final UserDefinedFunction clone = (UserDefinedFunction) super.clone();
+
+            clone.currentArguments = null;
+            clone.contextDocs = null;
+
+            clone.body = this.body; // so body will be analyzed and optimized for all calls of such functions in recursion.
+
+            return clone;
+        } catch (final CloneNotSupportedException e) {
+            // this shouldn't happen, since we are Cloneable
+            throw new InternalError();
+        }
     }
-    
-    public FunctionCall getCaller(){
-    	return call;
+
+    public FunctionCall getCaller() {
+        return call;
     }
-    
-    public void setCaller(FunctionCall call){
-    	this.call = call;
-    }
-    
-    public void setClosureVariables(List<ClosureVariable> vars) {
-    	this.closureVariables = vars;
-    	if (vars != null) {
-    		// register the closure with the context so it gets cleared after execution
-    		context.pushClosure(this);
-		}
+
+    public void setCaller(FunctionCall call) {
+        this.call = call;
     }
 
     public List<ClosureVariable> getClosureVariables() {
         return closureVariables;
+    }
+
+    public void setClosureVariables(List<ClosureVariable> vars) {
+        this.closureVariables = vars;
+        if (vars != null) {
+            // register the closure with the context so it gets cleared after execution
+            context.pushClosure(this);
+        }
     }
 
     protected Sequence[] getCurrentArguments() {

--- a/exist-core/src/test/xquery/maps/maps.xqm
+++ b/exist-core/src/test/xquery/maps/maps.xqm
@@ -49,6 +49,16 @@ declare variable $mt:integerKeys := map {
     7 : "Saturday"
 };
 
+declare variable $mt:places := map {
+    "Scotland": map {
+        "Highlands": map {
+            "Inverness": 1,
+            "Fort William": 1
+        },
+        "Lowlands": map { "Glasgow": 1 }
+    }
+};
+
 declare variable $mt:mapOfSequences := map {0: (), 1 : ("One", "Two") };
 
 declare
@@ -720,7 +730,7 @@ function mt:single-entry-map() {
         map:for-each($map, function($k, $v) { $k })
 };
 
-declare 
+declare
     %test:assertEquals(5)
 function mt:qname() {
     let $a := 1
@@ -988,4 +998,30 @@ function mt:map-merge-2-empty-options-map() {
     let $expected := map:merge($maps)
     let $actual := map:merge($maps, map {})
     return $expected?Su eq $actual?Su
+};
+
+(: test for issue https://github.com/eXist-db/exist/issues/5685 :)
+declare
+    %test:assertEquals("<ul><li>Scotland<ul><li>Highlands<ul><li>Fort William</li><li>Inverness</li></ul></li><li>Lowlands<ul><li>Glasgow</li></ul></li></ul></li></ul>")
+function mt:nested-map-for-each() {
+    <ul>{
+        map:for-each($mt:places, function($country-key, $region-map) {
+            <li>{
+                $country-key,
+                <ul>{
+                    map:for-each($region-map, function($region-key, $town-map) {
+                        <li>{
+                            $region-key,
+                            <ul>{
+                                map:for-each($town-map, function($town-key, $town-value) {
+                                    <li>{ $town-key }</li>
+                                })
+                            }</ul>
+                        }</li>
+                    })
+                }</ul>
+            }</li>
+        })
+    }</ul>
+    => serialize(map{'indent':false()})
 };


### PR DESCRIPTION
### Description:

Wrong comparison in FunctionSignature lead to tail call optimisation where no recursion was happening. This lead to at least the NPE reported in #5685
I do suspect that this does fix other related issues but will have to retest those scenarios to confirm

In general the attempt to compare the signature of two functions of which one or both is an anonymous function is a bad idea.
It will still work but only for _identical FunctionSignature objects_. This should also be the more common case for recursive calls to the same function.

### Reference:

fixes #5685

<img width="648" alt="Screenshot 2025-04-30 at 16 28 34" src="https://github.com/user-attachments/assets/13b69d9e-3529-4cc8-b2db-5bfc3c9e1afe" />

The screenshot illustrates how two anonymous functions were deemed equal because both had an empty name and the same number of arguments.

### Type of tests:

One XQSuite test added.