### PR TITLE
[bugfix] do not attempt to optimize an empty set

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -90,7 +90,8 @@ public class Optimize extends AbstractPragma {
         boolean optimize = false;
         NodeSet originalContext = null;
 
-        if (contextSequence == null || contextSequence.isPersistentSet()) {    // don't try to optimize in-memory node sets!
+        // don't try to optimize in-memory node sets!
+        if (contextSequence == null || contextSequence.isPersistentSet()) {
             // contextSequence will be overwritten
             originalContext = contextSequence == null ? null : contextSequence.toNodeSet();
             if (cachedContext != null && cachedContext == originalContext) {
@@ -103,26 +104,24 @@ public class Optimize extends AbstractPragma {
             // in the current context
             if (useCached) {
                 optimize = cachedOptimize;
-            } else {
-                if (optimizables != null) {
-                    for (final Optimizable optimizable : optimizables) {
-                        final Sequence canBeOptimized = optimizable.canOptimizeSequence(contextSequence);
-                        if (canBeOptimized == null) {
-                            optimize = false;
-                            break;  // exit for-each loop
-                        }
-                        if (canBeOptimized.getItemCount() == contextSequence.getItemCount()) {
-                            // everything in sequence can be optimized
-                            optimize = true;  // so far so good, head to next for-loop of `optimizable`
-                        } else {
-                            // nothing or only some bits can be optimized
-                            optimize = false;
-                            break;  // exit for-each loop
-                        }
+            } else if (optimizables != null && contextSequence != null) {
+                for (final Optimizable optimizable : optimizables) {
+                    final Sequence canBeOptimized = optimizable.canOptimizeSequence(contextSequence);
+                    if (
+                            canBeOptimized == null ||
+                            canBeOptimized.getItemCount() != contextSequence.getItemCount()
+                    ) {
+                        optimize = false;
+                        break;  // exit for-each loop
                     }
+                    // so far so good,
+                    // everything in sequence can be optimized
+                    optimize = true;
+                    // head to next for-loop of `optimizable`
                 }
             }
         }
+
         if (optimize) {
             cachedContext = originalContext;
             cachedTimestamp = originalContext == null ? 0 : originalContext.getState();


### PR DESCRIPTION
fixes #5707

When contextSequence is null after the context variable was evaluated there is nothing to optimize, even if there are optimizables. Otherwise, an NPE is thrown in exist/xquery/pragmas/Optimize.class. The conditions were refactored slightly for readability.
