### PR TITLE
Fix type checking of 'as' clause in for-binding

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ForExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ForExpr.java
@@ -189,29 +189,6 @@ public class ForExpr extends BindingExpression {
         }
 
         clearContext(getExpressionId(), in);
-        if (sequenceType != null) {
-            //Type.EMPTY is *not* a subtype of other types ; checking cardinality first
-            //only a check on empty sequence is accurate here
-            if (resultSequence.isEmpty() &&
-                    !sequenceType.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EMPTY_SEQUENCE))
-                {throw new XPathException(this, ErrorCodes.XPTY0004,
-                    "Invalid cardinality for variable $" + varName + ". Expected " +
-                    sequenceType.getCardinality().getHumanDescription() +
-                    ", got " + Cardinality.EMPTY_SEQUENCE.getHumanDescription());}
-            //TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType
-            if (!Type.subTypeOf(sequenceType.getPrimaryType(), Type.NODE)) {
-                if (!resultSequence.isEmpty() &&
-                        !Type.subTypeOf(resultSequence.getItemType(),
-                        sequenceType.getPrimaryType()))
-                    {throw new XPathException(this, ErrorCodes.XPTY0004,
-                        "Invalid type for variable $" + varName +
-                        ". Expected " + Type.getTypeName(sequenceType.getPrimaryType()) +
-                        ", got " +Type.getTypeName(resultSequence.getItemType()));}
-            //trigger the old behaviour
-            } else {
-                var.checkType();
-            }
-        }
         setActualReturnType(resultSequence.getItemType());
 
         if (callPostEval()) {
@@ -235,8 +212,7 @@ public class ForExpr extends BindingExpression {
         final Sequence contextSequence = contextItem.toSequence();
         // set variable value to current item
         var.setValue(contextSequence);
-        if (sequenceType == null)
-            {var.checkType();} //because it makes some conversions !
+        var.checkType();
         //Reset the context position
         context.setContextSequencePosition(0, null);
 

--- a/exist-core/src/test/xquery/xquery3/flwor.xql
+++ b/exist-core/src/test/xquery/xquery3/flwor.xql
@@ -19,7 +19,7 @@
  : License along with this library; if not, write to the Free Software
  : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  :)
-xquery version "3.0";
+xquery version "3.1";
 
 module namespace flwor="http://exist-db.org/xquery/test/flwor";
 
@@ -184,4 +184,57 @@ function flwor:no-allow-empty($n as xs:integer) {
         else
             for $x at $y in $sequence
             return $x || ":" || $y
+};
+
+(:~
+ : Type declaration in for-binding should constrain the iteration variable,
+ : not the return type. See https://github.com/eXist-db/exist/issues/3553
+ :)
+declare
+    %test:assertEquals("<p>a</p>", "<p>b</p>", "<p>c</p>")
+function flwor:for-as-string-return-element() {
+    for $i as xs:string in ("a", "b", "c")
+    return <p>{$i}</p>
+};
+
+(:~
+ : Type declaration with function type in for-binding.
+ : Adapted from XQTS hof-046.
+ :)
+declare
+    %test:assertTrue
+function flwor:for-as-function() {
+    for $f as function(*) in (string-join#1)
+    return true()
+};
+
+(:~
+ : Type declaration should still raise XPTY0004 when the binding
+ : sequence items do not match the declared type.
+ :)
+declare
+    %test:assertError
+function flwor:for-as-type-mismatch() {
+    for $i as xs:integer in ("a", "b", "c")
+    return $i
+};
+
+(:~
+ : Subtype promotion: xs:integer items should match xs:decimal declaration.
+ :)
+declare
+    %test:assertEquals(1, 2, 3)
+function flwor:for-as-decimal-with-integers() {
+    for $n as xs:decimal in (xs:integer(1), xs:integer(2), xs:integer(3))
+    return $n
+};
+
+(:~
+ : Type declaration with xs:string should pass when binding string values.
+ :)
+declare
+    %test:assertTrue
+function flwor:for-as-string-binding() {
+    for $x as xs:string in "foo"
+    return true()
 };


### PR DESCRIPTION
## Summary

- Fix incorrect type validation of `as` clause in `for` bindings that checked the **return expression result** instead of the **iteration variable value**
- Expressions like `for $i as xs:string in ('a', 'b', 'c') return <p>{$i}</p>` no longer incorrectly raise XPTY0004
- Also fixes the related XQTS test case `hof-046` (function type in for-binding)

## Details

The `as` type declaration in a `for` binding specifies the expected type of each item bound to the iteration variable ([XQuery 3.1 spec §3.12.2](https://www.w3.org/TR/xquery-31/#prod-xquery31-ForBinding)). The previous implementation had two bugs in `ForExpr.java`:

1. **Per-item type checking was skipped** when a `sequenceType` was declared — `var.checkType()` was only called when `sequenceType == null`
2. **Post-loop type checking validated the wrong thing** — after the loop, the code checked `resultSequence` (output of the `return` clause) against the for-binding's type declaration, instead of the binding sequence

The fix ensures `var.checkType()` is always called per iteration item (validating the bound value against the declared type) and removes the incorrect post-loop check on the return expression's result.

Closes #3553

## Test plan

- [x] Added 5 xqsuite tests to `flwor.xql`:
  - `for-as-string-return-element`: string type declaration with element return (the reported bug)
  - `for-as-function`: function type declaration (XQTS hof-046 equivalent)
  - `for-as-type-mismatch`: type mismatch still raises error
  - `for-as-decimal-with-integers`: subtype promotion works
  - `for-as-string-binding`: string binding passes type check
- [x] All 945 XQuery3 tests pass (0 failures)
- [x] XQTS `prod-ForClause`: 188 tests, 167 pass, 21 failures — identical to develop baseline (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)