### PR TITLE
fix: version in two submodule poms

### DIFF
--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>6.3.1-SNAPSHOT</version>
+        <version>6.4.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>6.3.1-SNAPSHOT</version>
+        <version>6.4.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
### Description:

Building is broken because the commit to prepare for the next development iteration does not update two submodules by default. This is a separate issue.

This PR just updates the submodules to match the others and allows to build again.

