### PR TITLE
Fix fn:filter return type checking per W3C spec

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -147,9 +147,15 @@ public class FunHigherOrderFun extends BasicFunction {
                     final Item item = i.nextItem();
                     final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});
 
-                    // call to effectiveBooleanValue is not spec compliant
-                    // spec: https://www.w3.org/TR/xpath-functions/#func-filter
-                    // two pending tests in exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
+                    // W3C spec: fn:filter requires function to return xs:boolean
+                    // https://www.w3.org/TR/xpath-functions/#func-filter
+                    if (!r.hasOne() || !Type.subTypeOf(r.itemAt(0).getType(), Type.BOOLEAN)) {
+                        throw new XPathException(this, ErrorCodes.XPTY0004,
+                                "fn:filter: the supplied function must return a single xs:boolean value"
+                                        + "; got: " + (r.isEmpty() ? "empty sequence"
+                                        : !r.hasOne() ? "sequence of " + r.getItemCount() + " items"
+                                        : Type.getTypeName(r.itemAt(0).getType())));
+                    }
                     if (r.effectiveBooleanValue()) {
                         result.add(item);
                     }

--- a/exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
+++ b/exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
@@ -130,7 +130,6 @@ function hofs:declared-function-test () {
 
 (: https://github.com/eXist-db/exist/issues/3382 :)
 declare
-    %test:pending
     %test:assertError("XPTY0004")
 function hofs:function-has-wrong-return-type () {
     filter((0 to 1), function ($a) { $a })
@@ -138,7 +137,6 @@ function hofs:function-has-wrong-return-type () {
 
 (: https://github.com/eXist-db/exist/issues/3382 :)
 declare
-    %test:pending
     %test:assertError("XPTY0004")
 function hofs:return-mixed-types () {
     filter((true(), false(), 1, ""), function ($a) { $a })


### PR DESCRIPTION
## Summary

Fixes #3382.

`fn:filter` previously used `effectiveBooleanValue()` to evaluate the result of its function argument, which silently coerced any value (integers, strings, nodes, etc.) to a boolean. Per the [W3C XQuery 3.1 spec (Section 3.22.3)](https://www.w3.org/TR/xpath-functions/#func-filter), `fn:filter` requires its function argument to have the signature `function(item()) as xs:boolean` — the function must return exactly one `xs:boolean` value.

### What changed

**`FunHigherOrderFun.java`** — Added a dynamic type check in the `fn:filter` evaluation path that validates each return value is a single `xs:boolean` before using it. Non-boolean values, empty sequences, and multi-item sequences now correctly raise `XPTY0004`.

**`fnHigherOrderFunctions.xql`** — Removed `%test:pending` from two existing XQSuite tests that verify this behavior.

### Scope

This fix addresses only `fn:filter`'s return type requirement (`xs:boolean`). The other HOFs (`fn:for-each`, `fn:fold-left`, `fn:fold-right`, `fn:for-each-pair`) accept `item()*` as the return type of their function argument, so no additional validation is needed for them.

A related but separate issue — HOFs not checking the *parameter types* of the supplied function — is tracked in #3754 and is not addressed here.

## Test results

### XQSuite

- `fnHigherOrderFunctions.xql`: all tests pass, including 2 previously pending tests
- Full `exist-core` suite: 6,471 tests run, 0 failures related to this change (1 pre-existing flaky `RenameCollectionTest`)

### XQTS (before → after)

| Test Set | Errors | Failures (before) | Failures (after) | Delta |
|---|---|---|---|---|
| `fn-filter` | 3 | 6 | **0** | **6 fixed** |
| `misc-HigherOrderFunctions` | 3 | 24 | 24 | no change |

The 6 newly passing `fn-filter` tests: `filter-901`, `filter-902`, `filter-903`, `fn-filter-015`, `fn-filter-018`, `fn-filter-021`.

## Test plan

- [x] XQSuite `fnHigherOrderFunctions.xql` — all pass
- [x] Full `exist-core` test suite — no regressions
- [x] XQTS `fn-filter` — 6 previously failing tests now pass
- [x] XQTS `misc-HigherOrderFunctions` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)