### PR TITLE
Fix/debug docker image

### DIFF
--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-FROM openjdk:21-jdk-slim-bullseye
+FROM eclipse-temurin:21-jdk-noble
 RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y expat fontconfig     # Install tools required by FOP
 


### PR DESCRIPTION
### Description:

Since November 3rd the base image used to create the DEBUG docker image no longer exists.
Therefore this PR switches the base image to ~~maven:3-eclipse-temurin-21 (the same one used by duncdrum/existdb:7.0.0-SNAPSHOT-DEBUG)~~ eclipse-temurin:21-jdk-noble (suggested by @duncdrum)

### Reference:

last failure https://github.com/eXist-db/exist/actions/runs/19256716288

### Type of tests:

Manual tests with the running container