### PR TITLE
[ci] use gh CLI to find previous XQTS baseline on develop

### DIFF
--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -42,30 +42,35 @@ jobs:
           name: exist-xqts-runner-hprof
           retention-days: 1
           path: /tmp/*.hprof.zst
-      - name: Get List of Previous XQTS Logs
-        run: |
-          curl \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/exist-db/exist/actions/artifacts?name=xqts-logs \
-          > /tmp/artifacts-list.json
-      - name: Get Download URL of Latest Run on Develop
-        run: |
-          cat /tmp/artifacts-list.json | \
-          jq -r '[.artifacts[] | select(.workflow_run.head_branch == "develop")][0].archive_download_url' \
-          > /tmp/download_url.txt
-      - name: Download XQTS Logs Archive
+      - name: Find Latest Successful XQTS Run on Develop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat /tmp/download_url.txt | \
-          xargs curl -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          --location \
-          --output /tmp/previous-xqts-output.zip
-      - name: Extract XQTS Logs Archive
+          RUN_ID=$(gh run list \
+            --repo eXist-db/exist \
+            --workflow ci-xqts.yml \
+            --branch develop \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error::Could not find a previous successful XQTS run on develop"
+            exit 1
+          fi
+
+          echo "Found develop run: ${RUN_ID}"
+          echo "$RUN_ID" > /tmp/previous_run_id.txt
+      - name: Download Previous XQTS Logs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir /tmp/previous-xqts-output && \
-          unzip /tmp/previous-xqts-output.zip -d /tmp/previous-xqts-output
+          gh run download \
+            --repo eXist-db/exist \
+            "$(cat /tmp/previous_run_id.txt)" \
+            --name xqts-logs \
+            --dir /tmp/previous-xqts-output
       - name: Compare Previous and Current XQTS Logs
         run: |
           java \


### PR DESCRIPTION
## Summary

- Replaces `curl` + `jq` artifact lookup with `gh run list` and `gh run download` to find the previous XQTS baseline on develop, as [suggested by @line-o](https://github.com/eXist-db/exist/pull/6098#issuecomment-4000068788)
- Fixes the pagination bug where the develop artifact was pushed off the first page of results (default 30 per page), causing all XQTS CI runs to fail with `Could not resolve host: null`
- Builds on #6099

## What Changed

**`.github/workflows/ci-xqts.yml`**
- Replaced 4 steps (list artifacts via curl, extract URL via jq, download zip via curl, unzip) with 2 steps using `gh run list` and `gh run download`
- `gh run list --branch develop --status success` filters server-side, eliminating the pagination problem entirely
- `gh run download` handles authentication, download, and extraction in one step
- Added `--status success` filter to ensure comparison is only against runs that completed successfully
- Added explicit error handling with `::error::` annotation if no previous develop run is found

Note: `gh` CLI [v2.87.3 is pre-installed](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) on `ubuntu-latest` runners.

## Test Plan

- [x] Verify the XQTS CI job passes on this PR (the job itself will exercise the new baseline lookup logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)