### PR TITLE
[6xx] Updating 3rd party libs and build plugins

### DIFF
--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.openjdk.jcstress</groupId>
             <artifactId>jcstress-core</artifactId>
-            <version>0.15</version>
+            <version>0.16</version>
         </dependency>
         <dependency>
             <groupId>org.exist-db</groupId>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -39,7 +39,7 @@
     <description>JMH Benchmarks for exist-core</description>
 
     <properties>
-        <jmh.version>1.36</jmh.version>
+        <jmh.version>1.37</jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -57,9 +57,10 @@
         </dependency>
 
         <dependency>
+            <!-- keep in sync with monex -->
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.3</version>
+            <version>2.19.1</version>
         </dependency>
 
         <!-- dependency>
@@ -145,13 +146,13 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.83</version>
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
+            <version>1.10.2</version>
         </dependency>
 
         <dependency>
@@ -162,7 +163,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
         </dependency>
 
         <dependency>
@@ -191,7 +192,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.29.0</version>
+            <version>3.30.6</version>
         </dependency>
 
         <dependency>
@@ -239,7 +240,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.1</version>
         </dependency>
 
         <dependency>
@@ -432,7 +433,7 @@
         <dependency>
             <groupId>com.fifesoft</groupId>
             <artifactId>rsyntaxtextarea</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.1</version>
         </dependency>
 
         <dependency>
@@ -571,7 +572,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <!--

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -785,6 +785,7 @@
                             <user.timezone>Europe/Berlin</user.timezone>
                             <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
                             <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                            <log4j2.disableJmx>false</log4j2.disableJmx>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -561,12 +561,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.5</version>
+                    <version>4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>
@@ -600,7 +600,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.code54.mojo</groupId>
@@ -615,7 +615,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
-                    <version>1.1.0</version>
+                    <version>1.2.0</version>
                     <configuration>
                         <transformerFactory>net.sf.saxon.TransformerFactoryImpl</transformerFactory>
                     </configuration>
@@ -630,7 +630,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.1</version>
                     <configuration>
                         <source>${project.build.source}</source>
                         <target>${project.build.target}</target>
@@ -640,7 +640,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -664,7 +664,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -688,7 +688,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <source>${project.build.source}</source>
                         <archive>
@@ -719,7 +719,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.12</version>
+                    <version>0.8.14</version>
                     <configuration>
                         <propertyName>jacocoArgLine</propertyName>
                         <excludes>
@@ -739,12 +739,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jarsigner-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.4</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.platform</groupId>
@@ -791,17 +791,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.9.0</version>
                     <configuration>
                         <dependencyDetailsEnabled>false</dependencyDetailsEnabled>  <!-- TODO(AR) disabled due to slow `mvn site` build times -->
                     </configuration>
@@ -817,17 +817,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -851,22 +851,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>eXist-@{project.version}</tagNameFormat>
@@ -885,7 +885,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.3</version>
+                    <version>3.2.8</version>
                 </plugin>
                 <plugin>
                     <groupId>de.jutzig</groupId>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -809,7 +809,10 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.17.1</version>
+                    <version>2.20.1</version>
+                    <configuration>
+                        <rulesUri>file:///${maven.multiModuleProjectDirectory}/maven-version-rules.xml</rulesUri>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -113,13 +113,13 @@
         <jaxb.api.version>3.0.1</jaxb.api.version>
         <jaxb.impl.version>3.0.2</jaxb.impl.version>
         <jdom1.version>1.1.3</jdom1.version>
-        <log4j.version>2.22.1</log4j.version>
-        <jetty.version>9.4.57.v20241219</jetty.version>
+        <log4j.version>2.25.3</log4j.version>
+        <jetty.version>9.4.58.v20250814</jetty.version>
         <lucene.version>4.10.4</lucene.version>
         <milton.version>1.8.1.3</milton.version>
         <saxon.version>9.9.1-8</saxon.version>
         <xmlresolver.version>4.6.4</xmlresolver.version>
-        <xmlunit.version>2.10.0</xmlunit.version>
+        <xmlunit.version>2.11.0</xmlunit.version>
         <junit.version>4.13.2</junit.version>
         <junit.platform.version>1.10.2</junit.platform.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
@@ -217,13 +217,13 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.18.0</version>
+                <version>1.20.0</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.18.0</version>
+                <version>2.21.0</version>
             </dependency>
 
             <dependency>
