### PR TITLE
Bump version of exist-xqts-runner-2.13

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           docker pull --platform linux/amd64 --platform linux/arm64 gcr.io/distroless/java21-debian12:latest
       - name: Build images
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -V -B -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package
       - name: Check local images
         run: docker image ls

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -59,6 +59,8 @@ jobs:
           cache: 'true'
       - name: Maven Build
         timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -21,6 +21,8 @@ jobs:
           key: xqts-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: xqts-${{ runner.os }}-maven
       - name: Maven XQTS Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -V -B clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
       - name: Run XQTS
         timeout-minutes: 60

--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.exist-db</groupId>
             <artifactId>exist-xqts-runner_2.13</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
             <exclusions>
                 <!-- use the exist-core version of this project instead -->
                 <exclusion>


### PR DESCRIPTION
### Description:

Use version 2.0.0-SNAPSHOT which is compatible with exist-7.0.0-SNAPSHOT
This is expected to reinstate the XQTS test runs to run all 31 thousand tests again.
The delta will only become visible once this was merged and the full result cached again.

### Reference:

refs #5953 

### Type of tests:

none added but now all xqts tests are executed again

```xml
<cr:results
  tests="31815"
  skipped="1185"
  failures="3734"
  errors="190"
  time="677.388"
/>
 ```

**edit:** we do have a delta +29068 tests are run

```xml
   <cr:change>
      <cr:results tests="29068"
                  tests-pct="1058.1725518747724"
                  skipped="595"
                  skipped-pct="100.84745762711864"
                  failures="2967"
                  failures-pct="386.8318122555411"
                  errors="168"
                  errors-pct="763.6363636363636"
                  time="586.1054"
                  time-pct="1234.9200396114704"/>
```