### PR TITLE
[Feature] Improve webdav extension 

### DIFF
--- a/exist-distribution/src/main/config/webdav.properties
+++ b/exist-distribution/src/main/config/webdav.properties
@@ -27,7 +27,7 @@
 #expand-xincludes=no
 #indent=yes
 #omit-original-xml-declaration=no
-#omit-xml-declaration=no
+#omit-xml-declaration=yes
 #output-doctype=yes
 #process-xsl-pi=no
 
@@ -68,5 +68,5 @@
 ##
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #
-# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-# org.exist.webdav.GET_METHOD_XML_SIZE=NULL
+# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=EXACT
+# org.exist.webdav.GET_METHOD_XML_SIZE=EXACT

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -99,6 +99,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
@@ -49,7 +49,7 @@ import java.util.Properties;
  */
 public class ExistResourceFactory implements ResourceFactory {
 
-    private final static Logger LOG = LogManager.getLogger(ExistResourceFactory.class);
+    private static final Logger LOG = LogManager.getLogger(ExistResourceFactory.class);
     private BrokerPool brokerPool = null;
 
     /**
@@ -67,6 +67,7 @@ public class ExistResourceFactory implements ResourceFactory {
 
         } catch (EXistException e) {
             LOG.error("Unable to initialize WebDAV interface.", e);
+            return;
         }
 
         // load specific options
@@ -91,7 +92,7 @@ public class ExistResourceFactory implements ResourceFactory {
 
             // Read from file if existent
             if (Files.isReadable(config)) {
-                LOG.info("Read WebDAV configuration from {}", config.toAbsolutePath().toString());
+                LOG.info("Read WebDAV configuration from {}", config.toAbsolutePath());
                 try (final InputStream is = Files.newInputStream(config)) {
                     webDavOptions.load(is);
                 }

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -68,5 +68,5 @@ output-doctype=yes
 ##
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #
-# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-# org.exist.webdav.GET_METHOD_XML_SIZE=NULL
+org.exist.webdav.PROPFIND_METHOD_XML_SIZE=EXACT
+org.exist.webdav.GET_METHOD_XML_SIZE=EXACT


### PR DESCRIPTION
The webdav extension unnecessarily pulls in a large number of (spring) dependencies whilst they are not used by eXist-db.
Less deps are better as it reduces potential conflicts, attack vectors etc etc.

```
+- org.exist-db.thirdparty.com.ettrema:milton-servlet:jar:1.8.1.3-jakarta5:compile
[INFO] |  +- org.springframework:spring-webmvc:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-aop:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-beans:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-context:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-core:jar:6.0.0-M6:compile
[INFO] |  |  |  \- org.springframework:spring-jcl:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-expression:jar:6.0.0-M6:compile
[INFO] |  |  \- org.springframework:spring-web:jar:6.0.0-M6:compile
[INFO] |  |     \- io.micrometer:micrometer-observation:jar:1.10.0-M6:compile
[INFO] |  |        \- io.micrometer:micrometer-commons:jar:1.10.0-M6:compile
```

This PR effectively removes 6 megs of jars.