### PR TITLE
[fix] Resolve namespace for prefixed attribute names in range index conditions

### DIFF
--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -69,7 +69,7 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
                         fields.put(field.getName(), field);
                     }
                     case CONDITION_ELEMENT ->
-                            conditions.add(new RangeIndexConfigAttributeCondition((Element) child, path));
+                            conditions.add(new RangeIndexConfigAttributeCondition((Element) child, path, namespaces));
                     case FILTER_ELEMENT -> analyzer.addFilter((Element) child);
                     case null, default ->
                             LOG.warn("Invalid element encountered for range index configuration: {}", child.getLocalName());

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
@@ -75,22 +75,7 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
             throw new DatabaseConfigurationException("Range index module: Empty or no attribute qname in condition");
         }
 
-        try {
-            final String prefix = QName.extractPrefix(attributeName);
-            final String localName = QName.extractLocalName(attributeName);
-            String namespaceURI = XMLConstants.NULL_NS_URI;
-            if (prefix != null) {
-                namespaceURI = namespaces.get(prefix);
-                if (namespaceURI == null) {
-                    throw new DatabaseConfigurationException(
-                            "Range index module: No namespace defined for prefix: " + prefix +
-                                    " in condition attribute '" + attributeName + "'");
-                }
-            }
-            attribute = new QName(localName, namespaceURI, prefix, ElementValue.ATTRIBUTE);
-        } catch (final QName.IllegalQNameException e) {
-            throw new DatabaseConfigurationException("Range index module error: " + e.getMessage(), e);
-        }
+        attribute = resolveAttributeQName(attributeName, namespaces);
         value = elem.getAttribute("value");
 
         // parse operator (default to 'eq' if missing)
@@ -141,6 +126,25 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
             }
         }
 
+    }
+
+    private static QName resolveAttributeQName(final String attributeName, final Map<String, String> namespaces) throws DatabaseConfigurationException {
+        try {
+            final String prefix = QName.extractPrefix(attributeName);
+            final String localName = QName.extractLocalName(attributeName);
+            String namespaceURI = XMLConstants.NULL_NS_URI;
+            if (prefix != null) {
+                namespaceURI = namespaces.get(prefix);
+                if (namespaceURI == null) {
+                    throw new DatabaseConfigurationException(
+                            "Range index module: No namespace defined for prefix: " + prefix +
+                                    " in condition attribute '" + attributeName + "'");
+                }
+            }
+            return new QName(localName, namespaceURI, prefix, ElementValue.ATTRIBUTE);
+        } catch (final QName.IllegalQNameException e) {
+            throw new DatabaseConfigurationException("Range index module error: " + e.getMessage(), e);
+        }
     }
 
     // lazily evaluate lowercase value to convert once when needed

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.xml.XMLConstants;
+import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -62,7 +63,7 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
     private String lowercaseValue = null;
     private Pattern pattern = null;
 
