### PR TITLE
Reinstate integration tests in maven

### DIFF
--- a/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
@@ -142,7 +142,7 @@ public class XMLTestRunner extends AbstractTestRunner {
 
     private static @Nullable String getIdValue(final Node test) {
         final String id = ((Element)test).getAttribute("id");
-        return id.isEmpty() ? null : id;
+        return id.isBlank() ? null : id;
     }
 
     private static @Nullable String getTaskText(final Node test) {

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -807,7 +807,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.3</version>
+                    <!-- NOTE: version 3.5.3 fails to run XSuite tests -->
+                    <version>3.5.2</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
The latest release of maven-surefire-plugin lead to a large amount of integration tests not running.

Integration test for us means tests written in XQuery and also those defined XML.
I could confirm that deliberately breaking a test in core did not lead to a failing build.

**NOTE:** The build of this PR will break because some tests are really broken.
Those tests will be fixed in separate PRs.

fixes #5805 

possibly related issues from the maven plugins in us: 
- https://github.com/apache/maven-surefire/issues/3156
- https://github.com/apache/maven-surefire/issues/2634