### PR TITLE
Fix duplicate node elimination for function calls in path expressions

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2338,6 +2338,7 @@ throws PermissionDeniedException, EXistException, XPathException
     #(
         ABSOLUTE_SLASH
         {
+            path.setHasSlash();
             RootNode root= new RootNode(context);
             path.add(root);
         }
@@ -2348,6 +2349,7 @@ throws PermissionDeniedException, EXistException, XPathException
     #(
         ABSOLUTE_DSLASH
         {
+            path.setHasSlash();
             RootNode root= new RootNode(context);
             path.add(root);
         }
@@ -2948,6 +2950,9 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     #(
         SLASH step=expr [path]
+        {
+            path.setHasSlash();
+        }
         (
             rightStep=expr [path]
             {
@@ -2972,6 +2977,9 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     #(
         DSLASH step=expr [path]
+        {
+            path.setHasSlash();
+        }
         (
             rightStep=expr [path]
             {

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -309,10 +309,16 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
             } else {
                 return Constants.SUPERIOR;
             }
-        } else if(document.docId < other.document.docId) {
-            return Constants.INFERIOR;
         } else {
-            return Constants.SUPERIOR;
+            final long thisDocId = document != null ? document.docId : 0;
+            final long otherDocId = other.document != null ? other.document.docId : 0;
+            if (thisDocId < otherDocId) {
+                return Constants.INFERIOR;
+            } else if (thisDocId > otherDocId) {
+                return Constants.SUPERIOR;
+            } else {
+                return Constants.EQUAL;
+            }
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -53,6 +53,14 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
 
     protected boolean inPredicate = false;
 
+    /**
+     * Set to true when this PathExpr represents an actual XPath path
+     * expression with '/' or '//' steps, as opposed to a generic expression
+     * container. When true, duplicate node elimination is applied per
+     * XPath 3.1 §3.3.1.1.
+     */
+    private boolean hasSlash = false;
+
     protected Expression parent;
 
     public PathExpr(final XQueryContext context) {
@@ -298,7 +306,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                             !Type.subTypeOf(result.getItemType(), Type.NODE)) {
                         gotAtomicResult = true;
                     }
-                    if (steps.size() > 1 && getLastExpression() instanceof Step) {
+                    if (hasSlash) {
                         // remove duplicate nodes if this is a path
                         // expression with more than one step
                         result.removeDuplicates();
@@ -373,6 +381,14 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
 
     public Expression getLastExpression() {
         return steps.isEmpty() ? null : steps.getLast();
+    }
+
+    /**
+     * Marks this PathExpr as containing a '/' or '//' path operator.
+     * Called from the grammar tree walker when SLASH or DSLASH is encountered.
+     */
+    public void setHasSlash() {
+        this.hasSlash = true;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -306,7 +306,8 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                             !Type.subTypeOf(result.getItemType(), Type.NODE)) {
                         gotAtomicResult = true;
                     }
-                    if (hasSlash) {
+                    if (hasSlash && !result.isEmpty()
+                            && Type.subTypeOf(result.getItemType(), Type.NODE)) {
                         // remove duplicate nodes if this is a path
                         // expression with more than one step
                         result.removeDuplicates();

--- a/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
@@ -59,10 +59,10 @@ public class PathExprDedupTest {
      */
     @Test
     public void functionCallInPathDedup() throws XMLDBException {
-        final String result = query(
-                "declare variable $root := <root><c/></root>;\n" +
-                "declare function local:function($arg) { $root[$arg] };\n" +
-                "count($root/descendant-or-self::node()/local:function(.))");
+        final String result = query("""
+                declare variable $root := <root><c/></root>;
+                declare function local:function($arg) { $root[$arg] };
+                count($root/descendant-or-self::node()/local:function(.))""");
         assertEquals("1", result);
     }
 
@@ -71,10 +71,10 @@ public class PathExprDedupTest {
      */
     @Test
     public void functionReturnsConstantNodeDedup() throws XMLDBException {
-        final String result = query(
-                "declare variable $root := <root><a/><b/></root>;\n" +
-                "declare function local:getroot($x) { $root };\n" +
-                "count($root/*/local:getroot(.))");
+        final String result = query("""
+                declare variable $root := <root><a/><b/></root>;
+                declare function local:getroot($x) { $root };
+                count($root/*/local:getroot(.))""");
         assertEquals("1", result);
     }
 
@@ -84,9 +84,9 @@ public class PathExprDedupTest {
      */
     @Test
     public void forLoopPreservesDuplicates() throws XMLDBException {
-        final String result = query(
-                "declare variable $root := <root/>;\n" +
-                "count(for $x in (1, 2, 3) return $root)");
+        final String result = query("""
+                declare variable $root := <root/>;
+                count(for $x in (1, 2, 3) return $root)""");
         assertEquals("3", result);
     }
 
@@ -95,9 +95,9 @@ public class PathExprDedupTest {
      */
     @Test
     public void globalVarForLoopPreservesDuplicates() throws XMLDBException {
-        final String result = query(
-                "declare variable $data := <item/>;\n" +
-                "count(for $i in 1 to 5 return $data)");
+        final String result = query("""
+                declare variable $data := <item/>;
+                count(for $i in 1 to 5 return $data)""");
         assertEquals("5", result);
     }
 
@@ -108,9 +108,9 @@ public class PathExprDedupTest {
     @Test
     public void pathEndingWithIntegerLiteral() throws XMLDBException {
         final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
-        final ResourceSet result = xqs.query(
-                "declare variable $myVar := <e/>;\n" +
-                "$myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/3");
+        final ResourceSet result = xqs.query("""
+                declare variable $myVar := <e/>;
+                $myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/3""");
         assertEquals(6, (int) result.getSize());
         for (int i = 0; i < 6; i++) {
             assertEquals("3", result.getResource(i).getContent().toString());
@@ -124,9 +124,9 @@ public class PathExprDedupTest {
     @Test
     public void pathEndingWithNumberFunction() throws XMLDBException {
         final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
-        final ResourceSet result = xqs.query(
-                "declare variable $myVar := <e/>;\n" +
-                "$myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/number()");
+        final ResourceSet result = xqs.query("""
+                declare variable $myVar := <e/>;
+                $myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/number()""");
         assertEquals(6, (int) result.getSize());
         for (int i = 0; i < 6; i++) {
             assertEquals("NaN", result.getResource(i).getContent().toString());
@@ -138,10 +138,10 @@ public class PathExprDedupTest {
      */
     @Test
     public void axisStepThenFunctionCallDedup() throws XMLDBException {
-        final String result = query(
-                "declare variable $doc := <doc><a/><b/><c/></doc>;\n" +
-                "declare function local:parent($n) { $n/.. };\n" +
-                "count($doc/*/local:parent(.))");
+        final String result = query("""
+                declare variable $doc := <doc><a/><b/><c/></doc>;
+                declare function local:parent($n) { $n/.. };
+                count($doc/*/local:parent(.))""");
         assertEquals("1", result);
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
@@ -102,6 +102,38 @@ public class PathExprDedupTest {
     }
 
     /**
+     * XQTS K2-Axes-48: path expression ending with integer literal.
+     * Must not NPE when removeDuplicates is called on atomic results.
+     */
+    @Test
+    public void pathEndingWithIntegerLiteral() throws XMLDBException {
+        final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query(
+                "declare variable $myVar := <e/>;\n" +
+                "$myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/3");
+        assertEquals(6, (int) result.getSize());
+        for (int i = 0; i < 6; i++) {
+            assertEquals("3", result.getResource(i).getContent().toString());
+        }
+    }
+
+    /**
+     * XQTS K2-Axes-49: path expression ending with number() function.
+     * Must not NPE when removeDuplicates is called on atomic results.
+     */
+    @Test
+    public void pathEndingWithNumberFunction() throws XMLDBException {
+        final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query(
+                "declare variable $myVar := <e/>;\n" +
+                "$myVar/(<a/>, <b/>, <?d ?>, <!-- e-->, attribute name {}, document {()})/number()");
+        assertEquals(6, (int) result.getSize());
+        for (int i = 0; i < 6; i++) {
+            assertEquals("NaN", result.getResource(i).getContent().toString());
+        }
+    }
+
+    /**
      * Path with axis step followed by function call — dedup should apply.
      */
     @Test

--- a/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/PathExprDedupTest.java
@@ -1,0 +1,115 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for duplicate node elimination in path expressions.
+ *
+ * Per XPath 3.1 §3.3.1.1, the path operator '/' must eliminate duplicate
+ * nodes (by identity) and return results in document order when every
+ * evaluation of E2 returns nodes. This must apply regardless of whether
+ * E2 is an axis step, function call, or other PostfixExpr.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-31/#id-path-operator">XPath 3.1 §3.3.1.1</a>
+ */
+public class PathExprDedupTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private String query(final String xquery) throws XMLDBException {
+        final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query(xquery);
+        return result.getResource(0).getContent().toString();
+    }
+
+    /**
+     * XQTS K2-Steps-31 (explicit expansion): function call in path where
+     * multiple context items produce the same result node. The path operator
+     * must deduplicate results per §3.3.1.1.
+     */
+    @Test
+    public void functionCallInPathDedup() throws XMLDBException {
+        final String result = query(
+                "declare variable $root := <root><c/></root>;\n" +
+                "declare function local:function($arg) { $root[$arg] };\n" +
+                "count($root/descendant-or-self::node()/local:function(.))");
+        assertEquals("1", result);
+    }
+
+    /**
+     * Simpler case: child::* / function that always returns the same node.
+     */
+    @Test
+    public void functionReturnsConstantNodeDedup() throws XMLDBException {
+        final String result = query(
+                "declare variable $root := <root><a/><b/></root>;\n" +
+                "declare function local:getroot($x) { $root };\n" +
+                "count($root/*/local:getroot(.))");
+        assertEquals("1", result);
+    }
+
+    /**
+     * Ensure for-loop results are NOT incorrectly deduplicated.
+     * This is the scenario from the 2009 bug fix (SF #2880394).
+     */
+    @Test
+    public void forLoopPreservesDuplicates() throws XMLDBException {
+        final String result = query(
+                "declare variable $root := <root/>;\n" +
+                "count(for $x in (1, 2, 3) return $root)");
+        assertEquals("3", result);
+    }
+
+    /**
+     * Global variable with for-loop should preserve all results.
+     */
+    @Test
+    public void globalVarForLoopPreservesDuplicates() throws XMLDBException {
+        final String result = query(
+                "declare variable $data := <item/>;\n" +
+                "count(for $i in 1 to 5 return $data)");
+        assertEquals("5", result);
+    }
+
+    /**
+     * Path with axis step followed by function call — dedup should apply.
+     */
+    @Test
+    public void axisStepThenFunctionCallDedup() throws XMLDBException {
+        final String result = query(
+                "declare variable $doc := <doc><a/><b/><c/></doc>;\n" +
+                "declare function local:parent($n) { $n/.. };\n" +
+                "count($doc/*/local:parent(.))");
+        assertEquals("1", result);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix the path operator `/` to correctly eliminate duplicate nodes when the right-hand step is a function call or other non-`Step` expression
- Per [XPath 3.1 §3.3.1.1](https://www.w3.org/TR/xpath-31/#id-path-operator), `/` must combine results, eliminate duplicates by node identity, and return in document order — regardless of the expression type of each step
- Fix NPE in `NodeImpl.compareTo` when sorting in-memory nodes from independent document contexts (e.g., standalone attribute or document constructors)

## Root Cause

In `PathExpr.eval()`, duplicate elimination was guarded by:

```java
if (steps.size() > 1 && getLastExpression() instanceof Step)
    result.removeDuplicates();
```

This only triggered when the last expression was a `Step` (LocationStep, RootNode, SimpleStep). Function calls (`Function extends PathExpr`), filtered expressions, and other PostfixExpr types were excluded, so paths like `$root/*/local:getroot(.)` could return duplicate nodes.

This guard was added in 2009 ([SF #2880394](https://sourceforge.net/tracker/?func=detail&aid=2880394&group_id=17691&atid=117691)) to prevent over-aggressive dedup on FLWOR results in PathExprs used as generic expression containers.

## Fix

Replace the `instanceof Step` heuristic with a `hasSlash` boolean flag that the grammar tree walker sets when it encounters `SLASH`, `DSLASH`, `ABSOLUTE_SLASH`, or `ABSOLUTE_DSLASH` tokens. This correctly distinguishes genuine path expressions from PathExprs that are merely expression containers.

Additionally:

1. **PathExpr.eval**: Guard `removeDuplicates()` with `!result.isEmpty() && Type.subTypeOf(result.getItemType(), Type.NODE)` so it is only called when the result actually contains nodes, not atomic values. This prevents unnecessary processing and avoids issues with paths like `$x/(...)/3` where the final step returns atomic values.

2. **NodeImpl.compareTo**: Handle null `document` references defensively. `DocumentImpl` nodes always have `document=null` (by design — `super(expression, null, 0)` in the constructor), so comparing two `DocumentImpl` instances from different constructor contexts would NPE at `document.docId`. This is a latent bug exposed when `removeDuplicates` sorts sequences containing nodes from independent constructor documents.

| Approach | Correctness | Performance | 2009 regression risk |
|---|---|---|---|
| Old: `getLastExpression() instanceof Step` | Misses function calls | O(1) | None (too conservative) |
| New: `hasSlash` flag + node-type guard | Correct by construction | O(1) | None (flag not set for FLWOR containers) |

## What Changed

| File | Change |
|------|--------|
| `exist-core/.../xquery/PathExpr.java` | Add `hasSlash` flag with setter; replace `instanceof Step` guard with flag check + node-type guard |
| `exist-core/.../parser/XQueryTree.g` | Call `path.setHasSlash()` at `SLASH`, `DSLASH`, `ABSOLUTE_SLASH`, `ABSOLUTE_DSLASH` |
| `exist-core/.../dom/memtree/NodeImpl.java` | Fix `compareTo` to handle null `document` field (DocumentImpl nodes) |
| `exist-core/.../xquery/PathExprDedupTest.java` | New test class: 7 tests covering dedup for function calls in paths, preservation of FLWOR duplicates, and K2-Axes-48/49 regression tests |

## Spec Reference

[XPath 3.1 §3.3.1.1 Path operator (/)](https://www.w3.org/TR/xpath-31/#id-path-operator):
> If every evaluation of E2 returns a (possibly empty) sequence of nodes, these sequences are combined, and duplicate nodes are eliminated based on node identity. The resulting node sequence is returned in document order.

## Related

- PR #6106 (fix `//` with non-LocationStep expressions — complements this fix; together they fully resolve XQTS K2-Steps-31)

## XQTS Results (W3C XQTS 3.1, prod-AxisStep)

K2-Axes-48 and K2-Axes-49 both **pass** (previously NPE).

## Test Plan

- [x] New JUnit tests pass: `PathExprDedupTest` (7 tests, including K2-Axes-48/49)
- [x] `XQueryTest` suite: 99 tests, 0 failures, 0 errors
- [x] XQTS prod-AxisStep: K2-Axes-48 ✅, K2-Axes-49 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)