-    public RangeIndexConfigAttributeCondition(final Element elem, final NodePath parentPath) throws DatabaseConfigurationException {
+    public RangeIndexConfigAttributeCondition(final Element elem, final NodePath parentPath, final Map<String, String> namespaces) throws DatabaseConfigurationException {
 
         if (parentPath.getLastComponent().getNameType() == ElementValue.ATTRIBUTE) {
             throw new DatabaseConfigurationException(
@@ -75,10 +76,20 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
         }
 
         try {
-            attribute = new QName(QName.extractLocalName(attributeName), XMLConstants.NULL_NS_URI,
-                    QName.extractPrefix(attributeName), ElementValue.ATTRIBUTE);
+            final String prefix = QName.extractPrefix(attributeName);
+            final String localName = QName.extractLocalName(attributeName);
+            String namespaceURI = XMLConstants.NULL_NS_URI;
+            if (prefix != null) {
+                namespaceURI = namespaces.get(prefix);
+                if (namespaceURI == null) {
+                    throw new DatabaseConfigurationException(
+                            "Range index module: No namespace defined for prefix: " + prefix +
+                                    " in condition attribute '" + attributeName + "'");
+                }
+            }
+            attribute = new QName(localName, namespaceURI, prefix, ElementValue.ATTRIBUTE);
         } catch (final QName.IllegalQNameException e) {
-            throw new DatabaseConfigurationException("Rand index module error: " + e.getMessage(), e);
+            throw new DatabaseConfigurationException("Range index module error: " + e.getMessage(), e);
         }
         value = elem.getAttribute("value");
 
@@ -142,8 +153,18 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
 
     @Override
     public boolean matches(final Node node) {
-        return node.getNodeType() == Node.ELEMENT_NODE
-                && matchValue(((Element) node).getAttribute(attributeName));
+        if (node.getNodeType() != Node.ELEMENT_NODE) {
+            return false;
+        }
+        final Element element = (Element) node;
+        final String ns = attribute.getNamespaceURI();
+        final String testValue;
+        if (XMLConstants.NULL_NS_URI.equals(ns)) {
+            testValue = element.getAttribute(attribute.getLocalPart());
+        } else {
+            testValue = element.getAttributeNS(ns, attribute.getLocalPart());
+        }
+        return matchValue(testValue);
     }
 
     private boolean matchValue(final String testValue) {

--- a/extensions/indexes/range/src/test/xquery/range/prefixed-conditions.xql
+++ b/extensions/indexes/range/src/test/xquery/range/prefixed-conditions.xql
@@ -1,0 +1,139 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Test prefixed attribute names in range index conditions.
+ :
+ : @see https://github.com/eXist-db/exist/issues/5189
+ :)
+module namespace pc="http://exist-db.org/xquery/range/test/prefixed-conditions";
+
+import module namespace range="http://exist-db.org/xquery/range" at "java:org.exist.xquery.modules.range.RangeIndexModule";
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare namespace tei="http://www.tei-c.org/ns/1.0";
+declare namespace wwp="http://www.wwp.northeastern.edu/ns/textbase";
+declare namespace stats="http://exist-db.org/xquery/profiling";
+
+declare variable $pc:COLLECTION_CONFIG :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:tei="http://www.tei-c.org/ns/1.0"
+               xmlns:wwp="http://www.wwp.northeastern.edu/ns/textbase">
+            <range>
+                <!-- Only match tei:title when @wwp:field="title" -->
+                <create qname="tei:title">
+                    <condition attribute="wwp:field" value="title"/>
+                    <field name="wwp-attr" type="xs:string"/>
+                </create>
+                <!-- Only match tei:title when unprefixed @field="title" -->
+                <create qname="tei:title">
+                    <condition attribute="field" value="title"/>
+                    <field name="ncname-attr" type="xs:string"/>
+                </create>
+            </range>
+        </index>
+    </collection>;
+
+declare variable $pc:DATA :=
+    <biblFull xmlns="http://www.tei-c.org/ns/1.0"
+              xmlns:wwp="http://www.wwp.northeastern.edu/ns/textbase">
+        <fileDesc>
+            <titleStmt>
+                <title type="main">A Peep at the Pilgrims, 1824</title>
+                <title type="display" wwp:field="title" field="title">A Peep at the Pilgrims</title>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>Northeastern University Women Writers Project</publisher>
+            </publicationStmt>
+            <sourceDesc>
+                <bibl>
+                    <title wwp:field="title" field="title">A peep at the pilgrims in sixteen hundred thirty-six.</title>
+                </bibl>
+            </sourceDesc>
+        </fileDesc>
+    </biblFull>;
+
+declare variable $pc:COLLECTION_NAME := "prefixed-conditions-test";
+declare variable $pc:COLLECTION := "/db/" || $pc:COLLECTION_NAME;
+
+declare
+%test:setUp
+function pc:setup() {
+    (xmldb:create-collection("/db/system", "config"), xmldb:create-collection("/db/system/config", "db")),
+    xmldb:create-collection("/db/system/config/db", $pc:COLLECTION_NAME),
+    xmldb:store("/db/system/config/db/" || $pc:COLLECTION_NAME, "collection.xconf", $pc:COLLECTION_CONFIG),
+    xmldb:create-collection("/db", $pc:COLLECTION_NAME),
+    xmldb:store($pc:COLLECTION, "data.xml", $pc:DATA)
+};
+
+declare
+%test:tearDown
+function pc:cleanup() {
+    xmldb:remove($pc:COLLECTION),
+    xmldb:remove("/db/system/config/db/" || $pc:COLLECTION_NAME)
+};
+
+(: Prefixed attribute condition should index matching elements :)
+declare
+%test:assertEquals(2)
+function pc:prefixed-attribute-indexed() {
+    count(range:index-keys-for-field("wwp-attr", function($k, $n) { $k }, 10))
+};
+
+(: Unprefixed attribute condition should also index matching elements :)
+declare
+%test:assertEquals(2)
+function pc:ncname-attribute-indexed() {
+    count(range:index-keys-for-field("ncname-attr", function($k, $n) { $k }, 10))
+};
+
+(: Prefixed attribute condition should return correct values :)
+declare
+%test:assertXPath("$result = 'A Peep at the Pilgrims' and $result = 'A peep at the pilgrims in sixteen hundred thirty-six.'")
+function pc:prefixed-attribute-values() {
+    range:index-keys-for-field("wwp-attr", function($k, $n) { $k }, 10)
+};
+
+(: Unprefixed attribute condition should return correct values :)
+declare
+%test:assertXPath("$result = 'A Peep at the Pilgrims' and $result = 'A peep at the pilgrims in sixteen hundred thirty-six.'")
+function pc:ncname-attribute-values() {
+    range:index-keys-for-field("ncname-attr", function($k, $n) { $k }, 10)
+};
+
+(: Optimizer should rewrite predicate on prefixed attribute :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
+function pc:optimize-prefixed-attribute() {
+    collection($pc:COLLECTION)//tei:title[@wwp:field eq "title"][. = "A Peep at the Pilgrims"]
+};
+
+(: Optimizer should rewrite predicate on unprefixed attribute :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
+function pc:optimize-ncname-attribute() {
+    collection($pc:COLLECTION)//tei:title[@field eq "title"][. = "A Peep at the Pilgrims"]
+};

--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -287,7 +287,7 @@
         <xs:attribute name="at" type="xs:anyURI" use="required" form="unqualified"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="attributeReq">
-        <xs:attribute name="attribute" type="xs:NCName" use="required"/>
+        <xs:attribute name="attribute" type="xs:string" use="required"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="binaryOpt">
         <xs:attribute name="binary" use="optional">


### PR DESCRIPTION
## Summary

- Fixes namespace resolution for prefixed attribute names (e.g. `wwp:field`) in range index `<condition>` elements
- Updates `collection.xconf.xsd` to accept prefixed attribute names
- Adds XQSuite tests for prefixed and unprefixed attribute conditions

Closes #5189

## What Changed

**`RangeIndexConfigAttributeCondition.java`** — The constructor now accepts a `Map<String, String> namespaces` parameter (the same namespace map already used by `<create qname="...">` resolution). When the `@attribute` value contains a prefix, the prefix is resolved to a namespace URI. The `matches()` method now uses `getAttributeNS()` for namespaced attributes instead of `getAttribute()` with the raw prefixed string.

**`ComplexRangeIndexConfigElement.java`** — Passes the `namespaces` map through to the `RangeIndexConfigAttributeCondition` constructor.

**`collection.xconf.xsd`** — Changed `attributeReq` type from `xs:NCName` to `xs:string`, consistent with how `@qname` is typed elsewhere in the schema. (`xs:QName` is unsuitable here because XSD QName validation requires the prefix to be resolvable in the schema instance context.)

**`prefixed-conditions.xql`** — 6 new XQSuite tests verifying that both prefixed (`wwp:field`) and unprefixed (`field`) attribute conditions correctly index matching elements and that the query optimizer rewrites predicates on both.

## Test Plan

- [x] Range index XQSuite tests: 351 pass, 0 failures
- [x] `RangeIndexConfigTest` unit test passes
- [x] CI: all checks pass (ubuntu/windows/macOS integration, unit tests, license, XQTS, Codacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)