### PR TITLE
[bugfix] Fix fn:lang corrupting XQueryContext during compilation

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
@@ -99,10 +99,11 @@ public class FunLang extends Function {
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		super.analyze(contextInfo);
 		try {
-			query = context.getBroker().getBrokerPool().getXQueryService().compile(context, queryString);
+			final XQueryContext innerContext = context.copyContext();
+			query = context.getBroker().getBrokerPool().getXQueryService().compile(innerContext, queryString);
 		} catch (final PermissionDeniedException e) {
 			throw new XPathException(this, e);
-		}		
+		}
 	}
 	
 	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
@@ -22,14 +22,24 @@
 package org.exist.xquery.functions.fn;
 
 import com.googlecode.junittoolbox.ParallelRunner;
+import org.exist.TestUtils;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xmldb.EXistResource;
+import org.exist.xmldb.XmldbURI;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.runner.RunWith;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.BinaryResource;
+import org.xmldb.api.modules.CollectionManagementService;
 
 /**
  *
@@ -40,6 +50,64 @@ public class FunLangTest {
 
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true, true, true);
+
+    private static final String TEST_COLLECTION = "fun-lang-test";
+
+    private static final String MODULE =
+        "module namespace mod = \"http://exist-db.org/test/fun-lang\";\n" +
+        "\n" +
+        "declare variable $mod:data := <root xml:lang=\"en\"><p>hello</p></root>;\n" +
+        "\n" +
+        "declare function mod:check-lang($lang as xs:string) as xs:boolean {\n" +
+        "    lang($lang, $mod:data/p)\n" +
+        "};\n";
+
+    @BeforeClass
+    public static void setUp() throws XMLDBException {
+        final Collection testCollection = createCollection(TEST_COLLECTION);
+        writeModule(testCollection, "mod.xqm", MODULE);
+    }
+
+    @AfterClass
+    public static void tearDown() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService cmService = root.getService(CollectionManagementService.class);
+        cmService.removeCollection(TEST_COLLECTION);
+    }
+
+    private static Collection createCollection(final String collectionName) throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService cmService = root.getService(CollectionManagementService.class);
+        Collection collection = root.getChildCollection(collectionName);
+        if (collection == null) {
+            cmService.createCollection(collectionName);
+        }
+        collection = DatabaseManager.getCollection(XmldbURI.LOCAL_DB + "/" + collectionName, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        assertNotNull(collection);
+        return collection;
+    }
+
+    private static void writeModule(final Collection collection, final String moduleName, final String module) throws XMLDBException {
+        final BinaryResource res = collection.createResource(moduleName, BinaryResource.class);
+        ((EXistResource) res).setMimeType("application/xquery");
+        res.setContent(module.getBytes());
+        collection.storeResource(res);
+        collection.close();
+    }
+
+    @Test
+    public void fnLangInLibraryModuleWithVariable() throws XMLDBException {
+        // Regression test for https://github.com/eXist-db/exist/issues/5103
+        // fn:lang in analyze() compiles a sub-query that corrupts the XQueryContext,
+        // causing module-level variables to fail with XPDY0002 on first access.
+        final String query =
+            "import module namespace mod = \"http://exist-db.org/test/fun-lang\"" +
+            "    at \"xmldb:exist:///db/" + TEST_COLLECTION + "/mod.xqm\";\n" +
+            "mod:check-lang(\"en\")";
+        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, resourceSet.getSize());
+        assertEquals("true", resourceSet.getResource(0).getContent());
+    }
 
     @Test
     public void testFnLangWithContext() throws XMLDBException {


### PR DESCRIPTION
## Summary

- Fix `FunLang.analyze()` to compile its internal sub-query in a **copied context** (`context.copyContext()`), preventing `XQuery.compile()` from corrupting the outer `XQueryContext`
- Add regression test: library module with a module-level variable and a function using `fn:lang`, imported from a main query — previously failed with `err:XPDY0002` on first access

Closes https://github.com/eXist-db/exist/issues/5103

## Test plan

- [x] New test `fnLangInLibraryModuleWithVariable` passes
- [x] Full `FunLangTest` suite passes (4/4)
- [x] XQTS `fn-lang` test set passes (36/36, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)