### PR TITLE
add new function `system:get-main-module-load-path#0`

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetMainModuleLoadPath.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetMainModuleLoadPath.java
@@ -24,34 +24,30 @@ package org.exist.xquery.functions.system;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 
-public class GetModuleLoadPath extends BasicFunction {
+public class GetMainModuleLoadPath extends BasicFunction {
 
-    protected final static Logger logger = LogManager.getLogger(GetModuleLoadPath.class);
+    protected final static Logger logger = LogManager.getLogger(GetMainModuleLoadPath.class);
 
     public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("get-module-load-path", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
-			"Returns the module load path from the current query context. The module load path " +
-            "corresponds to the source location from where this module is loaded." +
-            "The module load path is also used to resolve relative XInclude paths.",
+			new QName("get-main-module-load-path", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
+			"Returns the module load path from the root query context. The module load path " +
+            "corresponds to the location on the file system or the collection in the database " +
+            "of the main module that was compiled.",
 			FunctionSignature.NO_ARGS,
-			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the module load path"));
+			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the main module load path"));
 
-    public GetModuleLoadPath(XQueryContext context) {
+    public GetMainModuleLoadPath(XQueryContext context) {
         super(context, signature);
     }
 
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        return new StringValue(this, context.getModuleLoadPath());
+        return new StringValue(this, context.getRootContext().getModuleLoadPath());
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/SystemModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/SystemModule.java
@@ -65,6 +65,7 @@ public class SystemModule extends AbstractInternalModule {
             new FunctionDef(Shutdown.signatures[0], Shutdown.class),
             new FunctionDef(Shutdown.signatures[1], Shutdown.class),
             new FunctionDef(GetModuleLoadPath.signature, GetModuleLoadPath.class),
+			new FunctionDef(GetMainModuleLoadPath.signature, GetMainModuleLoadPath.class),
             new FunctionDef(TriggerSystemTask.signature, TriggerSystemTask.class),
             new FunctionDef(AsUser.FS_AS_USER, AsUser.class),
 			new FunctionDef(AsUser.FS_FUNCTION_AS_USER, AsUser.class),

--- a/exist-core/src/test/xquery/system/get-main-module-load-path.xqm
+++ b/exist-core/src/test/xquery/system/get-main-module-load-path.xqm
@@ -1,0 +1,81 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace test-system-get-main-module-load-path="http://exist-db.org/xquery/test/system/get-main-module-load-path";
+
+import module namespace system = "http://exist-db.org/xquery/system";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $test-system-get-main-module-load-path:lib := ``[xquery version "3.1";
+module namespace lib="//lib";
+declare function lib:path() {
+    system:get-main-module-load-path()
+};
+]``;
+
+declare variable $test-system-get-main-module-load-path:main := ``[xquery version "3.1";
+import module namespace lib="//lib" at 'xmldb:exist:///db/test/lib/lib.xqm';
+
+system:get-main-module-load-path(),
+lib:path()
+]``;
+
+declare
+    %test:setUp
+function test-system-get-main-module-load-path:setup() {
+    let $testCol := xmldb:create-collection("/db", "test")
+    let $indexCol := xmldb:create-collection("/db/test", "lib")
+    return
+        (
+            xmldb:store("/db/test", "main.xq", $test-system-get-main-module-load-path:main),
+            xmldb:store("/db/test/lib", "lib.xqm", $test-system-get-main-module-load-path:lib)
+        )
+};
+
+declare
+    %test:tearDown
+function test-system-get-main-module-load-path:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertEquals(".")
+function test-system-get-main-module-load-path:in-test-module() {
+    system:get-main-module-load-path()
+};
+
+declare
+    %test:assertEquals(".")
+function test-system-get-main-module-load-path:in-evaluated-string() {
+    let $eval-load-paths := util:eval($test-system-get-main-module-load-path:main)
+    return head($eval-load-paths)
+};
+
+declare
+    %test:assertEquals(".")
+function test-system-get-main-module-load-path:in-imported-library() {
+    let $eval-load-paths := util:eval($test-system-get-main-module-load-path:main)
+    return tail($eval-load-paths)
+};

--- a/exist-core/src/test/xquery/system/get-module-load-path.xqm
+++ b/exist-core/src/test/xquery/system/get-module-load-path.xqm
@@ -1,0 +1,81 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace test-system-get-module-load-path="http://exist-db.org/xquery/test/system/get-module-load-path";
+
+import module namespace system = "http://exist-db.org/xquery/system";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $test-system-get-module-load-path:lib := ``[xquery version "3.1";
+module namespace lib="//lib";
+declare function lib:path() {
+    system:get-module-load-path()
+};
+]``;
+
+declare variable $test-system-get-module-load-path:main := ``[xquery version "3.1";
+import module namespace lib="//lib" at 'xmldb:exist:///db/test/lib/lib.xqm';
+
+system:get-module-load-path(),
+lib:path()
+]``;
+
+declare
+    %test:setUp
+function test-system-get-module-load-path:setup() {
+    let $testCol := xmldb:create-collection("/db", "test")
+    let $indexCol := xmldb:create-collection("/db/test", "lib")
+    return
+        (
+            xmldb:store("/db/test", "main.xq", $test-system-get-module-load-path:main),
+            xmldb:store("/db/test/lib", "lib.xqm", $test-system-get-module-load-path:lib)
+        )
+};
+
+declare
+    %test:tearDown
+function test-system-get-module-load-path:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertXPath("matches($result, '^file://.*?exist-core/src/test/xquery/system$')")
+function test-system-get-module-load-path:in-test-module() {
+    system:get-module-load-path()
+};
+
+declare
+    %test:assertXPath("matches($result, '^file://.*?exist-core/src/test/xquery/system$')")
+function test-system-get-module-load-path:in-evaluated-string() {
+    let $eval-load-paths := util:eval($test-system-get-module-load-path:main)
+    return head($eval-load-paths)
+};
+
+declare
+    %test:assertEquals("xmldb:exist:///db/test/lib")
+function test-system-get-module-load-path:in-imported-library() {
+    let $eval-load-paths := util:eval($test-system-get-module-load-path:main)
+    return tail($eval-load-paths)
+};


### PR DESCRIPTION
refs #5731

This function will always return the moduleLoadPath of the root XQuery context.

Due to the fixes in module load path handling it became apparent that we will need a new function in the system module that would reliably always return the load path of the root context.

The documentation for `system:get-module-load-path` was ambigous and could be understood to do what the new function now does.