### PR TITLE
[Bugfix] 6XX sync: small number formatted with exponent fails

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -713,9 +713,6 @@ public class FnFormatNumbers extends BasicFunction {
         final int minimumExponentSize = subPicture.getMinimumExponentSize();
         if (minimumExponentSize > 0) {
             formatted.append(decimalFormat.exponentSeparator);
-            if (exp < 0) {
-                formatted.append(decimalFormat.minusSign);
-            }
 
             final CodePointString expStr = new CodePointString(String.valueOf(exp));
 

--- a/exist-core/src/test/xquery/numbers/format-numbers.xql
+++ b/exist-core/src/test/xquery/numbers/format-numbers.xql
@@ -304,3 +304,16 @@ declare
 function fd:decimal-zeros($picture as xs:string) {
     format-number(0, $picture)
 };
+
+declare
+    %test:args(1.234567E10,"0.000e0")
+    %test:assertEquals("1.235e10")
+    %test:args(1.234567E-10,"0.000e0")
+    %test:assertEquals("1.235e-10")
+    %test:args(0.000000000123456,"0.000e0")
+    %test:assertEquals("1.235e-10")
+    %test:args(1.234567e-10,"0.000e0")
+    %test:assertEquals("1.235e-10")
+function fd:exponent-fails($number as xs:double, $picture as xs:string) {
+    format-number($number, $picture)
+};


### PR DESCRIPTION
Syncs #5946

by request of @line-o 