### PR TITLE
[bugfix] consistently raise errors in fn:analyze-string

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -103,18 +103,15 @@ public class FunAnalyzeString extends BasicFunction {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             builder.startDocument();
             builder.startElement(new QName("analyze-string-result", Function.BUILTIN_FUNCTION_NS), null);
-            String input = "";
-            if (!args[0].isEmpty()) {
-                input = args[0].itemAt(0).getStringValue();
+
+            final String input = args[0].isEmpty() ? "" : args[0].itemAt(0).getStringValue();
+            final String pattern = args[1].itemAt(0).getStringValue();
+
+            String flags = "";
+            if (args.length == 3) {
+                flags = args[2].itemAt(0).getStringValue();
             }
-            if (input != null && !input.isEmpty()) {
-                final String pattern = args[1].itemAt(0).getStringValue();
-                String flags = "";
-                if (args.length == 3) {
-                    flags = args[2].itemAt(0).getStringValue();
-                }
-                analyzeString(builder, input, pattern, flags);
-            }
+            analyzeString(builder, input, pattern, flags);
             builder.endElement();
             builder.endDocument();
             return (NodeValue) builder.getDocument().getDocumentElement();

--- a/exist-core/src/test/xquery/xquery3/analyze-string.xqm
+++ b/exist-core/src/test/xquery/xquery3/analyze-string.xqm
@@ -1,0 +1,94 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace tas="http://exist-db.org/xquery/test/analyze-string";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("")
+    %test:assertError("err:FORX0003")
+    %test:args(".?")
+    %test:assertError("err:FORX0003")
+    %test:args(".*")
+    %test:assertError("err:FORX0003")
+    %test:args("(.*)")
+    %test:assertError("err:FORX0003")
+function tas:empty-match-fails($p as xs:string) {
+    analyze-string("",$p,"")
+};
+
+declare
+    %test:assertEmpty
+function tas:analyze-string-empty() {
+    analyze-string((), "\w")//(fn:match|fn:non-match)
+};
+
+declare
+    %test:assertEquals("a")
+    %test:args("a", "[A-Z]", "")
+    %test:assertEquals("a")
+    %test:args("a1", "\d", "")
+    %test:assertEquals("a")
+function tas:analyze-string-non-matches($v as xs:string, $p as xs:string, $f as xs:string) {
+    analyze-string($v, $p, $f)//fn:non-match/string()
+};
+
+declare
+    %test:args("a1", "\d", "")
+    %test:assertEquals("1")
+    %test:args("a", "\w", "")
+    %test:assertEquals("a")
+    %test:args("a", "[A-Z]", "i")
+    %test:assertEquals("a")
+function tas:analyze-string-matches($v as xs:string, $p as xs:string, $f as xs:string) {
+    analyze-string($v, $p, $f)//fn:match/string()
+};
+
+declare
+    %test:args("\")
+    %test:assertError("err:FORX0002")
+    %test:args("(")
+    %test:assertError("err:FORX0002")
+    %test:args("[")
+    %test:assertError("err:FORX0002")
+    %test:args("{")
+    %test:assertError("err:FORX0002")
+    %test:args("?")
+    %test:assertError("err:FORX0002")
+function tas:invalid-pattern($regex as xs:string) {
+    analyze-string("",$regex,"")
+};
+
+declare
+    %test:args("1")
+    %test:assertError("err:FORX0001")
+    %test:args("?")
+    %test:assertError("err:FORX0001")
+    %test:args("[")
+    %test:assertError("err:FORX0001")
+    %test:args("p")
+    %test:assertError("err:FORX0001")
+function tas:invalid-flag($flag as xs:string) {
+    analyze-string("",".+",$flag)
+};


### PR DESCRIPTION
# Description

`fn:analyze-string` was implemented such that an invalid pattern or flag or a pattern matching an empty string would only raise an error if the value was a non-empty string.

With this PR applied the error will be raised regardless of the provided value.

# References

> Error Conditions
> A dynamic error is raised [[err:FORX0002](https://www.w3.org/TR/xpath-functions-31/#ERRFORX0002)] if the value of $pattern is invalid according to the rules described in section [5.6.1 Regular expression syntax](https://www.w3.org/TR/xpath-functions-31/#regex-syntax).
>
> A dynamic error is raised [[err:FORX0001](https://www.w3.org/TR/xpath-functions-31/#ERRFORX0001)] if the value of $flags is invalid according to the rules described in section [5.6.2 Flags](https://www.w3.org/TR/xpath-functions-31/#flags).
>
> A dynamic error is raised [[err:FORX0003](https://www.w3.org/TR/xpath-functions-31/#ERRFORX0003)] if the supplied $pattern matches a zero-length string, that is, if fn:matches("", $pattern, $flags) returns true.

source: https://www.w3.org/TR/xpath-functions-31/#func-analyze-string

# Tests

XQSuite tests added