### PR TITLE
[fix] edge-case in parse-xml-fragment, parse-xml

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
@@ -77,9 +77,6 @@ public class ParsingFunctions extends BasicFunction {
 			return Sequence.EMPTY_SEQUENCE;
 		}
 		final String xmlString = args[0].itemAt(0).getStringValue();
-		if (xmlString.isEmpty()) {
-			return Sequence.EMPTY_SEQUENCE;
-		}
 
         if (isCalledAs("parse-xml-fragment")) {
             return parseFragment(xmlString);

--- a/exist-core/src/test/xquery/xquery3/parse-xml.xqm
+++ b/exist-core/src/test/xquery/xquery3/parse-xml.xqm
@@ -21,21 +21,21 @@
  :)
 xquery version "3.1";
 
-module namespace pxf="http://exist-db.org/xquery/test/parse-xml-fragment";
+module namespace px="http://exist-db.org/xquery/test/parse-xml";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare
-    %test:args("") %test:assertTrue
-    %test:args(" ") %test:assertTrue
-    %test:args("He was <i>so</i> kind") %test:assertTrue
-    %test:args("<a>a</a><b>b</b>") %test:assertTrue
+    %test:args("") %test:assertFalse
+    %test:args(" ") %test:assertFalse
+    %test:args("He was <i>so</i> kind") %test:assertFalse
+    %test:args("<a>a</a><b>b</b>") %test:assertFalse
     %test:args('<a>no') %test:assertFalse
     %test:args('<?xml version="1.0" encoding="utf8"?><a/>') %test:assertTrue
