### PR TITLE
Implement declare decimal-format (XQuery 3.1)

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -192,6 +192,8 @@ imaginaryTokenDefinitions
 	PREVIOUS_ITEM
 	NEXT_ITEM
 	WINDOW_VARS
+	DECIMAL_FORMAT_DECL
+	DEF_DECIMAL_FORMAT_DECL
 	;
 
 // === XPointer ===
@@ -256,7 +258,7 @@ prolog throws XPathException
 		(
 			importDecl
 			|
-			( "declare" ( "default" | "boundary-space" | "ordering" | "construction" | "base-uri" | "copy-namespaces" | "namespace" ) ) =>
+			( "declare" ( "default" | "boundary-space" | "ordering" | "construction" | "base-uri" | "copy-namespaces" | "namespace" | "decimal-format" ) ) =>
 			s:setter
 			{
 				if(!inSetters)
@@ -311,6 +313,9 @@ setter
 			{ #setter= #(#[DEF_FUNCTION_NS_DECL, "defaultFunctionNSDecl"], deff); }
 			|
 			"order"^ "empty"! ( "greatest" | "least" )
+			|
+			"decimal-format"! ( dfDefProperty )*
+			{ #setter = #(#[DEF_DECIMAL_FORMAT_DECL, "defaultDecimalFormatDecl"], #setter); }
 		)
 		|
 		( "declare" "boundary-space" ) =>
@@ -330,7 +335,28 @@ setter
 		|
 		( "declare" "namespace" ) =>
         namespaceDecl
+		|
+		( "declare" "decimal-format" ) =>
+		decimalFormatDecl
 	)
+	;
+
+decimalFormatDecl
+{ String eq = null; }
+:
+	decl:"declare"! "decimal-format"! eq=eqName! ( dfDefProperty )*
+	{
+		#decimalFormatDecl = #(#[DECIMAL_FORMAT_DECL, eq], #decimalFormatDecl);
+		#decimalFormatDecl.copyLexInfo(#decl);
+	}
+	;
+
+dfDefProperty
+:
+	( "decimal-separator"^ | "grouping-separator"^ | "infinity"^ | "minus-sign"^
+	| "NaN"^ | "percent"^ | "per-mille"^ | "zero-digit"^ | "digit"^
+	| "pattern-separator"^ | "exponent-separator"^ )
+	EQ! STRING_LITERAL
 	;
 
 preserveMode
@@ -2304,6 +2330,30 @@ reservedKeywords returns [String name]
 	"next" { name = "next"; }
 	|
 	"when" { name = "when"; }
+	|
+	"decimal-format" { name = "decimal-format"; }
+	|
+	"decimal-separator" { name = "decimal-separator"; }
+	|
+	"grouping-separator" { name = "grouping-separator"; }
+	|
+	"infinity" { name = "infinity"; }
+	|
+	"minus-sign" { name = "minus-sign"; }
+	|
+	"NaN" { name = "NaN"; }
+	|
+	"percent" { name = "percent"; }
+	|
+	"per-mille" { name = "per-mille"; }
+	|
+	"zero-digit" { name = "zero-digit"; }
+	|
+	"digit" { name = "digit"; }
+	|
+	"pattern-separator" { name = "pattern-separator"; }
+	|
+	"exponent-separator" { name = "exponent-separator"; }
 	;
 
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -211,7 +211,7 @@ options {
         }
     }
 
-    private static String requireSingleChar(final AST node, final String propName, final String value) throws XPathException {
+    private static String dfRequireSingleChar(final AST node, final String propName, final String value) throws XPathException {
         if (value.codePointCount(0, value.length()) != 1) {
             throw new XPathException(node.getLine(), node.getColumn(), ErrorCodes.XQST0098,
                 "The value of decimal-format property '" + propName + "' must be a single character, but got: \"" + value + "\"");
@@ -219,7 +219,7 @@ options {
         return value;
     }
 
-    private static void validateZeroDigit(final AST node, final String value) throws XPathException {
+    private static void dfValidateZeroDigit(final AST node, final String value) throws XPathException {
         final int cp = value.codePointAt(0);
         if (Character.getType(cp) != Character.DECIMAL_DIGIT_NUMBER || Character.getNumericValue(cp) != 0) {
             throw new XPathException(node.getLine(), node.getColumn(), ErrorCodes.XQST0098,
@@ -227,7 +227,7 @@ options {
         }
     }
 
-    private static void validateDistinctPictureChars(final AST node, final DecimalFormat df) throws XPathException {
+    private static void dfValidateDistinctPictureChars(final AST node, final DecimalFormat df) throws XPathException {
         // The 8 single-character picture-string properties must all have distinct values
         final int[] chars = { df.decimalSeparator, df.groupingSeparator, df.percent, df.perMille,
                               df.zeroDigit, df.digit, df.patternSeparator, df.exponentSeparator };
@@ -270,46 +270,46 @@ options {
 
             switch (propName) {
                 case "decimal-separator":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     decimalSeparator = value.codePointAt(0);
                     break;
                 case "grouping-separator":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     groupingSeparator = value.codePointAt(0);
                     break;
                 case "infinity":
                     infinity = value;
                     break;
                 case "minus-sign":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     minusSign = value.codePointAt(0);
                     break;
                 case "NaN":
                     nan = value;
                     break;
                 case "percent":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     percent = value.codePointAt(0);
                     break;
                 case "per-mille":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     perMille = value.codePointAt(0);
                     break;
                 case "zero-digit":
-                    requireSingleChar(child, propName, value);
-                    validateZeroDigit(child, value);
+                    dfRequireSingleChar(child, propName, value);
+                    dfValidateZeroDigit(child, value);
                     zeroDigit = value.codePointAt(0);
                     break;
                 case "digit":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     digit = value.codePointAt(0);
                     break;
                 case "pattern-separator":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     patternSeparator = value.codePointAt(0);
                     break;
                 case "exponent-separator":
-                    requireSingleChar(child, propName, value);
+                    dfRequireSingleChar(child, propName, value);
                     exponentSeparator = value.codePointAt(0);
                     break;
                 default:
@@ -323,7 +323,7 @@ options {
             percent, perMille, zeroDigit, digit,
             patternSeparator, infinity, nan, minusSign
         );
-        validateDistinctPictureChars(parentNode, df);
+        dfValidateDistinctPictureChars(parentNode, df);
         return df;
     }
 }

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -210,6 +210,122 @@ options {
             return variableName;
         }
     }
+
+    private static String requireSingleChar(final AST node, final String propName, final String value) throws XPathException {
+        if (value.codePointCount(0, value.length()) != 1) {
+            throw new XPathException(node.getLine(), node.getColumn(), ErrorCodes.XQST0098,
+                "The value of decimal-format property '" + propName + "' must be a single character, but got: \"" + value + "\"");
+        }
+        return value;
+    }
+
+    private static void validateZeroDigit(final AST node, final String value) throws XPathException {
+        final int cp = value.codePointAt(0);
+        if (Character.getType(cp) != Character.DECIMAL_DIGIT_NUMBER || Character.getNumericValue(cp) != 0) {
+            throw new XPathException(node.getLine(), node.getColumn(), ErrorCodes.XQST0098,
+                "The value of decimal-format property 'zero-digit' must be a Unicode digit with numeric value zero, but got: \"" + value + "\"");
+        }
+    }
+
+    private static void validateDistinctPictureChars(final AST node, final DecimalFormat df) throws XPathException {
+        // The 8 single-character picture-string properties must all have distinct values
+        final int[] chars = { df.decimalSeparator, df.groupingSeparator, df.percent, df.perMille,
+                              df.zeroDigit, df.digit, df.patternSeparator, df.exponentSeparator };
+        final String[] names = { "decimal-separator", "grouping-separator", "percent", "per-mille",
+                                 "zero-digit", "digit", "pattern-separator", "exponent-separator" };
+        for (int i = 0; i < chars.length; i++) {
+            for (int j = i + 1; j < chars.length; j++) {
+                if (chars[i] == chars[j]) {
+                    throw new XPathException(node.getLine(), node.getColumn(), ErrorCodes.XQST0098,
+                        "Decimal-format properties '" + names[i] + "' and '" + names[j] +
+                        "' must have distinct values, but both are: '" + new String(Character.toChars(chars[i])) + "'");
+                }
+            }
+        }
+    }
+
+    private DecimalFormat processDecimalFormatProperties(final AST parentNode) throws XPathException {
+        // Start with UNNAMED defaults
+        int decimalSeparator = DecimalFormat.UNNAMED.decimalSeparator;
+        int exponentSeparator = DecimalFormat.UNNAMED.exponentSeparator;
+        int groupingSeparator = DecimalFormat.UNNAMED.groupingSeparator;
+        int percent = DecimalFormat.UNNAMED.percent;
+        int perMille = DecimalFormat.UNNAMED.perMille;
+        int zeroDigit = DecimalFormat.UNNAMED.zeroDigit;
+        int digit = DecimalFormat.UNNAMED.digit;
+        int patternSeparator = DecimalFormat.UNNAMED.patternSeparator;
+        String infinity = DecimalFormat.UNNAMED.infinity;
+        String nan = DecimalFormat.UNNAMED.NaN;
+        int minusSign = DecimalFormat.UNNAMED.minusSign;
+
+        AST child = parentNode.getFirstChild();
+        while (child != null) {
+            final String propName = child.getText();
+            final AST valueNode = child.getFirstChild();
+            if (valueNode == null) {
+                child = child.getNextSibling();
+                continue;
+            }
+            final String value = valueNode.getText();
+
+            switch (propName) {
+                case "decimal-separator":
+                    requireSingleChar(child, propName, value);
+                    decimalSeparator = value.codePointAt(0);
+                    break;
+                case "grouping-separator":
+                    requireSingleChar(child, propName, value);
+                    groupingSeparator = value.codePointAt(0);
+                    break;
+                case "infinity":
+                    infinity = value;
+                    break;
+                case "minus-sign":
+                    requireSingleChar(child, propName, value);
+                    minusSign = value.codePointAt(0);
+                    break;
+                case "NaN":
+                    nan = value;
+                    break;
+                case "percent":
+                    requireSingleChar(child, propName, value);
+                    percent = value.codePointAt(0);
+                    break;
+                case "per-mille":
+                    requireSingleChar(child, propName, value);
+                    perMille = value.codePointAt(0);
+                    break;
+                case "zero-digit":
+                    requireSingleChar(child, propName, value);
+                    validateZeroDigit(child, value);
+                    zeroDigit = value.codePointAt(0);
+                    break;
+                case "digit":
+                    requireSingleChar(child, propName, value);
+                    digit = value.codePointAt(0);
+                    break;
+                case "pattern-separator":
+                    requireSingleChar(child, propName, value);
+                    patternSeparator = value.codePointAt(0);
+                    break;
+                case "exponent-separator":
+                    requireSingleChar(child, propName, value);
+                    exponentSeparator = value.codePointAt(0);
+                    break;
+                default:
+                    break;
+            }
+            child = child.getNextSibling();
+        }
+
+        final DecimalFormat df = new DecimalFormat(
+            decimalSeparator, exponentSeparator, groupingSeparator,
+            percent, perMille, zeroDigit, digit,
+            patternSeparator, infinity, nan, minusSign
+        );
+        validateDistinctPictureChars(parentNode, df);
+        return df;
+    }
 }
 
 xpointer [PathExpr path]
@@ -337,6 +453,8 @@ throws PermissionDeniedException, EXistException, XPathException
   boolean baseuri = false;
   boolean ordering = false;
   boolean construction = false;
+  Set declaredDecimalFormats = new HashSet();
+  boolean defaultDecimalFormatDeclared = false;
 
 }:
     (
@@ -630,6 +748,35 @@ throws PermissionDeniedException, EXistException, XPathException
                     }
                 }
             )
+        )
+        |
+        #(
+            dfDecl:DECIMAL_FORMAT_DECL (.)*
+            {
+                final QName dfQName;
+                try {
+                    dfQName = QName.parse(staticContext, dfDecl.getText(), null);
+                } catch (final IllegalQNameException iqe) {
+                    throw new XPathException(dfDecl.getLine(), dfDecl.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix in decimal format name: " + dfDecl.getText());
+                }
+                final String dfKey = dfQName.getNamespaceURI() + ":" + dfQName.getLocalPart();
+                if (declaredDecimalFormats.contains(dfKey))
+                    throw new XPathException(dfDecl, ErrorCodes.XQST0097, "Duplicate decimal format declaration: " + dfDecl.getText());
+                declaredDecimalFormats.add(dfKey);
+                final DecimalFormat df = processDecimalFormatProperties(dfDecl);
+                context.setStaticDecimalFormat(dfQName, df);
+            }
+        )
+        |
+        #(
+            defDfDecl:DEF_DECIMAL_FORMAT_DECL (.)*
+            {
+                if (defaultDecimalFormatDeclared)
+                    throw new XPathException(defDfDecl, ErrorCodes.XQST0097, "Duplicate default decimal format declaration.");
+                defaultDecimalFormatDeclared = true;
+                final DecimalFormat df = processDecimalFormatProperties(defDfDecl);
+                context.setDefaultStaticDecimalFormat(df);
+            }
         )
         |
         functionDecl [path]

--- a/exist-core/src/main/java/org/exist/xquery/DecimalFormat.java
+++ b/exist-core/src/main/java/org/exist/xquery/DecimalFormat.java
@@ -24,7 +24,7 @@ package org.exist.xquery;
 /**
  * Data class for a Decimal Format.
  *
- * See https://www.w3.org/TR/xpath-31/#dt-static-decimal-formats
+ * See https://www.w3.org/TR/xquery-31/#id-decimal-format-decl
  *
  * NOTE: UTF-16 characters are stored as code-points!
  *
@@ -32,6 +32,11 @@ package org.exist.xquery;
  */
 public class DecimalFormat {
 
+    /**
+     * The default (unnamed) decimal format as defined by the XQuery 3.1 specification.
+     *
+     * @see <a href="https://www.w3.org/TR/xquery-31/#id-decimal-format-decl">XQuery 3.1 §4.10: Decimal Format Declaration</a>
+     */
     public static final DecimalFormat UNNAMED = new DecimalFormat(
             '.',
             'e',

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -127,6 +127,13 @@ public class ErrorCodes {
 
     public static final ErrorCode XQST0094 = new W3CErrorCode("XQST0094", "The name of each grouping variable must be equal (by the eq operator on expanded QNames) to the name of a variable in the input tuple stream.");
 
+    public static final ErrorCode XQST0097 = new W3CErrorCode("XQST0097",
+        "It is a static error to have more than one decimal-format declaration with the same name, " +
+        "or more than one default decimal-format declaration, in the same module.");
+    public static final ErrorCode XQST0098 = new W3CErrorCode("XQST0098",
+        "It is a static error if the properties representing characters used in a picture string " +
+        "do not each have distinct values, or if a property value is not valid for its property.");
+
     public static final ErrorCode XQDY0101 = new W3CErrorCode("XQDY0101", "An error is raised if a computed namespace constructor attempts to do any of the following:\n" +
             "Bind the prefix xml to some namespace URI other than http://www.w3.org/XML/1998/namespace.\n" +
             "Bind a prefix other than xml to the namespace URI http://www.w3.org/XML/1998/namespace.\n" +

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -420,6 +420,9 @@ public class XQueryContext implements BinaryValueManager, Context {
      * HTTP context.
      */
     private @Nullable HttpContext httpContext = null;
+    /**
+     * Sentinel QName for the default (unnamed) decimal format per XQuery 3.1 §4.10.
+     */
     private static final QName UNNAMED_DECIMAL_FORMAT = new QName("__UNNAMED__", Function.BUILTIN_FUNCTION_NS);
 
     private final Map<QName, DecimalFormat> staticDecimalFormats = hashMap(Tuple(UNNAMED_DECIMAL_FORMAT, DecimalFormat.UNNAMED));

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2902,6 +2902,10 @@ public class XQueryContext implements BinaryValueManager, Context {
         staticDecimalFormats.put(qnDecimalFormat, decimalFormat);
     }
 
+    public void setDefaultStaticDecimalFormat(final DecimalFormat decimalFormat) {
+        staticDecimalFormats.put(UNNAMED_DECIMAL_FORMAT, decimalFormat);
+    }
+
     public Map<String, Sequence> getCachedUriCollectionResults() {
         return cachedUriCollectionResults;
     }

--- a/exist-core/src/test/xquery/numbers/format-numbers.xql
+++ b/exist-core/src/test/xquery/numbers/format-numbers.xql
@@ -317,3 +317,103 @@ declare
 function fd:exponent-fails($number as xs:double, $picture as xs:string) {
     format-number($number, $picture)
 };
+
+(:~
+ : Named decimal-format with European conventions (comma as decimal separator, dot as grouping separator).
+ :)
+declare
+    %test:assertEquals("1.234,50")
+function fd:named-decimal-format-eu() {
+    util:eval('
+        declare namespace local = "http://local";
+        declare decimal-format local:eu decimal-separator = "," grouping-separator = ".";
+        format-number(1234.5, "#.##0,00", "local:eu")
+    ')
+};
+
+(:~
+ : Default decimal-format with European conventions.
+ :)
+declare
+    %test:assertEquals("1.234,50")
+function fd:default-decimal-format-eu() {
+    util:eval('
+        declare default decimal-format decimal-separator = "," grouping-separator = ".";
+        format-number(1234.5, "#.##0,00")
+    ')
+};
+
+(:~
+ : Custom NaN property.
+ :)
+declare
+    %test:assertEquals("not a number")
+function fd:custom-nan() {
+    util:eval('
+        declare default decimal-format NaN = "not a number";
+        format-number(number(''NaN''), "#.00")
+    ')
+};
+
+(:~
+ : Custom infinity property.
+ :)
+declare
+    %test:assertEquals("INFINITY")
+function fd:custom-infinity() {
+    util:eval('
+        declare default decimal-format infinity = "INFINITY";
+        format-number(1 div 0e0, "#.00")
+    ')
+};
+
+(:~
+ : Error: duplicate named decimal-format declaration.
+ :)
+declare
+    %test:assertError("XQST0097")
+function fd:error-duplicate-named-decimal-format() {
+    util:eval('
+        declare namespace local = "http://local";
+        declare decimal-format local:eu decimal-separator = "," grouping-separator = ".";
+        declare decimal-format local:eu decimal-separator = "," grouping-separator = ".";
+        format-number(1234.5, "#.##0,00", "local:eu")
+    ')
+};
+
+(:~
+ : Error: duplicate default decimal-format declaration.
+ :)
+declare
+    %test:assertError("XQST0097")
+function fd:error-duplicate-default-decimal-format() {
+    util:eval('
+        declare default decimal-format decimal-separator = "," grouping-separator = ".";
+        declare default decimal-format decimal-separator = "," grouping-separator = ".";
+        format-number(1234.5, "#.##0,00")
+    ')
+};
+
+(:~
+ : Error: non-distinct property values (decimal-separator and grouping-separator are the same).
+ :)
+declare
+    %test:assertError("XQST0098")
+function fd:error-non-distinct-properties() {
+    util:eval('
+        declare default decimal-format decimal-separator = "." grouping-separator = ".";
+        format-number(1234.5, "#.##0.00")
+    ')
+};
+
+(:~
+ : Error: invalid zero-digit value.
+ :)
+declare
+    %test:assertError("XQST0098")
+function fd:error-invalid-zero-digit() {
+    util:eval('
+        declare default decimal-format zero-digit = "A";
+        format-number(1234.5, "#,##0.00")
+    ')
+};


### PR DESCRIPTION
## Summary
- Add parser support for XQuery 3.1 `declare decimal-format` and `declare default decimal-format` prolog declarations ([spec section 4.10](https://www.w3.org/TR/xquery-31/#id-decimal-format-decl))
- The runtime infrastructure was already in place (`DecimalFormat`, `XQueryContext` storage, `FnFormatNumbers` 3-arg support) — this adds the missing parser recognition and tree walker processing
- Enables users to customize number formatting (e.g., European comma-as-decimal-separator conventions) via `fn:format-number`

### Changes
| File | Change |
|------|--------|
| `XQuery.g` | Add tokens, grammar rules for named/default forms, property keywords in `reservedKeywords` |
| `XQueryTree.g` | Walk AST, validate properties (single-char, zero-digit, distinctness), register formats in context |
| `ErrorCodes.java` | Add `XQST0097` (duplicate declarations) and `XQST0098` (invalid/conflicting property values) |
| `XQueryContext.java` | Add `setDefaultStaticDecimalFormat()` convenience method |
| `format-numbers.xql` | 8 new tests for named/default formats, custom NaN/infinity, and error cases |

Closes #56

See also: eXist-db/exist-xqts-runner#44 (fix copy-paste typo in XQTS runner for exponent-separator attribute)

## Test plan
- [x] All 161 existing `format-numbers.xql` tests pass (0 failures, 0 errors)
- [x] New tests pass: named format, default format, custom NaN, custom infinity
- [x] New error tests pass: duplicate named (XQST0097), duplicate default (XQST0097), non-distinct properties (XQST0098), invalid zero-digit (XQST0098)
- [x] ANTLR grammar generates without errors
- [x] Full project compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)