### PR TITLE
[Feature] Revise default webDAV size reporting parameters

### DIFF
--- a/exist-distribution/src/main/config/webdav.properties
+++ b/exist-distribution/src/main/config/webdav.properties
@@ -27,7 +27,7 @@
 #expand-xincludes=no
 #indent=yes
 #omit-original-xml-declaration=no
-#omit-xml-declaration=no
+#omit-xml-declaration=yes
 #output-doctype=yes
 #process-xsl-pi=no
 
@@ -68,5 +68,5 @@
 ##
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #
-# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-# org.exist.webdav.GET_METHOD_XML_SIZE=NULL
+# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=EXACT
+# org.exist.webdav.GET_METHOD_XML_SIZE=EXACT

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
@@ -49,7 +49,7 @@ import java.util.Properties;
  */
 public class ExistResourceFactory implements ResourceFactory {
 
-    private final static Logger LOG = LogManager.getLogger(ExistResourceFactory.class);
+    private static final Logger LOG = LogManager.getLogger(ExistResourceFactory.class);
     private BrokerPool brokerPool = null;
 
     /**
@@ -67,6 +67,7 @@ public class ExistResourceFactory implements ResourceFactory {
 
         } catch (EXistException e) {
             LOG.error("Unable to initialize WebDAV interface.", e);
+            return;
         }
 
         // load specific options
@@ -91,7 +92,7 @@ public class ExistResourceFactory implements ResourceFactory {
 
             // Read from file if existent
             if (Files.isReadable(config)) {
-                LOG.info("Read WebDAV configuration from {}", config.toAbsolutePath().toString());
+                LOG.info("Read WebDAV configuration from {}", config.toAbsolutePath());
                 try (final InputStream is = Files.newInputStream(config)) {
                     webDavOptions.load(is);
                 }

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -68,5 +68,5 @@ output-doctype=yes
 ##
 ## Depending on the WebDAV client needs, one or both properties can be set.
 #
-# org.exist.webdav.PROPFIND_METHOD_XML_SIZE=APPROXIMATE
-# org.exist.webdav.GET_METHOD_XML_SIZE=NULL
+org.exist.webdav.PROPFIND_METHOD_XML_SIZE=EXACT
+org.exist.webdav.GET_METHOD_XML_SIZE=EXACT


### PR DESCRIPTION
In webDav details matter. Each and every client implementation has different assumptions on what shall and shall not be reported on document sizes.

In the past, for performance optimization, I decided to report mostly estimated XML document sizes. Today I found out that Cyberduck does not accept this anymore.

This PR defaults the parameters to the slowest but 100% accurate settings.

----

IMO the extension needs to be replaces. Funding is needed.