### PR TITLE
[ci] improve xqts workflow

### DIFF
--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -49,17 +49,38 @@ jobs:
           name: xqts-logs
           retention-days: 14
           path: /tmp/xqts-output
-      - name: Get Previous XQTS Logs Artifacts JSON
-        run: 'curl -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/exist-db/exist/actions/artifacts?name=xqts-logs > /tmp/previous-xqts-logs-artifacts.json'
-      - name: Extract Previous XQTS Logs Artifact JSON
-        run: cat /tmp/previous-xqts-logs-artifacts.json | jq -r "[.artifacts[] | select(.workflow_run.head_branch == \"develop\")][1].archive_download_url" > /tmp/previous-xqts-logs-artifact.json
-      - name: Get Previous XQTS Logs Artifact
+      - name: Get List of Previous XQTS Logs
+        run: |
+          curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/exist-db/exist/actions/artifacts?name=xqts-logs \
+          > /tmp/artifacts-list.json
+      - name: Get Download URL of Latest Run on Develop
+        run: |
+          cat /tmp/artifacts-list.json | \
+          jq -r '[.artifacts[] | select(.workflow_run.head_branch == "develop")][0].archive_download_url' \
+          > /tmp/download_url.txt
+      - name: Download XQTS Logs Archive
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: 'cat /tmp/previous-xqts-logs-artifact.json | xargs curl -H "Authorization: Bearer ${GITHUB_TOKEN}" --location --output /tmp/previous-xqts-output.zip'
-      - name: Extract Previous XQTS Logs Artifact
-        run: mkdir /tmp/previous-xqts-output && unzip /tmp/previous-xqts-output.zip -d /tmp/previous-xqts-output
+        run: |
+          cat /tmp/download_url.txt | \
+          xargs curl -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          --location \
+          --output /tmp/previous-xqts-output.zip
+      - name: Extract XQTS Logs Archive
+        run: |
+          mkdir /tmp/previous-xqts-output && \
+          unzip /tmp/previous-xqts-output.zip -d /tmp/previous-xqts-output
       - name: Compare Previous and Current XQTS Logs
-        run: java -jar ~/.m2/repository/net/sf/saxon/Saxon-HE/9.9.1-8/Saxon-HE-9.9.1-8.jar -xsl:exist-xqts/src/main/xslt/compare-results.xslt -it:compare-results -o:/tmp/comparison-results.xml xqts.previous.junit-data-path=/tmp/previous-xqts-output/junit/data xqts.current.junit-data-path=/tmp/xqts-output/junit/data
+        run: |
+          java \
+          -jar ~/.m2/repository/net/sf/saxon/Saxon-HE/9.9.1-8/Saxon-HE-9.9.1-8.jar \
+          -xsl:exist-xqts/src/main/xslt/compare-results.xslt \
+          -it:compare-results \
+          -o:/tmp/comparison-results.xml \
+          xqts.previous.junit-data-path=/tmp/previous-xqts-output/junit/data \
+          xqts.current.junit-data-path=/tmp/xqts-output/junit/data
       - name: Show Comparison Results
         run: cat /tmp/comparison-results.xml

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -42,13 +42,6 @@ jobs:
           name: exist-xqts-runner-hprof
           retention-days: 1
           path: /tmp/*.hprof.zst
-      - name: Archive XQTS Logs
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: xqts-logs
-          retention-days: 14
-          path: /tmp/xqts-output
       - name: Get List of Previous XQTS Logs
         run: |
           curl \
@@ -84,3 +77,10 @@ jobs:
           xqts.current.junit-data-path=/tmp/xqts-output/junit/data
       - name: Show Comparison Results
         run: cat /tmp/comparison-results.xml
+      - name: Archive XQTS Logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: xqts-logs
+          retention-days: 14
+          path: /tmp/xqts-output


### PR DESCRIPTION
- if only one XQTS run on develop was retained the jq script returned null
- the command line invocations were hard to read and are now split into multiple lines
- temporary files have file endings according to their contents and more meaningful names
- the names of the steps try to be as brief and clear as possible
