### PR TITLE
[bugfix] fn:transform: Conversion and treeIndex problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ dependency-reduced-pom.xml
 
 # OS specific files
 .DS_Store
-

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
@@ -26,17 +26,23 @@ import net.sf.saxon.s9api.*;
 import net.sf.saxon.type.BuiltInAtomicType;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.fn.FnTransform;
+import org.exist.xquery.functions.map.AbstractMapType;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import io.lacuna.bifurcan.IEntry;
+
 import javax.xml.transform.dom.DOMSource;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Type conversion to and from Saxon
@@ -119,11 +125,18 @@ class Convert {
         }
 
         XdmValue of(final Item item) throws XPathException {
+            if (item instanceof NodeProxy) {
+              return ofNode(((NodeProxy) item).getNode());
+            }
             final int itemType = item.getType();
             if (Type.subTypeOf(itemType, Type.ATOMIC)) {
                 return ofAtomic((AtomicValue) item);
             } else if (Type.subTypeOf(itemType, Type.NODE)) {
                 return ofNode((Node) item);
+            } else if (Type.subTypeOf(itemType, Type.MAP)) {
+                return ofMap((AbstractMapType) item);
+            } else if (Type.subTypeOf(itemType,  Type.ARRAY)) {
+                return ofArray((ArrayType) item);
             }
             throw new XPathException(ErrorCodes.XPTY0004,
                     "Item " + item + " of type " + Type.getTypeName(itemType) + COULD_NOT_BE_CONVERTED + "XdmValue");
@@ -140,14 +153,12 @@ class Convert {
             } else if (Type.subTypeOf(itemType, Type.STRING)) {
                 return XdmValue.makeValue(((StringValue) atomicValue).getStringValue());
             }
-
             throw new XPathException(ErrorCodes.XPTY0004,
                     "Atomic value " + atomicValue + " of type " + Type.getTypeName(itemType) +
                             COULD_NOT_BE_CONVERTED + "XdmValue");
         }
 
         private XdmValue ofNode(final Node node) throws XPathException {
-
             final DocumentBuilder sourceBuilder = newDocumentBuilder();
             try {
                 if (node instanceof DocumentImpl) {
@@ -165,6 +176,25 @@ class Convert {
             } catch (final SaxonApiException e) {
                 throw new XPathException(ErrorCodes.XPTY0004, "Node " + node + COULD_NOT_BE_CONVERTED + "XdmValue", e);
             }
+        }
+
+        private XdmValue ofMap(final AbstractMapType map) throws XPathException {
+            Map<XdmAtomicValue, XdmValue> xdmMap = new HashMap<XdmAtomicValue, XdmValue>();
+            for (IEntry<AtomicValue, Sequence> entry : map) {
+                XdmAtomicValue key = (XdmAtomicValue) ofAtomic(entry.key());
+                XdmValue value = of(entry.value());
+                xdmMap.put(key, value);
+            }
+            return new XdmMap(xdmMap);
+        }
+
+        private XdmValue ofArray(final ArrayType array) throws XPathException {
+          int size = array.getSize();
+          XdmValue[] members = new XdmValue[size];
+          for (int i = 0; i < size; ++i) {
+            members[i] = of(array.get(i));
+          }
+          return new XdmArray(members);
         }
 
         XdmValue[] of(final ArrayType values) throws XPathException {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Transform.java
@@ -192,8 +192,10 @@ public class Transform {
                 final Transform.TemplateInvocation invocation = new Transform.TemplateInvocation(
                         options, sourceNode, delivery, xslt30Transformer, resultDocuments);
                 return invocation.invoke();
-            } catch (final SaxonApiException | UncheckedXPathException e) {
-                throw originalXPathException("Could not transform input: ", e, ErrorCodes.FOXT0003);
+            } catch (final SaxonApiException e) {
+              throw originalXPathException("Could not transform with "+options.xsltSource._1+" line "+e.getLineNumber()+": ", e, ErrorCodes.FOXT0003);
+            } catch (final UncheckedXPathException e) {
+              throw originalXPathException("Could not transform with "+options.xsltSource._1+" line "+e.getXPathException().getLocationAsString()+": ", e, ErrorCodes.FOXT0003);
             }
 
         } else {

--- a/exist-core/src/test/xquery/xquery3/transform/fnTransform5882.xqm
+++ b/exist-core/src/test/xquery/xquery3/transform/fnTransform5882.xqm
@@ -1,0 +1,126 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace testTransform="http://exist-db.org/xquery/test/function_transform";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace xsl="http://www.w3.org/1999/XSL/Transform";
+
+(:~
+ : Regression test for PR 5882: fn:transform with MemTree nodes.
+ : A bare element constructor (element root { ... }) creates a MemTree node whose
+ : getParentNode() returns null (see issue #1463). We use initial-match-selection
+ : because that path calls Convert.ofNode/treeIndex. Without the TreeUtils fix:
+ : - For root: treeIndex returns [], xdmNodeAtIndex returns doc (wrong but works)
+ : - For second child: treeIndex returns [1] (missing leading 0 for root), doc has
+ :   only one child, so xdmNodeAtIndex(doc, [1]) returns null, causing failure.
+ : @see https://github.com/eXist-db/exist/pull/5882
+ :)
+declare variable $testTransform:transform-5882-simple-xsl := <xsl:stylesheet version='1.0'>
+    <xsl:template match='*'>
+        <out><xsl:value-of select='.'/></out>
+    </xsl:template>
+</xsl:stylesheet>;
+
+declare variable $testTransform:transform-5882-map-array-xsl := <xsl:stylesheet version='3.0'>
+    <xsl:param name='m' as='map(*)'/>
+    <xsl:param name='a' as='array(*)'/>
+    <xsl:template name='main'>
+        <out>
+            <xsl:attribute name='map-val' select='$m("k")'/>
+            <xsl:attribute name='array-val' select='$a(2)'/>
+        </out>
+    </xsl:template>
+</xsl:stylesheet>;
+
+declare variable $testTransform:transform-5882-stored-doc := <root id="attr"><child>stored-val</child></root>;
+
+declare variable $testTransform:transform-5882-coll := "/db/fn-transform-5882-stored";
+
+declare
+    %test:setUp
+function testTransform:setup() {
+    xmldb:create-collection("/db", "fn-transform-5882-stored"),
+    xmldb:store($testTransform:transform-5882-coll, "doc.xml", $testTransform:transform-5882-stored-doc)
+};
+
+declare
+    %test:tearDown
+function testTransform:tearDown() {
+    xmldb:remove($testTransform:transform-5882-coll)
+};
+
+(:~
+ : Select the second child of a MemTree root. Without the fix, treeIndex(b) = [1]
+ : (missing index 0 for root), but doc has only one child; xdmNodeAtIndex returns null.
+ :)
+declare
+    %test:assertEquals('<out>second</out>')
+function testTransform:memtree-second-child() {
+    let $source := element root { <a>first</a>, <b>second</b> }
+    let $selection := $source/b
+    let $result := (fn:transform(map{
+        "initial-match-selection": $selection,
+        "stylesheet-node": $testTransform:transform-5882-simple-xsl
+    }))?output
+    return $result
+};
+
+(:~
+ : PR 5882 adds Convert.ofMap/ofArray for stylesheet params. Without it, map/array
+ : params cause XPTY0004. XSLT 3.0 required for map(*) and array(*) param types.
+ : @see https://github.com/eXist-db/exist/pull/5882
+ :)
+declare
+    %test:assertEquals('v', 'y')
+function testTransform:stylesheet-params-map-array() {
+    let $result := fn:transform(map{
+        "stylesheet-node": $testTransform:transform-5882-map-array-xsl,
+        "initial-template": QName('','main'),
+        "stylesheet-params": map {
+            QName('','m'): map{'k':'v'},
+            QName('','a'): ['x','y','z']
+        }
+    })?output
+    return
+       ($result/out/@map-val/string(), $result/out/@array-val/string())
+
+};
+
+(:~
+ : PR 5882 fixes TreeUtils.previousSiblingNotAttribute for StoredNode: attributes
+ : appear as previous siblings of element children. Store a doc with attrs, select
+ : the child element as initial-match-selection.
+ : @see https://github.com/eXist-db/exist/pull/5882
+ :)
+declare
+    %test:assertEquals('<out>stored-val</out>')
+function testTransform:stored-doc-with-attributes() {
+    let $selection := doc($testTransform:transform-5882-coll || "/doc.xml")/root/child
+    let $result := (fn:transform(map{
+        "initial-match-selection": $selection,
+        "stylesheet-node": $testTransform:transform-5882-simple-xsl
+    }))?output
+    return $result
+};


### PR DESCRIPTION
# Description

This is a retry for #5680 which was botched after I changed my develop-6.x.x branch.

The `fn:transform` function sometimes produced `NullPointerException`s. This happened for documents containing nodes of type `org.exist.dom.memtree.ElementImpl` and other subtypes of `org.exist.dom.memtree.NodeImpl`.

The function `org.exist.xquery.functions.fn.transform.Convert.ToSaxon.ofNode(Node)` uses `org.exist.xquery.functions.fn.transform.TreeUtils.treeIndex(Node)` to get a 'path' (as a list of indexes) of the `Node` in its containing document. This 'path' is used to find the node in a newly built document that is suitable for use by Saxon.
Using the 'path' that the `treeIndex` function produces assumes that it starts at the document node.

However, some nodes do not have a containing document. Specifically, in `org.exist.dom.memtree.NodeImpl.getParentNode()`:
```
if (parent.getNodeType() == DOCUMENT_NODE && !((DocumentImpl) parent).isExplicitlyCreated()) {
            /*
                All nodes in the MemTree will return an Owner document due to how the MemTree is implemented,
                however the explicitlyCreated flag tells us whether there "really" was a Document Node or not.
                See https://github.com/eXist-db/exist/issues/1463
             */
            return null;
```
In this case, the 'path' returned by `treeIndex` does not contain the index (0) for the root node, and `org.exist.xquery.functions.fn.transform.TreeUtils.xdmNodeAtIndex(XdmNode, List<Integer>)` will return `null` when a node is expected.

The proposed fix tests for this case. Going up the ancestor chain, when a node that is not a document node and that does not have a parent is found, the index 0 for this root element is inserted in the 'path'.

The PR also adds support for using maps and arrays as parameters in a XSLT transformation.

# Testing

The` NullPointerException` happened in a rather complicated XQuery with documents composed from several sources.
I have not yet been able to make a simple test case.