### PR TITLE
[bugfix] GeneralComparison always retuns a boolean

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -445,7 +445,7 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
             // if we were optimizing and the preselect did not return anything,
             // we won't have any matches and can return
             if( ( preselectResult != null ) && preselectResult.isEmpty() ) {
-                result = Sequence.EMPTY_SEQUENCE;
+                result = new BooleanValue(false);
             } else {
 
                 if( ( contextStep == null ) || ( preselectResult == null ) ) {


### PR DESCRIPTION
### Description:

GeneralComparison MUST return a boolean. For cache misses on comparisons on persistent nodes the comparison returned an empty sequence instead.

### Reference:

closes #4958

### Type of tests:

TBD