### PR TITLE
[bugfix] 6XX: Make sure that the JMX servlet is started upon server start.

### DIFF
--- a/exist-jetty-config/src/main/resources/webapp/WEB-INF/web.xml
+++ b/exist-jetty-config/src/main/resources/webapp/WEB-INF/web.xml
@@ -176,6 +176,7 @@
     <servlet>
         <servlet-name>JMXServlet</servlet-name>
         <servlet-class>org.exist.management.client.JMXServlet</servlet-class>
+        <load-on-startup>4</load-on-startup>
     </servlet>
 
     <!--


### PR DESCRIPTION
Make sure that the JMX servlet is started upon server start.
This avoids an error in Monex.
Fix for #5831 
Port of #5836

