### PR TITLE
Make unique query history keys for monex

### DIFF
--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
@@ -123,7 +123,9 @@ ProcessReportMXBean extends PerInstanceMBean {
             if (other == null) {
                 return 1;
             }
-
+            if (id != other.id) {
+              return Integer.compare(id,  other.id);
+            }
             return key.compareTo(other.key);
         }
     }


### PR DESCRIPTION
This PR solves https://github.com/eXist-db/monex/issues/299

In the "recent queries", Monex shows only one query for a source URL, even if there have been more queries with the same URL.
The reason is that  the `QueryKey` class has a method `int compareTo(final QueryKey other)` that does not take all parts of the query key into account.
This PR cahnges the `compareTo` method, so that the whole key is compared.

See also the analysis in https://github.com/eXist-db/monex/issues/299#issuecomment-3322905361