### PR TITLE
[fix] bump container OS to debian 13

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -41,7 +41,7 @@ jobs:
         # Hack around #5450
       - name: pull base image
         run: |
-          docker pull --platform linux/amd64 --platform linux/arm64 gcr.io/distroless/java21-debian12:latest
+          docker pull --platform linux/amd64 --platform linux/arm64 gcr.io/distroless/java21-debian13:latest
       - name: Build images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-FROM gcr.io/distroless/java21-debian12:latest
+FROM gcr.io/distroless/java21-debian13:latest
 
 # Copy eXist-db
 COPY LICENSE /exist/LICENSE


### PR DESCRIPTION
Debian 12 will be dropped in June or so. No reason not to jump to the new hotness.

Distroless will drop deb 12 sooner, see [support policy](https://github.com/GoogleContainerTools/distroless/blob/main/SUPPORT_POLICY.md)
