### PR TITLE
Fix fn:not() predicate crashes on empty context and atomic sequences

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -106,13 +106,16 @@ public class FunNot extends Function {
             (contextSequence == null || contextSequence.isPersistentSet()) &&
             !Dependency.dependsOn(arg, Dependency.CONTEXT_ITEM)) {
 			if (contextSequence == null || contextSequence.isEmpty()) {
-				// TODO: special treatment if the context sequence is empty:
-				// within a predicate, we just return the empty sequence
-				// otherwise evaluate the argument and return a boolean result			    
-//				if (inPredicate && !inWhereClause)
-//                    result = Sequence.EMPTY_SEQUENCE;
-//				else
-                    result = evalBoolean(contextSequence, contextItem, arg);
+				if (inPredicate) {
+					// When used inside a predicate in NODE mode, the result is consumed
+					// as a node set by Predicate.selectByNodeSet(). An empty context
+					// means there are no nodes to filter — the set-difference result
+					// is always empty. Returning a boolean here would crash with
+					// "cannot convert xs:boolean to a node set" (GitHub #2159).
+					result = Sequence.EMPTY_SEQUENCE;
+				} else {
+					result = evalBoolean(contextSequence, contextItem, arg);
+				}
 			} else {
     			result = contextSequence.toNodeSet().copy();
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -26,8 +26,10 @@ import org.exist.dom.persistent.NodeSet;
 import org.exist.dom.QName;
 import org.exist.xquery.AnalyzeContextInfo;
 import org.exist.xquery.Cardinality;
+import org.exist.xquery.Constants;
 import org.exist.xquery.Dependency;
 import org.exist.xquery.Expression;
+import org.exist.xquery.LocationStep;
 import org.exist.xquery.Function;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.Profiler;
@@ -81,7 +83,21 @@ public class FunNot extends Function {
 	 * @see org.exist.xquery.functions.Function#getDependencies()
 	 */
 	public int getDependencies() {
-		return Dependency.CONTEXT_SET | getArgument(0).getDependencies();
+		final Expression arg = getArgument(0);
+		int deps = Dependency.CONTEXT_SET | arg.getDependencies();
+		// When the argument is the context item expression "." used inside a
+		// predicate on an atomic sequence (e.g., (0, 1, 2)[not(.)]), Predicate
+		// must iterate per-item. LocationStep.getDependencies() does not report
+		// CONTEXT_ITEM inside predicates (for the set-difference optimization),
+		// so we add it here to ensure correct per-item evaluation (GitHub #2308).
+		if (inPredicate && arg instanceof LocationStep) {
+			final LocationStep step = (LocationStep) arg;
+			if (step.getAxis() == Constants.SELF_AXIS
+					&& step.getTest().getType() == Type.NODE) {
+				deps = deps | Dependency.CONTEXT_ITEM;
+			}
+		}
+		return deps;
 	}
 	
 	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunNotBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunNotBenchmark.java
@@ -1,0 +1,175 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.*;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Performance benchmark for fn:not() predicate evaluation.
+ *
+ * <p>Verifies that the set-difference optimization for fn:not() on persistent
+ * node sets is preserved after the fixes for issues #2159 and #2308, and that
+ * the new boolean-per-item fallback path for atomic sequences performs
+ * acceptably.</p>
+ *
+ * <p>Skipped by default. Run with:</p>
+ * <pre>
+ * mvn test -pl exist-core -Dtest=FunNotBenchmark \
+ *     -Dexist.run.benchmarks=true -Ddependency-check.skip=true
+ * </pre>
+ */
+public class FunNotBenchmark {
+
+    private static final String COLLECTION_NAME = "bench-fn-not";
+    private static final int WARMUP_ITERATIONS = 100;
+    private static final int MEASURED_ITERATIONS = 500;
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    @BeforeClass
+    public static void setUp() throws XMLDBException {
+        assumeTrue("Benchmark skipped (pass -Dexist.run.benchmarks=true to enable)",
+                Boolean.getBoolean("exist.run.benchmarks"));
+
+        final CollectionManagementService cms =
+                server.getRoot().getService(CollectionManagementService.class);
+        final var col = cms.createCollection(COLLECTION_NAME);
+
+        // Generate test document: 200 items with varying children and attributes
+        final StringBuilder sb = new StringBuilder();
+        sb.append("<root>\n");
+        for (int i = 1; i <= 200; i++) {
+            sb.append("  <item id=\"").append(i).append("\"");
+            if (i % 3 == 0) {
+                sb.append(" attr=\"val").append(i).append("\"");
+            }
+            sb.append(">\n");
+            if (i % 2 == 0) {
+                sb.append("    <child>child-").append(i).append("</child>\n");
+            }
+            if (i % 5 == 0) {
+                sb.append("    <x>descendant-").append(i).append("</x>\n");
+            }
+            sb.append("  </item>\n");
+        }
+        sb.append("</root>");
+
+        final XMLResource res = col.createResource("data.xml", XMLResource.class);
+        res.setContent(sb.toString());
+        col.storeResource(res);
+        col.close();
+    }
+
+    @AfterClass
+    public static void tearDown() throws XMLDBException {
+        try {
+            final CollectionManagementService cms =
+                    server.getRoot().getService(CollectionManagementService.class);
+            cms.removeCollection(COLLECTION_NAME);
+        } catch (final XMLDBException e) {
+            // ignore cleanup failures
+        }
+    }
+
+    // --- Benchmark queries ---
+
+    private static final String DOC = "doc('/db/" + COLLECTION_NAME + "/data.xml')";
+
+    /** Set-difference optimization: child axis */
+    @Test
+    public void notChild() throws XMLDBException {
+        runBenchmark("not(child)",
+                DOC + "//item[not(child)]");
+    }
+
+    /** Set-difference optimization: attribute axis */
+    @Test
+    public void notAttribute() throws XMLDBException {
+        runBenchmark("not(@attr)",
+                DOC + "//item[not(@attr)]");
+    }
+
+    /** Set-difference optimization: descendant axis */
+    @Test
+    public void notDescendant() throws XMLDBException {
+        runBenchmark("not(descendant::x)",
+                DOC + "//item[not(descendant::x)]");
+    }
+
+    /** Boolean fallback: general comparison inside not() */
+    @Test
+    public void notComparison() throws XMLDBException {
+        runBenchmark("not(@id > 100)",
+                DOC + "//item[not(@id > 100)]");
+    }
+
+    /** Boolean fallback: not(.) on in-memory nodes */
+    @Test
+    public void notDotOnNodes() throws XMLDBException {
+        runBenchmark("not(.) on nodes",
+                DOC + "//item[not(.)]");
+    }
+
+    // --- Benchmark harness ---
+
+    private void runBenchmark(final String label, final String xquery) throws XMLDBException {
+        final XQueryService queryService = server.getRoot().getService(XQueryService.class);
+
+        // Warmup
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            queryService.query(xquery);
+        }
+
+        // Measured
+        final long[] timings = new long[MEASURED_ITERATIONS];
+        for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+            final long start = System.nanoTime();
+            queryService.query(xquery);
+            timings[i] = System.nanoTime() - start;
+        }
+
+        // Stats
+        long total = 0;
+        long min = Long.MAX_VALUE;
+        for (final long t : timings) {
+            total += t;
+            if (t < min) {
+                min = t;
+            }
+        }
+        final double avgMs = (total / (double) MEASURED_ITERATIONS) / 1_000_000.0;
+        final double minMs = min / 1_000_000.0;
+        final double opsPerSec = MEASURED_ITERATIONS / (total / 1_000_000_000.0);
+
+        System.out.printf("| %-25s | %8.3f ms | %8.3f ms | %10.1f ops/s |%n",
+                label, avgMs, minMs, opsPerSec);
+    }
+}

--- a/exist-core/src/test/xquery/boolean-sequences.xq
+++ b/exist-core/src/test/xquery/boolean-sequences.xq
@@ -49,10 +49,9 @@ function boolseq:countPositivesContextItem() {
 };
 
 (:~
-  this is the failing issue
+  this was the failing issue — fixed in GitHub #2308
 ~:)
 declare
-    %test:pending
     %test:assertEquals(1)
 function boolseq:countNegativesContextItem() {
     count($boolseq:sequence[not(.)])

--- a/exist-core/src/test/xquery/fn-not.xq
+++ b/exist-core/src/test/xquery/fn-not.xq
@@ -24,6 +24,7 @@ xquery version "3.1";
 (:~
   Tests for fn:not() predicate handling.
   https://github.com/eXist-db/exist/issues/2159
+  https://github.com/eXist-db/exist/issues/2308
 ~:)
 module namespace fn-not="http://exist-db.org/xquery/test/fn-not";
 
@@ -97,4 +98,32 @@ declare
 function fn-not:persistent-not-self() {
     let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
     return count($dom//item[not(@type = 'a')])
+};
+
+(: #2308 — not(.) on integer sequence :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-integers() {
+    count((0, 1, 2)[not(.)])
+};
+
+(: #2308 — not(.) on string sequence :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-strings() {
+    count(("", "a")[not(.)])
+};
+
+(: #2308 — not(.) on mixed booleans :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-booleans() {
+    count((true(), false())[not(.)])
+};
+
+(: not(.) on in-memory node sequence filters correctly :)
+declare
+    %test:assertEquals(0)
+function fn-not:not-dot-nodes() {
+    count((<a/>, <b/>)[not(.)])
 };

--- a/exist-core/src/test/xquery/fn-not.xq
+++ b/exist-core/src/test/xquery/fn-not.xq
@@ -1,0 +1,100 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+  Tests for fn:not() predicate handling.
+  https://github.com/eXist-db/exist/issues/2159
+~:)
+module namespace fn-not="http://exist-db.org/xquery/test/fn-not";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $fn-not:collection := 'test-fn-not';
+declare variable $fn-not:doc := 'test.xml';
+declare variable $fn-not:nodes := document {
+    <root>
+        <item type="a"><child/></item>
+        <item type="b"/>
+        <item type="a"/>
+    </root>
+};
+
+declare
+    %test:setUp
+function fn-not:setup() {
+    xmldb:create-collection('/db', $fn-not:collection),
+    xmldb:store('/db/' || $fn-not:collection, $fn-not:doc, $fn-not:nodes)
+};
+
+declare
+    %test:tearDown
+function fn-not:teardown() {
+    xmldb:remove('/db/' || $fn-not:collection)
+};
+
+(: #2159 — not(self::x) on empty derived path must not crash :)
+declare
+    %test:assertEquals(0)
+function fn-not:empty-path-not-self() {
+    let $doc := <root><abc/></root>
+    return count($doc/nonexistent/*[not(self::abc)])
+};
+
+(: #2159 — not(self::x) on non-empty path filters correctly :)
+declare
+    %test:assertEquals(1)
+function fn-not:non-empty-path-not-self() {
+    let $doc := <root><abc/><def/></root>
+    return count($doc/*[not(self::abc)])
+};
+
+(: #2159 — not(*) on empty path returns empty :)
+declare
+    %test:assertEquals(0)
+function fn-not:empty-path-not-wildcard() {
+    let $doc := <root><abc/></root>
+    return count($doc/nonexistent/*[not(*)])
+};
+
+(: Standalone not(()) returns true — boolean path unaffected :)
+declare
+    %test:assertTrue
+function fn-not:standalone-not-empty() {
+    not(())
+};
+
+(: Set-difference optimization on persistent nodes — not(child) :)
+declare
+    %test:assertEquals(2)
+function fn-not:persistent-not-child() {
+    let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
+    return count($dom//item[not(child)])
+};
+
+(: Set-difference optimization on persistent nodes — not(self::x) :)
+declare
+    %test:assertEquals(1)
+function fn-not:persistent-not-self() {
+    let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
+    return count($dom//item[not(@type = 'a')])
+};

--- a/exist-core/src/test/xquery/simple-map-predicate.xq
+++ b/exist-core/src/test/xquery/simple-map-predicate.xq
@@ -1,0 +1,136 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+  Tests for simple map operator inside predicates.
+  https://github.com/eXist-db/exist/issues/3289
+
+  The expression @*[name() ! contains(., 'DateTime')] crashes with
+  "Type error: the sequence cannot be converted into a node set.
+  Item type is xs:boolean" when used on persistent (stored) documents.
+~:)
+module namespace smp="http://exist-db.org/xquery/test/simple-map-predicate";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $smp:collection := 'test-simple-map-predicate';
+declare variable $smp:doc := 'sts135.xml';
+declare variable $smp:data :=
+    <launch>
+        <event launchDateTime="2011-07-08T11:29:00"
+               landDateTime="2011-07-21T05:57:00"
+               type="mission"/>
+        <event type="test"/>
+    </launch>;
+
+declare
+    %test:setUp
+function smp:setup() {
+    xmldb:create-collection('/db', $smp:collection),
+    xmldb:store('/db/' || $smp:collection, $smp:doc, $smp:data)
+};
+
+declare
+    %test:tearDown
+function smp:teardown() {
+    xmldb:remove('/db/' || $smp:collection)
+};
+
+(:~
+  #3289 — @*[name() ! contains(., 'DateTime')] on stored doc crashes with
+  "Type error: the sequence cannot be converted into a node set."
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-simple-map-contains-in-attr-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[name() ! contains(., 'DateTime')]])
+};
+
+(:~
+  Workaround from #3289: contains(name(.), ...) — should always work.
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-contains-name-dot() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[contains(name(.), 'DateTime')]])
+};
+
+(:~
+  Another workaround from #3289: @* ! name()[contains(., ...)]
+~:)
+declare
+    %test:assertEquals(2)
+function smp:persistent-attr-map-name-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    let $event := $doc//event[1]
+    return count($event/@* ! name()[contains(., 'DateTime')])
+};
+
+(:~
+  Workaround from #3289 comment: @*[name()[contains(., ...)]]
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-nested-name-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[name()[contains(., 'DateTime')]]])
+};
+
+(:~
+  Workaround from #3289 comment: //@*[name() ! contains(., ...)]/..
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-deref-attr-parent() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//@*[name() ! contains(., 'DateTime')]/..)
+};
+
+(:~
+  #3289 comment pattern 1: @* ! name() ! contains(., ...) is expected to fail
+  per spec when multiple attributes produce multiple booleans, since EBV is
+  undefined for a sequence of two or more booleans.
+~:)
+declare
+    %test:assertError("FORG0006")
+function smp:persistent-double-map-expected-error() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return $doc//*[@* ! name() ! contains(., 'DateTime')]
+};
+
+(:~
+  In-memory version should also work — same pattern, no stored doc.
+~:)
+declare
+    %test:assertEquals(1)
+function smp:inmemory-simple-map-contains-in-attr-predicate() {
+    let $doc :=
+        <launch>
+            <event launchDateTime="2011-07-08T11:29:00"
+                   landDateTime="2011-07-21T05:57:00"
+                   type="mission"/>
+        </launch>
+    return count($doc//*[@*[name() ! contains(., 'DateTime')]])
+};


### PR DESCRIPTION
## Summary

Fixes two long-standing bugs in `fn:not()` that cause unexpected errors when used in predicates:

- **#2159**: `$doc/*[not(self::abc)]` throws "cannot convert xs:boolean('true') to a node set" when `$doc` resolves to empty
- **#2308**: `(true(), false())[not(.)]` throws `err:FORG0006` instead of returning `(false())`

Both stem from optimizations in `FunNot` that assume node-set contexts but encounter empty sets or atomic values. These bugs have been open since 2018.

The `FunNot.getDependencies()` fix for #2308 also fixes **#3289**: `@*[name() ! contains(., 'DateTime')]` throws "the sequence cannot be converted into a node set. Item type is xs:boolean" on persistent (stored) documents. The fix ensures `not(.)` reports `CONTEXT_ITEM` dependency inside predicates, which prevents `Predicate.recomputeExecutionMode()` from pre-evaluating `not(.)` against the full context sequence.

## Approach

Per @wolfgangmm's [concern](https://github.com/eXist-db/exist/issues/2159#issuecomment-423218498): "eXist handles fn:not in a particular way by trying to evaluate it as a set operation. A naive fix would likely result in many expressions becoming slower by an order of magnitude."

These fixes **preserve the set-difference optimization** for all performance-critical patterns (`[not(child)]`, `[not(@attr)]`, `[not(descendant::x)]`, `[not(self::element)]`).

## Changes

### Fix #2159 — `FunNot.eval()` empty-context guard

When `fn:not()` is used inside a predicate and the context sequence is empty, the set-difference path returned a `BooleanValue` which `Predicate.selectByNodeSet()` cannot consume. Fix: return `EMPTY_SEQUENCE` when in a predicate with empty context (filtering an empty set always yields empty). Outside predicates, the boolean path is preserved. This matches the intent of the original commented-out TODO code.

### Fix #2308 — `FunNot.getDependencies()` targeted `CONTEXT_ITEM`

`LocationStep.getDependencies()` suppresses `CONTEXT_ITEM` for the self axis inside predicates to enable the set-difference optimization. This is correct for node-set predicates but causes `not(.)` on atomic sequences to be pre-evaluated against the full sequence instead of item-by-item, throwing `FORG0006`.

Fix: `FunNot.getDependencies()` adds `CONTEXT_ITEM` to the dependency flags when the argument is the context item expression `.` — specifically, a `LocationStep` with `SELF_AXIS` and a `node()` type test — and the function is inside a predicate. This is targeted and narrow: it only affects `.` (`self::node()`), not typed self-axis steps like `self::element`, forcing `Predicate` to use per-item boolean evaluation for that specific case. All other predicates (`not(child::bar)`, `not(@attr)`, `not(descendant::x)`, `not(self::element)`) are unaffected because their arguments use different axes, different type tests, or are not `LocationStep` instances.

`FunNot.returnsType()` and `LocationStep.getDependencies()` are unchanged from develop.

### Why the set-difference optimization is preserved

The optimization in `FunNot.eval()` runs when the argument returns NODE, context is a persistent set, and argument has no `CONTEXT_ITEM` dependency. After these changes:

| Pattern | Arg depends on CONTEXT_ITEM? | Set-difference? | Notes |
|---|---|---|---|
| `[not(child::bar)]` | No | Yes | Unchanged |
| `[not(@attr)]` | No | Yes | Unchanged |
| `[not(descendant::x)]` | No | Yes | Unchanged |
| `[not(self::abc)]` | No (element type test, not node()) | Yes | Unchanged |
| `[not(.)]` on atomics | Yes (self::node(), inPredicate) | No — boolean | Correct, was erroring before |
| `[not(.)]` on nodes | Yes (self::node(), inPredicate) | No — boolean | Trivial pattern, not perf-sensitive |

The promotion path via `Predicate.recomputeExecutionMode()` is unchanged.

## Performance benchmark

`FunNotBenchmark.java` measures 5 query patterns (100 warmup + 500 measured iterations each) against a 200-item generated XML document with no indexes (structural index only).

Run with:
```
mvn test -pl exist-core -Dtest=FunNotBenchmark \
    -Dexist.run.benchmarks=true -Ddependency-check.skip=true
```

### Results

| Query | develop avg (ms) | PR avg (ms) | develop ops/s | PR ops/s |
|---|---|---|---|---|
| `//item[not(child)]` | 0.277 | 0.270 | 3,609 | 3,698 |
| `//item[not(@attr)]` | 0.277 | 0.263 | 3,608 | 3,804 |
| `//item[not(descendant::x)]` | 0.266 | 0.262 | 3,756 | 3,821 |
| `//item[not(.)]` | 0.261 | 0.247 | 3,838 | 4,044 |
| `//item[not(@id > 100)]` | 0.724 | 0.720 | 1,382 | 1,388 |

**Takeaway**: All queries are within noise margin (~2%). The set-difference optimization is fully preserved for child, attribute, and descendant axis patterns. The `not(.)` pattern (boolean fallback path) also shows no regression. Environment: macOS, Zulu JDK 21, single-threaded, in-process embedded server.

## Test plan

- [x] New `fn-not.xq` XQSuite tests covering empty paths, persistent node set-difference, `not(.)` on integers/strings/booleans/nodes
- [x] Removed `%test:pending` from `boolseq:countNegativesContextItem` in `boolean-sequences.xq`
- [x] New `simple-map-predicate.xq` tests for #3289: `@*[name() ! contains(., 'DateTime')]` on persistent and in-memory documents
- [x] Performance benchmark (`FunNotBenchmark.java`): 5 queries × 500 iterations, no regression vs develop
- [x] Full `CoreTests` suite: 992 tests, 0 failures, 0 errors
- [x] `OptimizerTest`: 6 tests, 0 failures
- [x] `DateTest`: 46 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)