### PR TITLE
[bugfix] Reject xs:string as argument to format-date()

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/DynamicTypeCheck.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicTypeCheck.java
@@ -110,8 +110,7 @@ public class DynamicTypeCheck extends AbstractExpression {
             //Then, if duration, try to refine the type
             //No test on the type hierarchy ; this has to pass :
             //fn:months-from-duration(xs:duration("P1Y2M3DT10H30M"))
-            //TODO : find a way to enforce the test (by making a difference between casting and treating as ?)
-            } else if (Type.subTypeOf(requiredType, Type.DURATION) /*&& Type.subTypeOf(type, requiredType)*/) {
+            } else if (Type.subTypeOf(requiredType, Type.DURATION) && Type.subTypeOf(type, requiredType)) {
                 try {
                     item = item.convertTo(requiredType);
                 //No way
@@ -121,9 +120,7 @@ public class DynamicTypeCheck extends AbstractExpression {
                             item.getStringValue() + ")'");
                 }
             //Then, if date, try to refine the type
-            //No test on the type hierarchy
-            //TODO : find a way to enforce the test (by making a difference between casting and treating as ?)
-            } else if (Type.subTypeOf(requiredType, Type.DATE) /*&& Type.subTypeOf(type, requiredType)*/) {
+            } else if (Type.subTypeOf(requiredType, Type.DATE) && Type.subTypeOf(type, requiredType)) {
                 try {
                     item = item.convertTo(requiredType);
                 //No way

--- a/exist-core/src/test/xquery/dates/format-dates.xql
+++ b/exist-core/src/test/xquery/dates/format-dates.xql
@@ -594,3 +594,9 @@ declare
 function fd:written-day-en($date-str as xs:string) {
     format-date(xs:date($date-str), "[FNn]", "en", (), ())
 };
+
+declare
+    %test:assertError("XPTY0004")
+function fd:string-instead-of-date() {
+    format-date('2022-05-30', '[MNn] [D], [Y]')
+};


### PR DESCRIPTION
## Summary

- **Fix:** `format-date('2022-05-30', '[MNn] [D], [Y]')` now correctly raises `XPTY0004` instead of silently converting the string to a date
- **Root cause:** `DynamicTypeCheck.check()` had commented-out type hierarchy guards on the DATE and DURATION conversion branches, allowing any type to be converted to date/duration types
- **Change:** Uncomment the `Type.subTypeOf(type, requiredType)` guards so only within-family conversions are permitted (e.g., `xs:duration` → `xs:dayTimeDuration`), while `xs:string` → `xs:date` is correctly rejected

Closes #4425

## Test plan

- [x] New XQSuite test `fd:string-instead-of-date()` verifies `XPTY0004` is raised for string argument
- [x] All existing `DateTests` pass (122 tests, 0 failures)
- [x] XQTS conformance: zero regressions across `fn-format-date`, `fn-format-dateTime`, `fn-format-time`, and `fn-months-from-duration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)