### PR TITLE
refactor CI caches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+* text=auto eol=lf
+
+# Windows batch scripts: keep CRLF on checkout so they run on Windows
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files: do not normalize or diff
+*.jar binary
+*.zip binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.gif binary
+*.exe binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.hprof binary
+*.zst binary

--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -1,0 +1,14 @@
+# Shared Maven cache: restore only. Caller adds a separate Save step at end of job when appropriate (see plans/caching.md).
+name: Maven cache
+description: Restore Maven repository cache (one cache per branch, PRs read-only). Add actions/cache/save at end of job for the single job that should persist.
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore Maven cache
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.m2
+        key: maven-${{ github.event.pull_request.base.ref || github.ref_name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          maven-${{ github.event.pull_request.base.ref || github.ref_name }}-
+          maven-

--- a/.github/actions/maven-cache/action.yml
+++ b/.github/actions/maven-cache/action.yml
@@ -9,6 +9,7 @@ runs:
       with:
         path: ~/.m2
         key: maven-${{ github.event.pull_request.base.ref || github.ref_name }}-${{ hashFiles('**/pom.xml') }}
+        enableCrossOsArchive: true
         restore-keys: |
           maven-${{ github.event.pull_request.base.ref || github.ref_name }}-
           maven-

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -30,12 +30,7 @@ jobs:
         id: buildx
         with:
           install: true
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: deploy-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: deploy-${{ runner.os }}-maven
+      - uses: ./.github/actions/maven-cache
       - name: Install bats
         run: sudo apt-get install bats
         # Hack around #5450
@@ -57,6 +52,13 @@ jobs:
           sleep 35s
       - name: Run tests
         run: bats --tap exist-docker/src/test/bats/*.bats
+
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2
+          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}
 
       - name: debug logs
         if: failure()

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v3
         id: buildx
-        with:
-          install: true
       - uses: ./.github/actions/maven-cache
       - name: Install bats
         run: sudo apt-get install bats

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -53,13 +53,6 @@ jobs:
       - name: Run tests
         run: bats --tap exist-docker/src/test/bats/*.bats
 
-      - name: Save Maven cache
-        if: github.event_name == 'push'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.m2
-          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}
-
       - name: debug logs
         if: failure()
         run: docker logs exist-ci | grep 'ERROR'

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -42,11 +42,11 @@ jobs:
         timeout-minutes: 35
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -V -B -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package
+        run: mvn -V -B --no-transfer-progress -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package
       - name: Check local images
         run: docker image ls
       - name: Check license headers
-        run: mvn license:check
+        run: mvn --no-transfer-progress license:check
         working-directory: exist-docker
       - name: Start exist-ci container
         run: |
@@ -80,7 +80,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: mvn -q -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+        run: mvn --no-transfer-progress -q -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       - name: Publish release images
         if: github.ref == 'refs/heads/master'
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: mvn -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+        run: mvn --no-transfer-progress -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
       # - name: Publish experimental images

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Test and Publish Container Images
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # NOTE (DP): Publish on develop and master, test on PRs against these
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.base_ref ==  'develop' || github.base_ref ==  'master'
     steps:
@@ -38,6 +39,7 @@ jobs:
         run: |
           docker pull --platform linux/amd64 --platform linux/arm64 gcr.io/distroless/java21-debian13:latest
       - name: Build images
+        timeout-minutes: 35
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -V -B -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -V -B -q -DskipTests -Ddependency-check.skip=true \
+          mvn -V -B --no-transfer-progress -q -DskipTests -Ddependency-check.skip=true \
           -s $GITHUB_WORKSPACE/settings.xml \
           -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives \
           clean deploy

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -10,6 +10,7 @@ jobs:
   publish-snapshots:
     name: Deploy Snapshots
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v6
@@ -24,6 +25,7 @@ jobs:
           settings-path: ${{ github.workspace }}
       - uses: ./.github/actions/maven-cache
       - name: Deploy SNAPSHOT maven artefacts
+        timeout-minutes: 40
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -31,9 +31,3 @@ jobs:
           -s $GITHUB_WORKSPACE/settings.xml \
           -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives \
           clean deploy
-      - name: Save Maven cache
-        if: github.event_name == 'push'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.m2
-          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -22,12 +22,7 @@ jobs:
           java-version: '21'
           server-id: github
           settings-path: ${{ github.workspace }}
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: deploy-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: deploy-${{ runner.os }}-maven
+      - uses: ./.github/actions/maven-cache
       - name: Deploy SNAPSHOT maven artefacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,3 +31,9 @@ jobs:
           -s $GITHUB_WORKSPACE/settings.xml \
           -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives \
           clean deploy
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2
+          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,6 +9,7 @@ jobs:
   license:
     name: License check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -17,11 +18,12 @@ jobs:
           java-version: ${{ env.DEV_JDK }}
       - uses: ./.github/actions/maven-cache
       - run: mvn -V -B license:check
-        timeout-minutes: 60
+        timeout-minutes: 10
   dependencies:
     name: Dependency checks
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 95
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -41,7 +43,7 @@ jobs:
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn -V -B dependency-check:check
-        timeout-minutes: 60
+        timeout-minutes: 90
       - name: Save OWASP dependency-check cache
         if: github.event_name == 'push'
         uses: actions/cache/save@v5
@@ -50,12 +52,13 @@ jobs:
           key: owasp-dc-${{ env.WEEK }}
   test:
     name: ${{ matrix.os }} Test
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         jvm: ['21']
-    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           path: ~/.m2
           key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}
+          enableCrossOsArchive: true
       - name: Archive build logs
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: liberica
           java-version: ${{ env.DEV_JDK }}
       - uses: ./.github/actions/maven-cache
-      - run: mvn -V -B license:check
+      - run: mvn -V -B --no-transfer-progress license:check
         timeout-minutes: 10
   dependencies:
     name: Dependency checks
@@ -42,7 +42,7 @@ jobs:
       - name: OWASP dependency check
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: mvn -V -B dependency-check:check
+        run: mvn -V -B --no-transfer-progress dependency-check:check
         timeout-minutes: 90
       - name: Save OWASP dependency-check cache
         if: github.event_name == 'push'
@@ -78,13 +78,13 @@ jobs:
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
       - name: Javadoc (Linux only)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
       - name: Maven Code Coverage (Develop branch on Linux only)
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest' }}
         env:
@@ -93,7 +93,7 @@ jobs:
           CI_BUILD_NUMBER: ${{ github.run_id }}
           CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B jacoco:report coveralls:report
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress jacoco:report coveralls:report
       - name: Save Maven cache
         if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
         uses: actions/cache/save@v5

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           distribution: liberica
           java-version: ${{ env.DEV_JDK }}
-          cache: 'maven'
+      - uses: ./.github/actions/maven-cache
       - run: mvn -V -B license:check
         timeout-minutes: 60
   dependencies:
@@ -28,12 +28,26 @@ jobs:
         with:
           distribution: liberica
           java-version: ${{ env.DEV_JDK }}
-          cache: 'maven'
+      - uses: ./.github/actions/maven-cache
+      - name: Set week for OWASP cache key
+        run: echo "WEEK=$(date +%Y-%U)" >> $GITHUB_ENV
+      - name: Restore OWASP dependency-check cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.dependency-check-data
+          key: owasp-dc-${{ env.WEEK }}
+          restore-keys: owasp-dc-
       - name: OWASP dependency check
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn -V -B dependency-check:check
         timeout-minutes: 60
+      - name: Save OWASP dependency-check cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.dependency-check-data
+          key: owasp-dc-${{ env.WEEK }}
   test:
     name: ${{ matrix.os }} Test
     strategy:
@@ -49,7 +63,7 @@ jobs:
         with:
           distribution: liberica
           java-version: ${{ matrix.jvm }}
-          cache: 'maven'
+      - uses: ./.github/actions/maven-cache
       - name: Install Maven Daemon
         id: install-mvnd
         uses: ./.github/actions/install-mvnd
@@ -77,6 +91,12 @@ jobs:
           CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B jacoco:report coveralls:report
+      - name: Save Maven cache
+        if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2
+          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}
       - name: Archive build logs
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -60,9 +60,3 @@ jobs:
         run: java -jar ~/.m2/repository/net/sf/saxon/Saxon-HE/9.9.1-8/Saxon-HE-9.9.1-8.jar -xsl:exist-xqts/src/main/xslt/compare-results.xslt -it:compare-results -o:/tmp/comparison-results.xml xqts.previous.junit-data-path=/tmp/previous-xqts-output/junit/data xqts.current.junit-data-path=/tmp/xqts-output/junit/data
       - name: Show Comparison Results
         run: cat /tmp/comparison-results.xml
-      - name: Save Maven cache
-        if: github.event_name == 'push'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.m2
-          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -20,7 +20,7 @@ jobs:
         timeout-minutes: 25
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -V -B clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
+        run: mvn -V -B --no-transfer-progress clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
       - name: Run XQTS
         timeout-minutes: 60
         env:

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -14,12 +14,7 @@ jobs:
         with:
           distribution: liberica
           java-version: '21'
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: xqts-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: xqts-${{ runner.os }}-maven
+      - uses: ./.github/actions/maven-cache
       - name: Maven XQTS Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,3 +60,9 @@ jobs:
         run: java -jar ~/.m2/repository/net/sf/saxon/Saxon-HE/9.9.1-8/Saxon-HE-9.9.1-8.jar -xsl:exist-xqts/src/main/xslt/compare-results.xslt -it:compare-results -o:/tmp/comparison-results.xml xqts.previous.junit-data-path=/tmp/previous-xqts-output/junit/data xqts.current.junit-data-path=/tmp/xqts-output/junit/data
       - name: Show Comparison Results
         run: cat /tmp/comparison-results.xml
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2
+          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -7,6 +7,7 @@ jobs:
   xqts:
     name: W3C XQuery Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 21
@@ -16,6 +17,7 @@ jobs:
           java-version: '21'
       - uses: ./.github/actions/maven-cache
       - name: Maven XQTS Build
+        timeout-minutes: 25
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -V -B clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:
@@ -25,6 +26,7 @@ jobs:
           restore-keys: sonarcloud-${{ runner.os }}-cache
       - uses: ./.github/actions/maven-cache
       - name: Analyze
+        timeout-minutes: 55
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -V -B -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -V -B --no-transfer-progress -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,9 +29,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -V -B -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-      - name: Save Maven cache
-        if: github.event_name == 'push'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.m2
-          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,14 +23,15 @@ jobs:
           path: ~/.sonar/cache
           key: sonarcloud-${{ runner.os }}-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: sonarcloud-${{ runner.os }}-cache
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: sonarcloud-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: sonarcloud-${{ runner.os }}-maven
+      - uses: ./.github/actions/maven-cache
       - name: Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -V -B -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      - name: Save Maven cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.m2
+          key: maven-${{ github.ref_name }}-${{ hashFiles('**/pom.xml') }}

--- a/exist-docker/src/main/resources-filtered/README.md
+++ b/exist-docker/src/main/resources-filtered/README.md
@@ -16,7 +16,7 @@ The images are based on Google Cloud Platform's ["Distroless" Docker Images](htt
 ## Requirements
 *   [Docker](https://www.docker.com): `18-stable`
 ### For building
-*   [maven](https://maven.apache.org/): `^3.6.0`
+*   [maven](https://maven.apache.org/): `^3.9.x`
 *   [java](https://www.java.com/): `21`
 *   [bats](https://github.com/bats-core/bats-core): `^1.1.0` (for testing)
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -621,6 +621,7 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>12.2.0</version>
                     <configuration>
+                        <dataDirectory>${user.home}/.dependency-check-data</dataDirectory>
                         <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
                         <!-- The OSS Index Server (https://ossindex.sonatype.org) can sometimes be flaky -->
                         <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>


### PR DESCRIPTION
- switch to composite action for cache reuse and only save from linux builds.
- caches keys include branch reference so dependabot gets something.
- address the source of cache bloat on win
- minor fixes to docker workflow
- reduce log noise
- move owasp database into .m2

note: I want to see the PR run here first. The full monty will only be visible after multiple runs of CI on `develop`. Once this is ready and merged, I will monitor `develop` to see if urgent fixes will need to be pushed there.

close #4861
