### PR TITLE
[ci] Revise and reduce webDAV extension dependencies

### DIFF
--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -99,6 +99,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
The webdav extension unnecessarily pulls in a large number of (spring) dependencies whilst they are not used by eXist-db.
Less deps are better as it reduces potential conflicts, attack vectors etc etc.

```
+- org.exist-db.thirdparty.com.ettrema:milton-servlet:jar:1.8.1.3-jakarta5:compile
[INFO] |  +- org.springframework:spring-webmvc:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-aop:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-beans:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-context:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-core:jar:6.0.0-M6:compile
[INFO] |  |  |  \- org.springframework:spring-jcl:jar:6.0.0-M6:compile
[INFO] |  |  +- org.springframework:spring-expression:jar:6.0.0-M6:compile
[INFO] |  |  \- org.springframework:spring-web:jar:6.0.0-M6:compile
[INFO] |  |     \- io.micrometer:micrometer-observation:jar:1.10.0-M6:compile
[INFO] |  |        \- io.micrometer:micrometer-commons:jar:1.10.0-M6:compile
```

This PR effectively removes 6 megs of jars.