@@ -259,7 +259,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.12</version>
+                <version>2.0.17</version>
             </dependency>
 
             <dependency>
@@ -372,7 +372,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.17.0</version>
+                <version>3.20.0</version>
             </dependency>
 
             <dependency>
@@ -408,7 +408,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
-                <version>4.4</version>
+                <version>4.5.0</version>
             </dependency>
 
             <dependency>
@@ -438,7 +438,7 @@
             <dependency>
                 <groupId>it.unimi.dsi</groupId>
                 <artifactId>fastutil</artifactId>
-                <version>8.5.15</version>
+                <version>8.5.18</version>
             </dependency>
 
             <dependency>

--- a/exist-start/src/main/java/org/exist/start/Main.java
+++ b/exist-start/src/main/java/org/exist/start/Main.java
@@ -77,13 +77,13 @@ public class Main {
     public static final String PROP_EXIST_HOME = "exist.home";
     public static final String PROP_JETTY_HOME = "jetty.home";
     private static final String PROP_LOG4J_CONFIGURATION_FILE = "log4j.configurationFile";
+    private static final String PROP_LOG4J_DISABLEJMX = "log4j2.disableJmx";
     private static final String PROP_JUL_MANAGER = "java.util.logging.manager";
     private static final String PROP_JAVA_TEMP_DIR = "java.io.tmpdir";
 
     public static final String ENV_EXIST_JETTY_CONFIG = "EXIST_JETTY_CONFIG";
     public static final String ENV_EXIST_HOME = "EXIST_HOME";
     public static final String ENV_JETTY_HOME = "JETTY_HOME";
-
 
     private static Main exist;
 
@@ -170,6 +170,9 @@ public class Main {
 
         // Check if the OpenJDK version can corrupt eXist-db
         CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+        // Enable JMX support log4j since v2.24.0 [2024]
+        System.setProperty(PROP_LOG4J_DISABLEJMX, "false");
 
         final String _classname;
         if (args.length > 0) {

--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>java3d</groupId>
             <artifactId>vecmath</artifactId>
-            <version>1.3.1</version>
+            <version>1.5.2</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -190,8 +190,8 @@
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.geotools:gt2-epsg-wkt:jar:${geotools.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.hsqldb:hsqldb:jar</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>java3d:vecmath:jar:1.3.1</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>javax.media:jai_core:jar:1.1.3</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>java3d:vecmath:jar</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>javax.media:jai_core:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.junit.vintage:junit-vintage-engine:jar</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.jdom:jdom:jar:${jdom1.version}</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/modules/mail/pom.xml
+++ b/extensions/modules/mail/pom.xml
@@ -46,9 +46,9 @@
   </scm>
 
     <properties>
-        <jakarta.activation.version>2.0.1</jakarta.activation.version>
-        <jakarta.mail.version>2.0.1</jakarta.mail.version>
-        <greenmail.version>2.0.0-alpha-3</greenmail.version>
+        <jakarta.activation.version>2.1.3</jakarta.activation.version>
+        <jakarta.mail.version>2.0.2</jakarta.mail.version>
+        <greenmail.version>2.1.8</greenmail.version>
     </properties>
 
     <dependencies>

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.github.h-thurow</groupId>
             <artifactId>simple-jndi</artifactId>
-            <version>0.23.0</version>
+            <version>0.25.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
     <ignoreVersions>
         <ignoreVersion type="regex">.*-SNAPSHOT</ignoreVersion>
-        <ignoreVersion type="regex">.*-M\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-M.*</ignoreVersion>
         <ignoreVersion type="regex">.*-(alpha|beta).*</ignoreVersion>
         <ignoreVersion type="regex">.*-RC.*</ignoreVersion>
     </ignoreVersions>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -1,0 +1,10 @@
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <ignoreVersion type="regex">.*-SNAPSHOT</ignoreVersion>
+        <ignoreVersion type="regex">.*-M\d+</ignoreVersion>
+        <ignoreVersion type="regex">.*-(alpha|beta).*</ignoreVersion>
+        <ignoreVersion type="regex">.*-RC.*</ignoreVersion>
+    </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
Updating 3rd party libs and build plugins.

For Log4j additional code was needed to re-enable jetty/jmx output. Synced from https://github.com/eXist-db/exist/commit/7b3770f951756bcf39fa142ba393fe0c0d47a073 