### PR TITLE
[fix] FLWOR order by: downstream clauses now see tuples in sorted order (Issue #5089)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -31,7 +31,6 @@ import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -92,41 +91,9 @@ public class CountClause extends AbstractFLWORClause {
 
     @Override
     public Sequence preEval(final Sequence seq) throws XPathException {
-        // determine whether to count down or up
-        this.step = hasPreviousOrderByDescending() ? -1 : 1;
-
-        // get the count start position
-        if (this.step == 1) {
-            this.count = 0;
-        } else {
-            this.count = seq.getItemCountLong() + 1;
-        }
-
+        this.step = 1;
+        this.count = 0;
         return super.preEval(seq);
-    }
-
-    private boolean hasPreviousOrderByDescending() {
-        FLWORClause prev = getPreviousClause();
-        while (prev != null) {
-            switch (prev.getType()) {
-                case LET, GROUPBY, FOR -> {
-                    return false;
-                }
-                case ORDERBY -> {
-                    return isDescending(((OrderByClause) prev).getOrderSpecs());
-                }
-                default -> prev = prev.getPreviousClause();
-            }
-        }
-        return true;
-    }
-    private boolean isDescending(final List<OrderSpec> orderSpecs) {
-        for (final OrderSpec orderSpec : orderSpecs) {
-            if ((orderSpec.getModifiers() & OrderSpec.DESCENDING_ORDER) == OrderSpec.DESCENDING_ORDER) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
@@ -41,7 +41,10 @@ import java.util.stream.IntStream;
 public class OrderByClause extends AbstractFLWORClause {
 
     // Package-private instrumentation fields for memory benchmarking.
-    // Set in postEval() before sorting; zero-cost when not read.
+    // volatile is required: postEval() writes these in a query-executor worker thread,
+    // while OrderByClauseMemoryBenchmark reads them in the JUnit test thread immediately
+    // after executeQuery() returns. Without volatile there is no happens-before guarantee
+    // for the static field reads even though executeQuery() blocks until completion.
     static volatile int lastTupleCount;
     static volatile int lastVarCount;
 
@@ -55,7 +58,8 @@ public class OrderByClause extends AbstractFLWORClause {
     private FLWORClause rootClause = null;
 
     /*  OrderByClause needs to keep state between calls to eval and postEval. We thus need
-        to track state in a stack to avoid overwrites if we're called recursively. */
+        to track state in a stack to avoid overwrites if we're called recursively.
+        See {@link OrderByData} (inner class below) for what each frame holds. */
     private final Deque<OrderByData> stack = new ArrayDeque<>();
 
     public OrderByClause(final XQueryContext context, final List<OrderSpec> orderSpecs) {
@@ -258,7 +262,11 @@ public class OrderByClause extends AbstractFLWORClause {
             for (final OrderByTuple tuple : data.tuples) {
                 context.proceed(this);
 
-                // Restore variable bindings for this tuple (indexed parallel to variableNames)
+                // Restore variable bindings for this tuple (indexed parallel to variableNames).
+                // tuple.variableValues is always allocated as new Sequence[data.variableNames.length]
+                // (see eval()), so its length equals data.variableTemplates.length — no AOOB risk.
+                assert tuple.variableValues.length == data.variableTemplates.length
+                        : "variableValues length mismatch: " + tuple.variableValues.length + " vs " + data.variableTemplates.length;
                 for (int v = 0; v < data.variableTemplates.length; v++) {
                     data.variableTemplates[v].setValue(tuple.variableValues[v]);
                 }
@@ -288,6 +296,10 @@ public class OrderByClause extends AbstractFLWORClause {
      * </ul>
      */
     private void coerceSortKeys(final OrderByData data) throws XPathException {
+        // data.encounteredPrimitiveTypes is initialised with exactly orderSpecs.size() entries
+        // in OrderByData(numOrderSpecs), so get(t) is always in-bounds — no AOOB risk.
+        assert data.encounteredPrimitiveTypes.size() == orderSpecs.size()
+                : "encounteredPrimitiveTypes size mismatch: " + data.encounteredPrimitiveTypes.size() + " vs " + orderSpecs.size();
         for (int t = 0; t < orderSpecs.size(); t++) {
             final BitSet encounteredTypes = data.encounteredPrimitiveTypes.get(t);
             final int typeCardinality = encounteredTypes.cardinality();

--- a/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
@@ -23,22 +23,35 @@ package org.exist.xquery;
 
 import org.exist.dom.QName;
 import org.exist.xquery.util.ExpressionDumper;
-import org.exist.xquery.value.Item;
-import org.exist.xquery.value.OrderedValueSequence;
-import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Represents an "order by" clause within a FLWOR expression.
+ *
+ * <p>The W3C XQuery 3.1 specification requires that after an order by clause, all subsequent
+ * clauses in the FLWOR expression see tuples in the sorted order. This implementation achieves
+ * that by collecting the full variable state for each tuple during {@link #eval}, sorting the
+ * collected tuples in {@link #postEval}, and then replaying each sorted tuple through the
+ * downstream clause chain — mirroring the pattern used by {@link GroupByClause}.</p>
  */
 public class OrderByClause extends AbstractFLWORClause {
 
     private final List<OrderSpec> orderSpecs;
 
+    /**
+     * The outermost clause in the preceding FLWOR clause chain (e.g. the {@code ForExpr}).
+     * Used in {@link #eval} to locate the first runtime variable of the tuple stream, exactly
+     * as {@link GroupByClause} does via its own {@code rootClause} field.
+     */
+    private FLWORClause rootClause = null;
+
     /*  OrderByClause needs to keep state between calls to eval and postEval. We thus need
         to track state in a stack to avoid overwrites if we're called recursively. */
-    private final Deque<OrderedValueSequence> stack = new ArrayDeque<>();
+    private final Deque<OrderByData> stack = new ArrayDeque<>();
 
     public OrderByClause(final XQueryContext context, final List<OrderSpec> orderSpecs) {
         super(context);
@@ -58,10 +71,20 @@ public class OrderByClause extends AbstractFLWORClause {
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
         contextInfo.setParent(this);
         unordered = (contextInfo.getFlags() & UNORDERED) > 0;
+
+        // Walk the previousClause chain to find the outermost (root) clause, mirroring the
+        // pattern used by GroupByClause.analyze().  rootClause.getStartVariable() gives us the
+        // first runtime variable of the tuple stream during eval().
+        FLWORClause prevClause = getPreviousClause();
+        while (prevClause != null) {
+            rootClause = prevClause;
+            prevClause = prevClause.getPreviousClause();
+        }
+
         final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
         newContextInfo.addFlag(SINGLE_STEP_EXECUTION);
         if (orderSpecs != null) {
-            for (OrderSpec spec: orderSpecs) {
+            for (OrderSpec spec : orderSpecs) {
                 spec.analyze(newContextInfo);
             }
         }
@@ -69,42 +92,280 @@ public class OrderByClause extends AbstractFLWORClause {
     }
 
     @Override
-    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
-        OrderedValueSequence orderedResult = stack.pollFirst();
-
-        final Sequence result = getReturnExpression().eval(contextSequence, contextItem);
-
-        if (orderedResult == null) {
-            orderedResult = new OrderedValueSequence(orderSpecs, result != null ? result.getItemCount() : 100);
-        }
-
-        if (result != null) {
-            orderedResult.setContextSequence(contextSequence);
-            orderedResult.addAll(result);
-            orderedResult.setContextSequence(null);
-        }
-
-        stack.addFirst(orderedResult);
-
-        return result;
+    public Sequence preEval(final Sequence seq) throws XPathException {
+        final OrderByData data = new OrderByData(orderSpecs.size());
+        // Snapshot lastVar at preEval time.  data.mark is used in eval() as a reference
+        // to rootClause.getStartVariable() (which equals or precedes data.mark in the chain).
+        // Its .before link gives us the pre-FLWOR anchor X so that, when GroupByClause
+        // replaces the tuple variables (GroupBy+OrderBy), we can recover the first active
+        // variable via startVar.before.after (see eval()).
+        data.mark = context.markLocalVariables(false);
+        stack.push(data);
+        return super.preEval(seq);  // chains to returnExpr.preEval()
     }
 
+    /**
+     * Captures the current tuple state (all in-scope variable bindings and evaluated sort
+     * keys) without evaluating the downstream clause chain. The actual downstream evaluation
+     * happens in {@link #postEval} after all tuples have been sorted.
+     *
+     * @return always {@link Sequence#EMPTY_SEQUENCE}; downstream clauses are not called here.
+     */
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        // The stack may be empty when an inner OrderByClause is used inside an outer
+        // OrderByClause's replay loop (e.g. "for $a order by $a for $b order by $b return …").
+        // preEval() is called once (from the outermost for's preEval chain), but postEval()
+        // is called once per outer sorted tuple by ForExpr[$b].callPostEval().  After the first
+        // postEval() pops the frame, subsequent outer iterations arrive here with an empty stack.
+        // Push a fresh frame so each outer-loop iteration gets its own collection context.
+        if (stack.isEmpty()) {
+            stack.push(new OrderByData(orderSpecs.size()));
+        }
+        final OrderByData data = stack.peek();
+
+        // Capture variable state for this tuple.
+        //
+        // Use rootClause.getStartVariable() (= the first runtime variable, e.g. $x from ForExpr)
+        // as the anchor for the forward walk, the same strategy GroupByClause uses.  This is
+        // needed because ForExpr.createVariable() sets firstVariable to $x but may additionally
+        // declare a positional variable ($pos) AFTER $x before calling preEval(), which would
+        // make data.mark = $pos and cause $x to be missed by a walk starting there.
+        //
+        // Two distinct situations arise at eval() time:
+        //
+        //   (a) Simple for+orderby — rootClause.getStartVariable() ($x_runtime) is still in the
+        //       active variable chain.  We walk forward from $x_runtime; inner for/let/count
+        //       variables appear as $x_runtime.after and are captured automatically.
+        //
+        //   (b) GroupBy+OrderBy — ForExpr has already finished and popped $x_runtime from the
+        //       chain.  GroupByClause.postEval() declared its own template variables ($x_GB,
+        //       $key_GB, …) immediately after the same pre-FLWOR anchor X.  Therefore
+        //       $x_runtime.before.after == $x_GB (not $x_runtime), so we walk from $x_GB.
+        final LocalVariable startVar = (rootClause != null) ? rootClause.getStartVariable() : data.mark;
+        final LocalVariable walkStart;
+        if (startVar != null && startVar.before != null && startVar.before.after != startVar) {
+            // startVar is no longer in the active chain (GroupBy replaced the tuple variables).
+            // Walk from the first variable declared after the pre-FLWOR boundary.
+            walkStart = startVar.before.after;
+        } else if (startVar != null && startVar.before == null) {
+            // startVar was declared when lastVar was null (top-level FLWOR), so its .before is
+            // null.  In the normal case startVar is still the first active variable; but in a
+            // double-OrderBy FLWOR the inner OBC.eval() is called from the outer OBC.postEval()
+            // replay, where startVar is the stale original ForExpr variable (no longer in the
+            // active chain) while the actual first active variable is the outer OBC's template.
+            // Using the context's live first variable handles both cases correctly.
+            final LocalVariable ctxFirst = context.getFirstLocalVariable();
+            walkStart = (ctxFirst != null) ? ctxFirst : startVar;
+        } else {
+            walkStart = startVar;
+        }
+
+        final Map<QName, Sequence> varValues = new LinkedHashMap<>();
+        LocalVariable nextVar = walkStart;
+        while (nextVar != null) {
+            varValues.put(nextVar.getQName(), nextVar.getValue());
+            if (!data.initialized) {
+                // First call: create template LocalVariables for reuse in postEval()
+                final LocalVariable templateVar = new LocalVariable(nextVar.getQName());
+                templateVar.setSequenceType(nextVar.getSequenceType());
+                templateVar.setStaticType(nextVar.getStaticType());
+                templateVar.setContextDocs(nextVar.getContextDocs());
+                data.variableTemplates.put(nextVar.getQName(), templateVar);
+            }
+            nextVar = nextVar.after;
+        }
+        data.initialized = true;
+
+        // Evaluate sort keys for this tuple
+        final List<AtomicValue> sortKeys = new ArrayList<>(orderSpecs.size());
+        for (int i = 0; i < orderSpecs.size(); i++) {
+            final OrderSpec spec = orderSpecs.get(i);
+            final Sequence keySeq = spec.getSortExpression().eval(contextSequence, null);
+            final AtomicValue value;
+            if (keySeq.hasOne()) {
+                AtomicValue atomized = keySeq.itemAt(0).atomize();
+                // Cast xs:untypedAtomic to xs:string per W3C XQuery 3.1 §3.9.4
+                if (Type.UNTYPED_ATOMIC == atomized.getType()) {
+                    atomized = atomized.convertTo(Type.STRING);
+                }
+                data.encounteredPrimitiveTypes.get(i).set(Type.primitiveTypeOf(atomized.getType()));
+                value = atomized;
+            } else if (keySeq.hasMany()) {
+                throw new XPathException(this, ErrorCodes.XPTY0004,
+                        "Order by expression evaluates to more than one item: " +
+                        ExpressionDumper.dump(spec.getSortExpression()));
+            } else {
+                value = AtomicValue.EMPTY_VALUE;
+            }
+            sortKeys.add(value);
+        }
+
+        data.tuples.add(new OrderByTuple(varValues, sortKeys, data.tuples.size()));
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    /**
+     * Sorts the collected tuples and replays each one through the downstream clause chain
+     * (e.g. {@code count}, {@code where}, {@code let}, the {@code return} expression).
+     * This ensures all downstream clauses see tuples in the order specified by the order
+     * by clause, as required by W3C XQuery 3.1 §3.9.4.
+     */
     @Override
     public Sequence postEval(final Sequence seq) throws XPathException {
-        final OrderedValueSequence orderedResult = stack.pollFirst();
-        if (orderedResult == null) {
+        // Use a safe pop: the stack may already be empty when this postEval() is called as
+        // part of the final cleanup chain (e.g. BindingExpression.postEval() chains through
+        // ForExpr → OrderByClause after all per-iteration postEval() calls have already
+        // consumed their frames).
+        final OrderByData data = stack.isEmpty() ? null : stack.pop();
+        if (data == null || data.tuples.isEmpty()) {
             return seq;
         }
 
-        orderedResult.coerceTypesForOrderBy();
-        orderedResult.sort();
+        // Apply W3C type coercion rules before sorting
+        coerceSortKeys(data);
 
-        Sequence result = orderedResult;
+        // Sort tuples by their sort keys (stable: ties preserve insertion order)
+        data.tuples.sort((a, b) -> compareTuples(a, b, orderSpecs));
 
-        if (getReturnExpression() instanceof FLWORClause flworClause) {
+        Sequence result = new ValueSequence();
+        final LocalVariable mark = context.markLocalVariables(false);
+        try {
+            // Declare all variable templates in context (same pattern as GroupByClause.postEval())
+            for (final LocalVariable var : data.variableTemplates.values()) {
+                context.declareVariableBinding(var);
+            }
+
+            // Replay each sorted tuple through the downstream clause chain
+            for (final OrderByTuple tuple : data.tuples) {
+                context.proceed(this);
+
+                // Restore variable bindings for this tuple
+                for (final Map.Entry<QName, Sequence> entry : tuple.variableValues.entrySet()) {
+                    final LocalVariable var = data.variableTemplates.get(entry.getKey());
+                    if (var != null) {
+                        var.setValue(entry.getValue());
+                    }
+                }
+
+                // Evaluate downstream clauses (CountClause, WhereClause, LetExpr, return expr)
+                // in sorted order — this is where correct post-sort counting and filtering happen.
+                result.addAll(returnExpr.eval(null, null));
+            }
+        } finally {
+            context.popLocalVariables(mark, result);
+        }
+
+        // Chain downstream postEval for cleanup (resets firstVariable, etc.)
+        if (returnExpr instanceof FLWORClause flworClause) {
             result = flworClause.postEval(result);
         }
         return super.postEval(result);
+    }
+
+    /**
+     * Applies the W3C XQuery 3.1 type coercion rules for order by sort keys:
+     * <ul>
+     *   <li>xs:string and xs:anyURI mixed → cast all to xs:string</li>
+     *   <li>xs:decimal and xs:float mixed → cast all to xs:float</li>
+     *   <li>xs:decimal, xs:float, and/or xs:double mixed → cast all to xs:double</li>
+     *   <li>Any other mix → XPTY0004 error</li>
+     * </ul>
+     */
+    private void coerceSortKeys(final OrderByData data) throws XPathException {
+        for (int t = 0; t < orderSpecs.size(); t++) {
+            final BitSet encounteredTypes = data.encounteredPrimitiveTypes.get(t);
+            final int typeCardinality = encounteredTypes.cardinality();
+            if (typeCardinality <= 1) {
+                continue;
+            }
+
+            final int coerceToType;
+            if (typeCardinality == 2 && countSetBits(encounteredTypes, Type.STRING, Type.ANY_URI) == 2) {
+                coerceToType = Type.STRING;
+            } else if (typeCardinality == 2 && countSetBits(encounteredTypes, Type.DECIMAL, Type.FLOAT) == 2) {
+                coerceToType = Type.FLOAT;
+            } else if (typeCardinality <= 3 && countSetBits(encounteredTypes, Type.DECIMAL, Type.FLOAT, Type.DOUBLE) >= 2) {
+                coerceToType = Type.DOUBLE;
+            } else {
+                final StringBuilder message = new StringBuilder(
+                        "Order by contains a mix of primitive types which cannot be compared for sorting: [");
+                try (final IntStream stream = encounteredTypes.stream()) {
+                    message.append(stream.mapToObj(Type::getTypeName).collect(Collectors.joining(", ")));
+                }
+                message.append(']');
+                throw new XPathException(this, ErrorCodes.XPTY0004, message.toString());
+            }
+
+            final int slotIndex = t;
+            for (final OrderByTuple tuple : data.tuples) {
+                final AtomicValue value = tuple.sortKeys.get(slotIndex);
+                if (!value.isEmpty()) {
+                    tuple.sortKeys.set(slotIndex, value.convertTo(coerceToType));
+                }
+            }
+        }
+    }
+
+    private static int countSetBits(final BitSet bitSet, final int... bitIndexes) {
+        int count = 0;
+        for (final int index : bitIndexes) {
+            if (bitSet.get(index)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Compares two tuples by their sort keys, implementing the W3C XQuery 3.1 order by
+     * comparison semantics (empty-value / NaN handling, collator, descending modifier).
+     * Falls back to original insertion order for a stable sort when all keys are equal.
+     */
+    private static int compareTuples(final OrderByTuple a, final OrderByTuple b,
+                                     final List<OrderSpec> orderSpecs) {
+        int cmp = Constants.EQUAL;
+        for (int i = 0; i < a.sortKeys.size(); i++) {
+            final AtomicValue keyA = a.sortKeys.get(i);
+            final AtomicValue keyB = b.sortKeys.get(i);
+            final OrderSpec spec = orderSpecs.get(i);
+
+            try {
+                final boolean aIsEmpty = keyA.isEmpty()
+                        || (Type.subTypeOfUnion(keyA.getType(), Type.NUMERIC)
+                            && ((NumericValue) keyA).isNaN());
+                final boolean bIsEmpty = keyB.isEmpty()
+                        || (Type.subTypeOfUnion(keyB.getType(), Type.NUMERIC)
+                            && ((NumericValue) keyB).isNaN());
+
+                if (aIsEmpty && bIsEmpty) {
+                    cmp = Constants.EQUAL;
+                } else if (aIsEmpty) {
+                    cmp = (spec.getModifiers() & OrderSpec.EMPTY_LEAST) != 0
+                            ? Constants.INFERIOR : Constants.SUPERIOR;
+                } else if (bIsEmpty) {
+                    cmp = (spec.getModifiers() & OrderSpec.EMPTY_LEAST) != 0
+                            ? Constants.SUPERIOR : Constants.INFERIOR;
+                } else {
+                    cmp = keyA.compareTo(spec.getCollator(), keyB);
+                }
+            } catch (final XPathException e) {
+                // fall through with cmp unchanged
+            }
+
+            if ((spec.getModifiers() & OrderSpec.DESCENDING_ORDER) != 0) {
+                cmp = -cmp;
+            }
+            if (cmp != Constants.EQUAL) {
+                break;
+            }
+        }
+
+        // Stable sort: preserve original insertion order when all keys are equal
+        if (cmp == Constants.EQUAL) {
+            cmp = Integer.compare(a.originalPos, b.originalPos);
+        }
+        return cmp;
     }
 
     @Override
@@ -154,5 +415,51 @@ public class OrderByClause extends AbstractFLWORClause {
         }
 
         return vars;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal state classes
+    // -------------------------------------------------------------------------
+
+    /** Per-invocation state collected during {@link #eval} and consumed in {@link #postEval}. */
+    private static class OrderByData {
+        final List<OrderByTuple> tuples = new ArrayList<>();
+        /** One BitSet per OrderSpec slot, tracking which primitive types appear in sort keys. */
+        final List<BitSet> encounteredPrimitiveTypes;
+        /** Template LocalVariables declared in postEval(); keys = variable QNames. */
+        final Map<QName, LocalVariable> variableTemplates = new LinkedHashMap<>();
+        /**
+         * The {@code lastVar} snapshot taken in {@link #preEval} — the last variable
+         * in scope when preEval ran (equals {@code rootClause.getStartVariable()} in the
+         * simple case, or the positional variable {@code $pos} if one was declared after
+         * {@code $x}).  Its {@code .before} link points to the pre-FLWOR anchor X; this
+         * is used in {@link #eval} to recover the first active variable after GroupByClause
+         * has replaced the tuple variables (via {@code startVar.before.after}).
+         */
+        LocalVariable mark = null;
+        boolean initialized = false;
+
+        OrderByData(final int numOrderSpecs) {
+            this.encounteredPrimitiveTypes = new ArrayList<>(numOrderSpecs);
+            for (int i = 0; i < numOrderSpecs; i++) {
+                this.encounteredPrimitiveTypes.add(new BitSet(Type.ARRAY_ITEM + 1));
+            }
+        }
+    }
+
+    /** A snapshot of one tuple: all in-scope variable values and pre-evaluated sort keys. */
+    private static class OrderByTuple {
+        final Map<QName, Sequence> variableValues;
+        final List<AtomicValue> sortKeys;
+        /** Original insertion position, used to guarantee a stable sort. */
+        final int originalPos;
+
+        OrderByTuple(final Map<QName, Sequence> variableValues,
+                     final List<AtomicValue> sortKeys,
+                     final int originalPos) {
+            this.variableValues = variableValues;
+            this.sortKeys = sortKeys;
+            this.originalPos = originalPos;
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
@@ -40,6 +40,11 @@ import java.util.stream.IntStream;
  */
 public class OrderByClause extends AbstractFLWORClause {
 
+    // Package-private instrumentation fields for memory benchmarking.
+    // Set in postEval() before sorting; zero-cost when not read.
+    static volatile int lastTupleCount;
+    static volatile int lastVarCount;
+
     private final List<OrderSpec> orderSpecs;
 
     /**
@@ -161,28 +166,38 @@ public class OrderByClause extends AbstractFLWORClause {
             walkStart = startVar;
         }
 
-        final Map<QName, Sequence> varValues = new LinkedHashMap<>();
-        LocalVariable nextVar = walkStart;
-        while (nextVar != null) {
-            varValues.put(nextVar.getQName(), nextVar.getValue());
-            if (!data.initialized) {
-                // First call: create template LocalVariables for reuse in postEval()
+        if (!data.initialized) {
+            // First call: count variables and create templates
+            final List<QName> names = new ArrayList<>();
+            final List<LocalVariable> templates = new ArrayList<>();
+            LocalVariable nextVar = walkStart;
+            while (nextVar != null) {
+                names.add(nextVar.getQName());
                 final LocalVariable templateVar = new LocalVariable(nextVar.getQName());
                 templateVar.setSequenceType(nextVar.getSequenceType());
                 templateVar.setStaticType(nextVar.getStaticType());
                 templateVar.setContextDocs(nextVar.getContextDocs());
-                data.variableTemplates.put(nextVar.getQName(), templateVar);
+                templates.add(templateVar);
+                nextVar = nextVar.after;
             }
+            data.variableNames = names.toArray(new QName[0]);
+            data.variableTemplates = templates.toArray(new LocalVariable[0]);
+            data.initialized = true;
+        }
+
+        // Capture variable values into a compact array (indexed parallel to data.variableNames)
+        final Sequence[] varValues = new Sequence[data.variableNames.length];
+        LocalVariable nextVar = walkStart;
+        for (int v = 0; v < varValues.length && nextVar != null; v++) {
+            varValues[v] = nextVar.getValue();
             nextVar = nextVar.after;
         }
-        data.initialized = true;
 
         // Evaluate sort keys for this tuple
-        final List<AtomicValue> sortKeys = new ArrayList<>(orderSpecs.size());
+        final AtomicValue[] sortKeys = new AtomicValue[orderSpecs.size()];
         for (int i = 0; i < orderSpecs.size(); i++) {
             final OrderSpec spec = orderSpecs.get(i);
             final Sequence keySeq = spec.getSortExpression().eval(contextSequence, null);
-            final AtomicValue value;
             if (keySeq.hasOne()) {
                 AtomicValue atomized = keySeq.itemAt(0).atomize();
                 // Cast xs:untypedAtomic to xs:string per W3C XQuery 3.1 §3.9.4
@@ -190,15 +205,14 @@ public class OrderByClause extends AbstractFLWORClause {
                     atomized = atomized.convertTo(Type.STRING);
                 }
                 data.encounteredPrimitiveTypes.get(i).set(Type.primitiveTypeOf(atomized.getType()));
-                value = atomized;
+                sortKeys[i] = atomized;
             } else if (keySeq.hasMany()) {
                 throw new XPathException(this, ErrorCodes.XPTY0004,
                         "Order by expression evaluates to more than one item: " +
                         ExpressionDumper.dump(spec.getSortExpression()));
             } else {
-                value = AtomicValue.EMPTY_VALUE;
+                sortKeys[i] = AtomicValue.EMPTY_VALUE;
             }
-            sortKeys.add(value);
         }
 
         data.tuples.add(new OrderByTuple(varValues, sortKeys, data.tuples.size()));
@@ -222,6 +236,10 @@ public class OrderByClause extends AbstractFLWORClause {
             return seq;
         }
 
+        // Record instrumentation for memory benchmarking
+        lastTupleCount = data.tuples.size();
+        lastVarCount = data.variableNames.length;
+
         // Apply W3C type coercion rules before sorting
         coerceSortKeys(data);
 
@@ -232,7 +250,7 @@ public class OrderByClause extends AbstractFLWORClause {
         final LocalVariable mark = context.markLocalVariables(false);
         try {
             // Declare all variable templates in context (same pattern as GroupByClause.postEval())
-            for (final LocalVariable var : data.variableTemplates.values()) {
+            for (final LocalVariable var : data.variableTemplates) {
                 context.declareVariableBinding(var);
             }
 
@@ -240,12 +258,9 @@ public class OrderByClause extends AbstractFLWORClause {
             for (final OrderByTuple tuple : data.tuples) {
                 context.proceed(this);
 
-                // Restore variable bindings for this tuple
-                for (final Map.Entry<QName, Sequence> entry : tuple.variableValues.entrySet()) {
-                    final LocalVariable var = data.variableTemplates.get(entry.getKey());
-                    if (var != null) {
-                        var.setValue(entry.getValue());
-                    }
+                // Restore variable bindings for this tuple (indexed parallel to variableNames)
+                for (int v = 0; v < data.variableTemplates.length; v++) {
+                    data.variableTemplates[v].setValue(tuple.variableValues[v]);
                 }
 
                 // Evaluate downstream clauses (CountClause, WhereClause, LetExpr, return expr)
@@ -297,11 +312,10 @@ public class OrderByClause extends AbstractFLWORClause {
                 throw new XPathException(this, ErrorCodes.XPTY0004, message.toString());
             }
 
-            final int slotIndex = t;
             for (final OrderByTuple tuple : data.tuples) {
-                final AtomicValue value = tuple.sortKeys.get(slotIndex);
+                final AtomicValue value = tuple.sortKeys[t];
                 if (!value.isEmpty()) {
-                    tuple.sortKeys.set(slotIndex, value.convertTo(coerceToType));
+                    tuple.sortKeys[t] = value.convertTo(coerceToType);
                 }
             }
         }
@@ -325,9 +339,9 @@ public class OrderByClause extends AbstractFLWORClause {
     private static int compareTuples(final OrderByTuple a, final OrderByTuple b,
                                      final List<OrderSpec> orderSpecs) {
         int cmp = Constants.EQUAL;
-        for (int i = 0; i < a.sortKeys.size(); i++) {
-            final AtomicValue keyA = a.sortKeys.get(i);
-            final AtomicValue keyB = b.sortKeys.get(i);
+        for (int i = 0; i < a.sortKeys.length; i++) {
+            final AtomicValue keyA = a.sortKeys[i];
+            final AtomicValue keyB = b.sortKeys[i];
             final OrderSpec spec = orderSpecs.get(i);
 
             try {
@@ -426,8 +440,14 @@ public class OrderByClause extends AbstractFLWORClause {
         final List<OrderByTuple> tuples = new ArrayList<>();
         /** One BitSet per OrderSpec slot, tracking which primitive types appear in sort keys. */
         final List<BitSet> encounteredPrimitiveTypes;
-        /** Template LocalVariables declared in postEval(); keys = variable QNames. */
-        final Map<QName, LocalVariable> variableTemplates = new LinkedHashMap<>();
+        /**
+         * Variable names in declaration order, set on the first {@link #eval} call.
+         * Shared across all tuples — each tuple's {@code variableValues} array is indexed
+         * by the same positions.
+         */
+        QName[] variableNames;
+        /** Template LocalVariables for postEval() replay, parallel to {@link #variableNames}. */
+        LocalVariable[] variableTemplates;
         /**
          * The {@code lastVar} snapshot taken in {@link #preEval} — the last variable
          * in scope when preEval ran (equals {@code rootClause.getStartVariable()} in the
@@ -447,15 +467,19 @@ public class OrderByClause extends AbstractFLWORClause {
         }
     }
 
-    /** A snapshot of one tuple: all in-scope variable values and pre-evaluated sort keys. */
+    /**
+     * A snapshot of one tuple: all in-scope variable values and pre-evaluated sort keys.
+     * Uses parallel arrays instead of maps for minimal per-tuple memory overhead.
+     */
     private static class OrderByTuple {
-        final Map<QName, Sequence> variableValues;
-        final List<AtomicValue> sortKeys;
+        /** Variable values indexed by the same positions as {@link OrderByData#variableNames}. */
+        final Sequence[] variableValues;
+        final AtomicValue[] sortKeys;
         /** Original insertion position, used to guarantee a stable sort. */
         final int originalPos;
 
-        OrderByTuple(final Map<QName, Sequence> variableValues,
-                     final List<AtomicValue> sortKeys,
+        OrderByTuple(final Sequence[] variableValues,
+                     final AtomicValue[] sortKeys,
                      final int originalPos) {
             this.variableValues = variableValues;
             this.sortKeys = sortKeys;

--- a/exist-core/src/main/java/org/exist/xquery/WindowExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/WindowExpr.java
@@ -538,7 +538,7 @@ public class WindowExpr extends BindingExpression {
             return null;
         }
 
-        final LocalVariable windowReturnVariable = createVariable(windowContextVariable.getQName());
+        final LocalVariable windowReturnVariable = new LocalVariable(windowContextVariable.getQName());
         windowReturnVariable.setSequenceType(windowContextVariable.getSequenceType());
         windowReturnVariable.setStaticType(windowContextVariable.getStaticType());
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2036,6 +2036,26 @@ public class XQueryContext implements BinaryValueManager, Context {
         return null;
     }
 
+    /**
+     * Returns the first (earliest-declared) local variable currently in scope, or
+     * {@code null} if there are no local variables in scope.
+     *
+     * <p>Walks backward from {@code lastVar} to find the oldest variable declared in the
+     * current scope, stopping at the context-stack boundary.  Used by
+     * {@link OrderByClause#eval} to recover the true first active variable when
+     * {@link AbstractFLWORClause#getStartVariable()} returns a stale reference
+     * (e.g. in a FLWOR with two {@code order by} clauses where the inner one is
+     * evaluated during the outer one's {@code postEval} replay).</p>
+     */
+    LocalVariable getFirstLocalVariable() {
+        final LocalVariable end = contextStack.peek();
+        LocalVariable first = null;
+        for (LocalVariable var = lastVar; var != null && var != end; var = var.before) {
+            first = var;
+        }
+        return first;
+    }
+
     @Override
     public boolean isVarDeclared(final QName qname) {
         final Module[] modules = getModules(qname.getNamespaceURI());

--- a/exist-core/src/test/java/org/exist/xquery/OrderByClauseBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/OrderByClauseBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Micro-benchmark for {@code order by} clause performance.
+ *
+ * <p>Compares wall-clock throughput (ops/s) between:
+ * <ol>
+ *   <li><b>simple</b>  — {@code for $x in 1 to N order by $x return $x} — the most
+ *       common pattern; tests whether the new tuple-capture approach adds overhead
+ *       compared to the old deferred-sort approach.</li>
+ *   <li><b>withCount</b> — same query but with a {@code count $rank} clause after the
+ *       {@code order by} — the newly-correct pattern.</li>
+ *   <li><b>twoVars</b>  — nested for loops so two variables are in scope when
+ *       {@code order by} fires; tests the cost of capturing more variable bindings.</li>
+ *   <li><b>descending</b> — descending sort; used to verify the direction flag adds no
+ *       extra overhead after removing {@code hasPreviousOrderByDescending()}.</li>
+ * </ol>
+ *
+ * <p>Not included in the normal test suite — the class name does not match Surefire's
+ * default {@code *Test} pattern, so {@code mvn test} will never discover it.
+ * Run explicitly with:
+ * <pre>
+ *   mvn test -pl exist-core -Dtest=OrderByClauseBenchmark \
+ *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
+ * </pre>
+ */
+public class OrderByClauseBenchmark {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /** Number of warm-up iterations before timing starts. */
+    private static final int WARMUP = 200;
+    /** Number of timed iterations. */
+    private static final int ITERATIONS = 1_000;
+
+    // Query variants keyed by a short label
+    private static final Map<String, String[]> QUERIES = new LinkedHashMap<>();
+    static {
+        for (final int n : new int[]{10, 100, 1_000}) {
+            QUERIES.put("simple       N=" + n,
+                    new String[]{ "count(for $x in 1 to " + n + " order by $x return $x)" });
+            QUERIES.put("withCount    N=" + n,
+                    new String[]{ "count(for $x in 1 to " + n + " order by $x count $rank return $rank)" });
+            QUERIES.put("twoVars      N=" + n,
+                    new String[]{ "count(for $x in 1 to " + n + " for $y in 1 to 3 order by $x * 3 + $y return ($x, $y))" });
+            QUERIES.put("descending   N=" + n,
+                    new String[]{ "count(for $x in 1 to " + n + " order by $x descending return $x)" });
+        }
+    }
+
+    @Test
+    public void benchmark() throws XMLDBException {
+        Assume.assumeTrue(
+                "Benchmark skipped by default. Re-run with -Dexist.run.benchmarks=true",
+                Boolean.getBoolean("exist.run.benchmarks"));
+
+        System.out.println("\n=== OrderByClause benchmark ===");
+        System.out.printf("%-24s  %8s  %8s  %8s%n", "Query variant", "avg (ms)", "min (ms)", "ops/s");
+        System.out.println("-".repeat(58));
+
+        for (final Map.Entry<String, String[]> entry : QUERIES.entrySet()) {
+            final String label = entry.getKey();
+            final String query = entry.getValue()[0];
+
+            // warm up
+            for (int i = 0; i < WARMUP; i++) {
+                server.executeQuery(query);
+            }
+
+            // timed run
+            final long[] times = new long[ITERATIONS];
+            for (int i = 0; i < ITERATIONS; i++) {
+                final long t0 = System.nanoTime();
+                final ResourceSet rs = server.executeQuery(query);
+                rs.getResource(0).getContent(); // force result materialisation
+                times[i] = System.nanoTime() - t0;
+            }
+
+            long sum = 0, min = Long.MAX_VALUE;
+            for (final long t : times) {
+                sum += t;
+                if (t < min) min = t;
+            }
+            final double avgMs  = sum / (double) ITERATIONS / 1_000_000.0;
+            final double minMs  = min / 1_000_000.0;
+            final double opsPerSec = 1_000.0 / avgMs;
+
+            System.out.printf("%-24s  %8.3f  %8.3f  %8.0f%n", label, avgMs, minMs, opsPerSec);
+        }
+        System.out.println();
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/OrderByClauseBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/OrderByClauseBenchmark.java
@@ -109,7 +109,8 @@ public class OrderByClauseBenchmark {
                 times[i] = System.nanoTime() - t0;
             }
 
-            long sum = 0, min = Long.MAX_VALUE;
+            long sum = 0;
+            long min = Long.MAX_VALUE;
             for (final long t : times) {
                 sum += t;
                 if (t < min) min = t;

--- a/exist-core/src/test/java/org/exist/xquery/OrderByClauseMemoryBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/OrderByClauseMemoryBenchmark.java
@@ -117,7 +117,6 @@ public class OrderByClauseMemoryBenchmark {
         for (final Map.Entry<String, Object[]> entry : queryMatrix.entrySet()) {
             final String label = entry.getKey();
             final String queryTemplate = (String) entry.getValue()[0];
-            final int expectedV = (int) entry.getValue()[1];
             final int expectedK = (int) entry.getValue()[2];
 
             for (final int n : sizes) {

--- a/exist-core/src/test/java/org/exist/xquery/OrderByClauseMemoryBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/OrderByClauseMemoryBenchmark.java
@@ -1,0 +1,206 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.XMLDBException;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Memory-overhead benchmark for the {@code order by} clause's tuple-capture approach
+ * introduced in PR #6073.
+ *
+ * <p>Measures the heap cost of the new {@code OrderByTuple} / {@code LinkedHashMap} storage
+ * at various data sizes and variable counts, and compares measured values against theoretical
+ * estimates.</p>
+ *
+ * <p>Not included in the normal test suite — the class name does not match Surefire's
+ * default {@code *Test} pattern.  Run explicitly with:
+ * <pre>
+ *   mvn test -pl exist-core -Dtest=OrderByClauseMemoryBenchmark \
+ *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
+ * </pre>
+ */
+public class OrderByClauseMemoryBenchmark {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /** Number of GC-and-measure repetitions; we take the median. */
+    private static final int SAMPLES = 7;
+
+    /**
+     * Theoretical per-tuple overhead in bytes for the new approach (parallel-arrays optimization).
+     *
+     * <p>Breakdown per OrderByTuple:
+     * <ul>
+     *   <li>Object header: ~16 bytes</li>
+     *   <li>3 fields (variableValues ref, sortKeys ref, originalPos int): ~24 bytes</li>
+     *   <li>Sequence[] array: ~16 + 8*V bytes (header + one ref per variable)</li>
+     *   <li>AtomicValue[] array: ~16 + 8*K bytes (header + one ref per key)</li>
+     * </ul>
+     * Total ≈ 72 + 8*V + 8*K bytes per tuple.
+     */
+    private static long theoreticalBytesPerTupleNew(final int numVars, final int numKeys) {
+        return 72L + 8L * numVars + 8L * numKeys;
+    }
+
+    /**
+     * Theoretical per-tuple overhead in bytes for the old approach (OrderedValueSequence.Entry).
+     *
+     * <p>Breakdown per Entry:
+     * <ul>
+     *   <li>Object header: ~16 bytes</li>
+     *   <li>5 fields (refs to lists, item, pos int, values list ref): ~40 bytes</li>
+     *   <li>ArrayList for values: ~40 + 8*K bytes</li>
+     * </ul>
+     * Total ≈ 96 + 8*K bytes per tuple (but this only captures the result item, not variable
+     * bindings — it cannot support post-order-by clauses correctly).
+     */
+    private static long theoreticalBytesPerTupleOld(final int numKeys) {
+        return 96L + 8L * numKeys;
+    }
+
+    @Test
+    public void memoryBenchmark() throws XMLDBException {
+        Assume.assumeTrue(
+                "Benchmark skipped by default. Re-run with -Dexist.run.benchmarks=true",
+                Boolean.getBoolean("exist.run.benchmarks"));
+
+        // Query matrix: label -> { query template (use %d for N), expected V, expected K }
+        final Map<String, Object[]> queryMatrix = new LinkedHashMap<>();
+        queryMatrix.put("simple",
+                new Object[]{"for $x in 1 to %d order by $x return $x", 1, 1});
+        queryMatrix.put("withCount",
+                new Object[]{"for $x in 1 to %d order by $x count $rank return $rank", 2, 1});
+        queryMatrix.put("twoVars",
+                new Object[]{"for $x in 1 to %d for $y in 1 to 3 order by $x * 3 + $y return ($x, $y)", 2, 1});
+        queryMatrix.put("threeVarsLet",
+                new Object[]{"for $x in 1 to %d for $y in 1 to 3 let $z := $x + $y order by $z return ($x, $y, $z)", 3, 1});
+
+        final int[] sizes = {100, 1_000, 10_000, 100_000};
+
+        System.out.println("\n=== OrderByClause Memory Benchmark ===\n");
+
+        // Header
+        System.out.printf("%-16s  %7s  %4s  %4s  %12s  %12s  %12s  %8s%n",
+                "Query", "N", "V", "K",
+                "Measured(KB)", "Theory(KB)", "OldTheory(KB)", "Ratio");
+        System.out.println("-".repeat(90));
+
+        for (final Map.Entry<String, Object[]> entry : queryMatrix.entrySet()) {
+            final String label = entry.getKey();
+            final String queryTemplate = (String) entry.getValue()[0];
+            final int expectedV = (int) entry.getValue()[1];
+            final int expectedK = (int) entry.getValue()[2];
+
+            for (final int n : sizes) {
+                // For twoVars and threeVarsLet, effective N is n*3 tuples
+                final int effectiveN;
+                if (label.equals("twoVars") || label.equals("threeVarsLet")) {
+                    effectiveN = n * 3;
+                } else {
+                    effectiveN = n;
+                }
+
+                final String query = "count(" + String.format(queryTemplate, n) + ")";
+
+                // Warm up (also initializes any lazy structures)
+                for (int w = 0; w < 3; w++) {
+                    server.executeQuery(query);
+                }
+
+                // Measure heap delta across SAMPLES runs, take median
+                final long[] deltas = new long[SAMPLES];
+                for (int s = 0; s < SAMPLES; s++) {
+                    // Force GC and measure baseline
+                    forceGC();
+                    final long before = usedHeap();
+
+                    // Execute query (this will populate OrderByTuples in eval, sort in postEval)
+                    server.executeQuery(query);
+
+                    // The tuples are transient and GC'd after postEval, but we can measure
+                    // the peak by reading instrumentation and computing theoretical size.
+                    // For measured delta, we capture right after execution (tuples may already
+                    // be GC'd, so this is a lower bound — theoretical is more reliable).
+                    final long after = usedHeap();
+                    deltas[s] = after - before;
+                }
+                Arrays.sort(deltas);
+                final long measuredDelta = deltas[SAMPLES / 2]; // median
+
+                // Read instrumentation
+                final int tupleCount = OrderByClause.lastTupleCount;
+                final int varCount = OrderByClause.lastVarCount;
+
+                // Theoretical estimates
+                final long theoryNew = (long) tupleCount * theoreticalBytesPerTupleNew(varCount, expectedK);
+                final long theoryOld = (long) tupleCount * theoreticalBytesPerTupleOld(expectedK);
+                final double ratio = theoryOld > 0 ? (double) theoryNew / theoryOld : 0;
+
+                System.out.printf("%-16s  %7d  %4d  %4d  %12.1f  %12.1f  %12.1f  %8.1fx%n",
+                        label, effectiveN, varCount, expectedK,
+                        measuredDelta / 1024.0,
+                        theoryNew / 1024.0,
+                        theoryOld / 1024.0,
+                        ratio);
+            }
+            System.out.println();
+        }
+
+        // Summary
+        System.out.println("=== Summary ===");
+        System.out.println("- 'Measured' is the median heap delta (lower bound — tuples are transient).");
+        System.out.println("- 'Theory' is the estimated per-tuple overhead × tuple count for the new approach.");
+        System.out.println("- 'OldTheory' is the estimated per-tuple overhead for the old OrderedValueSequence.Entry approach.");
+        System.out.println("- 'Ratio' = Theory / OldTheory (overhead multiplier of new vs old).");
+        System.out.println("- All tuple memory is transient: freed after postEval() completes.");
+        System.out.println("- Variable values are references, not copies — no item data is duplicated.");
+        System.out.println();
+    }
+
+    /**
+     * Best-effort GC: call System.gc() twice with a short sleep to encourage finalization.
+     */
+    private static void forceGC() {
+        System.gc();
+        try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+        System.gc();
+        try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+    }
+
+    /**
+     * Returns the currently used heap in bytes.
+     */
+    private static long usedHeap() {
+        final Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/OrderByCountClauseTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/OrderByCountClauseTest.java
@@ -1,0 +1,337 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for FLWOR {@code order by} and {@code count} clause semantic compliance.
+ *
+ * <p>Verifies that downstream clauses ({@code count}, {@code where}, {@code let}) that follow
+ * an {@code order by} clause see tuples in the sorted order, as required by
+ * W3C XQuery 3.1 §3.9.4. Also tests {@code count} after tumbling/sliding window clauses
+ * (XQTS TumblingWindowExpr537/538/544 and SlidingWindowExpr538/544).</p>
+ *
+ * @see <a href="https://github.com/eXist-db/exist/issues/5089">Issue #5089</a>
+ */
+public class OrderByCountClauseTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /**
+     * XQTS count-009: {@code count} clause after {@code order by} must assign rank numbers
+     * based on the sorted tuple stream, not the original iteration order.
+     */
+    @Test
+    public void countAfterOrderBy() throws XMLDBException {
+        // Query equivalent to XQTS prod-CountClause/count-009, results encoded as "x/y/remainder/rank"
+        final String query =
+                "string-join((" +
+                "  for $x in 1 to 4" +
+                "  for $y in 1 to 4" +
+                "  count $index" +
+                "  let $remainder := $index mod 3" +
+                "  order by $remainder, $index" +
+                "  count $index2" +
+                "  return concat($x, '/', $y, '/', $remainder, '/', $index2)" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals(
+                "1/3/0/1 2/2/0/2 3/1/0/3 3/4/0/4 4/3/0/5 " +
+                "1/1/1/6 1/4/1/7 2/3/1/8 3/2/1/9 4/1/1/10 4/4/1/11 " +
+                "1/2/2/12 2/1/2/13 2/4/2/14 3/3/2/15 4/2/2/16",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * {@code count} after a descending {@code order by} must still produce ranks 1, 2, 3, …
+     * (not N, N-1, … in reverse).
+     */
+    @Test
+    public void countAfterDescendingOrderBy() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for $x in (3, 1, 2)" +
+                "  order by $x descending" +
+                "  count $rank" +
+                "  return concat($x, ':', $rank)" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("3:1 2:2 1:3", (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * {@code where} clause after {@code order by} must filter the sorted tuple stream.
+     * Ranks assigned by a preceding {@code count} must reflect sorted position.
+     */
+    @Test
+    public void whereAfterOrderBy() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for $x in (5, 3, 1, 4, 2)" +
+                "  order by $x" +
+                "  count $rank" +
+                "  where $rank le 3" +
+                "  return concat($x, ':', $rank)" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("1:1 2:2 3:3", (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * {@code let} binding after {@code order by} must see the variable values for each tuple
+     * in sorted order.
+     */
+    @Test
+    public void letAfterOrderBy() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for $x in (3, 1, 2)" +
+                "  order by $x" +
+                "  let $doubled := $x * 2" +
+                "  return string($doubled)" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("2 4 6", (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * Regression: {@code count} must be reset to 1 on each execution of an inner FLWOR
+     * expression (XQTS count-010).
+     */
+    @Test
+    public void countResetBetweenOuterIterations() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for $x in 1 to 4 return" +
+                "    for $y in 1 to 4" +
+                "    count $index" +
+                "    return $index" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS TumblingWindowExpr537: {@code count} clause after a tumbling window clause must
+     * number windows starting from 1.
+     */
+    @Test
+    public void countAfterTumblingWindow() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for tumbling window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  end $e when $e - $s eq 2" +
+                "  count $r" +
+                "  return concat('w', $r, ':(', string-join($w ! string(.), ','), ')')" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("w1:(1,2,3) w2:(4,5,6) w3:(7,8,9) w4:(10)",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS TumblingWindowExpr538: {@code count} and {@code where} after a tumbling window
+     * clause — the where clause must use the rank assigned by count.
+     */
+    @Test
+    public void countAndWhereAfterTumblingWindow() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for tumbling window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  end $e when $e - $s eq 2" +
+                "  count $r" +
+                "  where $r le 2" +
+                "  return concat('w', $r, ':(', string-join($w ! string(.), ','), ')')" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("w1:(1,2,3) w2:(4,5,6)", (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS SlidingWindowExpr538: {@code count} and {@code where} after a sliding window
+     * clause — the where clause must use the rank assigned by count.
+     */
+    @Test
+    public void countAndWhereAfterSlidingWindow() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for sliding window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  end $e when $e - $s eq 2" +
+                "  count $r" +
+                "  where $r le 2" +
+                "  return concat('w', $r, ':(', string-join($w ! string(.), ','), ')')" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("w1:(1,2,3) w2:(2,3,4)", (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS SlidingWindowExpr540: {@code order by} directly after a sliding window clause,
+     * where the return expression references the window variable.
+     */
+    @Test
+    public void orderByAfterSlidingWindow() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for sliding window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  only end $e when $e - $s eq 2" +
+                "  order by $w[2] descending" +
+                "  return string-join($w ! string(.), ' ')" +
+                "), '|')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        // Windows sorted by $w[2] descending: 8,9,10 (w[2]=9) ... 1,2,3 (w[2]=2)
+        assertEquals("8 9 10|7 8 9|6 7 8|5 6 7|4 5 6|3 4 5|2 3 4|1 2 3",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS TumblingWindowExpr540: {@code order by} directly after a tumbling window clause,
+     * where the return expression references the window variable.
+     */
+    @Test
+    public void orderByAfterTumblingWindow() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for tumbling window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  only end $e when $e - $s eq 2" +
+                "  order by $w[2] descending" +
+                "  return string-join($w ! string(.), ' ')" +
+                "), '|')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        // Windows: (1,2,3), (4,5,6), (7,8,9). Sorted by $w[2] desc: 9>6>3 → (7,8,9), (4,5,6), (1,2,3)
+        assertEquals("7 8 9|4 5 6|1 2 3",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS TumblingWindowExpr544: {@code count} after a tumbling window, with a nested
+     * {@code order by} inside the return expression — the outer count must be unaffected.
+     */
+    @Test
+    public void countAfterTumblingWindowWithNestedOrderBy() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for tumbling window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  only end $e when $e - $s eq 2" +
+                "  count $r" +
+                "  return concat('w', $r, ':(', string-join(" +
+                "    for $i in $w order by $i descending return string($i)" +
+                "  , ','), ')')" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("w1:(3,2,1) w2:(6,5,4) w3:(9,8,7)",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS orderBy66: two {@code order by} clauses in the same FLWOR, with {@code count}
+     * and {@code let} between them, and {@code where} after the second {@code order by}.
+     */
+    @Test
+    public void twoOrderByClausesWithCountLetWhere() throws XMLDBException {
+        // for $i in 1 to 100
+        // order by -$i                   → sorted: 100, 99, ..., 1
+        // count $count                   → $count = 1..100
+        // let $e := <e i="{$i}" pos="{$count}"/>
+        // order by number($e/@i)         → sorted: $i=1..100
+        // where $count gt 90             → keeps $i=1..10 (which had $count=100..91)
+        // return $e!@pos!number()        → 100, 99, 98, ..., 91
+        final String query =
+                "string-join((" +
+                "  for $i in 1 to 100" +
+                "  order by -$i" +
+                "  count $count" +
+                "  let $e := <e i=\"{$i}\" pos=\"{$count}\"/>" +
+                "  order by number($e/@i)" +
+                "  where $count gt 90" +
+                "  return string($e/@pos)" +
+                "), ',')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals("100,99,98,97,96,95,94,93,92,91",
+                (String) result.getResource(0).getContent());
+    }
+
+    /**
+     * XQTS SlidingWindowExpr544: {@code count} after a sliding window, with a nested
+     * {@code order by} inside the return expression — the outer count must be unaffected.
+     */
+    @Test
+    public void countAfterSlidingWindowWithNestedOrderBy() throws XMLDBException {
+        final String query =
+                "string-join((" +
+                "  for sliding window $w in (1 to 10)" +
+                "  start $s when true()" +
+                "  only end $e when $e - $s eq 2" +
+                "  count $r" +
+                "  return concat('w', $r, ':(', string-join(" +
+                "    for $i in $w order by $i descending return string($i)" +
+                "  , ','), ')')" +
+                "), ' ')";
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, result.getSize());
+        assertEquals(
+                "w1:(3,2,1) w2:(4,3,2) w3:(5,4,3) w4:(6,5,4) " +
+                "w5:(7,6,5) w6:(8,7,6) w7:(9,8,7) w8:(10,9,8)",
+                (String) result.getResource(0).getContent());
+    }
+}

--- a/exist-core/src/test/xquery/xquery3/count.xqm
+++ b/exist-core/src/test/xquery/xquery3/count.xqm
@@ -101,8 +101,7 @@ function ct:order-descending-index1-after() {
 };
 
 declare
-%test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
-%test:assertEquals(
+    %test:assertEquals(
         '<x index1="2" index2="1">b</x>',
         '<x index1="1" index2="2">a</x>'
     )
@@ -149,7 +148,6 @@ function ct:order-descending-indexes() {
 };
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>3</x></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
@@ -167,7 +165,6 @@ function ct:order-non-linear-ascending-indexes() {
 };
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>2</x></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
@@ -185,7 +182,6 @@ function ct:order-non-linear-descending-indexes() {
 };
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',
@@ -204,7 +200,6 @@ function ct:order-ascending-indexes-two-keys() {
 };
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
         '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
@@ -223,7 +218,6 @@ function ct:order-descending-indexes-two-keys() {
 };
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
         '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
@@ -243,7 +237,6 @@ function ct:order-ascending-descending-indexes-two-keys() {
 
 
 declare
-    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',

--- a/exist-core/src/test/xquery/xquery3/flwor.xql
+++ b/exist-core/src/test/xquery/xquery3/flwor.xql
@@ -238,3 +238,46 @@ function flwor:for-as-string-binding() {
     for $x as xs:string in "foo"
     return true()
 };
+
+(: https://github.com/eXist-db/exist/issues/4252 :)
+(: When a leading order-by key is the empty sequence, subsequent keys must still be applied. :)
+declare
+    %test:assertEquals("a3", "a4", "b1", "c2")
+function flwor:orderby-empty-ordering-spec-1st() {
+    let $xml := document { <root><a n="4"/><b n="1"/><c n="2"/><a n="3"/></root> }
+    for $elem in $xml/root/*
+    order by
+        (),
+        $elem/name(),
+        $elem/@n
+    return
+        $elem/name() || $elem/@n
+};
+
+(: When a middle order-by key is the empty sequence, subsequent keys must still be applied. :)
+declare
+    %test:assertEquals("a3", "a4", "b1", "c2")
+function flwor:orderby-empty-ordering-spec-2nd() {
+    let $xml := document { <root><a n="4"/><b n="1"/><c n="2"/><a n="3"/></root> }
+    for $elem in $xml/root/*
+    order by
+        $elem/name(),
+        (),
+        $elem/@n
+    return
+        $elem/name() || $elem/@n
+};
+
+(: When the trailing order-by key is the empty sequence, earlier keys must still be applied. :)
+declare
+    %test:assertEquals("a3", "a4", "b1", "c2")
+function flwor:orderby-empty-ordering-spec-last() {
+    let $xml := document { <root><a n="4"/><b n="1"/><c n="2"/><a n="3"/></root> }
+    for $elem in $xml/root/*
+    order by
+        $elem/name(),
+        $elem/@n,
+        ()
+    return
+        $elem/name() || $elem/@n
+};


### PR DESCRIPTION
Closes eXist-db/exist#5089. Also fixes eXist-db/exist#4252.

### Problem

W3C XQuery 3.1 §3.9.4 requires that after an `order by` clause, every subsequent clause in the same FLWOR expression — `count`, `where`, `let`, and inner `for` — sees tuples **in the sorted order**. eXist-db's previous implementation deferred the sort to `postEval()` but evaluated all downstream clauses eagerly during `eval()`, so they operated on the original, unsorted tuple stream.

This meant, for example:

```xquery
for $x in (5, 3, 1, 4, 2)
order by $x
count $rank          (: rank was assigned in unsorted order — WRONG :)
where $rank le 3
return concat($x, ':', $rank)
```

…produced wrong results. The `count` after `order by` was numbering tuples 1–5 based on the original iteration order, not the sorted order. XQTS `prod-CountClause/count-009` and `prod-OrderByClause/orderBy66` failed for this reason. A related flaw caused incorrect results in 11 `prod-GroupByClause` tests where `group by` was followed by `order by`.

A secondary bug: the `count` clause after a `window` clause counted in reverse (N, N-1, …, 1) because `hasPreviousOrderByDescending()` did not handle the `WINDOW` clause type, causing `TumblingWindowExpr537/538/544` and `SlidingWindowExpr538/544` to fail.

**Issue #4252** is also resolved as a direct consequence: when multiple `order by` sort keys are specified and a leading key evaluates to the empty sequence, subsequent keys were previously ignored. The new tuple-capture-and-replay approach pre-evaluates all sort keys per tuple before sorting, so all key specifications are respected.

### Approach

The fix rewrites `OrderByClause` using a **tuple-capture-and-replay** pattern that mirrors what `GroupByClause` already does for the analogous `group by` problem:

- **`eval()`** captures the full variable state (all in-scope bindings) and pre-evaluated sort keys for each tuple. It returns `EMPTY_SEQUENCE` without invoking any downstream clause.
- **`postEval()`** sorts the collected tuples using the same comparison semantics as before (empty/NaN handling, collator support, descending/ascending modifier, stable sort), then replays each sorted tuple through the downstream clause chain via `returnExpr.eval()`. Downstream clauses now receive tuples in the correct sorted order.

A `Deque<OrderByData>` stack ensures the pattern composes correctly under nested FLWOR expressions.

A small edge case arises when **two `order by` clauses** appear in the same FLWOR (XQTS `orderBy66`): the inner OBC's `eval()` is called from the outer OBC's `postEval()` replay, at which point `rootClause.getStartVariable()` returns a stale `ForExpr` variable that is no longer in the active variable chain. The new package-private helper `XQueryContext.getFirstLocalVariable()` walks backward from `lastVar` to recover the true first active variable, making the variable-capture walk correct in all cases.

With the new replay correctly delivering tuples in sorted order, `CountClause`'s `hasPreviousOrderByDescending()` hack is no longer needed and is removed.

### Commits

| # | Commit | What and why |
|---|--------|--------------|
| 1 | `[fix] WindowExpr` | One-line guard: set `firstVariable` only on the first window, so `rootClause.getStartVariable()` reliably returns the window variable. |
| 2 | `[fix] OrderByClause` | Full tuple-capture-and-replay rewrite; includes `XQueryContext.getFirstLocalVariable()`. |
| 3 | `[refactor] CountClause` | Remove `hasPreviousOrderByDescending()` and the `step` field — now vestigial. |
| 4 | `[test]` | 13 new integration tests in `OrderByCountClauseTest`; `OrderByClauseBenchmark` for performance tracking; removes `@pending` from `count.xqm` XQSuite tests; three new XQSuite tests in `flwor.xql` for issue #4252 (matching the test cases from the bug report). |
| 5 | `[optimize] OrderByClause` | Replace `LinkedHashMap` per tuple with compact parallel arrays (`Sequence[]`, `AtomicValue[]`). Adds `OrderByClauseMemoryBenchmark`. |

### XQTS results

| Test set | Before | After |
|---|---|---|
| `prod-CountClause` | 0 failures | 0 failures ✅ |
| `prod-GroupByClause` | **11 failures** | **0 failures** 🎉 |
| `prod-OrderByClause` | `orderBy66` failing | passes ✅ |
| `prod-WindowClause` | 0 failures | 0 failures ✅ |
| All others | unchanged | unchanged |

> **Note for CI reviewers:** `prod-OrderByClause` has 2 pre-existing failures unrelated to this PR (present on `develop` before these changes). They will show up in CI results but are not regressions introduced here.

### Milestones

> **Note:** Issue #4252 is currently milestoned to `eXist-7.0.1`. If this PR lands in the `eXist-7.0.0` release, that milestone should be updated accordingly.

### Performance

`OrderByClauseBenchmark` can be run with:

```bash
mvn test -pl exist-core -Dtest=OrderByClauseBenchmark \
    -Dexist.run.benchmarks=true -Ddependency-check.skip=true
```

The benchmark is excluded from the normal test suite (the class name does not match Surefire's `*Test` discovery pattern, and an `Assume` guard requires `-Dexist.run.benchmarks=true`).

Results on Intel Core i7-10700K / Java 21, comparing `develop` HEAD (before this PR) against this branch:

| Query | N | Before (avg ms) | After (avg ms) | Δ |
|---|---|---|---|---|
| `for $x order by $x` | 10 | 0.61 | 0.61 | ~0% |
| `for $x order by $x` | 100 | 0.48 | 0.51 | +6% |
| `for $x order by $x` | 1000 | 0.70 | 0.73 | +4% |
| `for $x order by $x count $rank` | 10 | 0.55 | 0.52 | -5% |
| `for $x order by $x count $rank` | 100 | 0.55 | 0.50 | -9% |
| `for $x order by $x count $rank` | 1000 | 0.85 | 0.85 | ~0% |
| `for $x for $y order by …` | 10 | 0.82 | 0.77 | -6% |
| `for $x for $y order by …` | 100 | 1.29 | 1.04 | -20% |
| `for $x for $y order by …` | 1000 | 7.53 | 5.00 | **-34%** |
| `for $x order by $x desc` | 100 | 0.50 | 0.44 | -12% |

**No performance regression.** The simple `for $x order by $x` pattern is within measurement noise (±6%). Multi-variable and descending-sort cases are measurably faster: the new implementation sorts pre-computed `AtomicValue` sort keys rather than full result sequences, which benefits more complex queries.

### Memory

In response to review feedback about memory impact, per-tuple storage was optimized to use compact parallel arrays instead of `LinkedHashMap`. `OrderByClauseMemoryBenchmark` can be run with:

```bash
mvn test -pl exist-core -Dtest=OrderByClauseMemoryBenchmark \
    -Dexist.run.benchmarks=true -Ddependency-check.skip=true
```

**Per-tuple overhead comparison** (V = in-scope variables, K = sort keys):

| Approach | Formula | Per-tuple (V=1, K=1) |
|---|---|---|
| Old (`OrderedValueSequence.Entry`) | ~96 + 8K bytes | ~104 bytes |
| New (`OrderByTuple` + parallel arrays) | ~72 + 8V + 8K bytes | ~88 bytes |

The new approach stores variable bindings (needed for spec-correct behavior) **and** is lighter than the old approach for the common 1–2 variable case:

| Scenario | Old | New | Ratio |
|---|---|---|---|
| 1 variable, 1 key (most common) | 104 B/tuple | 88 B/tuple | **0.8x** ✅ |
| 2 variables, 1 key | 104 B/tuple | 96 B/tuple | **0.9x** ✅ |
| 3 variables, 1 key | 104 B/tuple | 104 B/tuple | **1.0x** |

At N=100,000 tuples (single variable): the new approach uses ~8.4 MB vs the old approach's ~9.9 MB — **1.5 MB less**. All tuple memory is transient (freed after `postEval()`), and variable values are references, not copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
