### PR TITLE
[bugfix] Upgrade transient dependency apache-mime4j-core

### DIFF
--- a/extensions/expath/pom.xml
+++ b/extensions/expath/pom.xml
@@ -68,6 +68,16 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
 
+        <!--
+            Define explicit dependency on apache-mime4j-core to avoid transitive dependency issues
+            for http-client-java.
+        -->
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+            <version>0.8.13</version>
+        </dependency>
+
         <dependency>
             <groupId>org.expath.http.client</groupId>
             <artifactId>http-client-java</artifactId>
@@ -94,6 +104,26 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>org.apache.james:apache-mime4j-core</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>


### PR DESCRIPTION
fixing:

<img width="444" height="129" alt="image" src="https://github.com/user-attachments/assets/d0c1c8df-16ae-44d9-8d0b-46a69507c32b" />

until we upgrade the http library. It aligns all if the 'James' libs to the same version.
