### PR TITLE
[refactor] Enforce newer version op apache mina, until we upgrade jetty

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -443,6 +443,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Force newer MINA version for jetty-jaas -->
+        <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>2.2.5</version>
+        </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
@@ -1034,6 +1042,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-annotations:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-security:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>${project.groupId}:exist-jetty-config:jar:${project.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.mina:mina-core</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
 
                             <ignoredNonTestScopedDependencies>


### PR DESCRIPTION
Enforce newer version of apache mina, until we upgrade jetty.

<img width="444" height="108" alt="image" src="https://github.com/user-attachments/assets/9ed4722b-2074-4431-8520-61db4ad3b29e" />
