### PR TITLE
[ci] reduce WARNINGS for unit tests.

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -839,7 +839,7 @@
                             <user.country>UK</user.country>
                             <user.language>en</user.language>
                             <user.timezone>Europe/Berlin</user.timezone>
-                            <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
+                            <java.locale.providers>CLDR,SPI</java.locale.providers>
                             <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                             <log4j2.disableJmx>false</log4j2.disableJmx>
                             <xml.catalog.alwaysResolve>false</xml.catalog.alwaysResolve>

--- a/extensions/debuggee/pom.xml
+++ b/extensions/debuggee/pom.xml
@@ -102,7 +102,7 @@
                 <configuration>
                     <argLine>@{jacocoArgLine}</argLine>
                     <systemPropertyVariables>
-                        <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
+                        <java.locale.providers>CLDR,SPI</java.locale.providers>
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
                     </systemPropertyVariables>


### PR DESCRIPTION
Reduce WARNINGS for unit tests.

JRE/ & COMPAT are deprecated settings for locale providers are deprecated values.

```
Dec 18, 2025 10:56:46 PM sun.util.locale.provider.LocaleProviderAdapter <clinit> 
WARNING: COMPAT locale provider will be removed in a future release
```