-    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>') %test:assertFalse
-function pxf:return-type($in as xs:string) as xs:boolean {
+    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>') %test:assertTrue
+function px:return-type($in as xs:string) as xs:boolean {
     try {
-        fn:parse-xml-fragment($in) instance of document-node()
+        fn:parse-xml($in) instance of document-node()
     } catch err:FODC0006 {
         false()
     }
@@ -43,21 +43,21 @@ function pxf:return-type($in as xs:string) as xs:boolean {
 
 declare
     %test:assertTrue
-function pxf:empty-returns-empty() as xs:boolean {
-    fn:parse-xml-fragment(()) instance of empty-sequence()
+function px:empty-returns-empty() as xs:boolean {
+    fn:parse-xml(()) instance of empty-sequence()
 };
 
 declare
     %test:args("") %test:assertEquals(0)
-    %test:args(" ") %test:assertEquals(1)
-    %test:args("He was <i>so</i> kind") %test:assertEquals(3)
-    %test:args("<a>a</a><b>b</b>") %test:assertEquals(2)
+    %test:args(" ") %test:assertEquals(0)
+    %test:args("He was <i>so</i> kind") %test:assertEquals(0)
+    %test:args("<a>a</a><b>b</b>") %test:assertEquals(0)
     %test:args('<a>no') %test:assertEquals(0)
     %test:args('<?xml version="1.0" encoding="utf8"?><a/>') %test:assertEquals(1)
-    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>') %test:assertEquals(0)
-function pxf:node-count($in as xs:string) as xs:integer {
+    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>') %test:assertEquals(1)
+function px:node-count($in as xs:string) as xs:integer {
     try {
-        count(fn:parse-xml-fragment($in)/node())
+        count(fn:parse-xml($in)/node())
     } catch err:FODC0006 {
         0
     }
@@ -68,11 +68,11 @@ declare
     %test:assertEquals("VALID", 0, 0)
     %test:args('<a>no')
     %test:assertEquals("err:FODC0006", 75, 9)
-    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>')
-    %test:assertEquals("err:FODC0006", 75, 9)
-function pxf:error-code-and-location($in as xs:string) as xs:anyAtomicType* {
+    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a>VALID</a>')
+    %test:assertEquals("VALID", 0, 0)
+function px:error-code-and-location($in as xs:string) as xs:anyAtomicType* {
     try {
-        fn:parse-xml-fragment($in)/string(), 0, 0
+        fn:parse-xml($in)/string(), 0, 0
     } catch err:FODC0006 {
         $err:code, $err:line-number, $err:column-number
     }
@@ -82,12 +82,12 @@ declare
     %test:args('<text>Valid document</text>')
     %test:assertEquals("Valid document")
     %test:args('<a>no')
-    %test:assertEquals("String passed to fn:parse-xml is not a well-formed XML document. parse-xml-fragment failed with: The element type ""a"" must be terminated by the matching end-tag ""&lt;/a&gt;"".")
-    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a/>')
-    %test:assertEquals("String passed to fn:parse-xml is not a well-formed XML document. parse-xml-fragment failed with: Pseudo attribute ""standalone"" not allowed in input fragment")
-function pxf:error-description($in as xs:string) as xs:string {
+    %test:assertEquals("String passed to fn:parse-xml is not a well-formed XML document. parse-xml failed with: XML document structures must start and end within the same entity.")
+    %test:args('<?xml version="1.0" encoding="utf8" standalone="yes"?><a>Valid document</a>')
+    %test:assertEquals("Valid document")
+function px:error-description($in as xs:string) as xs:string {
     try {
-        fn:parse-xml-fragment($in)/string()
+        fn:parse-xml($in)/string()
     } catch err:FODC0006 {
         $err:description
     }

--- a/exist-core/src/test/xquery/xquery3/transform/fnTransform71.xqm
+++ b/exist-core/src/test/xquery/xquery3/transform/fnTransform71.xqm
@@ -26,33 +26,34 @@ module namespace testTransform="http://exist-db.org/xquery/test/function_transfo
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare variable $testTransform:transform-71-xsl := document {
-<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
-            xmlns:xs='http://www.w3.org/2001/XMLSchema'
-            xmlns:chrono='http://chronology.com/' version='2.0'>
-            <xsl:import-schema>
-              <xs:schema targetNamespace='http://chronology.com/'>
-                <xs:simpleType name='c4'>
-                  <xs:restriction base='xs:string'>
-                    <xs:pattern value='....'/>
-                  </xs:restriction>
-                </xs:simpleType>
-              </xs:schema>
-            </xsl:import-schema>
-            <xsl:template name='main'>
-              <out><xsl:value-of select="chrono:c4('abcd')"/></out>
-            </xsl:template>
-        </xsl:stylesheet> };
+  <xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+        xmlns:xs='http://www.w3.org/2001/XMLSchema'
+        xmlns:chrono='http://chronology.com/' version='2.0'>
+    <xsl:import-schema>
+      <xs:schema targetNamespace='http://chronology.com/'>
+        <xs:simpleType name='c4'>
+          <xs:restriction base='xs:string'>
+            <xs:pattern value='....'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:schema>
+    </xsl:import-schema>
+    <xsl:template name='main'>
+      <out><xsl:value-of select="chrono:c4('abcd')"/></out>
+    </xsl:template>
+  </xsl:stylesheet>
+};
 
 declare
     %test:assertError("XTSE1650")
 function testTransform:transform-71() {
-    let $xsl := $testTransform:transform-71-xsl
-    let $result := fn:transform(map{
-    "stylesheet-node":$xsl,
-                "source-node": parse-xml($xsl),
-                "initial-template": fn:QName('','main'),
-                    "delivery-format" : "serialized",
-                    "requested-properties" : map{fn:QName('http://www.w3.org/1999/XSL/Transform','is-schema-aware'):false()}
-                    })
-    return $result("output")
+    let $result := transform(map{
+        "stylesheet-node": $testTransform:transform-71-xsl,
+        "initial-template": QName('','main'),
+        "delivery-format" : "serialized",
+        "requested-properties" : map{
+          QName('http://www.w3.org/1999/XSL/Transform','is-schema-aware'): false()
+        }
+    })
+    return $result?output
 };


### PR DESCRIPTION
Previously an empty string passed to any of the above functions returned an empty sequence. This is not spec compliant.

- Return an empty document node when an empty string is passed to `parse-xml-fragment`
- Raise Error FODC0006 when an empty string is passed to `parse-xml`.

XQSuite tests were added and adapted to ensure spec compliance in the future.
