### PR TITLE
[bugfix] xml-to-json() validates namespace requirement per spec

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -24,6 +24,7 @@ package org.exist.xquery.functions.fn;
 import com.fasterxml.jackson.core.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.map.MapType;
@@ -120,6 +121,12 @@ public class FunXmlToJson extends BasicFunction {
                 switch (status) {
                     case XMLStreamReader.START_ELEMENT:
                         tempStringBuilder.setLength(0);
+                        final String elementNamespaceURI = reader.getNamespaceURI();
+                        if (!Namespaces.XPATH_FUNCTIONS_NS.equals(elementNamespaceURI)) {
+                            throw new XPathException(this, ErrorCodes.FOJS0006,
+                                    "Invalid XML representation of JSON. Element '" + reader.getLocalName()
+                                    + "' is not in the required namespace '" + Namespaces.XPATH_FUNCTIONS_NS + "'.");
+                        }
                         final String elementAttributeEscapedValue = reader.getAttributeValue(null, "escaped");
                         elementValueIsEscaped = "true".equals(elementAttributeEscapedValue);
                         final String elementAttributeEscapedKeyValue = reader.getAttributeValue(null, "escaped-key");

--- a/exist-core/src/test/xquery/xquery3/xml-to-json.xql
+++ b/exist-core/src/test/xquery/xquery3/xml-to-json.xql
@@ -23,6 +23,7 @@ xquery version "3.1";
 
 module namespace xtj="http://exist-db.org/xquery/test/xml-to-json";
 
+declare default element namespace "http://www.w3.org/2005/xpath-functions";
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare
@@ -306,8 +307,7 @@ declare
     %test:assertEquals('{"pcM9qSs":"YbFYeK10.e01xgS1DEJFaxxvm372Ru","wh5J8qAmnZx8WAHnHCeBpM":-1270212191.431,"ssEhB3U9zZhRNNH2Vm":["A","OIQwg4ICB9fkzihwpE.cQv1",false]}')
 function xtj:xml-to-json-generatedFromSchema-1() {
     let $node :=
-<map xmlns="http://www.w3.org/2005/xpath-functions"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<map xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <string key="pcM9qSs" escaped-key="false" escaped="false">YbFYeK10.e01xgS1DEJFaxxvm372Ru</string>
     <number key="wh5J8qAmnZx8WAHnHCeBpM" escaped-key="false">-1270212191.431</number>
     <array key="ssEhB3U9zZhRNNH2Vm" escaped-key="false">
@@ -323,8 +323,7 @@ declare
     %test:assertEquals('{"v-DhbQUwZO3zpW":[{"fRcP.5e9btnuR3dOnd":[false,"_aQ",null],"yVlXSsyg1pPatQ7ilEaSSA9":"DVbrO2wpIRJimrskkRk.7wg1Gvh","K9xGofqp":true,"PatQ7iK9xGof":false},11145450.201,584608693.252],"IU6lSWbLYTzc3QvIVAdmJ.CG":1600374222.048,"_o3UT5zEy":"WFUwRRW5Jc3rdwKCoO8iV3RYDu_5"}')
 function xtj:xml-to-json-generatedFromSchema-2() {
     let $node :=
-<map xmlns="http://www.w3.org/2005/xpath-functions"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<map xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <array key="v-DhbQUwZO3zpW" escaped-key="false">
         <map>
             <array key="fRcP.5e9btnuR3dOnd" escaped-key="false">
@@ -349,10 +348,23 @@ declare
     %test:assertError('FOJS0006')
 function xtj:xml-to-json-unsupportedElement() {
     let $node :=
-<map xmlns="http://www.w3.org/2005/xpath-functions"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<map xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <my-element key=""></my-element>
 </map>
+    return fn:xml-to-json($node)
+};
+
+declare
+    %test:assertError('FOJS0006')
+function xtj:xml-to-json-wrong-namespace() {
+    let $node := element { QName("", "map") } {}
+    return fn:xml-to-json($node)
+};
+
+declare
+    %test:assertError('FOJS0006')
+function xtj:xml-to-json-wrong-namespace-non-empty() {
+    let $node := element { QName("http://example.com", "map") } {}
     return fn:xml-to-json($node)
 };
 


### PR DESCRIPTION
## Summary
- **Fixes** xml-to-json() to validate that input elements are in the `http://www.w3.org/2005/xpath-functions` namespace, as required by the [XPath and XQuery Functions and Operators 3.1 spec](https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json)
- Raises `FOJS0006` ("Invalid XML representation of JSON") when elements are not in the required namespace
- Updates existing tests to use the correct namespace (via `declare default element namespace`) and adds two new tests for the wrong-namespace error case

Closes #5543

## Test plan
- [x] All 942 existing XQuery3 tests pass (0 failures, 0 errors)
- [x] New tests verify FOJS0006 is raised for elements with no namespace and elements with a wrong namespace
- [x] Existing tests with correct namespace (`generatedFromSchema-1`, `generatedFromSchema-2`, etc.) continue to pass
- [x] XQTS `fn-xml-to-json` test set (144 tests from [w3c/qt3tests](https://github.com/w3c/qt3tests) HEAD): **no regressions, no improvements** — 72 pass, 68 fail, 4 skipped, identical before and after this change. The XQTS tests already use the correct namespace, so the new validation doesn't affect them. The 4 skipped tests require `schemaImport` (unrelated). The 68 pre-existing failures break down as: 46 from `fn:doc()`-loaded content (streaming/element recognition issue), 11 missing FOJS0006 validation (duplicate keys, invalid escaped values), 6 escaping differences, and 5 other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)