### PR TITLE
[enhancement] deprecate Cardinality _MANY

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Cardinality.java
+++ b/exist-core/src/main/java/org/exist/xquery/Cardinality.java
@@ -47,7 +47,10 @@ public enum Cardinality {
     //TODO(AR) can we eliminate this?
     EXACTLY_ONE(ONE),
 
-    //TODO(AR) eliminate this in favour of probably ONE_OR_MORE
+    /**
+     * @deprecated for removal. Use #EMPTY_SEQUENCE and #EXACTLY_ONE to determine many records instead.
+     */
+    @Deprecated
     _MANY(MANY),
 
     /**


### PR DESCRIPTION
### Description:
Deprecate `_MANY` as it is not an available XPath indicator. 

Use `EMPTY_SEQUENCE` and `EXACTLY_ONE`  to achieve the same behavior if needed.