### PR TITLE
Normalize annotation values in XQSuite assertEquals for XML comparison

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -935,7 +935,12 @@ declare %private function test:equals($annotation-value as element(value), $resu
             default return
                 $result
     let $value := test:xdm-value-from-annotation-value($annotation-value)
-    let $normValue := test:cast-to-type($value, $result)
+    let $normValue :=
+        typeswitch ($result)
+            case node() return
+                test:cast-to-type($value, $result) => test:normalize()
+            default return
+                test:cast-to-type($value, $result)
     return
         typeswitch ($normResult)
             case node() return

--- a/exist-core/src/test/xquery/xqsuite/xqsuite-tests.xql
+++ b/exist-core/src/test/xquery/xqsuite/xqsuite-tests.xql
@@ -246,3 +246,12 @@ declare
 function t:args-assert-element($arg as element()) as element() {
     $arg
 };
+
+(: https://github.com/eXist-db/exist/issues/4327 :)
+declare
+    %test:assertEquals('
+  <span type="xml">Success!</span>
+')
+function t:assertEquals-normalize-annotation-whitespace() as element(span) {
+    <span type="xml">Success!</span>
+};


### PR DESCRIPTION
## Summary

- Fixes `%test:assertEquals` failing when the annotation value contains whitespace around XML (e.g., newlines before/after `<span>`)
- The actual result was already normalized (whitespace stripped via `test:normalize`) but the expected value from the annotation was not, causing `deep-equal` to fail
- Now both values are normalized before comparison, consistent with the [XQSuite docs](https://exist-db.org/exist/apps/doc/xqsuite): "The assertion argument is then parsed into XML and the two node trees are compared using the deep-equals function"

Closes https://github.com/eXist-db/exist/issues/4327

## Test plan

- [x] Added XQSuite test with whitespace in `%test:assertEquals` annotation around XML element
- [x] All 91 existing XQSuite tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)