### PR TITLE
[build] disable depency-check-maven

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -573,6 +573,7 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>10.0.3</version>
                     <configuration>
+                        <dataDirectory>${user.home}/.m2/dependency-check-data</dataDirectory>
                         <nvdApiKey>${nvdApiKey}</nvdApiKey>
                         <!-- The OSS Index Server (https://ossindex.sonatype.org) can sometimes be flaky -->
                         <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
@@ -964,17 +965,17 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.owasp</groupId>-->
+<!--                <artifactId>dependency-check-maven</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>check</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
### Description:

This PR will disable the maven-dependency-check plugin entirely.
Why is this necessary?
The last  version of the plugin that is compatible with java 8 is 10.0.4.
This version cannot download the vulnerability database from NVD as there were breaking changes in its API.

The only option to keep this build step would be to upgrade to version 12.1.0 or later. But this would require to raise the minimum required java version to build with to java 11. As this constitutes a breaking change this option was not selected. 

### Reference:

https://github.com/dependency-check/DependencyCheck/issues/7406

