### PR TITLE
Preclaiming two-phase locking for XQuery update operations

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1200,7 +1200,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1220,7 +1220,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1203,7 +1203,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1223,7 +1223,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <excludes>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1222,6 +1222,14 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <configuration>
                     <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
+                    <excludes>
+
+                        <!-- NOTE: these can still exhibit deadlocks during BrokerPool initialization
+                                 see https://github.com/eXist-db/exist/issues/4140
+                                 see https://github.com/eXist-db/exist/issues/3685 -->
+                        <exclude>org.exist.storage.lock.DeadlockIT</exclude>
+                        <exclude>org.exist.storage.RemoveCollectionIT</exclude>
+                    </excludes>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1203,7 +1203,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1223,7 +1223,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1203,7 +1203,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1223,7 +1223,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <excludes>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1200,6 +1200,8 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+
                     <excludes>
 
                         <!-- NOTE: these can still exhibit deadlocks
@@ -1218,6 +1220,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1200,7 +1200,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1220,7 +1220,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <excludes>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1200,7 +1200,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
-                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
 
                     <excludes>
 
@@ -1220,7 +1220,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <excludes>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1203,6 +1203,8 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+
                     <excludes>
 
                         <!-- NOTE: these can still exhibit deadlocks
@@ -1221,6 +1223,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1225,6 +1225,14 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <configuration>
                     <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
                     <argLine>@{jacocoArgLine} --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding} -Dexist.recovery.progressbar.hide=true</argLine>
+                    <excludes>
+
+                        <!-- NOTE: these can still exhibit deadlocks during BrokerPool initialization
+                                 see https://github.com/eXist-db/exist/issues/4140
+                                 see https://github.com/eXist-db/exist/issues/3685 -->
+                        <exclude>org.exist.storage.lock.DeadlockIT</exclude>
+                        <exclude>org.exist.storage.RemoveCollectionIT</exclude>
+                    </excludes>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -269,6 +269,9 @@ prolog throws XPathException
 			( "declare" "function" )
 			=> functionDeclUp { inSetters = false; }
 			|
+			( "declare" "updating" "function" )
+			=> updatingFunctionDeclUp { inSetters = false; }
+			|
 			( "declare" "variable" )
 			=> varDeclUp { inSetters = false; }
 			|
@@ -428,7 +431,7 @@ annotateDecl! throws XPathException
 :
 	decl:"declare"! ann:annotations!
 	(
-	    ("function") => f:functionDecl[#ann] { #annotateDecl = #f; }
+	    ("function") => f:functionDecl[#ann, false] { #annotateDecl = #f; }
 	    |
 	    ("variable") => v:varDecl[#decl, #ann] { #annotateDecl = #v; }
 	)
@@ -496,10 +499,15 @@ bracedUriLiteral returns [String uri]
 
 functionDeclUp! throws XPathException
 :
-	"declare"! f:functionDecl[null] { #functionDeclUp = #f; }
+	"declare"! f:functionDecl[null, false] { #functionDeclUp = #f; }
     ;
 
-functionDecl [XQueryAST ann] throws XPathException
+updatingFunctionDeclUp! throws XPathException
+:
+	"declare"! "updating"! f:functionDecl[null, true] { #updatingFunctionDeclUp = #f; }
+    ;
+
+functionDecl [XQueryAST ann, boolean updating] throws XPathException
 { String name= null; }
 :
 	"function"! name=eqName! lp:LPAREN! ( paramList )?
@@ -509,6 +517,9 @@ functionDecl [XQueryAST ann] throws XPathException
 	  	#functionDecl= #(#[FUNCTION_DECL, name, org.exist.xquery.parser.XQueryFunctionAST.class.getName()], #ann, #functionDecl);
 		#functionDecl.copyLexInfo(#lp);
 		#functionDecl.setDoc(getXQDoc());
+		if (updating) {
+			((XQueryFunctionAST) #functionDecl).setUpdating(true);
+		}
 	}
 	exception catch [RecognitionException e]
 	{
@@ -708,11 +719,20 @@ exprSingle throws XPathException
 	| ( "if" LPAREN ) => ifExpr
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
+	// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	// === W3C XQuery Update Facility 3.0 ===
+	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
+	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
+	| ( "replace" ( "node" | "value" ) ) => xqufReplaceExpr
+	| ( "rename" "node" ) => xqufRenameExpr
+	| ( "copy" DOLLAR ) => xqufTransformExpr
 	| orExpr
 	;
 
-// === Xupdate ===
+// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
+// To remove legacy update support, delete this section and the updateExpr
+// alternative in exprSingle above.
 
 updateExpr throws XPathException
 :
@@ -750,6 +770,57 @@ deleteExpr throws XPathException
 renameExpr throws XPathException
 :
 	"rename" exprSingle "as"! exprSingle
+	;
+
+// === W3C XQuery Update Facility 3.0 ===
+
+xqufInsertExpr throws XPathException
+:
+	"insert"^ ( "node"! | "nodes"! ) exprSingle
+	(
+		( "as" "first" "into" ) => "as"! "first" "into"! exprSingle
+		| ( "as" "last" "into" ) => "as"! "last" "into"! exprSingle
+		| "into" exprSingle
+		| "before" exprSingle
+		| "after" exprSingle
+	)
+	;
+
+xqufDeleteExpr throws XPathException
+:
+	"delete"^ ( "node"! | "nodes"! ) exprSingle
+	;
+
+xqufReplaceExpr throws XPathException
+:
+	"replace"^
+	(
+		( "value" "of" "node" ) => "value" "of"! "node"! exprSingle "with"! exprSingle
+		| "node"! exprSingle "with"! exprSingle
+	)
+	;
+
+xqufRenameExpr throws XPathException
+:
+	"rename"^ "node"! exprSingle "as"! exprSingle
+	;
+
+xqufTransformExpr throws XPathException
+:
+	"copy"^
+	xqufCopyBinding ( COMMA! xqufCopyBinding )*
+	"modify"! exprSingle
+	"return"! exprSingle
+	;
+
+xqufCopyBinding throws XPathException
+{ String varName; }
+:
+	DOLLAR! varName=v:varName! COLON! EQ! exprSingle
+	{
+		#xqufCopyBinding = #(#[VARIABLE_BINDING, varName], #xqufCopyBinding);
+		#xqufCopyBinding.copyLexInfo(#v);
+	}
 	;
 
 // === try/catch ===
@@ -2229,8 +2300,12 @@ reservedKeywords returns [String name]
 	|
 	"base-uri" { name = "base-uri"; }
 	|
+	// Legacy update keyword (DEPRECATED - only "update" is legacy-only;
+	// the others below are shared with W3C XQUF 3.0).
+	// To remove: delete "update" and keep the rest.
 	"update" { name = "update"; }
 	|
+	// Shared by legacy update and W3C XQUF 3.0
 	"replace" { name = "replace"; }
 	|
 	"delete" { name = "delete"; }
@@ -2304,6 +2379,49 @@ reservedKeywords returns [String name]
 	"next" { name = "next"; }
 	|
 	"when" { name = "when"; }
+	|
+	// W3C XQuery Update Facility 3.0 keywords
+	"copy" { name = "copy"; }
+	|
+	"modify" { name = "modify"; }
+	|
+	"nodes" { name = "nodes"; }
+	|
+	"before" { name = "before"; }
+	|
+	"after" { name = "after"; }
+	|
+	"first" { name = "first"; }
+	|
+	"last" { name = "last"; }
+	|
+	"updating" { name = "updating"; }
+	|
+	"ascending" { name = "ascending"; }
+	|
+	"descending" { name = "descending"; }
+	|
+	"greatest" { name = "greatest"; }
+	|
+	"least" { name = "least"; }
+	|
+	"satisfies" { name = "satisfies"; }
+	|
+	"schema-attribute" { name = "schema-attribute"; }
+	|
+	"revalidation" { name = "revalidation"; }
+	|
+	"skip" { name = "skip"; }
+	|
+	"strict" { name = "strict"; }
+	|
+	"lax" { name = "lax"; }
+	|
+	"castable" { name = "castable"; }
+	|
+	"idiv" { name = "idiv"; }
+	|
+	"processing-instruction" { name = "processing-instruction"; }
 	;
 
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -296,6 +296,9 @@ prolog throws XPathException
 			( "declare" "function" )
 			=> functionDeclUp { inSetters = false; }
 			|
+			( "declare" "updating" "function" )
+			=> updatingFunctionDeclUp { inSetters = false; }
+			|
 			( "declare" "variable" )
 			=> varDeclUp { inSetters = false; }
 			|
@@ -455,7 +458,7 @@ annotateDecl! throws XPathException
 :
 	decl:"declare"! ann:annotations!
 	(
-	    ("function") => f:functionDecl[#ann] { #annotateDecl = #f; }
+	    ("function") => f:functionDecl[#ann, false] { #annotateDecl = #f; }
 	    |
 	    ("variable") => v:varDecl[#decl, #ann] { #annotateDecl = #v; }
 	)
@@ -523,10 +526,15 @@ bracedUriLiteral returns [String uri]
 
 functionDeclUp! throws XPathException
 :
-	"declare"! f:functionDecl[null] { #functionDeclUp = #f; }
+	"declare"! f:functionDecl[null, false] { #functionDeclUp = #f; }
     ;
 
-functionDecl [XQueryAST ann] throws XPathException
+updatingFunctionDeclUp! throws XPathException
+:
+	"declare"! "updating"! f:functionDecl[null, true] { #updatingFunctionDeclUp = #f; }
+    ;
+
+functionDecl [XQueryAST ann, boolean updating] throws XPathException
 { String name= null; }
 :
 	"function"! name=eqName! lp:LPAREN! ( paramList )?
@@ -536,6 +544,9 @@ functionDecl [XQueryAST ann] throws XPathException
 	  	#functionDecl= #(#[FUNCTION_DECL, name, org.exist.xquery.parser.XQueryFunctionAST.class.getName()], #ann, #functionDecl);
 		#functionDecl.copyLexInfo(#lp);
 		#functionDecl.setDoc(getXQDoc());
+		if (updating) {
+			((XQueryFunctionAST) #functionDecl).setUpdating(true);
+		}
 	}
 	exception catch [RecognitionException e]
 	{
@@ -735,11 +746,20 @@ exprSingle throws XPathException
 	| ( "if" LPAREN ) => ifExpr
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
+	// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	// === W3C XQuery Update Facility 3.0 ===
+	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
+	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
+	| ( "replace" ( "node" | "value" ) ) => xqufReplaceExpr
+	| ( "rename" "node" ) => xqufRenameExpr
+	| ( "copy" DOLLAR ) => xqufTransformExpr
 	| orExpr
 	;
 
-// === Xupdate ===
+// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
+// To remove legacy update support, delete this section and the updateExpr
+// alternative in exprSingle above.
 
 updateExpr throws XPathException
 :
@@ -777,6 +797,57 @@ deleteExpr throws XPathException
 renameExpr throws XPathException
 :
 	"rename" exprSingle "as"! exprSingle
+	;
+
+// === W3C XQuery Update Facility 3.0 ===
+
+xqufInsertExpr throws XPathException
+:
+	"insert"^ ( "node"! | "nodes"! ) exprSingle
+	(
+		( "as" "first" "into" ) => "as"! "first" "into"! exprSingle
+		| ( "as" "last" "into" ) => "as"! "last" "into"! exprSingle
+		| "into" exprSingle
+		| "before" exprSingle
+		| "after" exprSingle
+	)
+	;
+
+xqufDeleteExpr throws XPathException
+:
+	"delete"^ ( "node"! | "nodes"! ) exprSingle
+	;
+
+xqufReplaceExpr throws XPathException
+:
+	"replace"^
+	(
+		( "value" "of" "node" ) => "value" "of"! "node"! exprSingle "with"! exprSingle
+		| "node"! exprSingle "with"! exprSingle
+	)
+	;
+
+xqufRenameExpr throws XPathException
+:
+	"rename"^ "node"! exprSingle "as"! exprSingle
+	;
+
+xqufTransformExpr throws XPathException
+:
+	"copy"^
+	xqufCopyBinding ( COMMA! xqufCopyBinding )*
+	"modify"! exprSingle
+	"return"! exprSingle
+	;
+
+xqufCopyBinding throws XPathException
+{ String varName; }
+:
+	DOLLAR! varName=v:varName! COLON! EQ! exprSingle
+	{
+		#xqufCopyBinding = #(#[VARIABLE_BINDING, varName], #xqufCopyBinding);
+		#xqufCopyBinding.copyLexInfo(#v);
+	}
 	;
 
 // === try/catch ===
@@ -2288,8 +2359,12 @@ reservedKeywords returns [String name]
 	|
 	"base-uri" { name = "base-uri"; }
 	|
+	// Legacy update keyword (DEPRECATED - only "update" is legacy-only;
+	// the others below are shared with W3C XQUF 3.0).
+	// To remove: delete "update" and keep the rest.
 	"update" { name = "update"; }
 	|
+	// Shared by legacy update and W3C XQUF 3.0
 	"replace" { name = "replace"; }
 	|
 	"delete" { name = "delete"; }
@@ -2367,6 +2442,49 @@ reservedKeywords returns [String name]
 	"next" { name = "next"; }
 	|
 	"when" { name = "when"; }
+	|
+	// W3C XQuery Update Facility 3.0 keywords
+	"copy" { name = "copy"; }
+	|
+	"modify" { name = "modify"; }
+	|
+	"nodes" { name = "nodes"; }
+	|
+	"before" { name = "before"; }
+	|
+	"after" { name = "after"; }
+	|
+	"first" { name = "first"; }
+	|
+	"last" { name = "last"; }
+	|
+	"updating" { name = "updating"; }
+	|
+	"ascending" { name = "ascending"; }
+	|
+	"descending" { name = "descending"; }
+	|
+	"greatest" { name = "greatest"; }
+	|
+	"least" { name = "least"; }
+	|
+	"satisfies" { name = "satisfies"; }
+	|
+	"schema-attribute" { name = "schema-attribute"; }
+	|
+	"revalidation" { name = "revalidation"; }
+	|
+	"skip" { name = "skip"; }
+	|
+	"strict" { name = "strict"; }
+	|
+	"lax" { name = "lax"; }
+	|
+	"castable" { name = "castable"; }
+	|
+	"idiv" { name = "idiv"; }
+	|
+	"processing-instruction" { name = "processing-instruction"; }
 	;
 
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3964,6 +3964,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( updateAST:"update"
         {
+            context.markLegacyUpdate(updateAST);
+
             PathExpr p1 = new PathExpr(context);
             p1.setASTNode(updateExpr_AST_in);
 
@@ -4021,6 +4023,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( insertAST:"insert"
         {
+            context.markXQUFUpdate(insertAST);
+
             PathExpr sourceExpr = new PathExpr(context);
             sourceExpr.setASTNode(xqufInsertExpr_AST_in);
 
@@ -4058,6 +4062,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( deleteAST:"delete"
         {
+            context.markXQUFUpdate(deleteAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufDeleteExpr_AST_in);
         }
@@ -4078,6 +4084,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( replaceAST:"replace"
         {
+            context.markXQUFUpdate(replaceAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufReplaceExpr_AST_in);
 
@@ -4112,6 +4120,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( renameAST:"rename"
         {
+            context.markXQUFUpdate(renameAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufRenameExpr_AST_in);
 
@@ -4136,6 +4146,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( copyAST:"copy"
         {
+            context.markXQUFUpdate(copyAST);
+
             java.util.List copyBindings = new java.util.ArrayList();
 
             PathExpr modifyExpr = new PathExpr(context);

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -53,6 +53,7 @@ header {
     import org.exist.xquery.value.*;
     import org.exist.xquery.functions.fn.*;
     import org.exist.xquery.update.*;
+    import org.exist.xquery.xquf.*;
     import org.exist.storage.ElementValue;
     import org.exist.xquery.functions.map.MapExpr;
     import org.exist.xquery.functions.array.ArrayConstructor;
@@ -148,7 +149,7 @@ options {
         String ns = qname.getNamespaceURI();
         if (ns.equals(Namespaces.XPATH_FUNCTIONS_NS)) {
             String ln = qname.getLocalPart();
-            return ("private".equals(ln) || "public".equals(ln));
+            return ("private".equals(ln) || "public".equals(ln) || "updating".equals(ln));
         } else {
             return !(ns.equals(Namespaces.XML_NS)
                      || ns.equals(Namespaces.SCHEMA_NS)
@@ -211,6 +212,15 @@ options {
 
         //set the Annotations on the Function Signature
         signature.setAnnotations(anns);
+
+        // W3C XQuery Update Facility 3.0: %updating annotation
+        for (Annotation a : anns) {
+            if ("updating".equals(a.getName().getLocalPart())
+                    && Namespaces.XPATH_FUNCTIONS_NS.equals(a.getName().getNamespaceURI())) {
+                signature.setUpdating(true);
+                break;
+            }
+        }
     }
 
     private static void processParams(List varList, UserDefinedFunction func, FunctionSignature signature)
@@ -857,6 +867,9 @@ throws PermissionDeniedException, EXistException, XPathException
             }
             FunctionSignature signature= new FunctionSignature(qn);
             signature.setDescription(name.getDoc());
+            if (name instanceof XQueryFunctionAST && ((XQueryFunctionAST) name).isUpdating()) {
+                signature.setUpdating(true);
+            }
             UserDefinedFunction func= new UserDefinedFunction(context, signature);
             func.setASTNode(name);
             List varList= new ArrayList(3);
@@ -882,7 +895,14 @@ throws PermissionDeniedException, EXistException, XPathException
                 "as"
                 { SequenceType type= new SequenceType(); }
                 sequenceType [type]
-                { signature.setReturnType(type); }
+                {
+                    signature.setReturnType(type);
+                    // XUST0028: updating functions must not declare a return type
+                    if (signature.isUpdating()) {
+                        throw new XPathException(name.getLine(), name.getColumn(),
+                            ErrorCodes.XUST0028, "An updating function must not declare a return type.");
+                    }
+                }
             )
         )?
         (
@@ -2443,7 +2463,19 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=numericExpr [path]
     |
+    // Legacy update (DEPRECATED)
     step=updateExpr [path]
+    |
+    // W3C XQuery Update Facility 3.0
+    step=xqufInsertExpr [path]
+    |
+    step=xqufDeleteExpr [path]
+    |
+    step=xqufReplaceExpr [path]
+    |
+    step=xqufRenameExpr [path]
+    |
+    step=xqufTransformExpr [path]
     ;
 
 /**
@@ -3978,6 +4010,10 @@ throws XPathException, PermissionDeniedException, EXistException
     }
     ;
 
+// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
+// To remove legacy update support, delete this rule and the updateExpr
+// alternative in the expr dispatch above.
+
 updateExpr [PathExpr path]
 returns [Expression step]
 throws XPathException, PermissionDeniedException, EXistException
@@ -4029,6 +4065,169 @@ throws XPathException, PermissionDeniedException, EXistException
             mod.setASTNode(updateAST);
             path.add(mod);
             step = mod;
+        }
+    )
+    ;
+
+// === W3C XQuery Update Facility 3.0 tree walker rules ===
+
+xqufInsertExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( insertAST:"insert"
+        {
+            PathExpr sourceExpr = new PathExpr(context);
+            sourceExpr.setASTNode(xqufInsertExpr_AST_in);
+
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufInsertExpr_AST_in);
+
+            int mode = XQUFInsertExpr.INSERT_INTO;
+        }
+        step=expr [sourceExpr]
+        (
+            "first" { mode = XQUFInsertExpr.INSERT_INTO_AS_FIRST; }
+            |
+            "last" { mode = XQUFInsertExpr.INSERT_INTO_AS_LAST; }
+            |
+            "into" { mode = XQUFInsertExpr.INSERT_INTO; }
+            |
+            "before" { mode = XQUFInsertExpr.INSERT_BEFORE; }
+            |
+            "after" { mode = XQUFInsertExpr.INSERT_AFTER; }
+        )
+        step=expr [targetExpr]
+        {
+            XQUFInsertExpr ins = new XQUFInsertExpr(context, sourceExpr, targetExpr, mode);
+            ins.setASTNode(insertAST);
+            path.add(ins);
+            step = ins;
+        }
+    )
+    ;
+
+xqufDeleteExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( deleteAST:"delete"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufDeleteExpr_AST_in);
+        }
+        step=expr [targetExpr]
+        {
+            XQUFDeleteExpr del = new XQUFDeleteExpr(context, targetExpr);
+            del.setASTNode(deleteAST);
+            path.add(del);
+            step = del;
+        }
+    )
+    ;
+
+xqufReplaceExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( replaceAST:"replace"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufReplaceExpr_AST_in);
+
+            PathExpr withExpr = new PathExpr(context);
+            withExpr.setASTNode(xqufReplaceExpr_AST_in);
+
+            boolean isValueOf = false;
+        }
+        (
+            "value" { isValueOf = true; }
+        )?
+        step=expr [targetExpr]
+        step=expr [withExpr]
+        {
+            Expression replExpr;
+            if (isValueOf) {
+                replExpr = new XQUFReplaceValueExpr(context, targetExpr, withExpr);
+            } else {
+                replExpr = new XQUFReplaceNodeExpr(context, targetExpr, withExpr);
+            }
+            replExpr.setASTNode(replaceAST);
+            path.add(replExpr);
+            step = replExpr;
+        }
+    )
+    ;
+
+xqufRenameExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( renameAST:"rename"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufRenameExpr_AST_in);
+
+            PathExpr nameExpr = new PathExpr(context);
+            nameExpr.setASTNode(xqufRenameExpr_AST_in);
+        }
+        step=expr [targetExpr]
+        step=expr [nameExpr]
+        {
+            XQUFRenameExpr ren = new XQUFRenameExpr(context, targetExpr, nameExpr);
+            ren.setASTNode(renameAST);
+            path.add(ren);
+            step = ren;
+        }
+    )
+    ;
+
+xqufTransformExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( copyAST:"copy"
+        {
+            java.util.List copyBindings = new java.util.ArrayList();
+
+            PathExpr modifyExpr = new PathExpr(context);
+            modifyExpr.setASTNode(xqufTransformExpr_AST_in);
+
+            PathExpr returnExpr = new PathExpr(context);
+            returnExpr.setASTNode(xqufTransformExpr_AST_in);
+        }
+        (
+            #( VARIABLE_BINDING
+                {
+                    PathExpr bindingExpr = new PathExpr(context);
+                    bindingExpr.setASTNode(xqufTransformExpr_AST_in);
+                    String varName = #VARIABLE_BINDING.getText();
+                }
+                step=expr [bindingExpr]
+                {
+                    final org.exist.dom.QName copyVarQName;
+                    try {
+                        copyVarQName = org.exist.dom.QName.parse(context, varName, null);
+                    } catch (final org.exist.dom.QName.IllegalQNameException e) {
+                        throw new XPathException(xqufTransformExpr_AST_in, ErrorCodes.XPST0081,
+                            "Invalid variable name in copy binding: " + varName);
+                    }
+                    copyBindings.add(new XQUFTransformExpr.CopyBinding(copyVarQName, bindingExpr));
+                }
+            )
+        )+
+        step=expr [modifyExpr]
+        step=expr [returnExpr]
+        {
+            XQUFTransformExpr trans = new XQUFTransformExpr(context, copyBindings, modifyExpr, returnExpr);
+            trans.setASTNode(copyAST);
+            path.add(trans);
+            step = trans;
         }
     )
     ;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -4021,6 +4021,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( updateAST:"update"
         {
+            context.markLegacyUpdate(updateAST);
+
             PathExpr p1 = new PathExpr(context);
             p1.setASTNode(updateExpr_AST_in);
 
@@ -4078,6 +4080,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( insertAST:"insert"
         {
+            context.markXQUFUpdate(insertAST);
+
             PathExpr sourceExpr = new PathExpr(context);
             sourceExpr.setASTNode(xqufInsertExpr_AST_in);
 
@@ -4115,6 +4119,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( deleteAST:"delete"
         {
+            context.markXQUFUpdate(deleteAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufDeleteExpr_AST_in);
         }
@@ -4135,6 +4141,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( replaceAST:"replace"
         {
+            context.markXQUFUpdate(replaceAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufReplaceExpr_AST_in);
 
@@ -4169,6 +4177,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( renameAST:"rename"
         {
+            context.markXQUFUpdate(renameAST);
+
             PathExpr targetExpr = new PathExpr(context);
             targetExpr.setASTNode(xqufRenameExpr_AST_in);
 
@@ -4193,6 +4203,8 @@ throws XPathException, PermissionDeniedException, EXistException
 }:
     #( copyAST:"copy"
         {
+            context.markXQUFUpdate(copyAST);
+
             java.util.List copyBindings = new java.util.ArrayList();
 
             PathExpr modifyExpr = new PathExpr(context);

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -53,6 +53,7 @@ header {
     import org.exist.xquery.value.*;
     import org.exist.xquery.functions.fn.*;
     import org.exist.xquery.update.*;
+    import org.exist.xquery.xquf.*;
     import org.exist.storage.ElementValue;
     import org.exist.xquery.functions.map.MapExpr;
     import org.exist.xquery.functions.array.ArrayConstructor;
@@ -148,7 +149,7 @@ options {
         String ns = qname.getNamespaceURI();
         if (ns.equals(Namespaces.XPATH_FUNCTIONS_NS)) {
             String ln = qname.getLocalPart();
-            return ("private".equals(ln) || "public".equals(ln));
+            return ("private".equals(ln) || "public".equals(ln) || "updating".equals(ln));
         } else {
             return !(ns.equals(Namespaces.XML_NS)
                      || ns.equals(Namespaces.SCHEMA_NS)
@@ -185,6 +186,15 @@ options {
 
         //set the Annotations on the Function Signature
         signature.setAnnotations(anns);
+
+        // W3C XQuery Update Facility 3.0: %updating annotation
+        for (Annotation a : anns) {
+            if ("updating".equals(a.getName().getLocalPart())
+                    && Namespaces.XPATH_FUNCTIONS_NS.equals(a.getName().getNamespaceURI())) {
+                signature.setUpdating(true);
+                break;
+            }
+        }
     }
 
     private static void processParams(List varList, UserDefinedFunction func, FunctionSignature signature)
@@ -834,6 +844,9 @@ throws PermissionDeniedException, EXistException, XPathException
             }
             FunctionSignature signature= new FunctionSignature(qn);
             signature.setDescription(name.getDoc());
+            if (name instanceof XQueryFunctionAST && ((XQueryFunctionAST) name).isUpdating()) {
+                signature.setUpdating(true);
+            }
             UserDefinedFunction func= new UserDefinedFunction(context, signature);
             func.setASTNode(name);
             List varList= new ArrayList(3);
@@ -859,7 +872,14 @@ throws PermissionDeniedException, EXistException, XPathException
                 "as"
                 { SequenceType type= new SequenceType(); }
                 sequenceType [type]
-                { signature.setReturnType(type); }
+                {
+                    signature.setReturnType(type);
+                    // XUST0028: updating functions must not declare a return type
+                    if (signature.isUpdating()) {
+                        throw new XPathException(name.getLine(), name.getColumn(),
+                            ErrorCodes.XUST0028, "An updating function must not declare a return type.");
+                    }
+                }
             )
         )?
         (
@@ -2409,7 +2429,19 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=numericExpr [path]
     |
+    // Legacy update (DEPRECATED)
     step=updateExpr [path]
+    |
+    // W3C XQuery Update Facility 3.0
+    step=xqufInsertExpr [path]
+    |
+    step=xqufDeleteExpr [path]
+    |
+    step=xqufReplaceExpr [path]
+    |
+    step=xqufRenameExpr [path]
+    |
+    step=xqufTransformExpr [path]
     ;
 
 /**
@@ -3921,6 +3953,10 @@ throws XPathException, PermissionDeniedException, EXistException
     }
     ;
 
+// === Legacy update (DEPRECATED - use W3C XQuery Update Facility 3.0 syntax instead) ===
+// To remove legacy update support, delete this rule and the updateExpr
+// alternative in the expr dispatch above.
+
 updateExpr [PathExpr path]
 returns [Expression step]
 throws XPathException, PermissionDeniedException, EXistException
@@ -3972,6 +4008,169 @@ throws XPathException, PermissionDeniedException, EXistException
             mod.setASTNode(updateAST);
             path.add(mod);
             step = mod;
+        }
+    )
+    ;
+
+// === W3C XQuery Update Facility 3.0 tree walker rules ===
+
+xqufInsertExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( insertAST:"insert"
+        {
+            PathExpr sourceExpr = new PathExpr(context);
+            sourceExpr.setASTNode(xqufInsertExpr_AST_in);
+
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufInsertExpr_AST_in);
+
+            int mode = XQUFInsertExpr.INSERT_INTO;
+        }
+        step=expr [sourceExpr]
+        (
+            "first" { mode = XQUFInsertExpr.INSERT_INTO_AS_FIRST; }
+            |
+            "last" { mode = XQUFInsertExpr.INSERT_INTO_AS_LAST; }
+            |
+            "into" { mode = XQUFInsertExpr.INSERT_INTO; }
+            |
+            "before" { mode = XQUFInsertExpr.INSERT_BEFORE; }
+            |
+            "after" { mode = XQUFInsertExpr.INSERT_AFTER; }
+        )
+        step=expr [targetExpr]
+        {
+            XQUFInsertExpr ins = new XQUFInsertExpr(context, sourceExpr, targetExpr, mode);
+            ins.setASTNode(insertAST);
+            path.add(ins);
+            step = ins;
+        }
+    )
+    ;
+
+xqufDeleteExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( deleteAST:"delete"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufDeleteExpr_AST_in);
+        }
+        step=expr [targetExpr]
+        {
+            XQUFDeleteExpr del = new XQUFDeleteExpr(context, targetExpr);
+            del.setASTNode(deleteAST);
+            path.add(del);
+            step = del;
+        }
+    )
+    ;
+
+xqufReplaceExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( replaceAST:"replace"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufReplaceExpr_AST_in);
+
+            PathExpr withExpr = new PathExpr(context);
+            withExpr.setASTNode(xqufReplaceExpr_AST_in);
+
+            boolean isValueOf = false;
+        }
+        (
+            "value" { isValueOf = true; }
+        )?
+        step=expr [targetExpr]
+        step=expr [withExpr]
+        {
+            Expression replExpr;
+            if (isValueOf) {
+                replExpr = new XQUFReplaceValueExpr(context, targetExpr, withExpr);
+            } else {
+                replExpr = new XQUFReplaceNodeExpr(context, targetExpr, withExpr);
+            }
+            replExpr.setASTNode(replaceAST);
+            path.add(replExpr);
+            step = replExpr;
+        }
+    )
+    ;
+
+xqufRenameExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( renameAST:"rename"
+        {
+            PathExpr targetExpr = new PathExpr(context);
+            targetExpr.setASTNode(xqufRenameExpr_AST_in);
+
+            PathExpr nameExpr = new PathExpr(context);
+            nameExpr.setASTNode(xqufRenameExpr_AST_in);
+        }
+        step=expr [targetExpr]
+        step=expr [nameExpr]
+        {
+            XQUFRenameExpr ren = new XQUFRenameExpr(context, targetExpr, nameExpr);
+            ren.setASTNode(renameAST);
+            path.add(ren);
+            step = ren;
+        }
+    )
+    ;
+
+xqufTransformExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+    #( copyAST:"copy"
+        {
+            java.util.List copyBindings = new java.util.ArrayList();
+
+            PathExpr modifyExpr = new PathExpr(context);
+            modifyExpr.setASTNode(xqufTransformExpr_AST_in);
+
+            PathExpr returnExpr = new PathExpr(context);
+            returnExpr.setASTNode(xqufTransformExpr_AST_in);
+        }
+        (
+            #( VARIABLE_BINDING
+                {
+                    PathExpr bindingExpr = new PathExpr(context);
+                    bindingExpr.setASTNode(xqufTransformExpr_AST_in);
+                    String varName = #VARIABLE_BINDING.getText();
+                }
+                step=expr [bindingExpr]
+                {
+                    final org.exist.dom.QName copyVarQName;
+                    try {
+                        copyVarQName = org.exist.dom.QName.parse(context, varName, null);
+                    } catch (final org.exist.dom.QName.IllegalQNameException e) {
+                        throw new XPathException(xqufTransformExpr_AST_in, ErrorCodes.XPST0081,
+                            "Invalid variable name in copy binding: " + varName);
+                    }
+                    copyBindings.add(new XQUFTransformExpr.CopyBinding(copyVarQName, bindingExpr));
+                }
+            )
+        )+
+        step=expr [modifyExpr]
+        step=expr [returnExpr]
+        {
+            XQUFTransformExpr trans = new XQUFTransformExpr(context, copyBindings, modifyExpr, returnExpr);
+            trans.setASTNode(copyAST);
+            path.add(trans);
+            step = trans;
         }
     )
     ;

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -49,6 +49,8 @@ import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -143,6 +145,11 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     protected int nextReferenceIdx = 0;
     // end reference nodes
 
+
+    // Override for first-child lookup after in-memory mutations.
+    // Maps parent node number -> first child node number when the first child
+    // is no longer at the positional (parent + 1) slot due to insertions.
+    private Map<Integer, Integer> firstChildOverride = null;
 
     protected XQueryContext context;
     protected final boolean explicitlyCreated;
@@ -605,41 +612,99 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
     public int getChildCountFor(final int nr) {
         int count = 0;
+        final short childLevel = (short) (treeLevel[nr] + 1);
         int nextNode = getFirstChildFor(nr);
-        while(nextNode > nr) {
-            ++count;
-            nextNode = next[nextNode];
+        int steps = 0;
+        while (nextNode >= 0 && steps < size) {
+            if (nodeKind[nextNode] != -1 && treeLevel[nextNode] == childLevel) {
+                ++count;
+            }
+            final int following = getNextSiblingFor(nextNode);
+            if (following < 0) {
+                break;
+            }
+            nextNode = following;
+            steps++;
         }
         return count;
     }
 
     public int getFirstChildFor(final int nodeNumber) {
+        // Check for override from in-memory mutations (e.g. insert as first)
+        if (firstChildOverride != null) {
+            final Integer override = firstChildOverride.get(nodeNumber);
+            if (override != null) {
+                return override;
+            }
+        }
+
         if (nodeNumber == 0) {
             // optimisation for document-node
             if (size > 1) {
-                return 1;
+                // skip soft-deleted nodes, but remember first deleted child
+                int n = 1;
+                int firstDeleted = -1;
+                while (n < size && nodeKind[n] == -1) {
+                    if (firstDeleted < 0) {
+                        firstDeleted = n;
+                    }
+                    n++;
+                }
+                return n < size ? n : firstDeleted;
             } else {
                 return -1;
             }
         }
 
         final short level = treeLevel[nodeNumber];
-        final int nextNode = nodeNumber + 1;
-        if((nextNode < size) && (treeLevel[nextNode] > level)) {
-            return nextNode;
+        int nextNode = nodeNumber + 1;
+        int firstDeletedChild = -1;
+        // Scan positional children (nodes immediately after parent in the array at a deeper level)
+        while (nextNode < size && treeLevel[nextNode] > level) {
+            if (nodeKind[nextNode] != -1) {
+                return nextNode;  // found a non-deleted child
+            }
+            if (firstDeletedChild < 0) {
+                firstDeletedChild = nextNode;
+            }
+            nextNode++;
         }
-        return -1;
+        // No non-deleted positional child found. Return the first deleted child
+        // so callers can follow the next[] chain to find children that were
+        // appended beyond the positional range via insertChildren().
+        return firstDeletedChild;
     }
 
     public int getNextSiblingFor(final int nodeNumber) {
         final int nextNr = next[nodeNumber];
-        return nextNr < nodeNumber ? -1 : nextNr;
+        if (nextNr < 0) {
+            return -1;
+        }
+        if (nextNr < nodeNumber) {
+            // Backwards reference: after in-memory mutations, siblings may be at
+            // lower positions. Check tree level to distinguish sibling from parent.
+            if (treeLevel[nextNr] == treeLevel[nodeNumber]) {
+                return nextNr;
+            }
+            return -1;  // lower level = parent pointer, no next sibling
+        }
+        return nextNr;
     }
 
     public int getParentNodeFor(final int nodeNumber) {
+        if (nodeNumber == 0) {
+            return -1;
+        }
+        final short level = treeLevel[nodeNumber];
         int nextNode = next[nodeNumber];
-        while(nextNode > nodeNumber) {
+        int steps = 0;
+        while (nextNode >= 0 && steps < size) {
+            if (treeLevel[nextNode] < level) {
+                return nextNode;  // found a node at a lower level = parent
+            }
+            // same or higher level — keep walking the chain
             nextNode = next[nextNode];
+            steps++;
         }
         return nextNode;
     }
@@ -1634,5 +1699,960 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         }
 
         throw unsupported();
+    }
+
+    // === W3C XQuery Update Facility 3.0 - In-memory mutation methods ===
+
+    /**
+     * Rename a node in this document.
+     *
+     * @param nodeNum the node number to rename
+     * @param newName the new QName
+     */
+    public void renameNode(final int nodeNum, final QName newName) {
+        final short kind = nodeKind[nodeNum];
+        switch (kind) {
+            case Node.ELEMENT_NODE:
+            case Node.PROCESSING_INSTRUCTION_NODE:
+                nodeName[nodeNum] = namePool.getSharedName(newName);
+                break;
+            default:
+                throw new DOMException(DOMException.NOT_SUPPORTED_ERR,
+                        "Cannot rename node of type " + kind);
+        }
+    }
+
+    /**
+     * Rename an attribute node. The attrNum parameter is an index into the
+     * attribute arrays (attrName, attrValue, etc.), NOT the main node arrays.
+     *
+     * @param attrNum the attribute index
+     * @param newName the new QName
+     */
+    public void renameAttribute(final int attrNum, final QName newName) {
+        attrName[attrNum] = namePool.getSharedName(newName);
+    }
+
+    /**
+     * Replace the string value of a node.
+     *
+     * @param nodeNum the node number
+     * @param value the new string value
+     */
+    public void replaceValue(final int nodeNum, final String value) {
+        final short kind = nodeKind[nodeNum];
+        switch (kind) {
+            case Node.TEXT_NODE:
+            case Node.COMMENT_NODE:
+            case Node.CDATA_SECTION_NODE:
+            case Node.PROCESSING_INSTRUCTION_NODE: {
+                // Replace the character content
+                final char[] chars = value.toCharArray();
+                if (characters == null) {
+                    characters = new char[chars.length > CHAR_BUF_SIZE ? chars.length : CHAR_BUF_SIZE];
+                } else if ((nextChar + chars.length) >= characters.length) {
+                    int newLen = (characters.length * 3) / 2;
+                    if (newLen < (nextChar + chars.length)) {
+                        newLen = nextChar + chars.length;
+                    }
+                    final char[] nc = new char[newLen];
+                    System.arraycopy(characters, 0, nc, 0, characters.length);
+                    characters = nc;
+                }
+                alpha[nodeNum] = nextChar;
+                alphaLen[nodeNum] = chars.length;
+                System.arraycopy(chars, 0, characters, nextChar, chars.length);
+                nextChar += chars.length;
+                break;
+            }
+            case Node.ELEMENT_NODE: {
+                // W3C replaceElementContent: replace all children with a single text node.
+                // We must be careful to only modify THIS element's children, not nodes
+                // belonging to sibling elements that happen to be adjacent in the array.
+                final short childLevel = (short) (treeLevel[nodeNum] + 1);
+
+                // Determine the boundary of this element's positional subtree.
+                // Only nodes at positions nodeNum+1..subtreeEnd (where subtreeEnd is the
+                // first position at the same or lower level) are this element's children.
+                int subtreeEnd = nodeNum + 1;
+                while (subtreeEnd < size && treeLevel[subtreeEnd] > treeLevel[nodeNum]) {
+                    subtreeEnd++;
+                }
+
+                // Find and modify/create a text child within the positional range
+                int firstTextChild = -1;
+                for (int c = nodeNum + 1; c < subtreeEnd; c++) {
+                    if (firstTextChild == -1 && treeLevel[c] == childLevel
+                            && nodeKind[c] == Node.TEXT_NODE) {
+                        firstTextChild = c;
+                    } else if (c != firstTextChild) {
+                        nodeKind[c] = -1;  // delete other children
+                    }
+                }
+
+                // Also delete any chain-linked children (from previous insertions)
+                if (firstChildOverride != null && firstChildOverride.containsKey(nodeNum)) {
+                    int chainChild = firstChildOverride.get(nodeNum);
+                    while (chainChild >= 0 && chainChild != nodeNum) {
+                        if (chainChild >= subtreeEnd && nodeKind[chainChild] != -1) {
+                            nodeKind[chainChild] = -1;  // delete appended children
+                        }
+                        final int nx = next[chainChild];
+                        if (nx < 0 || nx == nodeNum) break;
+                        chainChild = nx;
+                    }
+                    firstChildOverride.remove(nodeNum);
+                }
+
+                if (firstTextChild >= 0) {
+                    // Modify existing text child in place
+                    final char[] chars = value.toCharArray();
+                    if ((nextChar + chars.length) >= characters.length) {
+                        int newLen = (characters.length * 3) / 2;
+                        if (newLen < (nextChar + chars.length)) {
+                            newLen = nextChar + chars.length;
+                        }
+                        final char[] nc = new char[newLen];
+                        System.arraycopy(characters, 0, nc, 0, characters.length);
+                        characters = nc;
+                    }
+                    alpha[firstTextChild] = nextChar;
+                    alphaLen[firstTextChild] = chars.length;
+                    System.arraycopy(chars, 0, characters, nextChar, chars.length);
+                    nextChar += chars.length;
+                } else if (nodeNum + 1 < subtreeEnd) {
+                    // No text child but has positional children — convert first to text
+                    final int firstChild = nodeNum + 1;
+                    nodeKind[firstChild] = Node.TEXT_NODE;
+                    nodeName[firstChild] = null;
+                    final char[] chars = value.toCharArray();
+                    if ((nextChar + chars.length) >= characters.length) {
+                        int newLen = (characters.length * 3) / 2;
+                        if (newLen < (nextChar + chars.length)) {
+                            newLen = nextChar + chars.length;
+                        }
+                        final char[] nc = new char[newLen];
+                        System.arraycopy(characters, 0, nc, 0, characters.length);
+                        characters = nc;
+                    }
+                    alpha[firstChild] = nextChar;
+                    alphaLen[firstChild] = chars.length;
+                    System.arraycopy(chars, 0, characters, nextChar, chars.length);
+                    nextChar += chars.length;
+                    // Mark remaining positional children as deleted
+                    for (int c = firstChild + 1; c < subtreeEnd; c++) {
+                        nodeKind[c] = -1;
+                    }
+                } else if (value != null && !value.isEmpty()) {
+                    // Element has no positional children — insert via insertChildren
+                    try {
+                        final org.exist.xquery.value.StringValue textVal =
+                                new org.exist.xquery.value.StringValue(value);
+                        insertChildren(nodeNum, textVal, true);
+                    } catch (final org.exist.xquery.XPathException e) {
+                        throw new DOMException(DOMException.INVALID_STATE_ERR,
+                                "Failed to insert text child: " + e.getMessage());
+                    }
+                }
+                break;
+            }
+            default:
+                throw new DOMException(DOMException.NOT_SUPPORTED_ERR,
+                        "Cannot replace value of node of type " + kind);
+        }
+    }
+
+    /**
+     * Replace the value of an attribute node. The attrNum parameter is an index
+     * into the attribute arrays (attrName, attrValue, etc.), NOT the main node arrays.
+     *
+     * @param attrNum the attribute index
+     * @param value the new value
+     */
+    public void replaceAttributeValue(final int attrNum, final String value) {
+        attrValue[attrNum] = value;
+    }
+
+    /**
+     * Remove an attribute from this document.
+     * Compacts the attribute arrays by shifting subsequent entries down.
+     * Also updates the alpha[] pointers for elements whose first attribute
+     * index is affected.
+     *
+     * @param attrNum the attribute index to remove
+     */
+    public void removeAttribute(final int attrNum) {
+        if (attrNum < 0 || attrNum >= nextAttr) {
+            return;
+        }
+
+        // Shift all attribute arrays down by one
+        final int remaining = nextAttr - attrNum - 1;
+        if (remaining > 0) {
+            System.arraycopy(attrName, attrNum + 1, attrName, attrNum, remaining);
+            System.arraycopy(attrNodeId, attrNum + 1, attrNodeId, attrNum, remaining);
+            System.arraycopy(attrParent, attrNum + 1, attrParent, attrNum, remaining);
+            System.arraycopy(attrValue, attrNum + 1, attrValue, attrNum, remaining);
+            System.arraycopy(attrType, attrNum + 1, attrType, attrNum, remaining);
+        }
+        nextAttr--;
+
+        // Update alpha[] pointers: alpha[nodeNum] stores the first attribute index
+        // for each element. If the removed attribute index is <= the element's
+        // first attribute, we need to adjust.
+        for (int i = 0; i < size; i++) {
+            if (nodeKind[i] == Node.ELEMENT_NODE && alpha[i] >= 0) {
+                if (alpha[i] > attrNum) {
+                    alpha[i]--;
+                } else if (alpha[i] == attrNum) {
+                    // Check if this element still has attributes
+                    if (attrNum < nextAttr && attrParent[attrNum] == i) {
+                        // Still has attributes at the same index (shifted down)
+                    } else {
+                        alpha[i] = -1; // No more attributes for this element
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Find any node whose next[] pointer targets the given node.
+     * After in-memory mutations, predecessors may be at any array position,
+     * so we must scan all nodes, not just those before targetNodeNum.
+     *
+     * @param targetNodeNum the node to find a predecessor for
+     * @return the predecessor node number, or -1 if not found
+     */
+    private int findPredecessor(final int targetNodeNum) {
+        final short targetLevel = treeLevel[targetNodeNum];
+        // Search backward first (most common case for unmutated trees)
+        for (int i = targetNodeNum - 1; i >= 0; i--) {
+            if (next[i] == targetNodeNum && nodeKind[i] != -1 && treeLevel[i] == targetLevel) {
+                return i;
+            }
+        }
+        // Search forward (for nodes inserted after targetNodeNum in array order)
+        for (int i = targetNodeNum + 1; i < size; i++) {
+            if (next[i] == targetNodeNum && nodeKind[i] != -1 && treeLevel[i] == targetLevel) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Remove a node from this document.
+     * This is a soft-delete: the node's kind is set to -1 to mark it as deleted.
+     * This is sufficient for the copy-modify pattern where the document is
+     * consumed once and not reused.
+     *
+     * @param nodeNum the node number to remove
+     */
+    public void removeNode(final int nodeNum) {
+        if (nodeNum <= 0 || nodeNum >= size) {
+            return;
+        }
+
+        // Find the parent and re-stitch the next[] chain to skip this node
+        final int origNext = next[nodeNum];
+        final short level = treeLevel[nodeNum];
+
+        // Find the previous node that points to nodeNum
+        final int prev = findPredecessor(nodeNum);
+
+        if (prev >= 0) {
+            // Find the next node after this node's subtree in the sibling chain.
+            // Walk the next[] chain from nodeNum to find the first node that's
+            // at the same or lower level (a sibling or the parent).
+            int chainNode = origNext;
+            int steps = 0;
+            while (chainNode >= 0 && steps < size) {
+                if (nodeKind[chainNode] == -1) {
+                    // skip deleted nodes in chain
+                    chainNode = next[chainNode];
+                    steps++;
+                    continue;
+                }
+                if (treeLevel[chainNode] <= level) {
+                    // Found a sibling or parent
+                    break;
+                }
+                chainNode = next[chainNode];
+                steps++;
+            }
+            next[prev] = chainNode >= 0 ? chainNode : origNext;
+        }
+
+        // Mark the node and its subtree as deleted
+        final short nodeLevel = treeLevel[nodeNum];
+        nodeKind[nodeNum] = -1;
+        for (int i = nodeNum + 1; i < size && treeLevel[i] > nodeLevel; i++) {
+            nodeKind[i] = -1;
+        }
+    }
+
+    /**
+     * Merge adjacent text nodes throughout the document.
+     * Per the W3C XQuery Update Facility spec, after applying updates,
+     * adjacent text nodes among children of any element or document node
+     * must be merged. Empty text nodes are removed.
+     *
+     * This walks all non-deleted nodes and for each parent (document or element),
+     * finds runs of consecutive text node children and merges them.
+     */
+    public void mergeAdjacentTextNodes() {
+        // Walk the document looking for parent nodes (document or element)
+        for (int parent = 0; parent < size; parent++) {
+            if (nodeKind[parent] == -1) {
+                continue;
+            }
+            if (nodeKind[parent] != Node.DOCUMENT_NODE && nodeKind[parent] != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            // Iterate through children of this parent using the next[] chain
+            final short childLevel = (short) (treeLevel[parent] + 1);
+            int child = getFirstChildFor(parent);
+            if (child < 0) {
+                continue;
+            }
+
+            int prevTextNode = -1;
+            while (child >= 0 && child < size && treeLevel[child] >= childLevel) {
+                if (nodeKind[child] == -1) {
+                    // Skip deleted nodes — follow next[] chain
+                    child = next[child];
+                    if (child <= parent) break;
+                    continue;
+                }
+                if (treeLevel[child] > childLevel) {
+                    // Descendant, not direct child — skip
+                    child = next[child];
+                    if (child <= parent) break;
+                    continue;
+                }
+
+                // Direct child at childLevel
+                if (nodeKind[child] == Node.TEXT_NODE) {
+                    if (prevTextNode >= 0) {
+                        // Merge this text node into prevTextNode
+                        final String prevText = new String(characters, alpha[prevTextNode], alphaLen[prevTextNode]);
+                        final String thisText = new String(characters, alpha[child], alphaLen[child]);
+                        final String merged = prevText + thisText;
+
+                        // Store merged text in prevTextNode
+                        final char[] chars = merged.toCharArray();
+                        if ((nextChar + chars.length) >= characters.length) {
+                            int newLen = (characters.length * 3) / 2;
+                            if (newLen < (nextChar + chars.length)) {
+                                newLen = nextChar + chars.length;
+                            }
+                            final char[] nc = new char[newLen];
+                            System.arraycopy(characters, 0, nc, 0, characters.length);
+                            characters = nc;
+                        }
+                        alpha[prevTextNode] = nextChar;
+                        alphaLen[prevTextNode] = chars.length;
+                        System.arraycopy(chars, 0, characters, nextChar, chars.length);
+                        nextChar += chars.length;
+
+                        // Soft-delete the merged text node and restitch
+                        removeNode(child);
+
+                        // Continue from prevTextNode's next (don't advance prevTextNode)
+                        child = next[prevTextNode];
+                        if (child <= parent) break;
+                    } else {
+                        // Check for empty text nodes
+                        if (alphaLen[child] == 0) {
+                            final int nextChild = next[child];
+                            removeNode(child);
+                            child = nextChild;
+                            if (child <= parent) break;
+                        } else {
+                            prevTextNode = child;
+                            child = next[child];
+                            if (child <= parent) break;
+                        }
+                    }
+                } else {
+                    prevTextNode = -1;
+                    child = next[child];
+                    if (child <= parent) break;
+                }
+            }
+        }
+
+        // Invalidate cached node IDs since the structure changed
+        if (nodeId != null) {
+            nodeId[0] = null;
+        }
+    }
+
+    /**
+     * Insert children into an element node.
+     * Uses the serialization rebuild approach for correctness.
+     *
+     * @param parentNodeNum the node number of the parent element
+     * @param content the content to insert
+     * @param asFirst if true, insert as first children; if false, as last
+     * @throws XPathException if the content cannot be processed
+     */
+    public void insertChildren(final int parentNodeNum, final Sequence content, final boolean asFirst)
+            throws XPathException {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        final short childLevel = (short) (treeLevel[parentNodeNum] + 1);
+
+        if (asFirst) {
+            // Insert as first children: find the current first child and link new nodes before it
+            final int firstChild = getFirstChildFor(parentNodeNum);
+
+            int lastInserted = -1;
+            int firstInserted = -1;
+            for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+                final org.exist.xquery.value.Item item = i.nextItem();
+                final java.util.List<Integer> inserted = copyItemIntoDocument(item, parentNodeNum, childLevel);
+                for (final int newNodeNum : inserted) {
+                    if (firstInserted == -1) {
+                        firstInserted = newNodeNum;
+                    }
+                    if (lastInserted >= 0) {
+                        next[lastInserted] = newNodeNum;
+                    }
+                    lastInserted = newNodeNum;
+                }
+            }
+            // Link last inserted to the old first child (or parent if no children)
+            if (lastInserted >= 0) {
+                next[lastInserted] = firstChild >= 0 ? firstChild : parentNodeNum;
+            }
+            // Override the first-child lookup so navigation finds the new nodes first
+            if (firstInserted >= 0) {
+                if (firstChildOverride == null) {
+                    firstChildOverride = new HashMap<>();
+                }
+                firstChildOverride.put(parentNodeNum, firstInserted);
+            }
+        } else {
+            // Insert as last children: find the last child and link after it
+            // Walk the sibling chain from first child to find the last one
+            int lastChild = -1;
+            final int firstChild = getFirstChildFor(parentNodeNum);
+            if (firstChild >= 0) {
+                lastChild = firstChild;
+                int nextSib = getNextSiblingFor(lastChild);
+                while (nextSib >= 0) {
+                    lastChild = nextSib;
+                    nextSib = getNextSiblingFor(lastChild);
+                }
+            }
+
+            int firstInsertedAsLast = -1;
+            for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+                final org.exist.xquery.value.Item item = i.nextItem();
+                final java.util.List<Integer> inserted = copyItemIntoDocument(item, parentNodeNum, childLevel);
+                for (final int newNodeNum : inserted) {
+                    if (firstInsertedAsLast == -1) {
+                        firstInsertedAsLast = newNodeNum;
+                    }
+                    if (lastChild >= 0) {
+                        next[lastChild] = newNodeNum;
+                    }
+                    lastChild = newNodeNum;
+                }
+            }
+            // If the parent had no visible children, the appended nodes are beyond
+            // the positional scan range. Set firstChildOverride so they can be found.
+            if (firstChild < 0 && firstInsertedAsLast >= 0) {
+                if (firstChildOverride == null) {
+                    firstChildOverride = new HashMap<>();
+                }
+                firstChildOverride.put(parentNodeNum, firstInsertedAsLast);
+            }
+        }
+    }
+
+    /**
+     * Insert sibling nodes before or after a reference node.
+     *
+     * @param refNodeNum the reference node number
+     * @param content the content to insert
+     * @param before if true, insert before; if false, insert after
+     * @throws XPathException if the content cannot be processed
+     */
+    public void insertSiblings(final int refNodeNum, final Sequence content, final boolean before)
+            throws XPathException {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        final short level = treeLevel[refNodeNum];
+        // Find the parent using level-aware parent finding
+        final int parentNum = getParentNodeFor(refNodeNum);
+        if (parentNum < 0) {
+            // Cannot insert siblings of the document node (no parent)
+            return;
+        }
+
+        if (before) {
+            // Insert before: find the node whose next[] points to refNodeNum and re-link
+            final int prevNode = findPredecessor(refNodeNum);
+
+            int lastInserted = -1;
+            int firstInserted = -1;
+            for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+                final org.exist.xquery.value.Item item = i.nextItem();
+                final java.util.List<Integer> inserted = copyItemIntoDocument(item, parentNum, level);
+                for (final int newNodeNum : inserted) {
+                    if (firstInserted == -1) {
+                        firstInserted = newNodeNum;
+                    }
+                    if (prevNode >= 0 && lastInserted == -1) {
+                        next[prevNode] = newNodeNum;
+                    }
+                    if (lastInserted >= 0) {
+                        next[lastInserted] = newNodeNum;
+                    }
+                    lastInserted = newNodeNum;
+                }
+            }
+            // Link last inserted to refNode
+            if (lastInserted >= 0) {
+                next[lastInserted] = refNodeNum;
+            }
+            // If no predecessor found, refNode was the first child (found positionally).
+            // Set override so navigation finds the new nodes first.
+            if (prevNode < 0 && firstInserted >= 0 && parentNum >= 0) {
+                if (firstChildOverride == null) {
+                    firstChildOverride = new HashMap<>();
+                }
+                firstChildOverride.put(parentNum, firstInserted);
+            }
+        } else {
+            // Insert after: link new nodes after refNode
+            final int origNext = next[refNodeNum];
+            int lastInserted = refNodeNum;
+            for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+                final org.exist.xquery.value.Item item = i.nextItem();
+                final java.util.List<Integer> inserted = copyItemIntoDocument(item, parentNum, level);
+                for (final int newNodeNum : inserted) {
+                    next[lastInserted] = newNodeNum;
+                    lastInserted = newNodeNum;
+                }
+            }
+            // Last inserted points to where refNode originally pointed
+            if (lastInserted != refNodeNum) {
+                next[lastInserted] = origNext;
+            }
+        }
+    }
+
+    /**
+     * Insert attributes into an element.
+     *
+     * @param elementNodeNum the element node number
+     * @param content the attribute nodes to insert
+     * @throws XPathException if the content cannot be processed
+     */
+    public void insertAttributes(final int elementNodeNum, final Sequence content) throws XPathException {
+        insertAttributes(elementNodeNum, content, true);
+    }
+
+    /**
+     * Insert attributes into an element.
+     *
+     * @param elementNodeNum the target element's node number
+     * @param content the attributes to insert
+     * @param replaceExisting if true, replace existing attributes with the same name;
+     *                        if false, always add as new attributes (for PUL application
+     *                        where a DELETE may separately remove the original)
+     */
+    public void insertAttributes(final int elementNodeNum, final Sequence content,
+                                  final boolean replaceExisting) throws XPathException {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        // Collect new attributes to insert
+        final java.util.List<Object[]> newAttrs = new java.util.ArrayList<>();
+        for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+            final org.exist.xquery.value.Item item = i.nextItem();
+            if (org.exist.xquery.value.Type.subTypeOf(item.getType(), org.exist.xquery.value.Type.NODE)) {
+                final Node node = ((org.exist.xquery.value.NodeValue) item).getNode();
+                if (node.getNodeType() == Node.ATTRIBUTE_NODE) {
+                    final Attr attr = (Attr) node;
+                    final QName qname = new QName(
+                            attr.getLocalName() != null ? attr.getLocalName() : attr.getName(),
+                            attr.getNamespaceURI() != null ? attr.getNamespaceURI() : "",
+                            attr.getPrefix() != null ? attr.getPrefix() : "");
+                    newAttrs.add(new Object[]{qname, attr.getValue()});
+                }
+            }
+        }
+
+        if (newAttrs.isEmpty()) {
+            return;
+        }
+
+        // Check for duplicates and replace existing values (only when not in PUL mode)
+        if (replaceExisting) {
+            final java.util.Iterator<Object[]> it = newAttrs.iterator();
+            while (it.hasNext()) {
+                final Object[] entry = it.next();
+                final QName qname = (QName) entry[0];
+                final String value = (String) entry[1];
+                if (alpha[elementNodeNum] >= 0) {
+                    int a = alpha[elementNodeNum];
+                    while (a < nextAttr && attrParent[a] == elementNodeNum) {
+                        if (attrName[a].equals(qname)) {
+                            // Replace existing attribute value
+                            attrValue[a] = value;
+                            it.remove();
+                            break;
+                        }
+                        a++;
+                    }
+                }
+            }
+        }
+
+        if (newAttrs.isEmpty()) {
+            return;
+        }
+
+        final int count = newAttrs.size();
+
+        // Find insertion point: right after the last contiguous attribute of this element
+        int insertPos;
+        if (alpha[elementNodeNum] >= 0) {
+            insertPos = alpha[elementNodeNum];
+            while (insertPos < nextAttr && attrParent[insertPos] == elementNodeNum) {
+                insertPos++;
+            }
+        } else {
+            // Element has no attrs yet — insert at nextAttr (already contiguous)
+            insertPos = nextAttr;
+        }
+
+        // Ensure capacity
+        while (nextAttr + count > attrName.length) {
+            growAttributes();
+        }
+
+        // Shift everything from insertPos onwards to make room
+        if (insertPos < nextAttr) {
+            System.arraycopy(attrParent, insertPos, attrParent, insertPos + count, nextAttr - insertPos);
+            System.arraycopy(attrName, insertPos, attrName, insertPos + count, nextAttr - insertPos);
+            System.arraycopy(attrValue, insertPos, attrValue, insertPos + count, nextAttr - insertPos);
+            System.arraycopy(attrType, insertPos, attrType, insertPos + count, nextAttr - insertPos);
+
+            // Update alpha pointers for elements whose attrs shifted
+            for (int n = 0; n < size; n++) {
+                if (nodeKind[n] == Node.ELEMENT_NODE && alpha[n] >= insertPos && n != elementNodeNum) {
+                    alpha[n] += count;
+                }
+            }
+        }
+
+        // Insert new attributes at the contiguous position
+        for (int j = 0; j < count; j++) {
+            final Object[] entry = newAttrs.get(j);
+            final QName qname = (QName) entry[0];
+            final String value = (String) entry[1];
+            final QName attrQname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), ElementValue.ATTRIBUTE);
+            attrParent[insertPos + j] = elementNodeNum;
+            this.attrName[insertPos + j] = namePool.getSharedName(attrQname);
+            attrValue[insertPos + j] = value;
+            attrType[insertPos + j] = AttrImpl.ATTR_CDATA_TYPE;
+        }
+
+        // Set alpha if element didn't have attrs before
+        if (alpha[elementNodeNum] < 0) {
+            alpha[elementNodeNum] = insertPos;
+        }
+
+        nextAttr += count;
+    }
+
+    /**
+     * Replace a node with new content.
+     *
+     * @param nodeNum the node number to replace
+     * @param content the replacement content
+     * @throws XPathException if the content cannot be processed
+     */
+    public void replaceNode(final int nodeNum, final Sequence content) throws XPathException {
+        if (content == null || content.isEmpty()) {
+            removeNode(nodeNum);
+            return;
+        }
+
+        final short level = treeLevel[nodeNum];
+        final int parentNum = getParentNodeFor(nodeNum);
+
+        // Find the predecessor that points to nodeNum
+        final int prev = findPredecessor(nodeNum);
+
+        // Find the next node after nodeNum's subtree (the node nodeNum's chain leads to
+        // at the same or lower level)
+        int afterNode = next[nodeNum];
+        int steps = 0;
+        while (afterNode >= 0 && steps < size) {
+            if (nodeKind[afterNode] != -1 && treeLevel[afterNode] <= level) {
+                break;
+            }
+            afterNode = next[afterNode];
+            steps++;
+        }
+
+        // Copy new content nodes and link them into the chain.
+        // Uses copyItemIntoDocument to handle document nodes and atomic values.
+        int firstNew = -1;
+        int lastNew = -1;
+        try {
+            for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
+                final org.exist.xquery.value.Item item = i.nextItem();
+                final java.util.List<Integer> newNodes = copyItemIntoDocument(item, parentNum, level);
+                for (final int newNodeNum : newNodes) {
+                    if (firstNew == -1) {
+                        firstNew = newNodeNum;
+                    }
+                    if (lastNew >= 0) {
+                        next[lastNew] = newNodeNum;
+                    }
+                    lastNew = newNodeNum;
+                }
+            }
+        } catch (final org.exist.xquery.XPathException e) {
+            throw new DOMException(DOMException.INVALID_STATE_ERR, e.getMessage());
+        }
+
+        // Link new nodes into the chain
+        if (prev >= 0 && firstNew >= 0) {
+            next[prev] = firstNew;
+        } else if (prev < 0 && firstNew >= 0 && parentNum >= 0) {
+            // No same-level predecessor: the replaced node was the first child.
+            // Set firstChildOverride so getFirstChildFor() can find the new nodes
+            // (they're appended at the end of the array, beyond positional scan).
+            if (firstChildOverride == null) {
+                firstChildOverride = new HashMap<>();
+            }
+            firstChildOverride.put(parentNum, firstNew);
+        }
+        if (lastNew >= 0) {
+            next[lastNew] = afterNode >= 0 ? afterNode : parentNum;
+        }
+
+        // Soft-delete the original node and its subtree
+        final short nodeLevel = treeLevel[nodeNum];
+        nodeKind[nodeNum] = -1;
+        for (int i = nodeNum + 1; i < size && treeLevel[i] > nodeLevel; i++) {
+            nodeKind[i] = -1;
+        }
+    }
+
+    /**
+     * Copy a DOM node into this document's arrays.
+     * This is a simplified version for the copy-modify pattern.
+     *
+     * @return the node number of the top-level copied node
+     */
+    /**
+     * Copy a content item into the document arrays, handling atomic values,
+     * document nodes, and regular nodes per the W3C XQuery Update Facility spec.
+     *
+     * @param item the content item to copy
+     * @param parentNodeNum the parent node number
+     * @param level the tree level for the new node(s)
+     * @return list of top-level node numbers that were inserted
+     */
+    private java.util.List<Integer> copyItemIntoDocument(final org.exist.xquery.value.Item item,
+                                                          final int parentNodeNum, final short level)
+            throws XPathException {
+        final java.util.List<Integer> result = new java.util.ArrayList<>();
+        if (org.exist.xquery.value.Type.subTypeOf(item.getType(), org.exist.xquery.value.Type.NODE)) {
+            final Node node = ((org.exist.xquery.value.NodeValue) item).getNode();
+            if (node.getNodeType() == Node.DOCUMENT_NODE) {
+                // For document nodes: insert the document's children, not the document itself
+                Node child = node.getFirstChild();
+                while (child != null) {
+                    result.add(copyNodeIntoDocument(child, parentNodeNum, level));
+                    child = child.getNextSibling();
+                }
+            } else {
+                result.add(copyNodeIntoDocument(node, parentNodeNum, level));
+            }
+        } else {
+            // Atomic value: convert to text node per W3C spec
+            final String text = item.getStringValue();
+            if (!text.isEmpty()) {
+                final int nodeNum = addNode(Node.TEXT_NODE, level, null);
+                addChars(nodeNum, text.toCharArray(), 0, text.length());
+                next[nodeNum] = parentNodeNum;
+                result.add(nodeNum);
+            }
+        }
+        return result;
+    }
+
+    private int copyNodeIntoDocument(final Node node, final int parentNodeNum, final short level) {
+        switch (node.getNodeType()) {
+            case Node.ELEMENT_NODE: {
+                final String localName = node.getLocalName() != null ? node.getLocalName() : node.getNodeName();
+                final String nsUri = node.getNamespaceURI() != null ? node.getNamespaceURI() : "";
+                final String prefix = node.getPrefix() != null ? node.getPrefix() : "";
+                final QName qname = new QName(localName, nsUri, prefix);
+                final int nodeNum = addNode(Node.ELEMENT_NODE, level, qname);
+                next[nodeNum] = parentNodeNum;
+
+                // Copy attributes (skip xmlns declarations — handled separately below)
+                final NamedNodeMap attrs = node.getAttributes();
+                if (attrs != null) {
+                    for (int i = 0; i < attrs.getLength(); i++) {
+                        final Attr attr = (Attr) attrs.item(i);
+                        // Skip namespace declarations
+                        if (javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                            continue;
+                        }
+                        final String attrLocal = attr.getLocalName() != null ? attr.getLocalName() : attr.getName();
+                        final String attrNs = attr.getNamespaceURI() != null ? attr.getNamespaceURI() : "";
+                        final String attrPrefix = attr.getPrefix() != null ? attr.getPrefix() : "";
+                        addAttribute(nodeNum, new QName(attrLocal, attrNs, attrPrefix),
+                                attr.getValue(), AttrImpl.ATTR_CDATA_TYPE);
+                    }
+                }
+
+                // Copy namespace declarations
+                if (node instanceof ElementImpl memElement) {
+                    // Memtree element: copy from namespace arrays
+                    final java.util.Map<String, String> nsMap = memElement.getNamespaceMap();
+                    for (final java.util.Map.Entry<String, String> e : nsMap.entrySet()) {
+                        final QName nsQName = new QName(e.getKey(), e.getValue(),
+                                javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
+                        addNamespace(nodeNum, nsQName);
+                    }
+                } else if (attrs != null) {
+                    // DOM element: extract xmlns attributes
+                    for (int i = 0; i < attrs.getLength(); i++) {
+                        final Attr attr = (Attr) attrs.item(i);
+                        if (javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                            final String nsPrefix = attr.getLocalName() != null
+                                    && !javax.xml.XMLConstants.XMLNS_ATTRIBUTE.equals(attr.getLocalName())
+                                    ? attr.getLocalName() : "";
+                            final QName nsQName = new QName(nsPrefix, attr.getValue(),
+                                    javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
+                            addNamespace(nodeNum, nsQName);
+                        }
+                    }
+                }
+
+                // Copy children recursively, linking siblings together
+                int prevChild = -1;
+                Node child = node.getFirstChild();
+                while (child != null) {
+                    final int childNum = copyNodeIntoDocument(child, nodeNum, (short) (level + 1));
+                    if (prevChild >= 0) {
+                        next[prevChild] = childNum;
+                    }
+                    prevChild = childNum;
+                    child = child.getNextSibling();
+                }
+                return nodeNum;
+            }
+            case Node.TEXT_NODE: {
+                final String text = node.getTextContent();
+                final int nodeNum = addNode(Node.TEXT_NODE, level, null);
+                addChars(nodeNum, text.toCharArray(), 0, text.length());
+                next[nodeNum] = parentNodeNum;
+                return nodeNum;
+            }
+            case Node.COMMENT_NODE: {
+                final String text = node.getTextContent();
+                final int nodeNum = addNode(Node.COMMENT_NODE, level, null);
+                addChars(nodeNum, text.toCharArray(), 0, text.length());
+                next[nodeNum] = parentNodeNum;
+                return nodeNum;
+            }
+            case Node.PROCESSING_INSTRUCTION_NODE: {
+                final String target = node.getNodeName();
+                final String data = node.getNodeValue() != null ? node.getNodeValue() : "";
+                final QName qname = new QName(target, "", "");
+                final int nodeNum = addNode(Node.PROCESSING_INSTRUCTION_NODE, level, qname);
+                addChars(nodeNum, data.toCharArray(), 0, data.length());
+                next[nodeNum] = parentNodeNum;
+                return nodeNum;
+            }
+            case Node.CDATA_SECTION_NODE: {
+                final String text = node.getTextContent();
+                final int nodeNum = addNode(Node.CDATA_SECTION_NODE, level, null);
+                addChars(nodeNum, text.toCharArray(), 0, text.length());
+                next[nodeNum] = parentNodeNum;
+                return nodeNum;
+            }
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Compact the document by rebuilding all internal arrays from the logical
+     * tree structure. After in-memory mutations (insert, delete, replace),
+     * nodes may be appended at the end of the arrays, breaking the positional
+     * invariant that the XQuery engine relies on for document order. This method
+     * serializes the mutated tree into a fresh document and replaces the internal
+     * arrays, restoring correct positional ordering.
+     *
+     * Must be called after all mutations and text merging are complete.
+     */
+    public void compact() {
+        try {
+            final MemTreeBuilder builder = new MemTreeBuilder(context);
+            builder.startDocument();
+            final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(builder, true);
+            receiver.setSuppressWhitespace(false);
+
+            // Walk the document tree in logical order using chain-aware traversal
+            int child = getFirstChildFor(0);
+            while (child >= 0) {
+                if (nodeKind[child] != -1) {
+                    final NodeImpl node = getNode(child);
+                    copyTo(node, receiver, false);
+                }
+                child = getNextSiblingFor(child);
+            }
+
+            builder.endDocument();
+            final DocumentImpl newDoc = builder.getDocument();
+
+            // Replace internal arrays with the rebuilt document's arrays
+            this.nodeKind = newDoc.nodeKind;
+            this.treeLevel = newDoc.treeLevel;
+            this.next = newDoc.next;
+            this.nodeName = newDoc.nodeName;
+            this.nodeId = newDoc.nodeId;
+            this.alpha = newDoc.alpha;
+            this.alphaLen = newDoc.alphaLen;
+            this.characters = newDoc.characters;
+            this.nextChar = newDoc.nextChar;
+            this.attrName = newDoc.attrName;
+            this.attrType = newDoc.attrType;
+            this.attrNodeId = newDoc.attrNodeId;
+            this.attrParent = newDoc.attrParent;
+            this.attrValue = newDoc.attrValue;
+            this.nextAttr = newDoc.nextAttr;
+            this.namespaceParent = newDoc.namespaceParent;
+            this.namespaceCode = newDoc.namespaceCode;
+            this.nextNamespace = newDoc.nextNamespace;
+            this.size = newDoc.size;
+            this.references = newDoc.references;
+            this.nextReferenceIdx = newDoc.nextReferenceIdx;
+            this.firstChildOverride = null;
+        } catch (final SAXException e) {
+            throw new RuntimeException("Failed to compact document after mutations", e);
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -48,6 +48,7 @@ import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -634,7 +635,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
             if (i > rootNodeNum && treeLevel[i] <= rootLevel) {
                 break; // past the subtree
             }
-            if (nodeKind[i] != Node.ELEMENT_NODE) {
+            if (nodeKind[i] != ELEMENT_NODE) {
                 continue;
             }
             stripUnusedNamespacesForElement(i);
@@ -663,7 +664,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         }
 
         // Collect used namespace declarations (to re-add later)
-        final java.util.List<QName> usedNs = new java.util.ArrayList<>();
+        final java.util.List<QName> usedNs = new ArrayList<>();
         while (ns < nextNamespace && namespaceParent[ns] == nodeNum) {
             final QName nsQName = namespaceCode[ns];
             if (usedPrefixes.contains(nsQName.getLocalPart())) {
@@ -1785,8 +1786,8 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     public void renameNode(final int nodeNum, final QName newName) {
         final short kind = nodeKind[nodeNum];
         switch (kind) {
-            case Node.ELEMENT_NODE:
-            case Node.PROCESSING_INSTRUCTION_NODE:
+            case ELEMENT_NODE:
+            case PROCESSING_INSTRUCTION_NODE:
                 nodeName[nodeNum] = namePool.getSharedName(newName);
                 break;
             default:
@@ -1815,10 +1816,10 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     public void replaceValue(final int nodeNum, final String value) {
         final short kind = nodeKind[nodeNum];
         switch (kind) {
-            case Node.TEXT_NODE:
-            case Node.COMMENT_NODE:
-            case Node.CDATA_SECTION_NODE:
-            case Node.PROCESSING_INSTRUCTION_NODE: {
+            case TEXT_NODE:
+            case COMMENT_NODE:
+            case CDATA_SECTION_NODE:
+            case PROCESSING_INSTRUCTION_NODE: {
                 // Replace the character content
                 final char[] chars = value.toCharArray();
                 if (characters == null) {
@@ -1838,7 +1839,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 nextChar += chars.length;
                 break;
             }
-            case Node.ELEMENT_NODE: {
+            case ELEMENT_NODE: {
                 // W3C replaceElementContent: replace all children with a single text node.
                 // We must be careful to only modify THIS element's children, not nodes
                 // belonging to sibling elements that happen to be adjacent in the array.
@@ -1856,7 +1857,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 int firstTextChild = -1;
                 for (int c = nodeNum + 1; c < subtreeEnd; c++) {
                     if (firstTextChild == -1 && treeLevel[c] == childLevel
-                            && nodeKind[c] == Node.TEXT_NODE) {
+                            && nodeKind[c] == TEXT_NODE) {
                         firstTextChild = c;
                     } else if (c != firstTextChild) {
                         nodeKind[c] = -1;  // delete other children
@@ -1896,7 +1897,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 } else if (nodeNum + 1 < subtreeEnd) {
                     // No text child but has positional children — convert first to text
                     final int firstChild = nodeNum + 1;
-                    nodeKind[firstChild] = Node.TEXT_NODE;
+                    nodeKind[firstChild] = TEXT_NODE;
                     nodeName[firstChild] = null;
                     final char[] chars = value.toCharArray();
                     if ((nextChar + chars.length) >= characters.length) {
@@ -1996,7 +1997,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         // for each element. If the removed attribute index is <= the element's
         // first attribute, we need to adjust.
         for (int i = 0; i < size; i++) {
-            if (nodeKind[i] == Node.ELEMENT_NODE && alpha[i] >= 0) {
+            if (nodeKind[i] == ELEMENT_NODE && alpha[i] >= 0) {
                 if (alpha[i] > attrNum) {
                     alpha[i]--;
                 } else if (alpha[i] == attrNum) {
@@ -2102,7 +2103,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
             if (nodeKind[parent] == -1) {
                 continue;
             }
-            if (nodeKind[parent] != Node.DOCUMENT_NODE && nodeKind[parent] != Node.ELEMENT_NODE) {
+            if (nodeKind[parent] != DOCUMENT_NODE && nodeKind[parent] != ELEMENT_NODE) {
                 continue;
             }
 
@@ -2129,7 +2130,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 }
 
                 // Direct child at childLevel
-                if (nodeKind[child] == Node.TEXT_NODE) {
+                if (nodeKind[child] == TEXT_NODE) {
                     if (prevTextNode >= 0) {
                         // Merge this text node into prevTextNode
                         final String prevText = new String(characters, alpha[prevTextNode], alphaLen[prevTextNode]);
@@ -2373,12 +2374,12 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         }
 
         // Collect new attributes to insert
-        final java.util.List<Object[]> newAttrs = new java.util.ArrayList<>();
+        final java.util.List<Object[]> newAttrs = new ArrayList<>();
         for (final org.exist.xquery.value.SequenceIterator i = content.iterate(); i.hasNext(); ) {
             final org.exist.xquery.value.Item item = i.nextItem();
             if (org.exist.xquery.value.Type.subTypeOf(item.getType(), org.exist.xquery.value.Type.NODE)) {
                 final Node node = ((org.exist.xquery.value.NodeValue) item).getNode();
-                if (node.getNodeType() == Node.ATTRIBUTE_NODE) {
+                if (node.getNodeType() == ATTRIBUTE_NODE) {
                     final Attr attr = (Attr) node;
                     final QName qname = new QName(
                             attr.getLocalName() != null ? attr.getLocalName() : attr.getName(),
@@ -2447,7 +2448,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
             // Update alpha pointers for elements whose attrs shifted
             for (int n = 0; n < size; n++) {
-                if (nodeKind[n] == Node.ELEMENT_NODE && alpha[n] >= insertPos && n != elementNodeNum) {
+                if (nodeKind[n] == ELEMENT_NODE && alpha[n] >= insertPos && n != elementNodeNum) {
                     alpha[n] += count;
                 }
             }
@@ -2570,14 +2571,14 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
             throws XPathException {
         // When no-inherit is active, pass an empty scope map to materialize namespaces
         // within inserted subtrees (so FunInScopePrefixes self-only mode still finds them)
-        final java.util.Map<String, String> scopeNs =
+        final Map<String, String> scopeNs =
                 (context != null && !context.inheritNamespaces())
                         ? new java.util.LinkedHashMap<>() : null;
 
-        final java.util.List<Integer> result = new java.util.ArrayList<>();
+        final java.util.List<Integer> result = new ArrayList<>();
         if (org.exist.xquery.value.Type.subTypeOf(item.getType(), org.exist.xquery.value.Type.NODE)) {
             final Node node = ((org.exist.xquery.value.NodeValue) item).getNode();
-            if (node.getNodeType() == Node.DOCUMENT_NODE) {
+            if (node.getNodeType() == DOCUMENT_NODE) {
                 // For document nodes: insert the document's children, not the document itself
                 Node child = node.getFirstChild();
                 while (child != null) {
@@ -2591,17 +2592,13 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
             // Atomic value: convert to text node per W3C spec
             final String text = item.getStringValue();
             if (!text.isEmpty()) {
-                final int nodeNum = addNode(Node.TEXT_NODE, level, null);
+                final int nodeNum = addNode(TEXT_NODE, level, null);
                 addChars(nodeNum, text.toCharArray(), 0, text.length());
                 next[nodeNum] = parentNodeNum;
                 result.add(nodeNum);
             }
         }
         return result;
-    }
-
-    private int copyNodeIntoDocument(final Node node, final int parentNodeNum, final short level) {
-        return copyNodeIntoDocument(node, parentNodeNum, level, null);
     }
 
     /**
@@ -2616,14 +2613,14 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
      *        Pass null to skip materialization (normal copy behavior).
      */
     private int copyNodeIntoDocument(final Node node, final int parentNodeNum, final short level,
-                                      final java.util.Map<String, String> scopeNamespaces) {
+                                      final Map<String, String> scopeNamespaces) {
         switch (node.getNodeType()) {
-            case Node.ELEMENT_NODE: {
+            case ELEMENT_NODE: {
                 final String localName = node.getLocalName() != null ? node.getLocalName() : node.getNodeName();
                 final String nsUri = node.getNamespaceURI() != null ? node.getNamespaceURI() : "";
                 final String prefix = node.getPrefix() != null ? node.getPrefix() : "";
                 final QName qname = new QName(localName, nsUri, prefix);
-                final int nodeNum = addNode(Node.ELEMENT_NODE, level, qname);
+                final int nodeNum = addNode(ELEMENT_NODE, level, qname);
                 next[nodeNum] = parentNodeNum;
 
                 // Collect attribute prefixes (needed for no-preserve filtering)
@@ -2636,7 +2633,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                     for (int i = 0; i < attrs.getLength(); i++) {
                         final Attr attr = (Attr) attrs.item(i);
                         // Skip namespace declarations
-                        if (javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                        if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
                             continue;
                         }
                         final String attrLocal = attr.getLocalName() != null ? attr.getLocalName() : attr.getName();
@@ -2652,35 +2649,35 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 final boolean noPreserve = context != null && !context.preserveNamespaces();
 
                 // Collect this element's own namespace declarations
-                final java.util.Map<String, String> selfNsDecls = new java.util.LinkedHashMap<>();
+                final Map<String, String> selfNsDecls = new java.util.LinkedHashMap<>();
 
                 // Copy namespace declarations (filtered by no-preserve if applicable)
                 if (node instanceof ElementImpl memElement) {
                     // Memtree element: copy from namespace arrays
-                    final java.util.Map<String, String> nsMap = memElement.getNamespaceMap();
-                    for (final java.util.Map.Entry<String, String> e : nsMap.entrySet()) {
+                    final Map<String, String> nsMap = memElement.getNamespaceMap();
+                    for (final Map.Entry<String, String> e : nsMap.entrySet()) {
                         if (noPreserve && !usedPrefixes.contains(e.getKey())) {
                             continue; // strip unused namespace declaration
                         }
                         selfNsDecls.put(e.getKey(), e.getValue());
                         final QName nsQName = new QName(e.getKey(), e.getValue(),
-                                javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
+                                XMLConstants.XMLNS_ATTRIBUTE);
                         addNamespace(nodeNum, nsQName);
                     }
                 } else if (attrs != null) {
                     // DOM element: extract xmlns attributes
                     for (int i = 0; i < attrs.getLength(); i++) {
                         final Attr attr = (Attr) attrs.item(i);
-                        if (javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                        if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
                             final String nsPrefix = attr.getLocalName() != null
-                                    && !javax.xml.XMLConstants.XMLNS_ATTRIBUTE.equals(attr.getLocalName())
+                                    && !XMLConstants.XMLNS_ATTRIBUTE.equals(attr.getLocalName())
                                     ? attr.getLocalName() : "";
                             if (noPreserve && !usedPrefixes.contains(nsPrefix)) {
                                 continue; // strip unused namespace declaration
                             }
                             selfNsDecls.put(nsPrefix, attr.getValue());
                             final QName nsQName = new QName(nsPrefix, attr.getValue(),
-                                    javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
+                                    XMLConstants.XMLNS_ATTRIBUTE);
                             addNamespace(nodeNum, nsQName);
                         }
                     }
@@ -2689,20 +2686,19 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 // No-inherit materialization: add ancestor namespace bindings from within
                 // the subtree that are not already declared on this element
                 if (scopeNamespaces != null) {
-                    for (final java.util.Map.Entry<String, String> e : scopeNamespaces.entrySet()) {
-                        if (!selfNsDecls.containsKey(e.getKey())) {
-                            if (!noPreserve || usedPrefixes.contains(e.getKey())) {
-                                final QName nsQName = new QName(e.getKey(), e.getValue(),
-                                        javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
-                                addNamespace(nodeNum, nsQName);
-                                selfNsDecls.put(e.getKey(), e.getValue());
-                            }
+                    for (final Map.Entry<String, String> e : scopeNamespaces.entrySet()) {
+                        if (!selfNsDecls.containsKey(e.getKey())
+                                && (!noPreserve || usedPrefixes.contains(e.getKey()))) {
+                            final QName nsQName = new QName(e.getKey(), e.getValue(),
+                                    XMLConstants.XMLNS_ATTRIBUTE);
+                            addNamespace(nodeNum, nsQName);
+                            selfNsDecls.put(e.getKey(), e.getValue());
                         }
                     }
                 }
 
                 // Build effective namespace scope for children
-                final java.util.Map<String, String> childScope;
+                final Map<String, String> childScope;
                 if (scopeNamespaces != null) {
                     childScope = new java.util.LinkedHashMap<>(scopeNamespaces);
                     childScope.putAll(selfNsDecls);
@@ -2723,32 +2719,32 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 }
                 return nodeNum;
             }
-            case Node.TEXT_NODE: {
+            case TEXT_NODE: {
                 final String text = node.getTextContent();
-                final int nodeNum = addNode(Node.TEXT_NODE, level, null);
+                final int nodeNum = addNode(TEXT_NODE, level, null);
                 addChars(nodeNum, text.toCharArray(), 0, text.length());
                 next[nodeNum] = parentNodeNum;
                 return nodeNum;
             }
-            case Node.COMMENT_NODE: {
+            case COMMENT_NODE: {
                 final String text = node.getTextContent();
-                final int nodeNum = addNode(Node.COMMENT_NODE, level, null);
+                final int nodeNum = addNode(COMMENT_NODE, level, null);
                 addChars(nodeNum, text.toCharArray(), 0, text.length());
                 next[nodeNum] = parentNodeNum;
                 return nodeNum;
             }
-            case Node.PROCESSING_INSTRUCTION_NODE: {
+            case PROCESSING_INSTRUCTION_NODE: {
                 final String target = node.getNodeName();
                 final String data = node.getNodeValue() != null ? node.getNodeValue() : "";
                 final QName qname = new QName(target, "", "");
-                final int nodeNum = addNode(Node.PROCESSING_INSTRUCTION_NODE, level, qname);
+                final int nodeNum = addNode(PROCESSING_INSTRUCTION_NODE, level, qname);
                 addChars(nodeNum, data.toCharArray(), 0, data.length());
                 next[nodeNum] = parentNodeNum;
                 return nodeNum;
             }
-            case Node.CDATA_SECTION_NODE: {
+            case CDATA_SECTION_NODE: {
                 final String text = node.getTextContent();
-                final int nodeNum = addNode(Node.CDATA_SECTION_NODE, level, null);
+                final int nodeNum = addNode(CDATA_SECTION_NODE, level, null);
                 addChars(nodeNum, text.toCharArray(), 0, text.length());
                 next[nodeNum] = parentNodeNum;
                 return nodeNum;
@@ -2812,7 +2808,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
             this.nextReferenceIdx = newDoc.nextReferenceIdx;
             this.firstChildOverride = null;
         } catch (final SAXException e) {
-            throw new RuntimeException("Failed to compact document after mutations", e);
+            throw new IllegalStateException("Failed to compact document after mutations", e);
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -610,6 +610,79 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         return count;
     }
 
+    /**
+     * Strip unused namespace declarations from an element and all its descendants.
+     * A namespace declaration is "unused" if its prefix is not used by the element's
+     * own name or any of its attribute names.
+     *
+     * <p>This implements the W3C copy-namespaces {@code no-preserve} semantics:
+     * only namespace bindings that are used by element/attribute names are preserved.</p>
+     *
+     * <p>Works by invalidating unused namespace array entries (setting parent to -2)
+     * and re-adding only used ones. The invalidated entries are dead space that
+     * is cleaned up on the next {@link #compact()} call.</p>
+     *
+     * @param rootNodeNum the root element node number of the subtree to process
+     */
+    public void stripUnusedNamespacesInSubtree(final int rootNodeNum) {
+        if (namespaceCode == null) {
+            return;
+        }
+        // Walk the subtree: process rootNodeNum and all descendants at deeper levels
+        final short rootLevel = treeLevel[rootNodeNum];
+        for (int i = rootNodeNum; i < size; i++) {
+            if (i > rootNodeNum && treeLevel[i] <= rootLevel) {
+                break; // past the subtree
+            }
+            if (nodeKind[i] != Node.ELEMENT_NODE) {
+                continue;
+            }
+            stripUnusedNamespacesForElement(i);
+        }
+    }
+
+    private void stripUnusedNamespacesForElement(final int nodeNum) {
+        int ns = alphaLen[nodeNum];
+        if (ns < 0) {
+            return; // no namespace declarations
+        }
+
+        // Collect used prefixes: element name + attribute names
+        final java.util.Set<String> usedPrefixes = new java.util.HashSet<>();
+        final QName elemName = nodeName[nodeNum];
+        usedPrefixes.add(elemName.getPrefix() != null ? elemName.getPrefix() : "");
+        int attr = alpha[nodeNum];
+        if (attr >= 0) {
+            while (attr < nextAttr && attrParent[attr] == nodeNum) {
+                final QName aName = attrName[attr];
+                if (aName.getPrefix() != null && !aName.getPrefix().isEmpty()) {
+                    usedPrefixes.add(aName.getPrefix());
+                }
+                attr++;
+            }
+        }
+
+        // Collect used namespace declarations (to re-add later)
+        final java.util.List<QName> usedNs = new java.util.ArrayList<>();
+        while (ns < nextNamespace && namespaceParent[ns] == nodeNum) {
+            final QName nsQName = namespaceCode[ns];
+            if (usedPrefixes.contains(nsQName.getLocalPart())) {
+                usedNs.add(nsQName);
+            }
+            // Invalidate the old entry
+            namespaceParent[ns] = -2;
+            ns++;
+        }
+
+        // Reset alphaLen so addNamespace can set it fresh
+        alphaLen[nodeNum] = -1;
+
+        // Re-add only used namespace declarations
+        for (final QName nsQName : usedNs) {
+            addNamespace(nodeNum, nsQName);
+        }
+    }
+
     public int getChildCountFor(final int nr) {
         int count = 0;
         final short childLevel = (short) (treeLevel[nr] + 1);
@@ -1881,6 +1954,28 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
      *
      * @param attrNum the attribute index to remove
      */
+    /**
+     * Find an attribute index by QName on a given element.
+     *
+     * @param elementNodeNum the element node number
+     * @param qname the attribute QName to find
+     * @return the attribute index, or -1 if not found
+     */
+    public int findAttribute(final int elementNodeNum, final QName qname) {
+        int a = alpha[elementNodeNum];
+        if (a < 0) {
+            return -1;
+        }
+        while (a < nextAttr && attrParent[a] == elementNodeNum) {
+            if (attrName[a].getLocalPart().equals(qname.getLocalPart())
+                    && attrName[a].getNamespaceURI().equals(qname.getNamespaceURI())) {
+                return a;
+            }
+            a++;
+        }
+        return -1;
+    }
+
     public void removeAttribute(final int attrNum) {
         if (attrNum < 0 || attrNum >= nextAttr) {
             return;
@@ -2473,6 +2568,12 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     private java.util.List<Integer> copyItemIntoDocument(final org.exist.xquery.value.Item item,
                                                           final int parentNodeNum, final short level)
             throws XPathException {
+        // When no-inherit is active, pass an empty scope map to materialize namespaces
+        // within inserted subtrees (so FunInScopePrefixes self-only mode still finds them)
+        final java.util.Map<String, String> scopeNs =
+                (context != null && !context.inheritNamespaces())
+                        ? new java.util.LinkedHashMap<>() : null;
+
         final java.util.List<Integer> result = new java.util.ArrayList<>();
         if (org.exist.xquery.value.Type.subTypeOf(item.getType(), org.exist.xquery.value.Type.NODE)) {
             final Node node = ((org.exist.xquery.value.NodeValue) item).getNode();
@@ -2480,11 +2581,11 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 // For document nodes: insert the document's children, not the document itself
                 Node child = node.getFirstChild();
                 while (child != null) {
-                    result.add(copyNodeIntoDocument(child, parentNodeNum, level));
+                    result.add(copyNodeIntoDocument(child, parentNodeNum, level, scopeNs));
                     child = child.getNextSibling();
                 }
             } else {
-                result.add(copyNodeIntoDocument(node, parentNodeNum, level));
+                result.add(copyNodeIntoDocument(node, parentNodeNum, level, scopeNs));
             }
         } else {
             // Atomic value: convert to text node per W3C spec
@@ -2500,6 +2601,22 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     }
 
     private int copyNodeIntoDocument(final Node node, final int parentNodeNum, final short level) {
+        return copyNodeIntoDocument(node, parentNodeNum, level, null);
+    }
+
+    /**
+     * Copy a node into this document.
+     *
+     * @param node the source node
+     * @param parentNodeNum the parent in this document
+     * @param level tree level for the new node
+     * @param scopeNamespaces when non-null, namespace bindings accumulated from ancestors
+     *        within the current subtree (for no-inherit materialization). Each element gets
+     *        explicit declarations for ancestor bindings not already declared on self.
+     *        Pass null to skip materialization (normal copy behavior).
+     */
+    private int copyNodeIntoDocument(final Node node, final int parentNodeNum, final short level,
+                                      final java.util.Map<String, String> scopeNamespaces) {
         switch (node.getNodeType()) {
             case Node.ELEMENT_NODE: {
                 final String localName = node.getLocalName() != null ? node.getLocalName() : node.getNodeName();
@@ -2509,8 +2626,12 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                 final int nodeNum = addNode(Node.ELEMENT_NODE, level, qname);
                 next[nodeNum] = parentNodeNum;
 
-                // Copy attributes (skip xmlns declarations — handled separately below)
+                // Collect attribute prefixes (needed for no-preserve filtering)
                 final NamedNodeMap attrs = node.getAttributes();
+                final java.util.Set<String> usedPrefixes = new java.util.HashSet<>();
+                usedPrefixes.add(prefix); // element prefix is always "used"
+
+                // Copy attributes (skip xmlns declarations — handled separately below)
                 if (attrs != null) {
                     for (int i = 0; i < attrs.getLength(); i++) {
                         final Attr attr = (Attr) attrs.item(i);
@@ -2521,16 +2642,27 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                         final String attrLocal = attr.getLocalName() != null ? attr.getLocalName() : attr.getName();
                         final String attrNs = attr.getNamespaceURI() != null ? attr.getNamespaceURI() : "";
                         final String attrPrefix = attr.getPrefix() != null ? attr.getPrefix() : "";
+                        usedPrefixes.add(attrPrefix);
                         addAttribute(nodeNum, new QName(attrLocal, attrNs, attrPrefix),
                                 attr.getValue(), AttrImpl.ATTR_CDATA_TYPE);
                     }
                 }
 
-                // Copy namespace declarations
+                // Check if no-preserve mode should strip unused namespace declarations
+                final boolean noPreserve = context != null && !context.preserveNamespaces();
+
+                // Collect this element's own namespace declarations
+                final java.util.Map<String, String> selfNsDecls = new java.util.LinkedHashMap<>();
+
+                // Copy namespace declarations (filtered by no-preserve if applicable)
                 if (node instanceof ElementImpl memElement) {
                     // Memtree element: copy from namespace arrays
                     final java.util.Map<String, String> nsMap = memElement.getNamespaceMap();
                     for (final java.util.Map.Entry<String, String> e : nsMap.entrySet()) {
+                        if (noPreserve && !usedPrefixes.contains(e.getKey())) {
+                            continue; // strip unused namespace declaration
+                        }
+                        selfNsDecls.put(e.getKey(), e.getValue());
                         final QName nsQName = new QName(e.getKey(), e.getValue(),
                                 javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
                         addNamespace(nodeNum, nsQName);
@@ -2543,6 +2675,10 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                             final String nsPrefix = attr.getLocalName() != null
                                     && !javax.xml.XMLConstants.XMLNS_ATTRIBUTE.equals(attr.getLocalName())
                                     ? attr.getLocalName() : "";
+                            if (noPreserve && !usedPrefixes.contains(nsPrefix)) {
+                                continue; // strip unused namespace declaration
+                            }
+                            selfNsDecls.put(nsPrefix, attr.getValue());
                             final QName nsQName = new QName(nsPrefix, attr.getValue(),
                                     javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
                             addNamespace(nodeNum, nsQName);
@@ -2550,11 +2686,35 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
                     }
                 }
 
+                // No-inherit materialization: add ancestor namespace bindings from within
+                // the subtree that are not already declared on this element
+                if (scopeNamespaces != null) {
+                    for (final java.util.Map.Entry<String, String> e : scopeNamespaces.entrySet()) {
+                        if (!selfNsDecls.containsKey(e.getKey())) {
+                            if (!noPreserve || usedPrefixes.contains(e.getKey())) {
+                                final QName nsQName = new QName(e.getKey(), e.getValue(),
+                                        javax.xml.XMLConstants.XMLNS_ATTRIBUTE);
+                                addNamespace(nodeNum, nsQName);
+                                selfNsDecls.put(e.getKey(), e.getValue());
+                            }
+                        }
+                    }
+                }
+
+                // Build effective namespace scope for children
+                final java.util.Map<String, String> childScope;
+                if (scopeNamespaces != null) {
+                    childScope = new java.util.LinkedHashMap<>(scopeNamespaces);
+                    childScope.putAll(selfNsDecls);
+                } else {
+                    childScope = null;
+                }
+
                 // Copy children recursively, linking siblings together
                 int prevChild = -1;
                 Node child = node.getFirstChild();
                 while (child != null) {
-                    final int childNum = copyNodeIntoDocument(child, nodeNum, (short) (level + 1));
+                    final int childNum = copyNodeIntoDocument(child, nodeNum, (short) (level + 1), childScope);
                     if (prevChild >= 0) {
                         next[prevChild] = childNum;
                     }

--- a/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
@@ -91,7 +91,7 @@ public class ElementImpl extends NodeImpl implements Element {
         while(nextNode > nodeNumber) {
             if (document.nodeKind[nextNode] != -1) {
                 final Node n = document.getNode(nextNode);
-                if(n.getNodeType() != Node.ATTRIBUTE_NODE) {
+                if(n.getNodeType() != ATTRIBUTE_NODE) {
                     nl.add(n);
                 }
             }
@@ -318,7 +318,7 @@ public class ElementImpl extends NodeImpl implements Element {
         throws XPathException {
         int child = document.getFirstChildFor(parentNum);
         while (child >= 0) {
-            if (document.nodeKind[child] != -1 && document.nodeKind[child] == Node.ELEMENT_NODE) {
+            if (document.nodeKind[child] != -1 && document.nodeKind[child] == ELEMENT_NODE) {
                 final NodeImpl n = document.getNode(child);
                 n.selectAttributes(test, result);
                 selectDescendantAttributesWalk(child, test, result);
@@ -373,7 +373,7 @@ public class ElementImpl extends NodeImpl implements Element {
                     result.add(n);
                 }
                 // Recurse into element children
-                if (document.nodeKind[child] == Node.ELEMENT_NODE) {
+                if (document.nodeKind[child] == ELEMENT_NODE) {
                     selectDescendantsWalk(child, test, result);
                 }
             }

--- a/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
@@ -64,15 +64,21 @@ public class ElementImpl extends NodeImpl implements Element {
 
     @Override
     public boolean hasChildNodes() {
-        return (nodeNumber + 1) < document.size && document.treeLevel[nodeNumber + 1] > document.treeLevel[nodeNumber];
+        return getFirstChild() != null;
     }
 
     @Override
     public Node getFirstChild() {
-        final short level = document.treeLevel[nodeNumber];
-        final int nextNode = nodeNumber + 1;
-        if(nextNode < document.size && document.treeLevel[nextNode] > level) {
-            return document.getNode(nextNode);
+        int firstChild = document.getFirstChildFor(nodeNumber);
+        // Skip deleted nodes (nodeKind == -1) after in-memory mutations
+        while (firstChild >= 0 && document.nodeKind[firstChild] == -1) {
+            firstChild = document.next[firstChild];
+            if (firstChild < 0 || firstChild <= nodeNumber) {
+                return null;
+            }
+        }
+        if (firstChild >= 0) {
+            return document.getNode(firstChild);
         }
         return null;
     }
@@ -83,9 +89,11 @@ public class ElementImpl extends NodeImpl implements Element {
         final NodeListImpl nl = new NodeListImpl(1);  // nil elements are rare, so we use 1 here
         int nextNode = document.getFirstChildFor(nodeNumber);
         while(nextNode > nodeNumber) {
-            final Node n = document.getNode(nextNode);
-            if(n.getNodeType() != Node.ATTRIBUTE_NODE) {
-                nl.add(n);
+            if (document.nodeKind[nextNode] != -1) {
+                final Node n = document.getNode(nextNode);
+                if(n.getNodeType() != Node.ATTRIBUTE_NODE) {
+                    nl.add(n);
+                }
             }
             nextNode = document.next[nextNode];
         }
@@ -300,15 +308,22 @@ public class ElementImpl extends NodeImpl implements Element {
 
     @Override
     public void selectDescendantAttributes(final NodeTest test, final Sequence result) throws XPathException {
-        final int treeLevel = document.treeLevel[nodeNumber];
-        int nextNode = nodeNumber;
-        NodeImpl n = document.getNode(nextNode);
-        n.selectAttributes(test, result);
-        while(++nextNode < document.size && document.treeLevel[nextNode] > treeLevel) {
-            n = document.getNode(nextNode);
-            if(n.getNodeType() == Node.ELEMENT_NODE) {
+        // Use chain-based traversal to find descendant attributes,
+        // including nodes appended by in-memory mutations.
+        selectAttributes(test, result);
+        selectDescendantAttributesWalk(nodeNumber, test, result);
+    }
+
+    private void selectDescendantAttributesWalk(final int parentNum, final NodeTest test, final Sequence result)
+        throws XPathException {
+        int child = document.getFirstChildFor(parentNum);
+        while (child >= 0) {
+            if (document.nodeKind[child] != -1 && document.nodeKind[child] == Node.ELEMENT_NODE) {
+                final NodeImpl n = document.getNode(child);
                 n.selectAttributes(test, result);
+                selectDescendantAttributesWalk(child, test, result);
             }
+            child = document.getNextSiblingFor(child);
         }
     }
 
@@ -316,9 +331,11 @@ public class ElementImpl extends NodeImpl implements Element {
     public void selectChildren(final NodeTest test, final Sequence result) throws XPathException {
         int nextNode = document.getFirstChildFor(nodeNumber);
         while(nextNode > nodeNumber) {
-            final NodeImpl n = document.getNode(nextNode);
-            if(test.matches(n)) {
-                result.add(n);
+            if (document.nodeKind[nextNode] != -1) {
+                final NodeImpl n = document.getNode(nextNode);
+                if(test.matches(n)) {
+                    result.add(n);
+                }
             }
             nextNode = document.next[nextNode];
         }
@@ -333,21 +350,34 @@ public class ElementImpl extends NodeImpl implements Element {
     @Override
     public void selectDescendants(final boolean includeSelf, final NodeTest test, final Sequence result)
         throws XPathException {
-        final int treeLevel = document.treeLevel[nodeNumber];
-        int nextNode = nodeNumber;
-
-        if(includeSelf) {
-            final NodeImpl n = document.getNode(nextNode);
-            if(test.matches(n)) {
+        if (includeSelf) {
+            final NodeImpl n = document.getNode(nodeNumber);
+            if (test.matches(n)) {
                 result.add(n);
             }
         }
+        // Use chain-based tree walking instead of flat array scanning.
+        // Flat scanning from nodeNumber+1 misses nodes appended by in-memory
+        // mutations (insert as first, insert before, etc.) since those are placed
+        // at positions beyond the original tree.
+        selectDescendantsWalk(nodeNumber, test, result);
+    }
 
-        while(++nextNode < document.size && document.treeLevel[nextNode] > treeLevel) {
-            final NodeImpl n = document.getNode(nextNode);
-            if(test.matches(n)) {
-                result.add(n);
+    private void selectDescendantsWalk(final int parentNum, final NodeTest test, final Sequence result)
+        throws XPathException {
+        int child = document.getFirstChildFor(parentNum);
+        while (child >= 0) {
+            if (document.nodeKind[child] != -1) {
+                final NodeImpl n = document.getNode(child);
+                if (test.matches(n)) {
+                    result.add(n);
+                }
+                // Recurse into element children
+                if (document.nodeKind[child] == Node.ELEMENT_NODE) {
+                    selectDescendantsWalk(child, test, result);
+                }
             }
+            child = document.getNextSiblingFor(child);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -221,14 +221,14 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
 
     @Override
     public Node getParentNode() {
-        int next = document.next[nodeNumber];
-        while (next > nodeNumber) {
-            next = document.next[next];
-        }
-        if (next < 0) {
+        if (nodeNumber == 0) {
             return null;
         }
-        final NodeImpl parent = document.getNode(next);
+        final int parentNum = document.getParentNodeFor(nodeNumber);
+        if (parentNum < 0) {
+            return null;
+        }
+        final NodeImpl parent = document.getNode(parentNum);
         if (parent.getNodeType() == DOCUMENT_NODE && !((DocumentImpl) parent).isExplicitlyCreated()) {
             /*
                 All nodes in the MemTree will return an Owner document due to how the MemTree is implemented,
@@ -246,17 +246,14 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         if(nodeNumber == 0) {
             return null;
         }
-        int next = document.next[nodeNumber];
-        while(next > nodeNumber) {
-            next = document.next[next];
-        }
-        if(next < 0) { //Is this even possible ?
+        final int parentNum = document.getParentNodeFor(nodeNumber);
+        if(parentNum < 0) {
             return null;
         }
-        if(next == 0) {
+        if(parentNum == 0) {
             return this.document.explicitlyCreated ? this.document : null;
         }
-        return document.getNode(next);
+        return document.getNode(parentNum);
     }
 
     @Override
@@ -271,6 +268,11 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         }
         return document == o.document && nodeNumber == o.nodeNumber &&
             getNodeType() == o.getNodeType();
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(document) * 31 + nodeNumber;
     }
 
     @Override
@@ -361,8 +363,23 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
 
     @Override
     public Node getNextSibling() {
-        final int nextNr = document.next[nodeNumber];
-        return nextNr < nodeNumber ? null : document.getNode(nextNr);
+        int nextNr = document.next[nodeNumber];
+        // Skip deleted nodes (nodeKind == -1) in the sibling chain
+        while (nextNr >= 0 && document.nodeKind[nextNr] == -1) {
+            nextNr = document.next[nextNr];
+        }
+        if (nextNr < 0) {
+            return null;
+        }
+        if (nextNr < nodeNumber) {
+            // Backwards reference: check tree level to distinguish sibling from parent.
+            // After in-memory mutations, siblings may be at lower positions than this node.
+            if (document.treeLevel[nextNr] == document.treeLevel[nodeNumber]) {
+                return document.getNode(nextNr);
+            }
+            return null;  // lower level = parent, no next sibling
+        }
+        return document.getNode(nextNr);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -221,14 +221,14 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
 
     @Override
     public Node getParentNode() {
-        int next = document.next[nodeNumber];
-        while (next > nodeNumber) {
-            next = document.next[next];
-        }
-        if (next < 0) {
+        if (nodeNumber == 0) {
             return null;
         }
-        final NodeImpl parent = document.getNode(next);
+        final int parentNum = document.getParentNodeFor(nodeNumber);
+        if (parentNum < 0) {
+            return null;
+        }
+        final NodeImpl parent = document.getNode(parentNum);
         if (parent.getNodeType() == DOCUMENT_NODE && !((DocumentImpl) parent).isExplicitlyCreated()) {
             /*
                 All nodes in the MemTree will return an Owner document due to how the MemTree is implemented,
@@ -246,17 +246,14 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         if(nodeNumber == 0) {
             return null;
         }
-        int next = document.next[nodeNumber];
-        while(next > nodeNumber) {
-            next = document.next[next];
-        }
-        if(next < 0) { //Is this even possible ?
+        final int parentNum = document.getParentNodeFor(nodeNumber);
+        if(parentNum < 0) {
             return null;
         }
-        if(next == 0) {
+        if(parentNum == 0) {
             return this.document.explicitlyCreated ? this.document : null;
         }
-        return document.getNode(next);
+        return document.getNode(parentNum);
     }
 
     @Override
@@ -271,6 +268,11 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         }
         return document == o.document && nodeNumber == o.nodeNumber &&
             getNodeType() == o.getNodeType();
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(document) * 31 + nodeNumber;
     }
 
     @Override
@@ -355,8 +357,23 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
 
     @Override
     public Node getNextSibling() {
-        final int nextNr = document.next[nodeNumber];
-        return nextNr < nodeNumber ? null : document.getNode(nextNr);
+        int nextNr = document.next[nodeNumber];
+        // Skip deleted nodes (nodeKind == -1) in the sibling chain
+        while (nextNr >= 0 && document.nodeKind[nextNr] == -1) {
+            nextNr = document.next[nextNr];
+        }
+        if (nextNr < 0) {
+            return null;
+        }
+        if (nextNr < nodeNumber) {
+            // Backwards reference: check tree level to distinguish sibling from parent.
+            // After in-memory mutations, siblings may be at lower positions than this node.
+            if (document.treeLevel[nextNr] == document.treeLevel[nodeNumber]) {
+                return document.getNode(nextNr);
+            }
+            return null;  // lower level = parent, no next sibling
+        }
+        return document.getNode(nextNr);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -772,6 +772,10 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         int count = 0;
 
         for(int i = nodeNumber - 1; i > 0; i--) {
+            // Skip deleted nodes (soft-deleted by removeNode, nodeKind set to -1)
+            if(document.nodeKind[i] == -1) {
+                continue;
+            }
             final NodeImpl n = document.getNode(i);
             if(!myNodeId.isDescendantOf(n.getNodeId()) && test.matches(n)) {
                 if((position < 0) || (++count == position)) {
@@ -801,17 +805,15 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         throws XPathException {
         final int parent = document.getParentNodeFor(nodeNumber);
         if(parent == 0) {
-            // parent is the document node
-            if(getNodeType() == Node.ELEMENT_NODE) {
-                return;
-            }
+            // parent is the document node — walk document-level siblings after this node
+            final boolean isDocElement = (getNodeType() == Node.ELEMENT_NODE);
             NodeImpl next = (NodeImpl) getNextSibling();
             while(next != null) {
-                if(test.matches(next)) {
+                if(!isDocElement && next.getNodeType() == Node.ELEMENT_NODE) {
+                    // Context is before the doc element — include element and its descendants
                     next.selectDescendants(true, test, result);
-                }
-                if(next.getNodeType() == Node.ELEMENT_NODE) {
-                    break;
+                } else if(next.getNodeType() != Node.ELEMENT_NODE && test.matches(next)) {
+                    result.add(next);
                 }
                 next = (NodeImpl) next.getNextSibling();
             }
@@ -820,6 +822,11 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
             int count = 0;
             int nextNode = nodeNumber + 1;
             while(nextNode < document.size) {
+                // Skip deleted nodes (soft-deleted by removeNode, nodeKind set to -1)
+                if(document.nodeKind[nextNode] == -1) {
+                    nextNode++;
+                    continue;
+                }
                 final NodeImpl n = document.getNode(nextNode);
                 if(!n.getNodeId().isDescendantOf(myNodeId) && test.matches(n)) {
                     if((position < 0) || (++count == position)) {

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -778,6 +778,10 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         int count = 0;
 
         for(int i = nodeNumber - 1; i > 0; i--) {
+            // Skip deleted nodes (soft-deleted by removeNode, nodeKind set to -1)
+            if(document.nodeKind[i] == -1) {
+                continue;
+            }
             final NodeImpl n = document.getNode(i);
             if(!myNodeId.isDescendantOf(n.getNodeId()) && test.matches(n)) {
                 if((position < 0) || (++count == position)) {
@@ -807,17 +811,15 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
         throws XPathException {
         final int parent = document.getParentNodeFor(nodeNumber);
         if(parent == 0) {
-            // parent is the document node
-            if(getNodeType() == Node.ELEMENT_NODE) {
-                return;
-            }
+            // parent is the document node — walk document-level siblings after this node
+            final boolean isDocElement = (getNodeType() == Node.ELEMENT_NODE);
             NodeImpl next = (NodeImpl) getNextSibling();
             while(next != null) {
-                if(test.matches(next)) {
+                if(!isDocElement && next.getNodeType() == Node.ELEMENT_NODE) {
+                    // Context is before the doc element — include element and its descendants
                     next.selectDescendants(true, test, result);
-                }
-                if(next.getNodeType() == Node.ELEMENT_NODE) {
-                    break;
+                } else if(next.getNodeType() != Node.ELEMENT_NODE && test.matches(next)) {
+                    result.add(next);
                 }
                 next = (NodeImpl) next.getNextSibling();
             }
@@ -826,6 +828,11 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
             int count = 0;
             int nextNode = nodeNumber + 1;
             while(nextNode < document.size) {
+                // Skip deleted nodes (soft-deleted by removeNode, nodeKind set to -1)
+                if(document.nodeKind[nextNode] == -1) {
+                    nextNode++;
+                    continue;
+                }
                 final NodeImpl n = document.getNode(nextNode);
                 if(!n.getNodeId().isDescendantOf(myNodeId) && test.matches(n)) {
                     if((position < 0) || (++count == position)) {

--- a/exist-core/src/main/java/org/exist/xquery/AbstractFLWORClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractFLWORClause.java
@@ -104,6 +104,11 @@ public abstract class AbstractFLWORClause extends AbstractExpression implements 
     }
 
     @Override
+    public boolean isUpdating() {
+        return returnExpr != null && returnExpr.isUpdating();
+    }
+
+    @Override
     public int getDependencies() {
         return returnExpr.getDependencies();
     }

--- a/exist-core/src/main/java/org/exist/xquery/BinaryOp.java
+++ b/exist-core/src/main/java/org/exist/xquery/BinaryOp.java
@@ -69,8 +69,12 @@ public abstract class BinaryOp extends PathExpr {
     	inPredicate = (contextInfo.getFlags() & IN_PREDICATE) != 0;
     	contextId = contextInfo.getContextId();
     	inWhereClause = (contextInfo.getFlags() & IN_WHERE_CLAUSE) != 0;
-    	getLeft().analyze(new AnalyzeContextInfo(contextInfo));
-    	getRight().analyze(new AnalyzeContextInfo(contextInfo));
+    	final AnalyzeContextInfo leftInfo = new AnalyzeContextInfo(contextInfo);
+    	leftInfo.addFlag(NON_UPDATING_CONTEXT);
+    	getLeft().analyze(leftInfo);
+    	final AnalyzeContextInfo rightInfo = new AnalyzeContextInfo(contextInfo);
+    	rightInfo.addFlag(NON_UPDATING_CONTEXT);
+    	getRight().analyze(rightInfo);
     }
 
     /*

--- a/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
@@ -47,8 +47,13 @@ public abstract class CombiningExpression extends AbstractExpression {
 	@Override
     public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
     	contextInfo.setParent(this);
-        left.analyze(contextInfo);
-        right.analyze(contextInfo);
+    	// Operands of union/intersect/except are non-updating contexts
+    	final AnalyzeContextInfo leftInfo = new AnalyzeContextInfo(contextInfo);
+    	leftInfo.addFlag(NON_UPDATING_CONTEXT);
+        left.analyze(leftInfo);
+        final AnalyzeContextInfo rightInfo = new AnalyzeContextInfo(contextInfo);
+        rightInfo.addFlag(NON_UPDATING_CONTEXT);
+        right.analyze(rightInfo);
     }
 
 	@Override

--- a/exist-core/src/main/java/org/exist/xquery/ConditionalExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ConditionalExpression.java
@@ -70,6 +70,11 @@ public class ConditionalExpression extends AbstractExpression implements Rewrita
         return Cardinality.superCardinalityOf(thenExpr.getCardinality(), elseExpr.getCardinality());
     }
 
+    @Override
+    public boolean isUpdating() {
+        return thenExpr.isUpdating() || elseExpr.isUpdating();
+    }
+
     /* (non-Javadoc)
      * @see org.exist.xquery.Expression#analyze(org.exist.xquery.Expression)
      */
@@ -77,12 +82,29 @@ public class ConditionalExpression extends AbstractExpression implements Rewrita
         AnalyzeContextInfo myContextInfo = new AnalyzeContextInfo(contextInfo);
         myContextInfo.setFlags(myContextInfo.getFlags() & (~IN_PREDICATE));
         myContextInfo.setParent(this);
-        testExpr.analyze(myContextInfo);
+        // Test expression is always a non-updating context
+        final AnalyzeContextInfo testInfo = new AnalyzeContextInfo(myContextInfo);
+        testInfo.addFlag(NON_UPDATING_CONTEXT);
+        testExpr.analyze(testInfo);
         // parent may have been modified by testExpr: set it again
         myContextInfo.setParent(this);
         thenExpr.analyze(myContextInfo);
         myContextInfo.setParent(this);
         elseExpr.analyze(myContextInfo);
+
+        // XUST0001: if one branch is updating and the other is non-updating (and not vacuous)
+        final boolean thenUpdating = thenExpr.isUpdating();
+        final boolean elseUpdating = elseExpr.isUpdating();
+        if (thenUpdating != elseUpdating) {
+            if (thenUpdating && !elseExpr.isVacuous()) {
+                throw new XPathException(this, ErrorCodes.XUST0001,
+                        "then branch is updating but else branch is not updating and not vacuous");
+            }
+            if (elseUpdating && !thenExpr.isVacuous()) {
+                throw new XPathException(this, ErrorCodes.XUST0001,
+                        "else branch is updating but then branch is not updating and not vacuous");
+            }
+        }
     }
 
     /* (non-Javadoc)

--- a/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
@@ -90,6 +90,11 @@ public class DebuggableExpression implements Expression, RewritableExpression {
     	return true;
     }
 
+    @Override
+    public boolean isUpdating() {
+        return expression.isUpdating();
+    }
+
     public void accept(ExpressionVisitor visitor) {
         expression.accept(visitor);
     }

--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -168,6 +168,7 @@ public class ElementConstructor extends NodeConstructor {
         final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
         newContextInfo.setParent(this);
         newContextInfo.addFlag(IN_NODE_CONSTRUCTOR);
+        newContextInfo.addFlag(NON_UPDATING_CONTEXT);
         qnameExpr.analyze(newContextInfo);
         if(attributes != null) {
             for (AttributeConstructor attribute : attributes) {

--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -170,6 +170,7 @@ public class ElementConstructor extends NodeConstructor {
         final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
         newContextInfo.setParent(this);
         newContextInfo.addFlag(IN_NODE_CONSTRUCTOR);
+        newContextInfo.addFlag(NON_UPDATING_CONTEXT);
         qnameExpr.analyze(newContextInfo);
         if(attributes != null) {
             for (AttributeConstructor attribute : attributes) {

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -144,7 +144,33 @@ public class ErrorCodes {
     public static final ErrorCode XQDY0137 = new W3CErrorCode("XQDY0137", "No two keys in a map may have the same key value");
     public static final ErrorCode XQDY0138 = new W3CErrorCode("XQDY0138", "Position n does not exist in this array");
 
+    /* W3C XQuery Update Facility 3.0 error codes */
+    public static final ErrorCode XUDY0009 = new W3CErrorCode("XUDY0009", "It is a dynamic error if the target node of a replace expression is a node without a parent.");
+    public static final ErrorCode XUDY0014 = new W3CErrorCode("XUDY0014", "It is a dynamic error if the result of applying all update primitives on a single document node would result in that document having more than one element or text child.");
+    public static final ErrorCode XUDY0015 = new W3CErrorCode("XUDY0015", "It is a dynamic error if more than one rename primitive is applied to the same target node.");
+    public static final ErrorCode XUDY0016 = new W3CErrorCode("XUDY0016", "It is a dynamic error if more than one replace primitive is applied to the same target node.");
+    public static final ErrorCode XUDY0017 = new W3CErrorCode("XUDY0017", "It is a dynamic error if two or more upd:replaceValue primitives in a PUL have the same target node.");
+    public static final ErrorCode XUDY0021 = new W3CErrorCode("XUDY0021", "It is a dynamic error if an insert, replace, or rename expression affects an element node by introducing an attribute node with a namespace binding that conflicts with a namespace binding of the element node.");
     public static final ErrorCode XUDY0023 = new W3CErrorCode("XUDY0023", "It is a dynamic error if an insert, replace, or rename expression affects an element node by introducing a new namespace binding that conflicts with one of its existing namespace bindings.");
+    public static final ErrorCode XUDY0024 = new W3CErrorCode("XUDY0024", "It is a dynamic error if the new namespace bindings added to an element by an update conflict with its existing namespace bindings.");
+    public static final ErrorCode XUDY0027 = new W3CErrorCode("XUDY0027", "It is a dynamic error if the target of an insert before or insert after expression is a root element or root text node of a document.");
+    public static final ErrorCode XUDY0029 = new W3CErrorCode("XUDY0029", "It is a dynamic error if the target of an insert into, insert as first into, insert as last into, or replace expression is not an element or document node.");
+    public static final ErrorCode XUDY0030 = new W3CErrorCode("XUDY0030", "It is a dynamic error if the target of an insert attributes expression is not an element node.");
+    public static final ErrorCode XUDY0031 = new W3CErrorCode("XUDY0031", "It is a dynamic error if two or more fn:put primitives have the same URI.");
+    public static final ErrorCode XUST0001 = new W3CErrorCode("XUST0001", "It is a static error if an updating expression is used in a context where it is not allowed.");
+    public static final ErrorCode XUST0002 = new W3CErrorCode("XUST0002", "It is a static error if a non-updating expression other than an empty sequence is used where an updating expression is expected.");
+    public static final ErrorCode XUST0003 = new W3CErrorCode("XUST0003", "It is a static error if a revalidation declaration specifies a revalidation mode that is not supported by the implementation.");
+    public static final ErrorCode XUST0028 = new W3CErrorCode("XUST0028", "It is a static error if a function declaration is declared as updating and also declares a return type.");
+    public static final ErrorCode XUTY0004 = new W3CErrorCode("XUTY0004", "It is a type error if the content sequence of an insert expression with into, as first into, or as last into contains an attribute node following a node that is not an attribute node.");
+    public static final ErrorCode XUTY0005 = new W3CErrorCode("XUTY0005", "It is a type error if the target expression of an insert expression with into, as first into, or as last into does not return a single element or document node.");
+    public static final ErrorCode XUTY0006 = new W3CErrorCode("XUTY0006", "It is a type error if the target expression of an insert expression with before or after does not return a single element, text, comment, or processing instruction node with a parent.");
+    public static final ErrorCode XUTY0007 = new W3CErrorCode("XUTY0007", "It is a type error if the target expression of a replace value of expression does not return a single element, attribute, text, comment, or processing instruction node.");
+    public static final ErrorCode XUTY0008 = new W3CErrorCode("XUTY0008", "It is a type error if the target expression of a replace expression returns a document node.");
+    public static final ErrorCode XUTY0010 = new W3CErrorCode("XUTY0010", "It is a type error if in a replace expression where the target is an element, text, comment, or processing instruction node, the content expression does not return a sequence of zero or more element, text, comment, or processing instruction nodes.");
+    public static final ErrorCode XUTY0011 = new W3CErrorCode("XUTY0011", "It is a type error if in a replace expression where the target is an attribute node, the content expression does not return a sequence of zero or more attribute nodes.");
+    public static final ErrorCode XUTY0012 = new W3CErrorCode("XUTY0012", "It is a type error if the target expression of a rename expression does not return a single element, attribute, or processing instruction node.");
+    public static final ErrorCode XUTY0013 = new W3CErrorCode("XUTY0013", "It is a type error if the source expression of a copy expression does not return a single node.");
+    public static final ErrorCode XUTY0022 = new W3CErrorCode("XUTY0022", "It is a type error if an insert expression specifies the insertion of an attribute node into a document node.");
 
     /* XQuery 1.0 and XPath 2.0 Functions and Operators http://www.w3.org/TR/xpath-functions/#error-summary */
     public static final ErrorCode FOER0000 = new W3CErrorCode("FOER0000", "Unidentified error.");

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -138,7 +138,33 @@ public class ErrorCodes {
     public static final ErrorCode XQDY0137 = new W3CErrorCode("XQDY0137", "No two keys in a map may have the same key value");
     public static final ErrorCode XQDY0138 = new W3CErrorCode("XQDY0138", "Position n does not exist in this array");
 
+    /* W3C XQuery Update Facility 3.0 error codes */
+    public static final ErrorCode XUDY0009 = new W3CErrorCode("XUDY0009", "It is a dynamic error if the target node of a replace expression is a node without a parent.");
+    public static final ErrorCode XUDY0014 = new W3CErrorCode("XUDY0014", "It is a dynamic error if the result of applying all update primitives on a single document node would result in that document having more than one element or text child.");
+    public static final ErrorCode XUDY0015 = new W3CErrorCode("XUDY0015", "It is a dynamic error if more than one rename primitive is applied to the same target node.");
+    public static final ErrorCode XUDY0016 = new W3CErrorCode("XUDY0016", "It is a dynamic error if more than one replace primitive is applied to the same target node.");
+    public static final ErrorCode XUDY0017 = new W3CErrorCode("XUDY0017", "It is a dynamic error if two or more upd:replaceValue primitives in a PUL have the same target node.");
+    public static final ErrorCode XUDY0021 = new W3CErrorCode("XUDY0021", "It is a dynamic error if an insert, replace, or rename expression affects an element node by introducing an attribute node with a namespace binding that conflicts with a namespace binding of the element node.");
     public static final ErrorCode XUDY0023 = new W3CErrorCode("XUDY0023", "It is a dynamic error if an insert, replace, or rename expression affects an element node by introducing a new namespace binding that conflicts with one of its existing namespace bindings.");
+    public static final ErrorCode XUDY0024 = new W3CErrorCode("XUDY0024", "It is a dynamic error if the new namespace bindings added to an element by an update conflict with its existing namespace bindings.");
+    public static final ErrorCode XUDY0027 = new W3CErrorCode("XUDY0027", "It is a dynamic error if the target of an insert before or insert after expression is a root element or root text node of a document.");
+    public static final ErrorCode XUDY0029 = new W3CErrorCode("XUDY0029", "It is a dynamic error if the target of an insert into, insert as first into, insert as last into, or replace expression is not an element or document node.");
+    public static final ErrorCode XUDY0030 = new W3CErrorCode("XUDY0030", "It is a dynamic error if the target of an insert attributes expression is not an element node.");
+    public static final ErrorCode XUDY0031 = new W3CErrorCode("XUDY0031", "It is a dynamic error if two or more fn:put primitives have the same URI.");
+    public static final ErrorCode XUST0001 = new W3CErrorCode("XUST0001", "It is a static error if an updating expression is used in a context where it is not allowed.");
+    public static final ErrorCode XUST0002 = new W3CErrorCode("XUST0002", "It is a static error if a non-updating expression other than an empty sequence is used where an updating expression is expected.");
+    public static final ErrorCode XUST0003 = new W3CErrorCode("XUST0003", "It is a static error if a revalidation declaration specifies a revalidation mode that is not supported by the implementation.");
+    public static final ErrorCode XUST0028 = new W3CErrorCode("XUST0028", "It is a static error if a function declaration is declared as updating and also declares a return type.");
+    public static final ErrorCode XUTY0004 = new W3CErrorCode("XUTY0004", "It is a type error if the content sequence of an insert expression with into, as first into, or as last into contains an attribute node following a node that is not an attribute node.");
+    public static final ErrorCode XUTY0005 = new W3CErrorCode("XUTY0005", "It is a type error if the target expression of an insert expression with into, as first into, or as last into does not return a single element or document node.");
+    public static final ErrorCode XUTY0006 = new W3CErrorCode("XUTY0006", "It is a type error if the target expression of an insert expression with before or after does not return a single element, text, comment, or processing instruction node with a parent.");
+    public static final ErrorCode XUTY0007 = new W3CErrorCode("XUTY0007", "It is a type error if the target expression of a replace value of expression does not return a single element, attribute, text, comment, or processing instruction node.");
+    public static final ErrorCode XUTY0008 = new W3CErrorCode("XUTY0008", "It is a type error if the target expression of a replace expression returns a document node.");
+    public static final ErrorCode XUTY0010 = new W3CErrorCode("XUTY0010", "It is a type error if in a replace expression where the target is an element, text, comment, or processing instruction node, the content expression does not return a sequence of zero or more element, text, comment, or processing instruction nodes.");
+    public static final ErrorCode XUTY0011 = new W3CErrorCode("XUTY0011", "It is a type error if in a replace expression where the target is an attribute node, the content expression does not return a sequence of zero or more attribute nodes.");
+    public static final ErrorCode XUTY0012 = new W3CErrorCode("XUTY0012", "It is a type error if the target expression of a rename expression does not return a single element, attribute, or processing instruction node.");
+    public static final ErrorCode XUTY0013 = new W3CErrorCode("XUTY0013", "It is a type error if the source expression of a copy expression does not return a single node.");
+    public static final ErrorCode XUTY0022 = new W3CErrorCode("XUTY0022", "It is a type error if an insert expression specifies the insertion of an attribute node into a document node.");
 
     /* XQuery 1.0 and XPath 2.0 Functions and Operators http://www.w3.org/TR/xpath-functions/#error-summary */
     public static final ErrorCode FOER0000 = new W3CErrorCode("FOER0000", "Unidentified error.");

--- a/exist-core/src/main/java/org/exist/xquery/Expression.java
+++ b/exist-core/src/main/java/org/exist/xquery/Expression.java
@@ -77,6 +77,14 @@ public interface Expression extends Materializable {
     public final static int UNORDERED = 1024;
 
     /**
+     * Indicates that the expression is in a context where updating expressions
+     * (insert, delete, replace, rename) are not allowed.
+     * Per W3C XQuery Update Facility 3.0, XUST0001 should be raised if an
+     * updating expression appears in such a context.
+     */
+    public final static int NON_UPDATING_CONTEXT = 2048;
+
+    /**
      * Indicates that no context id is supplied to an expression.
      */
     public final static int NO_CONTEXT_ID = -1;
@@ -202,6 +210,30 @@ public interface Expression extends Materializable {
     public Expression getSubExpression(int index);
 
     public boolean allowMixedNodesInReturn();
+
+    /**
+     * Returns true if this expression is an updating expression per the
+     * W3C XQuery Update Facility 3.0 specification.
+     * Updating expressions include: insert, delete, replace, rename expressions,
+     * calls to updating functions, and composite expressions where all branches
+     * are updating.
+     *
+     * @return true if this is an updating expression
+     */
+    default boolean isUpdating() {
+        return false;
+    }
+
+    /**
+     * Returns true if this expression is vacuous — neither updating nor producing
+     * a non-empty result. A vacuous expression is compatible with both updating
+     * and non-updating contexts per W3C XQuery Update Facility 3.0.
+     *
+     * @return true if this expression is vacuous
+     */
+    default boolean isVacuous() {
+        return !isUpdating() && getCardinality() == Cardinality.EMPTY_SEQUENCE;
+    }
 
     public Expression getParent();
 

--- a/exist-core/src/main/java/org/exist/xquery/ForExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ForExpr.java
@@ -70,6 +70,7 @@ public class ForExpr extends BindingExpression {
         try {
             contextInfo.setParent(this);
             final AnalyzeContextInfo varContextInfo = new AnalyzeContextInfo(contextInfo);
+            varContextInfo.addFlag(NON_UPDATING_CONTEXT);
             inputSequence.analyze(varContextInfo);
             // Declare the iteration variable
             final LocalVariable inVar = new LocalVariable(varName);

--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -422,6 +422,7 @@ public abstract class Function extends PathExpr {
             if (arg != null) {
                 // call analyze for each argument
                 final AnalyzeContextInfo argContextInfo = new AnalyzeContextInfo(contextInfo);
+                argContextInfo.addFlag(NON_UPDATING_CONTEXT);
                 arg.analyze(argContextInfo);
 
                 if (!argumentsChecked) {

--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -432,6 +432,7 @@ public abstract class Function extends PathExpr {
                 if (!(this instanceof Optimizable)) {
                     argContextInfo.removeFlag(IN_PREDICATE);
                 }
+                argContextInfo.addFlag(NON_UPDATING_CONTEXT);
                 arg.analyze(argContextInfo);
 
                 if (!argumentsChecked) {

--- a/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
@@ -119,6 +119,12 @@ public class FunctionCall extends Function {
 
         // check that FunctionCall#resolveForwardReference(UserDefinedFunction) has been called first!
         if (functionDef != null) {
+            // XUST0001: calling an updating function in a non-updating context
+            if (functionDef.getSignature().isUpdating() && contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+                throw new XPathException(this, ErrorCodes.XUST0001,
+                        "call to updating function " + functionDef.getSignature().getName() +
+                        " is not allowed in a non-updating context");
+            }
             final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
             newContextInfo.setParent(this);
             newContextInfo.removeFlag(IN_NODE_CONSTRUCTOR);
@@ -451,6 +457,11 @@ public class FunctionCall extends Function {
         this.recursive = recursive;
     }
     
+    @Override
+    public boolean isUpdating() {
+        return functionDef != null && functionDef.getSignature().isUpdating();
+    }
+
     public boolean isRecursive(){
     	return recursive;
     }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
@@ -59,6 +59,7 @@ public class FunctionSignature {
     private SequenceType[] arguments;
     private SequenceType returnType;
     private boolean isVariadic;
+    private boolean isUpdating;
     private String description;
     private String deprecated = null;
     private Map<String, String> metadata = null;
@@ -69,6 +70,7 @@ public class FunctionSignature {
         this.returnType = other.returnType;
         this.annotations = other.annotations != null ? Arrays.copyOf(other.annotations, other.annotations.length) : null;
         this.isVariadic = other.isVariadic;
+        this.isUpdating = other.isUpdating;
         this.deprecated = other.deprecated;
         this.description = other.description;
         this.metadata = other.metadata != null ? new HashMap<>(other.metadata) : null;
@@ -127,6 +129,14 @@ public class FunctionSignature {
 
     public QName getName() {
         return name;
+    }
+
+    public boolean isUpdating() {
+        return isUpdating;
+    }
+
+    public void setUpdating(final boolean updating) {
+        this.isUpdating = updating;
     }
 
     public int getArgumentCount() {

--- a/exist-core/src/main/java/org/exist/xquery/LetExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/LetExpr.java
@@ -54,6 +54,7 @@ public class LetExpr extends BindingExpression {
         try {
             contextInfo.setParent(this);
             final AnalyzeContextInfo varContextInfo = new AnalyzeContextInfo(contextInfo);
+            varContextInfo.addFlag(NON_UPDATING_CONTEXT);
             inputSequence.analyze(varContextInfo);
             //Declare the iteration variable
             final LocalVariable inVar = new LocalVariable(varName);

--- a/exist-core/src/main/java/org/exist/xquery/OrderSpec.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderSpec.java
@@ -48,7 +48,9 @@ public class OrderSpec {
 	}
 
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-	    expression.analyze(contextInfo);
+	    final AnalyzeContextInfo orderInfo = new AnalyzeContextInfo(contextInfo);
+	    orderInfo.addFlag(Expression.NON_UPDATING_CONTEXT);
+	    expression.analyze(orderInfo);
 	}
 	
 	public void setModifiers(int modifiers) {

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -179,7 +179,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                 }
             }
 
-            if (i > 1) {
+            if (i >= 1) {
                 contextInfo.setContextStep(steps.get(i - 1));
             }
             contextInfo.setParent(this);
@@ -390,6 +390,36 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
     @Override
     public int getSubExpressionCount() {
         return steps.size();
+    }
+
+    @Override
+    public boolean isVacuous() {
+        if (steps.isEmpty()) {
+            return true;
+        }
+        if (steps.size() == 1) {
+            return steps.getFirst().isVacuous();
+        }
+        // For multi-step paths, use default logic
+        return !isUpdating() && getCardinality() == Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        if (steps.isEmpty()) {
+            return false;
+        }
+        // A PathExpr with one step delegates to that step
+        if (steps.size() == 1) {
+            return steps.getFirst().isUpdating();
+        }
+        // For multi-step paths, check if any step is updating
+        for (final Expression step : steps) {
+            if (step.isUpdating()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -187,7 +187,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                 }
             }
 
-            if (i > 1) {
+            if (i >= 1) {
                 contextInfo.setContextStep(steps.get(i - 1));
             }
             contextInfo.setParent(this);
@@ -407,6 +407,36 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
     @Override
     public int getSubExpressionCount() {
         return steps.size();
+    }
+
+    @Override
+    public boolean isVacuous() {
+        if (steps.isEmpty()) {
+            return true;
+        }
+        if (steps.size() == 1) {
+            return steps.getFirst().isVacuous();
+        }
+        // For multi-step paths, use default logic
+        return !isUpdating() && getCardinality() == Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        if (steps.isEmpty()) {
+            return false;
+        }
+        // A PathExpr with one step delegates to that step
+        if (steps.size() == 1) {
+            return steps.getFirst().isUpdating();
+        }
+        // For multi-step paths, check if any step is updating
+        for (final Expression step : steps) {
+            if (step.isUpdating()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -129,6 +129,7 @@ public class Predicate extends PathExpr {
         final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
         // set flag to signal subexpression that we are in a predicate
         newContextInfo.addFlag(IN_PREDICATE);
+        newContextInfo.addFlag(NON_UPDATING_CONTEXT);
         newContextInfo.removeFlag(IN_WHERE_CLAUSE); // remove where clause flag
         newContextInfo.removeFlag(DOT_TEST);
         outerContextId = newContextInfo.getContextId();

--- a/exist-core/src/main/java/org/exist/xquery/QuantifiedExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/QuantifiedExpression.java
@@ -69,8 +69,12 @@ public class QuantifiedExpression extends BindingExpression {
 			context.declareVariableBinding(new LocalVariable(varName));
 
 			contextInfo.setParent(this);
-			inputSequence.analyze(contextInfo);
-			returnExpr.analyze(contextInfo);
+			final AnalyzeContextInfo inputInfo = new AnalyzeContextInfo(contextInfo);
+			inputInfo.addFlag(NON_UPDATING_CONTEXT);
+			inputSequence.analyze(inputInfo);
+			final AnalyzeContextInfo satisfiesInfo = new AnalyzeContextInfo(contextInfo);
+			satisfiesInfo.addFlag(NON_UPDATING_CONTEXT);
+			returnExpr.analyze(satisfiesInfo);
 		} finally {
 			context.popLocalVariables(mark);
 		}

--- a/exist-core/src/main/java/org/exist/xquery/RangeExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/RangeExpression.java
@@ -67,8 +67,13 @@ public class RangeExpression extends PathExpr {
     	inPredicate = (contextInfo.getFlags() & IN_PREDICATE) > 0;
     	contextId = contextInfo.getContextId();
     	contextInfo.setParent(this);
-    	start.analyze(contextInfo);
-    	end.analyze(contextInfo);
+    	// Operands of range expression are non-updating contexts
+    	final AnalyzeContextInfo startInfo = new AnalyzeContextInfo(contextInfo);
+    	startInfo.addFlag(NON_UPDATING_CONTEXT);
+    	start.analyze(startInfo);
+    	final AnalyzeContextInfo endInfo = new AnalyzeContextInfo(contextInfo);
+    	endInfo.addFlag(NON_UPDATING_CONTEXT);
+    	end.analyze(endInfo);
     }
     
    

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -57,6 +57,24 @@ public class SequenceConstructor extends PathExpr {
             }
         }
         contextInfo.setStaticReturnType(staticType);
+
+        // XUST0001: check compatibility of items in the comma expression.
+        // All must be updating, or all must be non-updating (vacuous items are allowed either way).
+        if (steps.size() > 1) {
+            boolean hasUpdating = false;
+            boolean hasNonUpdating = false;
+            for (final Expression expr : steps) {
+                if (expr.isUpdating()) {
+                    hasUpdating = true;
+                } else if (!expr.isVacuous()) {
+                    hasNonUpdating = true;
+                }
+            }
+            if (hasUpdating && hasNonUpdating) {
+                throw new XPathException(this, ErrorCodes.XUST0001,
+                        "comma expression mixes updating and non-updating expressions");
+            }
+        }
     }
 
     @Override
@@ -142,6 +160,17 @@ public class SequenceConstructor extends PathExpr {
     }
 
     @Override
+    public boolean isUpdating() {
+        boolean anyUpdating = false;
+        for (final Expression step : steps) {
+            if (step.isUpdating()) {
+                anyUpdating = true;
+            }
+        }
+        return anyUpdating;
+    }
+
+    @Override
     public int returnsType() {
         return Type.ITEM;
     }
@@ -149,6 +178,16 @@ public class SequenceConstructor extends PathExpr {
     @Override
     public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
+    }
+
+    @Override
+    public boolean isVacuous() {
+        for (final Expression step : steps) {
+            if (!step.isVacuous()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/SwitchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/SwitchExpression.java
@@ -131,13 +131,67 @@ public class SwitchExpression extends AbstractExpression {
         return Cardinality.ZERO_OR_MORE;
     }
     
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-        contextInfo.setParent(this);
-        operand.analyze(contextInfo);
-        for (final Case next : cases) {
-            next.returnClause.analyze(contextInfo);
+    @Override
+    public boolean isUpdating() {
+        for (final Case c : cases) {
+            if (c.returnClause.isUpdating()) {
+                return true;
+            }
         }
-        defaultClause.returnClause.analyze(contextInfo);
+        return defaultClause != null && defaultClause.returnClause.isUpdating();
+    }
+
+    @Override
+    public boolean isVacuous() {
+        for (final Case c : cases) {
+            if (!c.returnClause.isVacuous()) {
+                return false;
+            }
+        }
+        return defaultClause == null || defaultClause.returnClause.isVacuous();
+    }
+
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+        final AnalyzeContextInfo myContextInfo = new AnalyzeContextInfo(contextInfo);
+        myContextInfo.setParent(this);
+
+        // Operand and case operands are non-updating contexts
+        final AnalyzeContextInfo operandInfo = new AnalyzeContextInfo(myContextInfo);
+        operandInfo.addFlag(NON_UPDATING_CONTEXT);
+        operand.analyze(operandInfo);
+        for (final Case next : cases) {
+            for (final Expression caseOperand : next.operands) {
+                final AnalyzeContextInfo caseOpInfo = new AnalyzeContextInfo(myContextInfo);
+                caseOpInfo.addFlag(NON_UPDATING_CONTEXT);
+                caseOperand.analyze(caseOpInfo);
+            }
+            myContextInfo.setParent(this);
+            next.returnClause.analyze(myContextInfo);
+        }
+        myContextInfo.setParent(this);
+        defaultClause.returnClause.analyze(myContextInfo);
+
+        // XUST0001: check branch compatibility
+        boolean hasUpdating = false;
+        boolean hasNonUpdating = false;
+        for (final Case c : cases) {
+            if (c.returnClause.isUpdating()) {
+                hasUpdating = true;
+            } else if (!c.returnClause.isVacuous()) {
+                hasNonUpdating = true;
+            }
+        }
+        if (defaultClause != null) {
+            if (defaultClause.returnClause.isUpdating()) {
+                hasUpdating = true;
+            } else if (!defaultClause.returnClause.isVacuous()) {
+                hasNonUpdating = true;
+            }
+        }
+        if (hasUpdating && hasNonUpdating) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "switch branches mix updating and non-updating expressions");
+        }
     }
 
     public void setContextDocSet(DocumentSet contextSet) {

--- a/exist-core/src/main/java/org/exist/xquery/TypeswitchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TypeswitchExpression.java
@@ -161,12 +161,37 @@ public class TypeswitchExpression extends AbstractExpression {
         return Cardinality.ZERO_OR_MORE;
     }
     
+    @Override
+    public boolean isUpdating() {
+        for (final Case c : cases) {
+            if (c.returnClause.isUpdating()) {
+                return true;
+            }
+        }
+        return defaultClause != null && defaultClause.returnClause.isUpdating();
+    }
+
+    @Override
+    public boolean isVacuous() {
+        for (final Case c : cases) {
+            if (!c.returnClause.isVacuous()) {
+                return false;
+            }
+        }
+        return defaultClause == null || defaultClause.returnClause.isVacuous();
+    }
+
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-        contextInfo.setParent(this);
-        operand.analyze(contextInfo);
-        
+        final AnalyzeContextInfo myContextInfo = new AnalyzeContextInfo(contextInfo);
+        myContextInfo.setParent(this);
+
+        // Operand is a non-updating context
+        final AnalyzeContextInfo operandInfo = new AnalyzeContextInfo(myContextInfo);
+        operandInfo.addFlag(NON_UPDATING_CONTEXT);
+        operand.analyze(operandInfo);
+
         final LocalVariable mark0 = context.markLocalVariables(false);
-        
+
         try {
         	for (final Case next : cases) {
         		final LocalVariable mark1 = context.markLocalVariables(false);
@@ -178,7 +203,8 @@ public class TypeswitchExpression extends AbstractExpression {
                         }
         				context.declareVariableBinding(var);
         			}
-        			next.returnClause.analyze(contextInfo);
+        			myContextInfo.setParent(this);
+        			next.returnClause.analyze(myContextInfo);
         		} finally {
         			context.popLocalVariables(mark1);
         		}
@@ -187,9 +213,33 @@ public class TypeswitchExpression extends AbstractExpression {
         		final LocalVariable var = new LocalVariable(defaultClause.variable);
         		context.declareVariableBinding(var);
         	}
-        	defaultClause.returnClause.analyze(contextInfo);
+        	myContextInfo.setParent(this);
+        	defaultClause.returnClause.analyze(myContextInfo);
         } finally {
         	context.popLocalVariables(mark0);
+        }
+
+        // XUST0001: check branch compatibility
+        // All branches must be either all updating, all non-updating, or vacuous
+        boolean hasUpdating = false;
+        boolean hasNonUpdating = false;
+        for (final Case c : cases) {
+            if (c.returnClause.isUpdating()) {
+                hasUpdating = true;
+            } else if (!c.returnClause.isVacuous()) {
+                hasNonUpdating = true;
+            }
+        }
+        if (defaultClause != null) {
+            if (defaultClause.returnClause.isUpdating()) {
+                hasUpdating = true;
+            } else if (!defaultClause.returnClause.isVacuous()) {
+                hasNonUpdating = true;
+            }
+        }
+        if (hasUpdating && hasNonUpdating) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "typeswitch branches mix updating and non-updating expressions");
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
@@ -101,7 +101,22 @@ public class UserDefinedFunction extends Function implements Cloneable {
                 newContextInfo.setParent(this);
                 if (!bodyAnalyzed) {
                     if (body != null) {
+                        if (!getSignature().isUpdating()) {
+                            // Non-updating function body: updating expressions not allowed
+                            newContextInfo.addFlag(NON_UPDATING_CONTEXT);
+                        } else {
+                            // Updating function body: updating expressions are allowed
+                            newContextInfo.removeFlag(NON_UPDATING_CONTEXT);
+                        }
                         body.analyze(newContextInfo);
+
+                        // XUST0002: updating function body must be updating (or vacuous)
+                        if (getSignature().isUpdating() && !body.isUpdating()
+                                && !body.isVacuous()) {
+                            throw new XPathException(this, ErrorCodes.XUST0002,
+                                    "body of updating function " + getName() +
+                                    " must be an updating expression or an empty sequence");
+                        }
                     }
                     bodyAnalyzed = true;
                 }

--- a/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
@@ -120,7 +120,10 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
      */
     public void analyzeExpression(final AnalyzeContextInfo contextInfo) throws XPathException {
         if (expression.isPresent()) {
-            expression.get().analyze(contextInfo);
+            // Variable initializers are non-updating contexts
+            final AnalyzeContextInfo exprInfo = new AnalyzeContextInfo(contextInfo);
+            exprInfo.addFlag(NON_UPDATING_CONTEXT);
+            expression.get().analyze(exprInfo);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/WhereClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/WhereClause.java
@@ -59,7 +59,7 @@ public class WhereClause extends AbstractFLWORClause {
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
         contextInfo.setParent(this);
         AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
-        newContextInfo.setFlags(contextInfo.getFlags() | IN_PREDICATE | IN_WHERE_CLAUSE);
+        newContextInfo.setFlags(contextInfo.getFlags() | IN_PREDICATE | IN_WHERE_CLAUSE | NON_UPDATING_CONTEXT);
         newContextInfo.setContextId(getExpressionId());
         whereExpr.analyze(newContextInfo);
 

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -451,6 +451,13 @@ public class XQuery {
                     result = expression.eval(contextSequence, null);
                 }
 
+                // W3C XQuery Update Facility 3.0: apply Pending Update List at snapshot boundary
+                final org.exist.xquery.xquf.PendingUpdateList pul = context.getPendingUpdateList();
+                if (!pul.isEmpty()) {
+                    pul.apply(context);
+                    pul.clear();
+                }
+
                 if(LOG.isDebugEnabled()) {
                     final NumberFormat nf = NumberFormat.getNumberInstance();
                     LOG.debug("Execution took {} ms", nf.format(System.currentTimeMillis() - start));

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -45,6 +45,7 @@ import org.exist.source.FileSource;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
 import org.exist.storage.DBBroker;
+import org.exist.util.LockException;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
 import org.exist.xquery.parser.XQueryTreeParser;
@@ -381,7 +382,10 @@ public class XQuery {
         
         //do any preparation before execution
         context.prepareForExecution();
-        
+
+        // BaseX-style preclaiming: collect lock targets from compiled expression tree
+        context.collectLockTargets(context.getRootExpression());
+
         final Subject callingUser = broker.getCurrentSubject();
 
         //if setUid or setGid, become Effective User
@@ -411,6 +415,15 @@ public class XQuery {
             
             context.getProfiler().traceQueryStart();
             broker.getBrokerPool().getProcessMonitor().queryStarted(context.getWatchDog());
+
+            // Preclaim locks before evaluation if lock targets were collected
+            if (context.hasPreclaimTargets()) {
+                try {
+                    context.preclaimLocks();
+                } catch (final LockException e) {
+                    throw new XPathException((Expression) null, ErrorCodes.ERROR, "Failed to preclaim locks: " + e.getMessage(), e);
+                }
+            }
 
             FunctionCall call = null;
             try {
@@ -469,6 +482,11 @@ public class XQuery {
 
                 return result;
             } finally {
+                // Release preclaimed locks after PUL has been applied
+                if (context.hasPreclaimedLocks()) {
+                    context.releasePreclaimedLocks();
+                }
+
                 context.getProfiler().traceQueryEnd(context);
                 // track query stats before context is reset
                 broker.getBrokerPool().getProcessMonitor().queryCompleted(context.getWatchDog());

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1389,6 +1389,9 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param root the compiled expression tree root
      */
     public void collectLockTargets(final Expression root) {
+        if (root == null) {
+            return;
+        }
         final org.exist.xquery.lock.LockTargetCollector collector =
                 new org.exist.xquery.lock.LockTargetCollector();
         collector.collect(root);

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -294,6 +294,18 @@ public class XQueryContext implements BinaryValueManager, Context {
     private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
 
     /**
+     * Tracks whether the current module uses the legacy eXist-db update syntax
+     * (update insert/delete/replace/rename/value). Set during tree walking.
+     */
+    private boolean hasLegacyUpdate = false;
+
+    /**
+     * Tracks whether the current module uses W3C XQuery Update Facility 3.0 syntax
+     * (insert node, delete node, replace node, etc.). Set during tree walking.
+     */
+    private boolean hasXQUFUpdate = false;
+
+    /**
      * A general-purpose map to set attributes in the current query context.
      */
     protected Map<String, Object> attributes = new HashMap<>();
@@ -1433,6 +1445,40 @@ public class XQueryContext implements BinaryValueManager, Context {
         this.pendingUpdateList = pul;
     }
 
+    /**
+     * Mark that the current module uses the legacy eXist-db update syntax.
+     * Called during tree walking when a legacy update expression is encountered.
+     *
+     * @param ast the AST node for error reporting
+     * @throws XPathException if this module already uses W3C XQUF syntax
+     */
+    public void markLegacyUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+        if (hasXQUFUpdate) {
+            throw new XPathException(ast, ErrorCodes.XPST0003,
+                    "Cannot mix legacy 'update' syntax with W3C XQuery Update Facility expressions " +
+                    "in the same module. Migrate all updates to W3C syntax " +
+                    "(insert node, delete node, replace node, replace value of node, rename node).");
+        }
+        hasLegacyUpdate = true;
+    }
+
+    /**
+     * Mark that the current module uses W3C XQuery Update Facility 3.0 syntax.
+     * Called during tree walking when a XQUF expression is encountered.
+     *
+     * @param ast the AST node for error reporting
+     * @throws XPathException if this module already uses legacy update syntax
+     */
+    public void markXQUFUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+        if (hasLegacyUpdate) {
+            throw new XPathException(ast, ErrorCodes.XPST0003,
+                    "Cannot mix W3C XQuery Update Facility expressions with legacy 'update' syntax " +
+                    "in the same module. Migrate all updates to W3C syntax " +
+                    "(insert node, delete node, replace node, replace value of node, rename node).");
+        }
+        hasXQUFUpdate = true;
+    }
+
     @Override
     public void reset() {
         reset(false);
@@ -1468,6 +1514,10 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         // Reset the W3C XQuery Update Facility PUL
         pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+
+        // Reset update syntax tracking flags
+        hasLegacyUpdate = false;
+        hasXQUFUpdate = false;
 
         calendar = null;
         implicitTimeZone = null;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -390,6 +390,12 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     private LockedDocumentMap protectedDocuments = null;
 
+    // --- Preclaiming lock targets (BaseX-style two-phase locking) ---
+    private Set<XmldbURI> preclaimDocumentTargets;
+    private Set<XmldbURI> preclaimCollectionTargets;
+    private boolean preclaimRequiresGlobalLock = false;
+    private final List<AutoCloseable> preclaimedLocks = new ArrayList<>();
+
     /**
      * The profiler instance used by this context.
      */
@@ -1407,6 +1413,87 @@ public class XQueryContext implements BinaryValueManager, Context {
     @Override
     public boolean lockDocumentsOnLoad() {
         return false;
+    }
+
+    /**
+     * Collect lock targets from the compiled expression tree using
+     * a {@link org.exist.xquery.lock.LockTargetCollector}.
+     *
+     * @param root the compiled expression tree root
+     */
+    public void collectLockTargets(final Expression root) {
+        final org.exist.xquery.lock.LockTargetCollector collector =
+                new org.exist.xquery.lock.LockTargetCollector();
+        collector.collect(root);
+        this.preclaimDocumentTargets = collector.getDocumentTargets();
+        this.preclaimCollectionTargets = collector.getCollectionTargets();
+        this.preclaimRequiresGlobalLock = collector.requiresGlobalLock();
+    }
+
+    /**
+     * Returns true if lock targets have been collected and preclaiming
+     * should be performed before evaluation.
+     */
+    public boolean hasPreclaimTargets() {
+        return preclaimDocumentTargets != null &&
+                (preclaimRequiresGlobalLock ||
+                 !preclaimDocumentTargets.isEmpty() ||
+                 !preclaimCollectionTargets.isEmpty());
+    }
+
+    /**
+     * Acquire preclaimed locks on all collected document and collection
+     * targets. If static analysis could not determine all targets,
+     * acquires a global collection write lock on /db as a safe fallback.
+     *
+     * <p>Locks are acquired in a consistent order (TreeSet natural ordering)
+     * to prevent deadlocks.</p>
+     *
+     * @throws LockException if lock acquisition fails
+     */
+    public void preclaimLocks() throws LockException {
+        if (preclaimDocumentTargets == null) {
+            return;
+        }
+        final org.exist.storage.lock.LockManager lockManager =
+                getBroker().getBrokerPool().getLockManager();
+
+        if (preclaimRequiresGlobalLock) {
+            // Fall back to global collection write lock on /db
+            preclaimedLocks.add(lockManager.acquireCollectionWriteLock(XmldbURI.ROOT_COLLECTION_URI));
+        } else {
+            // Acquire collection write locks first (sorted order)
+            for (final XmldbURI collectionUri : preclaimCollectionTargets) {
+                preclaimedLocks.add(lockManager.acquireCollectionWriteLock(collectionUri));
+            }
+            // Then acquire document write locks (sorted order)
+            for (final XmldbURI docUri : preclaimDocumentTargets) {
+                preclaimedLocks.add(lockManager.acquireDocumentWriteLock(docUri));
+            }
+        }
+    }
+
+    /**
+     * Release all preclaimed locks. Should be called in a finally block
+     * after query evaluation completes.
+     */
+    public void releasePreclaimedLocks() {
+        // Release in reverse order of acquisition
+        for (int i = preclaimedLocks.size() - 1; i >= 0; i--) {
+            try {
+                preclaimedLocks.get(i).close();
+            } catch (final Exception e) {
+                LOG.warn("Error releasing preclaimed lock", e);
+            }
+        }
+        preclaimedLocks.clear();
+    }
+
+    /**
+     * Returns true if preclaimed locks are currently held.
+     */
+    public boolean hasPreclaimedLocks() {
+        return !preclaimedLocks.isEmpty();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -295,6 +295,18 @@ public class XQueryContext implements BinaryValueManager, Context {
     private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
 
     /**
+     * Tracks whether the current module uses the legacy eXist-db update syntax
+     * (update insert/delete/replace/rename/value). Set during tree walking.
+     */
+    private boolean hasLegacyUpdate = false;
+
+    /**
+     * Tracks whether the current module uses W3C XQuery Update Facility 3.0 syntax
+     * (insert node, delete node, replace node, etc.). Set during tree walking.
+     */
+    private boolean hasXQUFUpdate = false;
+
+    /**
      * A general-purpose map to set attributes in the current query context.
      */
     protected Map<String, Object> attributes = new HashMap<>();
@@ -1400,6 +1412,40 @@ public class XQueryContext implements BinaryValueManager, Context {
         this.pendingUpdateList = pul;
     }
 
+    /**
+     * Mark that the current module uses the legacy eXist-db update syntax.
+     * Called during tree walking when a legacy update expression is encountered.
+     *
+     * @param ast the AST node for error reporting
+     * @throws XPathException if this module already uses W3C XQUF syntax
+     */
+    public void markLegacyUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+        if (hasXQUFUpdate) {
+            throw new XPathException(ast, ErrorCodes.XPST0003,
+                    "Cannot mix legacy 'update' syntax with W3C XQuery Update Facility expressions " +
+                    "in the same module. Migrate all updates to W3C syntax " +
+                    "(insert node, delete node, replace node, replace value of node, rename node).");
+        }
+        hasLegacyUpdate = true;
+    }
+
+    /**
+     * Mark that the current module uses W3C XQuery Update Facility 3.0 syntax.
+     * Called during tree walking when a XQUF expression is encountered.
+     *
+     * @param ast the AST node for error reporting
+     * @throws XPathException if this module already uses legacy update syntax
+     */
+    public void markXQUFUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+        if (hasLegacyUpdate) {
+            throw new XPathException(ast, ErrorCodes.XPST0003,
+                    "Cannot mix W3C XQuery Update Facility expressions with legacy 'update' syntax " +
+                    "in the same module. Migrate all updates to W3C syntax " +
+                    "(insert node, delete node, replace node, replace value of node, rename node).");
+        }
+        hasXQUFUpdate = true;
+    }
+
     @Override
     public void reset() {
         reset(false);
@@ -1435,6 +1481,10 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         // Reset the W3C XQuery Update Facility PUL
         pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+
+        // Reset update syntax tracking flags
+        hasLegacyUpdate = false;
+        hasXQUFUpdate = false;
 
         calendar = null;
         implicitTimeZone = null;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -93,6 +93,7 @@ import org.exist.xquery.parser.*;
 import org.exist.xquery.pragmas.*;
 import org.exist.xquery.update.Modification;
 import org.exist.xquery.util.SerializerUtils;
+import org.exist.xquery.xquf.PendingUpdateList;
 import org.exist.xquery.value.*;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
@@ -292,7 +293,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * Accumulates update primitives during query evaluation and is applied
      * at snapshot boundaries.
      */
-    private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+    private PendingUpdateList pendingUpdateList = new PendingUpdateList();
 
     /**
      * Tracks whether the current module uses the legacy eXist-db update syntax
@@ -1398,7 +1399,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      *
      * @return the current pending update list
      */
-    public org.exist.xquery.xquf.PendingUpdateList getPendingUpdateList() {
+    public PendingUpdateList getPendingUpdateList() {
         return pendingUpdateList;
     }
 
@@ -1408,7 +1409,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      *
      * @param pul the new pending update list
      */
-    public void setPendingUpdateList(final org.exist.xquery.xquf.PendingUpdateList pul) {
+    public void setPendingUpdateList(final PendingUpdateList pul) {
         this.pendingUpdateList = pul;
     }
 
@@ -1419,7 +1420,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param ast the AST node for error reporting
      * @throws XPathException if this module already uses W3C XQUF syntax
      */
-    public void markLegacyUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+    public void markLegacyUpdate(final XQueryAST ast) throws XPathException {
         if (hasXQUFUpdate) {
             throw new XPathException(ast, ErrorCodes.XPST0003,
                     "Cannot mix legacy 'update' syntax with W3C XQuery Update Facility expressions " +
@@ -1436,7 +1437,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param ast the AST node for error reporting
      * @throws XPathException if this module already uses legacy update syntax
      */
-    public void markXQUFUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+    public void markXQUFUpdate(final XQueryAST ast) throws XPathException {
         if (hasLegacyUpdate) {
             throw new XPathException(ast, ErrorCodes.XPST0003,
                     "Cannot mix W3C XQuery Update Facility expressions with legacy 'update' syntax " +
@@ -1480,7 +1481,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         }
 
         // Reset the W3C XQuery Update Facility PUL
-        pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+        pendingUpdateList = new PendingUpdateList();
 
         // Reset update syntax tracking flags
         hasLegacyUpdate = false;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -287,6 +287,13 @@ public class XQueryContext implements BinaryValueManager, Context {
     protected MutableDocumentSet modifiedDocuments = null;
 
     /**
+     * W3C XQuery Update Facility 3.0 Pending Update List.
+     * Accumulates update primitives during query evaluation and is applied
+     * at snapshot boundaries.
+     */
+    private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+
+    /**
      * A general-purpose map to set attributes in the current query context.
      */
     protected Map<String, Object> attributes = new HashMap<>();
@@ -1407,6 +1414,25 @@ public class XQueryContext implements BinaryValueManager, Context {
         modifiedDocuments.add(document);
     }
 
+    /**
+     * Get the W3C XQuery Update Facility 3.0 Pending Update List for this context.
+     *
+     * @return the current pending update list
+     */
+    public org.exist.xquery.xquf.PendingUpdateList getPendingUpdateList() {
+        return pendingUpdateList;
+    }
+
+    /**
+     * Set the Pending Update List. Used by copy-modify expressions to create
+     * a nested PUL scope.
+     *
+     * @param pul the new pending update list
+     */
+    public void setPendingUpdateList(final org.exist.xquery.xquf.PendingUpdateList pul) {
+        this.pendingUpdateList = pul;
+    }
+
     @Override
     public void reset() {
         reset(false);
@@ -1439,6 +1465,9 @@ public class XQueryContext implements BinaryValueManager, Context {
             }
             modifiedDocuments = null;
         }
+
+        // Reset the W3C XQuery Update Facility PUL
+        pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
 
         calendar = null;
         implicitTimeZone = null;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -391,6 +391,12 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     private LockedDocumentMap protectedDocuments = null;
 
+    // --- Preclaiming lock targets (BaseX-style two-phase locking) ---
+    private Set<XmldbURI> preclaimDocumentTargets;
+    private Set<XmldbURI> preclaimCollectionTargets;
+    private boolean preclaimRequiresGlobalLock = false;
+    private final List<AutoCloseable> preclaimedLocks = new ArrayList<>();
+
     /**
      * The profiler instance used by this context.
      */
@@ -1374,6 +1380,87 @@ public class XQueryContext implements BinaryValueManager, Context {
     @Override
     public boolean lockDocumentsOnLoad() {
         return false;
+    }
+
+    /**
+     * Collect lock targets from the compiled expression tree using
+     * a {@link org.exist.xquery.lock.LockTargetCollector}.
+     *
+     * @param root the compiled expression tree root
+     */
+    public void collectLockTargets(final Expression root) {
+        final org.exist.xquery.lock.LockTargetCollector collector =
+                new org.exist.xquery.lock.LockTargetCollector();
+        collector.collect(root);
+        this.preclaimDocumentTargets = collector.getDocumentTargets();
+        this.preclaimCollectionTargets = collector.getCollectionTargets();
+        this.preclaimRequiresGlobalLock = collector.requiresGlobalLock();
+    }
+
+    /**
+     * Returns true if lock targets have been collected and preclaiming
+     * should be performed before evaluation.
+     */
+    public boolean hasPreclaimTargets() {
+        return preclaimDocumentTargets != null &&
+                (preclaimRequiresGlobalLock ||
+                 !preclaimDocumentTargets.isEmpty() ||
+                 !preclaimCollectionTargets.isEmpty());
+    }
+
+    /**
+     * Acquire preclaimed locks on all collected document and collection
+     * targets. If static analysis could not determine all targets,
+     * acquires a global collection write lock on /db as a safe fallback.
+     *
+     * <p>Locks are acquired in a consistent order (TreeSet natural ordering)
+     * to prevent deadlocks.</p>
+     *
+     * @throws LockException if lock acquisition fails
+     */
+    public void preclaimLocks() throws LockException {
+        if (preclaimDocumentTargets == null) {
+            return;
+        }
+        final org.exist.storage.lock.LockManager lockManager =
+                getBroker().getBrokerPool().getLockManager();
+
+        if (preclaimRequiresGlobalLock) {
+            // Fall back to global collection write lock on /db
+            preclaimedLocks.add(lockManager.acquireCollectionWriteLock(XmldbURI.ROOT_COLLECTION_URI));
+        } else {
+            // Acquire collection write locks first (sorted order)
+            for (final XmldbURI collectionUri : preclaimCollectionTargets) {
+                preclaimedLocks.add(lockManager.acquireCollectionWriteLock(collectionUri));
+            }
+            // Then acquire document write locks (sorted order)
+            for (final XmldbURI docUri : preclaimDocumentTargets) {
+                preclaimedLocks.add(lockManager.acquireDocumentWriteLock(docUri));
+            }
+        }
+    }
+
+    /**
+     * Release all preclaimed locks. Should be called in a finally block
+     * after query evaluation completes.
+     */
+    public void releasePreclaimedLocks() {
+        // Release in reverse order of acquisition
+        for (int i = preclaimedLocks.size() - 1; i >= 0; i--) {
+            try {
+                preclaimedLocks.get(i).close();
+            } catch (final Exception e) {
+                LOG.warn("Error releasing preclaimed lock", e);
+            }
+        }
+        preclaimedLocks.clear();
+    }
+
+    /**
+     * Returns true if preclaimed locks are currently held.
+     */
+    public boolean hasPreclaimedLocks() {
+        return !preclaimedLocks.isEmpty();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -288,6 +288,13 @@ public class XQueryContext implements BinaryValueManager, Context {
     protected MutableDocumentSet modifiedDocuments = null;
 
     /**
+     * W3C XQuery Update Facility 3.0 Pending Update List.
+     * Accumulates update primitives during query evaluation and is applied
+     * at snapshot boundaries.
+     */
+    private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+
+    /**
      * A general-purpose map to set attributes in the current query context.
      */
     protected Map<String, Object> attributes = new HashMap<>();
@@ -1374,6 +1381,25 @@ public class XQueryContext implements BinaryValueManager, Context {
         modifiedDocuments.add(document);
     }
 
+    /**
+     * Get the W3C XQuery Update Facility 3.0 Pending Update List for this context.
+     *
+     * @return the current pending update list
+     */
+    public org.exist.xquery.xquf.PendingUpdateList getPendingUpdateList() {
+        return pendingUpdateList;
+    }
+
+    /**
+     * Set the Pending Update List. Used by copy-modify expressions to create
+     * a nested PUL scope.
+     *
+     * @param pul the new pending update list
+     */
+    public void setPendingUpdateList(final org.exist.xquery.xquf.PendingUpdateList pul) {
+        this.pendingUpdateList = pul;
+    }
+
     @Override
     public void reset() {
         reset(false);
@@ -1406,6 +1432,9 @@ public class XQueryContext implements BinaryValueManager, Context {
             }
             modifiedDocuments = null;
         }
+
+        // Reset the W3C XQuery Update Facility PUL
+        pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
 
         calendar = null;
         implicitTimeZone = null;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -92,6 +92,7 @@ import org.exist.xquery.parser.*;
 import org.exist.xquery.pragmas.*;
 import org.exist.xquery.update.Modification;
 import org.exist.xquery.util.SerializerUtils;
+import org.exist.xquery.xquf.PendingUpdateList;
 import org.exist.xquery.value.*;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
@@ -291,7 +292,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * Accumulates update primitives during query evaluation and is applied
      * at snapshot boundaries.
      */
-    private org.exist.xquery.xquf.PendingUpdateList pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+    private PendingUpdateList pendingUpdateList = new PendingUpdateList();
 
     /**
      * Tracks whether the current module uses the legacy eXist-db update syntax
@@ -1431,7 +1432,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      *
      * @return the current pending update list
      */
-    public org.exist.xquery.xquf.PendingUpdateList getPendingUpdateList() {
+    public PendingUpdateList getPendingUpdateList() {
         return pendingUpdateList;
     }
 
@@ -1441,7 +1442,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      *
      * @param pul the new pending update list
      */
-    public void setPendingUpdateList(final org.exist.xquery.xquf.PendingUpdateList pul) {
+    public void setPendingUpdateList(final PendingUpdateList pul) {
         this.pendingUpdateList = pul;
     }
 
@@ -1452,7 +1453,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param ast the AST node for error reporting
      * @throws XPathException if this module already uses W3C XQUF syntax
      */
-    public void markLegacyUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+    public void markLegacyUpdate(final XQueryAST ast) throws XPathException {
         if (hasXQUFUpdate) {
             throw new XPathException(ast, ErrorCodes.XPST0003,
                     "Cannot mix legacy 'update' syntax with W3C XQuery Update Facility expressions " +
@@ -1469,7 +1470,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param ast the AST node for error reporting
      * @throws XPathException if this module already uses legacy update syntax
      */
-    public void markXQUFUpdate(final org.exist.xquery.parser.XQueryAST ast) throws XPathException {
+    public void markXQUFUpdate(final XQueryAST ast) throws XPathException {
         if (hasLegacyUpdate) {
             throw new XPathException(ast, ErrorCodes.XPST0003,
                     "Cannot mix W3C XQuery Update Facility expressions with legacy 'update' syntax " +
@@ -1513,7 +1514,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         }
 
         // Reset the W3C XQuery Update Facility PUL
-        pendingUpdateList = new org.exist.xquery.xquf.PendingUpdateList();
+        pendingUpdateList = new PendingUpdateList();
 
         // Reset update syntax tracking flags
         hasLegacyUpdate = false;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1422,6 +1422,9 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param root the compiled expression tree root
      */
     public void collectLockTargets(final Expression root) {
+        if (root == null) {
+            return;
+        }
         final org.exist.xquery.lock.LockTargetCollector collector =
                 new org.exist.xquery.lock.LockTargetCollector();
         collector.collect(root);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
@@ -112,7 +112,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     //Grab ancestors' NS
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
-                        stack.add((Element) node);
+                        stack.push((Element) node);
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
 
@@ -139,7 +139,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
                         if (node.getParentNode() == null || node.getParentNode() instanceof DocumentImpl) {
-                            stack.add((Element) node);
+                            stack.push((Element) node);
                         }
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
@@ -159,7 +159,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
                         if (node.getNodeType() == Node.ELEMENT_NODE) {
-                            stack.add((Element) node);
+                            stack.push((Element) node);
                         }
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
@@ -180,7 +180,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
                         if (node.getParentNode() == null || node.getParentNode() instanceof org.exist.dom.memtree.DocumentImpl) {
-                            stack.add((Element) node);
+                            stack.push((Element) node);
                         }
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
@@ -192,17 +192,15 @@ public class FunInScopePrefixes extends BasicFunction {
             }
         }
 
-        //clean up
-        String key = null;
-        String value = null;
-        for (final Entry<String, String> entry : prefixes.entrySet()) {
-            key = entry.getKey();
-            value = entry.getValue();
-
+        //clean up — use iterator to avoid ConcurrentModificationException
+        final var it = prefixes.entrySet().iterator();
+        while (it.hasNext()) {
+            final Entry<String, String> entry = it.next();
+            final String key = entry.getKey();
+            final String value = entry.getValue();
             if ((key == null || key.isEmpty()) && (value == null || value.isEmpty())) {
-                prefixes.remove(key);
+                it.remove();
             }
-
         }
 
         return prefixes;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
@@ -116,7 +116,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     //Grab ancestors' NS
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
-                        stack.add((Element) node);
+                        stack.push((Element) node);
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
 
@@ -143,7 +143,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
                         if (node.getParentNode() == null || node.getParentNode() instanceof DocumentImpl) {
-                            stack.add((Element) node);
+                            stack.push((Element) node);
                         }
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
@@ -179,7 +179,7 @@ public class FunInScopePrefixes extends BasicFunction {
                     final Deque<Element> stack = new ArrayDeque<>();
                     do {
                         if (node.getParentNode() == null || node.getParentNode() instanceof org.exist.dom.memtree.DocumentImpl) {
-                            stack.add((Element) node);
+                            stack.push((Element) node);
                         }
                         node = node.getParentNode();
                     } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);

--- a/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
+++ b/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
@@ -280,20 +280,21 @@ public class LockTargetCollector extends BasicExpressionVisitor {
     /**
      * Unwrap transparent expression wrappers to get to the underlying value.
      */
-    private Expression unwrap(Expression expr) {
+    private Expression unwrap(final Expression expr) {
+        Expression current = expr;
         while (true) {
-            if (expr instanceof PathExpr pathExpr && pathExpr.getLength() == 1) {
-                expr = pathExpr.getExpression(0);
-            } else if (expr instanceof final DynamicCardinalityCheck check) {
-                expr = check.getSubExpression(0);
-            } else if (expr instanceof final DynamicTypeCheck check) {
-                expr = check.getSubExpression(0);
-            } else if (expr instanceof final UntypedValueCheck check) {
-                expr = check.getSubExpression(0);
-            } else if (expr instanceof final Atomize atomize) {
-                expr = atomize.getExpression();
+            if (current instanceof PathExpr pathExpr && pathExpr.getLength() == 1) {
+                current = pathExpr.getExpression(0);
+            } else if (current instanceof final DynamicCardinalityCheck check) {
+                current = check.getSubExpression(0);
+            } else if (current instanceof final DynamicTypeCheck check) {
+                current = check.getSubExpression(0);
+            } else if (current instanceof final UntypedValueCheck check) {
+                current = check.getSubExpression(0);
+            } else if (current instanceof final Atomize atomize) {
+                current = atomize.getExpression();
             } else {
-                return expr;
+                return current;
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
+++ b/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
@@ -1,0 +1,312 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.lock;
+
+import org.exist.dom.QName;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.*;
+import org.exist.xquery.value.AtomicValue;
+import org.exist.xquery.value.Type;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Walks the compiled expression tree to statically determine which
+ * documents and collections a query will access. This enables
+ * "preclaiming" locks before query evaluation begins, following the
+ * BaseX approach of preclaiming two-phase locking.
+ *
+ * <p>Static targets (string literal arguments to fn:doc, fn:collection)
+ * are collected as specific URIs. If any document/collection reference
+ * is dynamic (non-literal argument), {@link #requiresGlobalLock()} returns
+ * true, indicating that a global write lock is needed as a safe fallback.</p>
+ *
+ * <p>Traversal strategy: each visit method handles the specific expression
+ * type and then calls {@link #traverseSubExpressions(Expression)} to
+ * recurse into children. This ensures the entire tree is walked even for
+ * expression types that don't explicitly delegate in their {@code accept()}
+ * method.</p>
+ */
+public class LockTargetCollector extends BasicExpressionVisitor {
+
+    private static final String FN_NS = Function.BUILTIN_FUNCTION_NS;
+
+    private final Set<XmldbURI> documentTargets = new TreeSet<>();
+    private final Set<XmldbURI> collectionTargets = new TreeSet<>();
+    private boolean globalLockRequired = false;
+
+    /**
+     * Collect lock targets from the given root expression.
+     *
+     * @param root the compiled expression tree root
+     */
+    public void collect(final Expression root) {
+        root.accept(this);
+    }
+
+    // --- Visitor methods ---
+
+    @Override
+    public void visit(final Expression expression) {
+        // Fallback for expression types without a specific visitor method.
+        traverseSubExpressions(expression);
+    }
+
+    @Override
+    public void visitBuiltinFunction(final Function function) {
+        final QName name = function.getSignature().getName();
+        if (FN_NS.equals(name.getNamespaceURI())) {
+            switch (name.getLocalPart()) {
+                case "doc":
+                case "doc-available":
+                    collectDocTarget(function);
+                    break;
+                case "collection":
+                case "uri-collection":
+                    collectCollectionTarget(function);
+                    break;
+                default:
+                    break;
+            }
+        }
+        // Traverse function arguments to find nested fn:doc/fn:collection calls
+        traverseSubExpressions(function);
+    }
+
+    @Override
+    public void visitFunctionCall(final FunctionCall call) {
+        // User-defined function call — traverse arguments
+        traverseSubExpressions(call);
+    }
+
+    @Override
+    public void visitPathExpr(final PathExpr expression) {
+        for (int i = 0; i < expression.getLength(); i++) {
+            expression.getExpression(i).accept(this);
+        }
+    }
+
+    @Override
+    public void visitUnionExpr(final Union union) {
+        union.getLeft().accept(this);
+        union.getRight().accept(this);
+    }
+
+    @Override
+    public void visitIntersectionExpr(final Intersect intersect) {
+        intersect.getLeft().accept(this);
+        intersect.getRight().accept(this);
+    }
+
+    @Override
+    public void visitForExpression(final ForExpr forExpr) {
+        forExpr.getInputSequence().accept(this);
+        final Expression returnExpr = forExpr.getReturnExpression();
+        if (returnExpr != null) {
+            returnExpr.accept(this);
+        }
+    }
+
+    @Override
+    public void visitLetExpression(final LetExpr letExpr) {
+        letExpr.getInputSequence().accept(this);
+        final Expression returnExpr = letExpr.getReturnExpression();
+        if (returnExpr != null) {
+            returnExpr.accept(this);
+        }
+    }
+
+    @Override
+    public void visitConditional(final ConditionalExpression conditional) {
+        conditional.getTestExpr().accept(this);
+        conditional.getThenExpr().accept(this);
+        conditional.getElseExpr().accept(this);
+    }
+
+    @Override
+    public void visitTryCatch(final TryCatchExpression tryCatch) {
+        tryCatch.getTryTargetExpr().accept(this);
+    }
+
+    @Override
+    public void visitFilteredExpr(final FilteredExpression filtered) {
+        filtered.getExpression().accept(this);
+        traverseSubExpressions(filtered);
+    }
+
+    @Override
+    public void visitWhereClause(final WhereClause where) {
+        traverseSubExpressions(where);
+        final Expression returnExpr = where.getReturnExpression();
+        if (returnExpr != null) {
+            returnExpr.accept(this);
+        }
+    }
+
+    @Override
+    public void visitOrderByClause(final OrderByClause orderBy) {
+        traverseSubExpressions(orderBy);
+        final Expression returnExpr = orderBy.getReturnExpression();
+        if (returnExpr != null) {
+            returnExpr.accept(this);
+        }
+    }
+
+    @Override
+    public void visitGroupByClause(final GroupByClause groupBy) {
+        traverseSubExpressions(groupBy);
+        final Expression returnExpr = groupBy.getReturnExpression();
+        if (returnExpr != null) {
+            returnExpr.accept(this);
+        }
+    }
+
+    // --- Results ---
+
+    /**
+     * Returns the set of document URIs found as static string literals
+     * in fn:doc() or fn:doc-available() calls.
+     */
+    public Set<XmldbURI> getDocumentTargets() {
+        return Collections.unmodifiableSet(documentTargets);
+    }
+
+    /**
+     * Returns the set of collection URIs found as static string literals
+     * in fn:collection() or fn:uri-collection() calls.
+     */
+    public Set<XmldbURI> getCollectionTargets() {
+        return Collections.unmodifiableSet(collectionTargets);
+    }
+
+    /**
+     * Returns true if any document/collection reference could not be
+     * resolved statically, requiring a global write lock as a safe fallback.
+     */
+    public boolean requiresGlobalLock() {
+        return globalLockRequired;
+    }
+
+    /**
+     * Returns true if any targets were collected or a global lock is required.
+     */
+    public boolean hasTargets() {
+        return !documentTargets.isEmpty() || !collectionTargets.isEmpty() || globalLockRequired;
+    }
+
+    // --- Internal ---
+
+    private void collectDocTarget(final Function function) {
+        if (function.getArgumentCount() == 0) {
+            return;
+        }
+        final String uri = extractStaticStringArg(function.getArgument(0));
+        if (uri != null) {
+            try {
+                documentTargets.add(XmldbURI.xmldbUriFor(uri));
+            } catch (final Exception e) {
+                // Malformed URI — can't preclaim, fall back to global
+                globalLockRequired = true;
+            }
+        } else {
+            // Dynamic argument — can't determine target statically
+            globalLockRequired = true;
+        }
+    }
+
+    private void collectCollectionTarget(final Function function) {
+        if (function.getArgumentCount() == 0) {
+            // Zero-arg fn:collection() — accesses context, need global lock
+            globalLockRequired = true;
+            return;
+        }
+        final String uri = extractStaticStringArg(function.getArgument(0));
+        if (uri != null) {
+            try {
+                collectionTargets.add(XmldbURI.xmldbUriFor(uri));
+            } catch (final Exception e) {
+                globalLockRequired = true;
+            }
+        } else {
+            globalLockRequired = true;
+        }
+    }
+
+    /**
+     * Try to extract a static string value from an expression.
+     * Returns the string if the expression is a string/anyURI literal,
+     * or null if it's dynamic.
+     */
+    private String extractStaticStringArg(final Expression expr) {
+        final Expression unwrapped = unwrap(expr);
+        if (unwrapped instanceof LiteralValue literalValue) {
+            final AtomicValue val = literalValue.getValue();
+            if (Type.subTypeOf(val.getType(), Type.STRING) ||
+                    Type.subTypeOf(val.getType(), Type.ANY_URI)) {
+                try {
+                    return val.getStringValue();
+                } catch (final Exception e) {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Unwrap transparent expression wrappers to get to the underlying value.
+     */
+    private Expression unwrap(Expression expr) {
+        while (true) {
+            if (expr instanceof PathExpr pathExpr && pathExpr.getLength() == 1) {
+                expr = pathExpr.getExpression(0);
+            } else if (expr instanceof final DynamicCardinalityCheck check) {
+                expr = check.getSubExpression(0);
+            } else if (expr instanceof final DynamicTypeCheck check) {
+                expr = check.getSubExpression(0);
+            } else if (expr instanceof final UntypedValueCheck check) {
+                expr = check.getSubExpression(0);
+            } else if (expr instanceof final Atomize atomize) {
+                expr = atomize.getExpression();
+            } else {
+                return expr;
+            }
+        }
+    }
+
+    /**
+     * Generic traversal of an expression's sub-expressions using
+     * the {@link Expression#getSubExpressionCount()} /
+     * {@link Expression#getSubExpression(int)} API.
+     */
+    private void traverseSubExpressions(final Expression expression) {
+        final int count = expression.getSubExpressionCount();
+        for (int i = 0; i < count; i++) {
+            final Expression sub = expression.getSubExpression(i);
+            if (sub != null) {
+                sub.accept(this);
+            }
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
+++ b/exist-core/src/main/java/org/exist/xquery/lock/LockTargetCollector.java
@@ -151,7 +151,10 @@ public class LockTargetCollector extends BasicExpressionVisitor {
 
     @Override
     public void visitFilteredExpr(final FilteredExpression filtered) {
-        filtered.getExpression().accept(this);
+        final Expression inner = filtered.getExpression();
+        if (inner != null) {
+            inner.accept(this);
+        }
         traverseSubExpressions(filtered);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/parser/XQueryFunctionAST.java
+++ b/exist-core/src/main/java/org/exist/xquery/parser/XQueryFunctionAST.java
@@ -29,6 +29,7 @@ import antlr.collections.AST;
 public class XQueryFunctionAST extends XQueryAST {
 
     private String doc = null;
+    private boolean updating = false;
 
     public XQueryFunctionAST() {
         super();
@@ -50,5 +51,13 @@ public class XQueryFunctionAST extends XQueryAST {
     @Override
     public String getDoc() {
         return doc;
+    }
+
+    public boolean isUpdating() {
+        return updating;
+    }
+
+    public void setUpdating(boolean updating) {
+        this.updating = updating;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
@@ -707,7 +707,7 @@ public class PendingUpdateList {
 
         // Apply in-memory updates (for copy-modify)
         if (!inMemoryPrimitives.isEmpty()) {
-            applyInMemory(context, inMemoryPrimitives);
+            applyInMemory(inMemoryPrimitives);
         }
 
         // Apply persistent updates
@@ -719,7 +719,7 @@ public class PendingUpdateList {
     /**
      * Apply updates to in-memory nodes (used in copy-modify expressions).
      */
-    private void applyInMemory(final XQueryContext context, final List<UpdatePrimitive> prims) throws XPathException {
+    private void applyInMemory(final List<UpdatePrimitive> prims) throws XPathException {
         // W3C XQuery Update Facility 3.0, Section 3.3.3 — Application order:
         // Phase 1: upd:insertInto, upd:insertAttributes, upd:replaceValue (non-element), upd:rename
         // Phase 2: upd:insertBefore, upd:insertAfter, upd:insertIntoAsFirst, upd:insertIntoAsLast
@@ -820,8 +820,8 @@ public class PendingUpdateList {
         // the removed position, which we've already processed.
 
         // Separate attribute and non-attribute replaceNodes
-        final List<UpdatePrimitive> attrReplaceNodes = new java.util.ArrayList<>();
-        final List<UpdatePrimitive> nonAttrReplaceNodes = new java.util.ArrayList<>();
+        final List<UpdatePrimitive> attrReplaceNodes = new ArrayList<>();
+        final List<UpdatePrimitive> nonAttrReplaceNodes = new ArrayList<>();
         for (final UpdatePrimitive p : replaceNodes) {
             if (!replaceElementContentTargets.isEmpty()) {
                 final Node replTarget = p.getTargetNode();
@@ -1513,6 +1513,7 @@ public class PendingUpdateList {
         }
     }
 
+    @SuppressWarnings("PMD.UnusedFormalParameter") // TODO: context+transaction will be used once fn:put for persistent storage is implemented; keep signature aligned with sibling applyPersistent* methods
     private void applyPersistentPut(final XQueryContext context, final Txn transaction,
                                      final UpdatePrimitive p) throws XPathException {
         // fn:put implementation - store a document at the given URI

--- a/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
@@ -801,6 +801,21 @@ public class PendingUpdateList {
         }
         // Phase 3: replaceNode — skip if the target's parent is targeted by
         // replaceElementContent (which will replace ALL children anyway)
+        //
+        // For attribute replaceNode: capture QNames BEFORE any removals, because
+        // removeAttribute shifts the attr arrays and invalidates stored node indices.
+        // Pre-capture into a parallel list so applyInMemoryReplaceNode can use fresh QNames.
+        final Map<UpdatePrimitive, QName> attrReplaceQNames = new HashMap<>();
+        for (final UpdatePrimitive p : replaceNodes) {
+            if (p.getTargetNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                final org.exist.dom.memtree.AttrImpl attr =
+                        (org.exist.dom.memtree.AttrImpl) p.getTargetNode();
+                attrReplaceQNames.put(p, new QName(
+                        attr.getLocalName() != null ? attr.getLocalName() : attr.getName(),
+                        attr.getNamespaceURI() != null ? attr.getNamespaceURI() : "",
+                        attr.getPrefix() != null ? attr.getPrefix() : ""));
+            }
+        }
         for (final UpdatePrimitive p : replaceNodes) {
             if (!replaceElementContentTargets.isEmpty()) {
                 final Node replTarget = p.getTargetNode();
@@ -812,7 +827,7 @@ public class PendingUpdateList {
                     continue;
                 }
             }
-            applyInMemoryReplaceNode(p);
+            applyInMemoryReplaceNode(p, attrReplaceQNames.get(p));
         }
         // Phase 4: replaceElementContent (after replaceNode, so node references are still valid)
         // Apply in reverse document order to prevent cross-contamination when
@@ -983,16 +998,24 @@ public class PendingUpdateList {
         }
     }
 
-    private void applyInMemoryReplaceNode(final UpdatePrimitive p) throws XPathException {
+    /**
+     * @param preCapQName for attribute targets, the QName captured before any removals
+     *                    (to avoid stale array indices); null for non-attribute targets
+     */
+    private void applyInMemoryReplaceNode(final UpdatePrimitive p, final QName preCapQName) throws XPathException {
         final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
         final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
-        if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
-            // For attribute nodes: remove old attribute, insert new attribute(s) into parent
-            final int attrNum = target.getNodeNumber();
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE && preCapQName != null) {
+            // For attribute nodes: look up by pre-captured QName since removeAttribute
+            // shifts the attr arrays and invalidates stored node indices.
+            final org.exist.dom.memtree.AttrImpl attrTarget = (org.exist.dom.memtree.AttrImpl) target;
             final org.exist.dom.memtree.NodeImpl parentElement =
-                    (org.exist.dom.memtree.NodeImpl) ((org.exist.dom.memtree.AttrImpl) target).getOwnerElement();
+                    (org.exist.dom.memtree.NodeImpl) attrTarget.getOwnerElement();
             final int parentElementNum = parentElement.getNodeNumber();
-            doc.removeAttribute(attrNum);
+            final int currentAttrNum = doc.findAttribute(parentElementNum, preCapQName);
+            if (currentAttrNum >= 0) {
+                doc.removeAttribute(currentAttrNum);
+            }
             final Sequence content = p.getContent();
             if (content != null && !content.isEmpty()) {
                 doc.insertAttributes(parentElementNum, content);

--- a/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
@@ -792,6 +792,16 @@ public class PendingUpdateList {
             }
             applyInMemoryInsert(p);
         }
+        // Pre-capture original attr indices for Phase 3 replaceNode BEFORE Phase 1
+        // renames, which can change attribute QNames and create ambiguity.
+        // We capture the index here (before any renames or removals).
+        final Map<UpdatePrimitive, Integer> attrReplaceIndices = new HashMap<>();
+        for (final UpdatePrimitive p : replaceNodes) {
+            if (p.getTargetNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                attrReplaceIndices.put(p, ((org.exist.dom.memtree.AttrImpl) p.getTargetNode()).getNodeNumber());
+            }
+        }
+
         // Phase 1: renames and non-element replaceValues
         for (final UpdatePrimitive p : renames) {
             applyInMemoryRename(p);
@@ -802,20 +812,16 @@ public class PendingUpdateList {
         // Phase 3: replaceNode — skip if the target's parent is targeted by
         // replaceElementContent (which will replace ALL children anyway)
         //
-        // For attribute replaceNode: capture QNames BEFORE any removals, because
-        // removeAttribute shifts the attr arrays and invalidates stored node indices.
-        // Pre-capture into a parallel list so applyInMemoryReplaceNode can use fresh QNames.
-        final Map<UpdatePrimitive, QName> attrReplaceQNames = new HashMap<>();
-        for (final UpdatePrimitive p : replaceNodes) {
-            if (p.getTargetNode().getNodeType() == Node.ATTRIBUTE_NODE) {
-                final org.exist.dom.memtree.AttrImpl attr =
-                        (org.exist.dom.memtree.AttrImpl) p.getTargetNode();
-                attrReplaceQNames.put(p, new QName(
-                        attr.getLocalName() != null ? attr.getLocalName() : attr.getName(),
-                        attr.getNamespaceURI() != null ? attr.getNamespaceURI() : "",
-                        attr.getPrefix() != null ? attr.getPrefix() : ""));
-            }
-        }
+        // For attribute replaceNode: use pre-captured original indices and process
+        // in descending index order. This handles two problems:
+        // 1. Phase 1 renames can change attribute QNames, making name-based lookup ambiguous
+        // 2. removeAttribute shifts the attr arrays, invalidating stored indices
+        // By processing highest index first, each removal only shifts indices above
+        // the removed position, which we've already processed.
+
+        // Separate attribute and non-attribute replaceNodes
+        final List<UpdatePrimitive> attrReplaceNodes = new java.util.ArrayList<>();
+        final List<UpdatePrimitive> nonAttrReplaceNodes = new java.util.ArrayList<>();
         for (final UpdatePrimitive p : replaceNodes) {
             if (!replaceElementContentTargets.isEmpty()) {
                 final Node replTarget = p.getTargetNode();
@@ -827,7 +833,21 @@ public class PendingUpdateList {
                     continue;
                 }
             }
-            applyInMemoryReplaceNode(p, attrReplaceQNames.get(p));
+            if (p.getTargetNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                attrReplaceNodes.add(p);
+            } else {
+                nonAttrReplaceNodes.add(p);
+            }
+        }
+        // Sort attribute replaces by descending original index
+        attrReplaceNodes.sort((a, b) -> Integer.compare(
+                attrReplaceIndices.getOrDefault(b, 0),
+                attrReplaceIndices.getOrDefault(a, 0)));
+        for (final UpdatePrimitive p : attrReplaceNodes) {
+            applyInMemoryReplaceNode(p, attrReplaceIndices.get(p));
+        }
+        for (final UpdatePrimitive p : nonAttrReplaceNodes) {
+            applyInMemoryReplaceNode(p, null);
         }
         // Phase 4: replaceElementContent (after replaceNode, so node references are still valid)
         // Apply in reverse document order to prevent cross-contamination when
@@ -999,26 +1019,27 @@ public class PendingUpdateList {
     }
 
     /**
-     * @param preCapQName for attribute targets, the QName captured before any removals
-     *                    (to avoid stale array indices); null for non-attribute targets
+     * @param preCapIndex for attribute targets, the original attr array index captured
+     *                    before Phase 1 renames. Attribute replaces are processed in
+     *                    descending index order so each removeAttribute only shifts
+     *                    indices above the removed position (already processed).
+     *                    null for non-attribute targets.
      */
-    private void applyInMemoryReplaceNode(final UpdatePrimitive p, final QName preCapQName) throws XPathException {
+    private void applyInMemoryReplaceNode(final UpdatePrimitive p, final Integer preCapIndex) throws XPathException {
         final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
         final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
-        if (target.getNodeType() == Node.ATTRIBUTE_NODE && preCapQName != null) {
-            // For attribute nodes: look up by pre-captured QName since removeAttribute
-            // shifts the attr arrays and invalidates stored node indices.
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE && preCapIndex != null) {
+            // For attribute nodes: use pre-captured index directly.
+            // Attribute replaces are sorted by descending index, so removeAttribute
+            // on this index won't affect any remaining (lower) indices.
             final org.exist.dom.memtree.AttrImpl attrTarget = (org.exist.dom.memtree.AttrImpl) target;
             final org.exist.dom.memtree.NodeImpl parentElement =
                     (org.exist.dom.memtree.NodeImpl) attrTarget.getOwnerElement();
             final int parentElementNum = parentElement.getNodeNumber();
-            final int currentAttrNum = doc.findAttribute(parentElementNum, preCapQName);
-            if (currentAttrNum >= 0) {
-                doc.removeAttribute(currentAttrNum);
-            }
+            doc.removeAttribute(preCapIndex);
             final Sequence content = p.getContent();
             if (content != null && !content.isEmpty()) {
-                doc.insertAttributes(parentElementNum, content);
+                doc.insertAttributes(parentElementNum, content, false);
             }
         } else {
             doc.replaceNode(target.getNodeNumber(), p.getContent());

--- a/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/PendingUpdateList.java
@@ -1,0 +1,1605 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
+import org.exist.indexing.IndexController;
+import org.exist.indexing.StreamListener.ReindexMode;
+import org.exist.Namespaces;
+import org.exist.collections.ManagedLocks;
+import org.exist.collections.triggers.DocumentTrigger;
+import org.exist.collections.triggers.DocumentTriggers;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.NodeListImpl;
+import org.exist.dom.QName;
+import org.exist.dom.persistent.*;
+import org.exist.dom.memtree.DocumentBuilderReceiver;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.security.Permission;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.NodePath;
+import org.exist.storage.NotificationService;
+import org.exist.storage.UpdateListener;
+import org.exist.storage.lock.ManagedDocumentLock;
+import org.exist.storage.serializers.Serializer;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import java.util.*;
+
+/**
+ * W3C XQuery Update Facility 3.0 Pending Update List.
+ *
+ * Accumulates update primitives during query evaluation and applies them
+ * atomically at snapshot boundaries (end of outermost expression evaluation).
+ *
+ * @see <a href="https://www.w3.org/TR/xquery-update-30/">XQuery Update Facility 3.0</a>
+ */
+public class PendingUpdateList {
+
+    private static final Logger LOG = LogManager.getLogger(PendingUpdateList.class);
+
+    private final List<UpdatePrimitive> primitives = new ArrayList<>();
+
+    /**
+     * Add a primitive to this PUL.
+     */
+    public void addPrimitive(final UpdatePrimitive primitive) {
+        primitives.add(primitive);
+    }
+
+    /**
+     * Merge another PUL into this one (for combining sub-expression PULs).
+     */
+    public void merge(final PendingUpdateList other) {
+        primitives.addAll(other.primitives);
+    }
+
+    /**
+     * @return true if this PUL contains no primitives
+     */
+    public boolean isEmpty() {
+        return primitives.isEmpty();
+    }
+
+    /**
+     * @return the number of primitives in this PUL
+     */
+    public int size() {
+        return primitives.size();
+    }
+
+    /**
+     * Check that all target nodes in this PUL are descendants of (or equal to)
+     * one of the given copied root nodes. Used for XUDY0014 in transform expressions.
+     *
+     * @param copiedRoots the root nodes created by copy bindings
+     * @param expr        the expression for error reporting
+     * @throws XPathException if any target is not a descendant of a copy root
+     */
+    public void checkTransformTargets(final List<Node> copiedRoots, final Expression expr) throws XPathException {
+        for (final UpdatePrimitive p : primitives) {
+            final Node target = p.getTargetNode();
+            if (!isDescendantOfAny(target, copiedRoots)) {
+                throw new XPathException(expr, ErrorCodes.XUDY0014,
+                        "Target node of update in transform expression was not created by the copy clause.");
+            }
+        }
+    }
+
+    private static boolean isDescendantOfAny(final Node target, final List<Node> roots) {
+        for (final Node root : roots) {
+            if (isDescendantOrSelf(target, root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDescendantOrSelf(final Node node, final Node ancestor) {
+        // Check self first (handles standalone attribute copies where owner element is null)
+        if (nodesAreSame(node, ancestor)) {
+            return true;
+        }
+        Node current = node;
+        // For attribute nodes, start from the owner element
+        if (current.getNodeType() == Node.ATTRIBUTE_NODE) {
+            current = ((Attr) current).getOwnerElement();
+            if (current == null) {
+                return false;
+            }
+        }
+        while (current != null) {
+            if (nodesAreSame(current, ancestor)) {
+                return true;
+            }
+            current = current.getParentNode();
+        }
+        // Fallback for memtree: getParentNode() returns null when the parent is a
+        // document that is not "explicitly created" (see NodeImpl line 232).
+        // Handle two cases:
+        // 1. Ancestor is a document node: check if target belongs to that document
+        // 2. Ancestor is an element: check if both share the same document
+        //    (the parent walk stopped at null because the doc wasn't explicitly created)
+        if (node instanceof org.exist.dom.memtree.NodeImpl memNode
+                && ancestor instanceof org.exist.dom.memtree.NodeImpl memAncestor) {
+            if (ancestor.getNodeType() == Node.DOCUMENT_NODE
+                    && ancestor instanceof org.exist.dom.memtree.DocumentImpl memDoc) {
+                return memNode.getOwnerDocument() == memDoc;
+            }
+            // Both are elements in the same (non-explicitly-created) document —
+            // verify ancestor's nodeNumber is actually an ancestor of node's
+            if (memNode.getOwnerDocument() == memAncestor.getOwnerDocument()) {
+                return isMemtreeAncestor(memNode, memAncestor);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Walk up the memtree parent chain using the internal parentNodeFor array,
+     * bypassing the isExplicitlyCreated check in NodeImpl.getParentNode().
+     */
+    private static boolean isMemtreeAncestor(final org.exist.dom.memtree.NodeImpl node,
+                                              final org.exist.dom.memtree.NodeImpl ancestor) {
+        final org.exist.dom.memtree.DocumentImpl doc = node.getOwnerDocument();
+        final int ancestorNum = ancestor.getNodeNumber();
+        int current = node.getNodeNumber();
+        while (current >= 0) {
+            if (current == ancestorNum) {
+                return true;
+            }
+            current = doc.getParentNodeFor(current);
+        }
+        return false;
+    }
+
+    private static boolean nodesAreSame(final Node a, final Node b) {
+        if (a == b) {
+            return true;
+        }
+        // memtree nodes: compare by document identity + nodeNumber
+        if (a instanceof org.exist.dom.memtree.NodeImpl && b instanceof org.exist.dom.memtree.NodeImpl) {
+            final org.exist.dom.memtree.NodeImpl memA = (org.exist.dom.memtree.NodeImpl) a;
+            final org.exist.dom.memtree.NodeImpl memB = (org.exist.dom.memtree.NodeImpl) b;
+            return memA.getOwnerDocument() == memB.getOwnerDocument()
+                    && memA.getNodeNumber() == memB.getNodeNumber();
+        }
+        return false;
+    }
+
+    /**
+     * Check the PUL for conflicts per the W3C spec before applying.
+     *
+     * Checks:
+     * - XUDY0015: multiple renames on same node
+     * - XUDY0016: multiple replace-node on same node
+     * - XUDY0017: multiple replace-value on same node
+     * - XUDY0021: duplicate attribute names on an element after updates
+     * - XUDY0023: new namespace binding conflicts with existing binding on element
+     * - XUDY0024: new namespace bindings from different primitives conflict with each other
+     * - XUDY0031: multiple fn:put with same URI
+     *
+     * @throws XPathException if conflicting primitives are found
+     */
+    public void checkConflicts() throws XPathException {
+        // Track nodes that have been targeted by rename, replaceNode, replaceValue.
+        // Use nodeKey() string representation instead of Node identity because
+        // persistent StoredNode objects don't override equals()/hashCode(), so
+        // different wrapper objects for the same underlying node need to be
+        // detected as duplicates.
+        final Set<String> renameTargets = new HashSet<>();
+        final Set<String> replaceNodeTargets = new HashSet<>();
+        final Set<String> replaceValueTargets = new HashSet<>();
+        final Set<String> putUris = new HashSet<>();
+
+        for (final UpdatePrimitive p : primitives) {
+            final Expression expr = p.getSourceExpression();
+
+            switch (p.getType()) {
+                case RENAME:
+                    if (!renameTargets.add(nodeKey(p.getTargetNode()))) {
+                        throw new XPathException(expr, ErrorCodes.XUDY0015,
+                                "Multiple rename primitives applied to the same target node.");
+                    }
+                    break;
+
+                case REPLACE_NODE:
+                    if (!replaceNodeTargets.add(nodeKey(p.getTargetNode()))) {
+                        throw new XPathException(expr, ErrorCodes.XUDY0016,
+                                "Multiple replace node primitives applied to the same target node.");
+                    }
+                    break;
+
+                case REPLACE_VALUE:
+                    if (!replaceValueTargets.add(nodeKey(p.getTargetNode()))) {
+                        throw new XPathException(expr, ErrorCodes.XUDY0017,
+                                "Multiple replace value primitives applied to the same target node.");
+                    }
+                    break;
+
+                case PUT:
+                    if (!putUris.add(p.getUri())) {
+                        throw new XPathException(expr, ErrorCodes.XUDY0031,
+                                "Multiple fn:put primitives with the same URI: " + p.getUri());
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        // Check XUDY0021 (duplicate attributes), XUDY0023 (conflict with existing ns),
+        // and XUDY0024 (conflict between new ns bindings)
+        checkAttributeAndNamespaceConflicts();
+    }
+
+    /**
+     * For each element affected by attribute-modifying operations,
+     * compute the resulting attribute set and check for:
+     * - XUDY0021: duplicate attribute QNames
+     * - XUDY0023: new namespace binding conflicts with existing element namespace binding
+     * - XUDY0024: new namespace bindings from different operations conflict with each other
+     */
+    private void checkAttributeAndNamespaceConflicts() throws XPathException {
+        // Group attribute operations by target element.
+        // We use a string key for node identity because persistent DOM proxies
+        // may return different Java objects for the same underlying node.
+        final Map<String, ElementAttrState> elementStates = new LinkedHashMap<>();
+
+        for (final UpdatePrimitive p : primitives) {
+            switch (p.getType()) {
+                case INSERT_INTO:
+                case INSERT_INTO_AS_FIRST:
+                case INSERT_INTO_AS_LAST: {
+                    // Target is the element; content may include attributes
+                    final Node target = p.getTargetNode();
+                    if (target.getNodeType() == Node.ELEMENT_NODE) {
+                        final ElementAttrState state = getOrCreateState(elementStates, target);
+                        addContentAttributes(state, p);
+                    }
+                    break;
+                }
+
+                case INSERT_BEFORE:
+                case INSERT_AFTER: {
+                    // For attribute insertion before/after, the target's parent is the element
+                    final Node target = p.getTargetNode();
+                    final Node parent = target.getNodeType() == Node.ATTRIBUTE_NODE
+                            ? ((Attr) target).getOwnerElement()
+                            : target.getParentNode();
+                    if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE) {
+                        final ElementAttrState state = getOrCreateState(elementStates, parent);
+                        addContentAttributes(state, p);
+                    }
+                    break;
+                }
+
+                case INSERT_ATTRIBUTES: {
+                    // Target is the element
+                    final Node target = p.getTargetNode();
+                    if (target.getNodeType() == Node.ELEMENT_NODE) {
+                        final ElementAttrState state = getOrCreateState(elementStates, target);
+                        addContentAttributes(state, p);
+                    }
+                    break;
+                }
+
+                case REPLACE_NODE: {
+                    final Node target = p.getTargetNode();
+                    if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+                        final Node parent = ((Attr) target).getOwnerElement();
+                        if (parent != null) {
+                            final ElementAttrState state = getOrCreateState(elementStates, parent);
+                            // Mark the old attribute as removed
+                            state.removedAttrs.add(getExpandedName(target));
+                            // Add new attributes from the replacement content
+                            addContentAttributes(state, p);
+                        }
+                    }
+                    break;
+                }
+
+                case DELETE: {
+                    final Node target = p.getTargetNode();
+                    if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+                        final Node parent = ((Attr) target).getOwnerElement();
+                        if (parent != null) {
+                            final ElementAttrState state = getOrCreateState(elementStates, parent);
+                            state.removedAttrs.add(getExpandedName(target));
+                        }
+                    }
+                    break;
+                }
+
+                case RENAME: {
+                    final Node target = p.getTargetNode();
+                    final QName newName = p.getNewName();
+                    if (target.getNodeType() == Node.ATTRIBUTE_NODE && newName != null) {
+                        final Node parent = ((Attr) target).getOwnerElement();
+                        if (parent != null) {
+                            final ElementAttrState state = getOrCreateState(elementStates, parent);
+                            state.removedAttrs.add(getExpandedName(target));
+                            state.addedAttrs.add(new ExpandedName(
+                                    newName.getNamespaceURI() == null ? "" : newName.getNamespaceURI(),
+                                    newName.getLocalPart(),
+                                    newName.getPrefix() == null ? "" : newName.getPrefix()));
+                            addNamespaceBinding(state, newName.getPrefix(), newName.getNamespaceURI(), p);
+                        }
+                    } else if (target.getNodeType() == Node.ELEMENT_NODE && newName != null) {
+                        // Renaming an element also introduces a namespace binding
+                        final ElementAttrState state = getOrCreateState(elementStates, target);
+                        addNamespaceBinding(state, newName.getPrefix(), newName.getNamespaceURI(), p);
+                    }
+                    break;
+                }
+
+                default:
+                    break;
+            }
+        }
+
+        // Now check each affected element
+        for (final Map.Entry<String, ElementAttrState> entry : elementStates.entrySet()) {
+            final Node element = entry.getValue().elementNode;
+            final ElementAttrState state = entry.getValue();
+
+            // Build the final attribute set: existing attrs - removed + added
+            final Set<ExpandedName> finalAttrs = new HashSet<>();
+
+            // Add existing attributes
+            final org.w3c.dom.NamedNodeMap existingAttrs = element.getAttributes();
+            if (existingAttrs != null) {
+                for (int i = 0; i < existingAttrs.getLength(); i++) {
+                    final Node attr = existingAttrs.item(i);
+                    // Skip xmlns declarations
+                    if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                        continue;
+                    }
+                    final ExpandedName name = getExpandedName(attr);
+                    if (!state.removedAttrs.contains(name)) {
+                        finalAttrs.add(name);
+                    }
+                }
+            }
+
+            // Check added attributes for duplicates with existing and with each other
+            for (final ExpandedName addedName : state.addedAttrs) {
+                if (!finalAttrs.add(addedName)) {
+                    // XUDY0021: duplicate attribute name
+                    throw new XPathException(state.firstExpr, ErrorCodes.XUDY0021,
+                            "Duplicate attribute name after update: " +
+                                    (addedName.prefix.isEmpty() ? "" : addedName.prefix + ":") +
+                                    addedName.localName);
+                }
+            }
+
+            // Check namespace bindings
+            // First, collect existing in-scope namespace bindings for this element
+            final Map<String, String> existingNsBindings = collectInScopeNamespaces(element);
+
+            // XUDY0023: check new bindings against existing bindings
+            for (final NsBinding binding : state.newNsBindings) {
+                if (binding.prefix == null || binding.prefix.isEmpty()) {
+                    continue; // default namespace doesn't conflict for attributes
+                }
+                if (binding.uri == null || binding.uri.isEmpty()) {
+                    continue; // empty URI doesn't conflict
+                }
+                final String existingUri = existingNsBindings.get(binding.prefix);
+                if (existingUri != null && !existingUri.equals(binding.uri)) {
+                    throw new XPathException(binding.expr.getSourceExpression(), ErrorCodes.XUDY0023,
+                            "New namespace binding for prefix '" + binding.prefix +
+                                    "' with URI '" + binding.uri +
+                                    "' conflicts with existing binding to URI '" + existingUri + "'.");
+                }
+            }
+
+            // XUDY0024: check new bindings against each other
+            final Map<String, String> newBindingsMap = new HashMap<>();
+            for (final NsBinding binding : state.newNsBindings) {
+                if (binding.prefix == null || binding.prefix.isEmpty()) {
+                    continue;
+                }
+                if (binding.uri == null || binding.uri.isEmpty()) {
+                    continue;
+                }
+                final String prevUri = newBindingsMap.put(binding.prefix, binding.uri);
+                if (prevUri != null && !prevUri.equals(binding.uri)) {
+                    throw new XPathException(binding.expr.getSourceExpression(), ErrorCodes.XUDY0024,
+                            "Conflicting namespace bindings for prefix '" + binding.prefix +
+                                    "': URI '" + prevUri + "' vs '" + binding.uri + "'.");
+                }
+            }
+        }
+    }
+
+    /**
+     * State tracking for attribute/namespace changes to a single element.
+     */
+    private static class ElementAttrState {
+        final Node elementNode;
+        final Set<ExpandedName> removedAttrs = new HashSet<>();
+        final List<ExpandedName> addedAttrs = new ArrayList<>();
+        final List<NsBinding> newNsBindings = new ArrayList<>();
+        Expression firstExpr;
+
+        ElementAttrState(final Node elementNode) {
+            this.elementNode = elementNode;
+        }
+    }
+
+    /**
+     * A namespace prefix-to-URI binding introduced by an update primitive.
+     */
+    private static class NsBinding {
+        final String prefix;
+        final String uri;
+        final UpdatePrimitive expr;
+
+        NsBinding(final String prefix, final String uri, final UpdatePrimitive expr) {
+            this.prefix = prefix;
+            this.uri = uri;
+            this.expr = expr;
+        }
+    }
+
+    /**
+     * Expanded name (namespace URI + local name) for attribute identity.
+     */
+    private static class ExpandedName {
+        final String namespaceURI;
+        final String localName;
+        final String prefix;
+
+        ExpandedName(final String namespaceURI, final String localName, final String prefix) {
+            this.namespaceURI = namespaceURI == null ? "" : namespaceURI;
+            this.localName = localName;
+            this.prefix = prefix == null ? "" : prefix;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ExpandedName)) return false;
+            final ExpandedName that = (ExpandedName) o;
+            return namespaceURI.equals(that.namespaceURI) && localName.equals(that.localName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(namespaceURI, localName);
+        }
+    }
+
+    private ElementAttrState getOrCreateState(final Map<String, ElementAttrState> states, final Node element) {
+        return states.computeIfAbsent(nodeKey(element), k -> new ElementAttrState(element));
+    }
+
+    /**
+     * Create a stable identity key for a DOM node that works for both
+     * in-memory (memtree) and persistent nodes.
+     * Both may create different Java objects for the same underlying node,
+     * so we can't rely on object identity.
+     */
+    private static String nodeKey(final Node node) {
+        if (node instanceof org.exist.dom.memtree.NodeImpl) {
+            final org.exist.dom.memtree.NodeImpl memNode = (org.exist.dom.memtree.NodeImpl) node;
+            return "mem:" + System.identityHashCode(memNode.getOwnerDocument()) + ":" + memNode.getNodeNumber();
+        } else if (node instanceof IStoredNode) {
+            final IStoredNode<?> storedNode = (IStoredNode<?>) node;
+            return "db:" + storedNode.getOwnerDocument().getDocId() + ":" + storedNode.getNodeId();
+        } else if (node instanceof NodeProxy) {
+            final NodeProxy proxy = (NodeProxy) node;
+            return "db:" + proxy.getOwnerDocument().getDocId() + ":" + proxy.getNodeId();
+        } else {
+            // Fallback: use identity hash
+            return "id:" + System.identityHashCode(node);
+        }
+    }
+
+    private static ExpandedName getExpandedName(final Node node) {
+        return new ExpandedName(
+                node.getNamespaceURI(),
+                node.getLocalName() != null ? node.getLocalName() : node.getNodeName(),
+                node.getPrefix());
+    }
+
+    /**
+     * Extract attribute nodes from the content sequence of an update primitive
+     * and add them to the element state.
+     */
+    private void addContentAttributes(final ElementAttrState state, final UpdatePrimitive p) throws XPathException {
+        if (state.firstExpr == null) {
+            state.firstExpr = p.getSourceExpression();
+        }
+        final Sequence content = p.getContent();
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        for (final SequenceIterator i = content.iterate(); i.hasNext(); ) {
+            final Item item = i.nextItem();
+            if (Type.subTypeOf(item.getType(), Type.ATTRIBUTE)) {
+                final Node attrNode = ((NodeValue) item).getNode();
+                final ExpandedName name = getExpandedName(attrNode);
+                state.addedAttrs.add(name);
+                addNamespaceBinding(state,
+                        attrNode.getPrefix(),
+                        attrNode.getNamespaceURI(),
+                        p);
+            } else if (Type.subTypeOf(item.getType(), Type.ELEMENT)) {
+                // Collect namespace bindings from the inserted element subtree.
+                // These must be checked against the target's in-scope namespaces
+                // for XUDY0023 (namespace propagation conflicts).
+                final Node elemNode = ((NodeValue) item).getNode();
+                collectElementNamespaceBindings(elemNode, state, p);
+            }
+        }
+    }
+
+    /**
+     * Collect namespace bindings from the top level of an inserted element for XUDY0023 checking.
+     * Only the root element's bindings are collected — descendants with their own re-declarations
+     * are handled by upd:propagateNamespace at each level individually.
+     */
+    private static void collectElementNamespaceBindings(final Node node, final ElementAttrState state,
+                                                         final UpdatePrimitive p) {
+        if (node.getNodeType() != Node.ELEMENT_NODE) {
+            return;
+        }
+        // Element's own namespace
+        addNamespaceBinding(state, node.getPrefix(), node.getNamespaceURI(), p);
+
+        // Namespace declarations on this element
+        if (node instanceof org.exist.dom.memtree.ElementImpl memElem) {
+            final Map<String, String> nsMap = memElem.getNamespaceMap();
+            for (final Map.Entry<String, String> e : nsMap.entrySet()) {
+                addNamespaceBinding(state, e.getKey(), e.getValue(), p);
+            }
+        }
+
+        // Namespace bindings from attributes
+        final org.w3c.dom.NamedNodeMap attrs = node.getAttributes();
+        if (attrs != null) {
+            for (int i = 0; i < attrs.getLength(); i++) {
+                final Node attr = attrs.item(i);
+                if (!XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                    addNamespaceBinding(state, attr.getPrefix(), attr.getNamespaceURI(), p);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add a namespace binding to the element state if the prefix is non-empty and URI is non-empty.
+     */
+    private static void addNamespaceBinding(final ElementAttrState state,
+                                            final String prefix, final String uri,
+                                            final UpdatePrimitive p) {
+        if (prefix != null && !prefix.isEmpty() && uri != null && !uri.isEmpty()) {
+            state.newNsBindings.add(new NsBinding(prefix, uri, p));
+        }
+    }
+
+    /**
+     * Collect the in-scope namespace bindings for an element node.
+     */
+    private static Map<String, String> collectInScopeNamespaces(final Node element) {
+        final Map<String, String> nsBindings = new HashMap<>();
+
+        // Walk up the ancestor chain to collect inherited namespace bindings
+        Node current = element;
+        while (current != null && current.getNodeType() == Node.ELEMENT_NODE) {
+            // Check element's own namespace
+            final String nsUri = current.getNamespaceURI();
+            final String prefix = current.getPrefix();
+            if (nsUri != null && !nsUri.isEmpty()) {
+                final String p = prefix == null ? "" : prefix;
+                nsBindings.putIfAbsent(p, nsUri);
+            }
+
+            // Check namespace declarations on this element
+            if (current instanceof org.exist.dom.memtree.ElementImpl) {
+                final Map<String, String> map = new LinkedHashMap<>();
+                ((org.exist.dom.memtree.ElementImpl) current).getNamespaceMap(map);
+                for (final Map.Entry<String, String> e : map.entrySet()) {
+                    nsBindings.putIfAbsent(e.getKey(), e.getValue());
+                }
+            } else if (current instanceof ElementImpl) {
+                final ElementImpl elemImpl =
+                        (ElementImpl) current;
+                if (elemImpl.declaresNamespacePrefixes()) {
+                    for (final Iterator<String> iter = elemImpl.getPrefixes(); iter.hasNext(); ) {
+                        final String p = iter.next();
+                        nsBindings.putIfAbsent(p, elemImpl.getNamespaceForPrefix(p));
+                    }
+                }
+            } else {
+                // Generic DOM: check attributes for xmlns declarations
+                final org.w3c.dom.NamedNodeMap attrs = current.getAttributes();
+                if (attrs != null) {
+                    for (int i = 0; i < attrs.getLength(); i++) {
+                        final Node attr = attrs.item(i);
+                        if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                            final String attrLocal = attr.getLocalName();
+                            final String p = XMLConstants.XMLNS_ATTRIBUTE.equals(attrLocal) ? "" : attrLocal;
+                            nsBindings.putIfAbsent(p, attr.getNodeValue());
+                        }
+                    }
+                }
+            }
+
+            current = current.getParentNode();
+        }
+
+        return nsBindings;
+    }
+
+    /**
+     * Apply all accumulated update primitives.
+     *
+     * The W3C spec defines a specific application order:
+     * 1. Insert before/after/into (merging compatible inserts)
+     * 2. Rename
+     * 3. Replace value
+     * 4. Replace node
+     * 5. Delete
+     * 6. Put
+     *
+     * This method handles both persistent and in-memory nodes.
+     *
+     * @param context the XQuery context
+     * @throws XPathException on update errors
+     */
+    public void apply(final XQueryContext context) throws XPathException {
+        if (primitives.isEmpty()) {
+            return;
+        }
+
+        checkConflicts();
+
+        // Separate into persistent and in-memory primitives
+        final List<UpdatePrimitive> persistentPrimitives = new ArrayList<>();
+        final List<UpdatePrimitive> inMemoryPrimitives = new ArrayList<>();
+
+        for (final UpdatePrimitive p : primitives) {
+            if (isPersistentNode(p.getTargetNode())) {
+                persistentPrimitives.add(p);
+            } else {
+                inMemoryPrimitives.add(p);
+            }
+        }
+
+        // Apply in-memory updates (for copy-modify)
+        if (!inMemoryPrimitives.isEmpty()) {
+            applyInMemory(context, inMemoryPrimitives);
+        }
+
+        // Apply persistent updates
+        if (!persistentPrimitives.isEmpty()) {
+            applyPersistent(context, persistentPrimitives);
+        }
+    }
+
+    /**
+     * Apply updates to in-memory nodes (used in copy-modify expressions).
+     */
+    private void applyInMemory(final XQueryContext context, final List<UpdatePrimitive> prims) throws XPathException {
+        // W3C XQuery Update Facility 3.0, Section 3.3.3 — Application order:
+        // Phase 1: upd:insertInto, upd:insertAttributes, upd:replaceValue (non-element), upd:rename
+        // Phase 2: upd:insertBefore, upd:insertAfter, upd:insertIntoAsFirst, upd:insertIntoAsLast
+        // Phase 3: upd:replaceNode
+        // Phase 4: upd:replaceElementContent (replaceValue on elements)
+        // Phase 5: upd:delete
+        final List<UpdatePrimitive> inserts = new ArrayList<>();
+        final List<UpdatePrimitive> renames = new ArrayList<>();
+        final List<UpdatePrimitive> replaceValues = new ArrayList<>();
+        final List<UpdatePrimitive> replaceElementContents = new ArrayList<>();
+        final List<UpdatePrimitive> replaceNodes = new ArrayList<>();
+        final List<UpdatePrimitive> deletes = new ArrayList<>();
+
+        for (final UpdatePrimitive p : prims) {
+            switch (p.getType()) {
+                case INSERT_INTO, INSERT_INTO_AS_FIRST, INSERT_INTO_AS_LAST,
+                     INSERT_BEFORE, INSERT_AFTER, INSERT_ATTRIBUTES:
+                    inserts.add(p);
+                    break;
+                case RENAME:
+                    renames.add(p);
+                    break;
+                case REPLACE_VALUE:
+                    // W3C spec distinguishes replaceValue (attr/text/comment/PI)
+                    // from replaceElementContent (element) — different application phase
+                    if (p.getTargetNode().getNodeType() == Node.ELEMENT_NODE) {
+                        replaceElementContents.add(p);
+                    } else {
+                        replaceValues.add(p);
+                    }
+                    break;
+                case REPLACE_NODE:
+                    replaceNodes.add(p);
+                    break;
+                case DELETE:
+                    deletes.add(p);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Collect elements targeted by replaceElementContent — per W3C spec,
+        // replaceElementContent replaces ALL children, so inserts of non-attribute
+        // children into these elements are redundant.
+        final Set<String> replaceElementContentTargets = new HashSet<>();
+        for (final UpdatePrimitive p : replaceElementContents) {
+            replaceElementContentTargets.add(nodeKey(p.getTargetNode()));
+        }
+
+        // Sort inserts by type priority per W3C spec Section 3.3.3:
+        // INSERT_INTO_AS_FIRST first, then BEFORE/AFTER/ATTRIBUTES/INTO, then INSERT_INTO_AS_LAST last.
+        inserts.sort((a, b) -> {
+            final int pa = insertPriority(a.getType());
+            final int pb = insertPriority(b.getType());
+            return Integer.compare(pa, pb);
+        });
+        for (final UpdatePrimitive p : inserts) {
+            // Skip non-attribute inserts into elements whose content will be replaced
+            if (!replaceElementContentTargets.isEmpty()) {
+                final Node insertTarget = p.getTargetNode();
+                final boolean isInsertIntoElement =
+                        (p.getType() == UpdatePrimitive.Type.INSERT_INTO ||
+                         p.getType() == UpdatePrimitive.Type.INSERT_INTO_AS_FIRST ||
+                         p.getType() == UpdatePrimitive.Type.INSERT_INTO_AS_LAST) &&
+                        insertTarget.getNodeType() == Node.ELEMENT_NODE;
+                if (isInsertIntoElement && replaceElementContentTargets.contains(nodeKey(insertTarget))) {
+                    continue;
+                }
+            }
+            applyInMemoryInsert(p);
+        }
+        // Phase 1: renames and non-element replaceValues
+        for (final UpdatePrimitive p : renames) {
+            applyInMemoryRename(p);
+        }
+        for (final UpdatePrimitive p : replaceValues) {
+            applyInMemoryReplaceValue(p);
+        }
+        // Phase 3: replaceNode — skip if the target's parent is targeted by
+        // replaceElementContent (which will replace ALL children anyway)
+        for (final UpdatePrimitive p : replaceNodes) {
+            if (!replaceElementContentTargets.isEmpty()) {
+                final Node replTarget = p.getTargetNode();
+                final Node parent = replTarget.getNodeType() == Node.ATTRIBUTE_NODE
+                        ? ((Attr) replTarget).getOwnerElement()
+                        : replTarget.getParentNode();
+                if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE
+                        && replaceElementContentTargets.contains(nodeKey(parent))) {
+                    continue;
+                }
+            }
+            applyInMemoryReplaceNode(p);
+        }
+        // Phase 4: replaceElementContent (after replaceNode, so node references are still valid)
+        // Apply in reverse document order to prevent cross-contamination when
+        // insertChildren appends text nodes at the end of the flat array for empty elements.
+        // Without reverse order, an appended text node for an earlier element may fall
+        // in the positional subtree range of a later sibling element.
+        replaceElementContents.sort((a, b) -> {
+            final int aNum = ((org.exist.dom.memtree.NodeImpl) a.getTargetNode()).getNodeNumber();
+            final int bNum = ((org.exist.dom.memtree.NodeImpl) b.getTargetNode()).getNodeNumber();
+            return Integer.compare(bNum, aNum);  // reverse order
+        });
+        for (final UpdatePrimitive p : replaceElementContents) {
+            applyInMemoryReplaceValue(p);
+        }
+        // Phase 5: deletes in reverse document order
+        for (int i = deletes.size() - 1; i >= 0; i--) {
+            applyInMemoryDelete(deletes.get(i));
+        }
+
+        // Per W3C XQuery Update Facility spec: after applying all updates,
+        // merge adjacent text nodes and remove empty text nodes.
+        // Collect all affected documents, tracking which had structural changes.
+        final Set<org.exist.dom.memtree.DocumentImpl> affectedDocs = new HashSet<>();
+        final Set<org.exist.dom.memtree.DocumentImpl> structurallyChanged = new HashSet<>();
+        for (final UpdatePrimitive p : prims) {
+            final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+            final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
+            affectedDocs.add(doc);
+            // Inserts, deletes, replaceNode, and replaceElementContent on elements
+            // change tree structure. replaceValue on element nodes may call insertChildren
+            // to add text nodes, which appends to the flat array and requires compact().
+            if (p.getType() != UpdatePrimitive.Type.RENAME
+                    && !(p.getType() == UpdatePrimitive.Type.REPLACE_VALUE
+                         && p.getTargetNode().getNodeType() != Node.ELEMENT_NODE)) {
+                structurallyChanged.add(doc);
+            }
+        }
+        for (final org.exist.dom.memtree.DocumentImpl doc : affectedDocs) {
+            doc.mergeAdjacentTextNodes();
+            // Only compact documents with structural changes — compact rebuilds
+            // the tree from scratch and would lose standalone attributes/nodes
+            // that aren't children of the document node.
+            if (structurallyChanged.contains(doc)) {
+                doc.compact();
+            }
+        }
+    }
+
+    private void applyInMemoryInsert(final UpdatePrimitive p) throws XPathException {
+        final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+        final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
+        final Sequence content = p.getContent();
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        switch (p.getType()) {
+            case INSERT_INTO, INSERT_INTO_AS_LAST:
+                doc.insertChildren(target.getNodeNumber(), content, false);
+                break;
+            case INSERT_INTO_AS_FIRST:
+                doc.insertChildren(target.getNodeNumber(), content, true);
+                break;
+            case INSERT_BEFORE:
+                doc.insertSiblings(target.getNodeNumber(), content, true);
+                break;
+            case INSERT_AFTER:
+                doc.insertSiblings(target.getNodeNumber(), content, false);
+                break;
+            case INSERT_ATTRIBUTES:
+                doc.insertAttributes(target.getNodeNumber(), content, false);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Validate content constraints for node values per the XML specification.
+     * Called during PUL application for replace value of node.
+     *
+     * @param nodeType the type of the target node
+     * @param value the new value to validate
+     * @param expr the source expression for error reporting
+     * @throws XPathException if the value violates XML constraints
+     */
+    private static void validateNodeContent(final short nodeType, final String value,
+                                            final Expression expr) throws XPathException {
+        switch (nodeType) {
+            case Node.COMMENT_NODE:
+                // XML spec: comment content must not contain "--" or end with "-"
+                if (value.contains("--") || value.endsWith("-")) {
+                    throw new XPathException(expr, ErrorCodes.XQDY0072,
+                            "Comment content must not contain '--' or end with '-'.");
+                }
+                break;
+            case Node.PROCESSING_INSTRUCTION_NODE:
+                // XML spec: PI content must not contain "?>"
+                if (value.contains("?>")) {
+                    throw new XPathException(expr, ErrorCodes.XQDY0026,
+                            "Processing instruction content must not contain '?>'.");
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Atomize a sequence and join the resulting string values with a single space.
+     * Per W3C XQuery Update Facility spec Section 2.4.4:
+     * "The string value is computed by atomizing the expression and joining
+     * the resulting values with a single space separator."
+     */
+    public static String atomizeAndJoin(final Sequence content) throws XPathException {
+        if (content == null || content.isEmpty()) {
+            return "";
+        }
+        if (content.getItemCount() == 1) {
+            return content.itemAt(0).atomize().getStringValue();
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (final SequenceIterator i = content.iterate(); i.hasNext(); ) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(i.nextItem().atomize().getStringValue());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Get the memtree DocumentImpl for a node. Handles the case where the node
+     * IS the document node (getOwnerDocument() returns null for document nodes).
+     */
+    private static org.exist.dom.memtree.DocumentImpl getDocument(final org.exist.dom.memtree.NodeImpl node) {
+        if (node instanceof org.exist.dom.memtree.DocumentImpl) {
+            return (org.exist.dom.memtree.DocumentImpl) node;
+        }
+        return node.getOwnerDocument();
+    }
+
+    private void applyInMemoryRename(final UpdatePrimitive p) throws XPathException {
+        final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+        final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+            // For attribute nodes, getNodeNumber() returns an index into the attr arrays
+            doc.renameAttribute(target.getNodeNumber(), p.getNewName());
+        } else {
+            doc.renameNode(target.getNodeNumber(), p.getNewName());
+        }
+    }
+
+    private void applyInMemoryReplaceValue(final UpdatePrimitive p) throws XPathException {
+        final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+        final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
+        // Per W3C spec: atomize content, join with single space separator
+        final String value = atomizeAndJoin(p.getContent());
+
+        // Validate content constraints per XML spec
+        validateNodeContent(target.getNodeType(), value, p.getSourceExpression());
+
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+            // For attribute nodes, getNodeNumber() returns an index into the attr arrays
+            doc.replaceAttributeValue(target.getNodeNumber(), value);
+        } else {
+            doc.replaceValue(target.getNodeNumber(), value);
+        }
+    }
+
+    private void applyInMemoryReplaceNode(final UpdatePrimitive p) throws XPathException {
+        final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+        final org.exist.dom.memtree.DocumentImpl doc = getDocument(target);
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+            // For attribute nodes: remove old attribute, insert new attribute(s) into parent
+            final int attrNum = target.getNodeNumber();
+            final org.exist.dom.memtree.NodeImpl parentElement =
+                    (org.exist.dom.memtree.NodeImpl) ((org.exist.dom.memtree.AttrImpl) target).getOwnerElement();
+            final int parentElementNum = parentElement.getNodeNumber();
+            doc.removeAttribute(attrNum);
+            final Sequence content = p.getContent();
+            if (content != null && !content.isEmpty()) {
+                doc.insertAttributes(parentElementNum, content);
+            }
+        } else {
+            doc.replaceNode(target.getNodeNumber(), p.getContent());
+        }
+    }
+
+    private void applyInMemoryDelete(final UpdatePrimitive p) throws XPathException {
+        final org.exist.dom.memtree.NodeImpl target = (org.exist.dom.memtree.NodeImpl) p.getTargetNode();
+        if (target instanceof org.exist.dom.memtree.DocumentImpl) {
+            // Per W3C spec, deleting a parentless node (document node) is a no-op
+            return;
+        }
+        final org.exist.dom.memtree.DocumentImpl doc = target.getOwnerDocument();
+        if (target.getNodeType() == Node.ATTRIBUTE_NODE) {
+            doc.removeAttribute(target.getNodeNumber());
+        } else {
+            doc.removeNode(target.getNodeNumber());
+        }
+    }
+
+    /**
+     * Apply updates to persistent (stored) database nodes.
+     * Follows locking and transaction patterns from existing Modification class.
+     */
+    private void applyPersistent(final XQueryContext context, final List<UpdatePrimitive> prims) throws XPathException {
+        final DBBroker broker = context.getBroker();
+        final MutableDocumentSet modifiedDocuments = new DefaultDocumentSet();
+        final Int2ObjectMap<DocumentTrigger> triggers = new Int2ObjectOpenHashMap<>();
+
+        // Collect all affected documents
+        final Set<DocumentImpl> affectedDocs = new LinkedHashSet<>();
+        for (final UpdatePrimitive p : prims) {
+            final Node node = p.getTargetNode();
+            if (node instanceof StoredNode) {
+                affectedDocs.add(((StoredNode) node).getOwnerDocument());
+            }
+        }
+
+        ManagedLocks<ManagedDocumentLock> lockedDocumentsLocks = null;
+
+        try {
+            // Acquire global update lock and then document-level write locks
+            final java.util.concurrent.locks.Lock globalLock = broker.getBrokerPool().getGlobalUpdateLock();
+            globalLock.lock();
+            try {
+                final DefaultDocumentSet docSet = new DefaultDocumentSet();
+                for (final DocumentImpl doc : affectedDocs) {
+                    docSet.add(doc);
+                }
+                lockedDocumentsLocks = docSet.lock(broker, true);
+
+                // Prepare triggers
+                for (final DocumentImpl doc : affectedDocs) {
+                    prepareTrigger(broker, triggers, doc);
+                }
+            } finally {
+                globalLock.unlock();
+            }
+
+            // Apply within a transaction
+            try (final Txn transaction = broker.continueOrBeginTransaction()) {
+
+                // W3C XQuery Update Facility 3.0, Section 3.3.3 — Application order:
+                // Phase 1: inserts, replaceValue (non-element), renames
+                // Phase 3: replaceNode
+                // Phase 4: replaceElementContent (replaceValue on elements)
+                // Phase 5: deletes
+                // Phase 6: puts
+                final List<UpdatePrimitive> inserts = new ArrayList<>();
+                final List<UpdatePrimitive> renames = new ArrayList<>();
+                final List<UpdatePrimitive> replaceValues = new ArrayList<>();
+                final List<UpdatePrimitive> replaceElementContents = new ArrayList<>();
+                final List<UpdatePrimitive> replaceNodes = new ArrayList<>();
+                final List<UpdatePrimitive> deletes = new ArrayList<>();
+                final List<UpdatePrimitive> puts = new ArrayList<>();
+
+                for (final UpdatePrimitive p : prims) {
+                    switch (p.getType()) {
+                        case INSERT_INTO, INSERT_INTO_AS_FIRST, INSERT_INTO_AS_LAST,
+                             INSERT_BEFORE, INSERT_AFTER, INSERT_ATTRIBUTES:
+                            inserts.add(p);
+                            break;
+                        case RENAME:
+                            renames.add(p);
+                            break;
+                        case REPLACE_VALUE:
+                            if (p.getTargetNode().getNodeType() == Node.ELEMENT_NODE) {
+                                replaceElementContents.add(p);
+                            } else {
+                                replaceValues.add(p);
+                            }
+                            break;
+                        case REPLACE_NODE:
+                            replaceNodes.add(p);
+                            break;
+                        case DELETE:
+                            deletes.add(p);
+                            break;
+                        case PUT:
+                            puts.add(p);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                // Collect elements targeted by replaceElementContent — per W3C spec,
+                // replaceElementContent replaces ALL children, so inserts into these
+                // elements and replaceNode of their children are redundant.
+                final Set<String> replaceElementContentTargets = new HashSet<>();
+                for (final UpdatePrimitive p : replaceElementContents) {
+                    replaceElementContentTargets.add(nodeKey(p.getTargetNode()));
+                }
+
+                for (final UpdatePrimitive p : inserts) {
+                    // Skip non-attribute inserts into elements whose content will be replaced
+                    if (!replaceElementContentTargets.isEmpty()) {
+                        final Node insertTarget = p.getTargetNode();
+                        final boolean isInsertIntoElement =
+                                (p.getType() == UpdatePrimitive.Type.INSERT_INTO ||
+                                 p.getType() == UpdatePrimitive.Type.INSERT_INTO_AS_FIRST ||
+                                 p.getType() == UpdatePrimitive.Type.INSERT_INTO_AS_LAST) &&
+                                insertTarget.getNodeType() == Node.ELEMENT_NODE;
+                        if (isInsertIntoElement && replaceElementContentTargets.contains(nodeKey(insertTarget))) {
+                            continue;
+                        }
+                    }
+                    applyPersistentInsert(context, transaction, p, modifiedDocuments);
+                }
+                for (final UpdatePrimitive p : renames) {
+                    applyPersistentRename(context, transaction, p, modifiedDocuments);
+                }
+                for (final UpdatePrimitive p : replaceValues) {
+                    applyPersistentReplaceValue(context, transaction, p, modifiedDocuments);
+                }
+                // Phase 3: replaceNode — skip if the target's parent is targeted by
+                // replaceElementContent (which will replace ALL children anyway)
+                for (final UpdatePrimitive p : replaceNodes) {
+                    if (!replaceElementContentTargets.isEmpty()) {
+                        final Node replTarget = p.getTargetNode();
+                        final Node parent = replTarget.getNodeType() == Node.ATTRIBUTE_NODE
+                                ? ((Attr) replTarget).getOwnerElement()
+                                : replTarget.getParentNode();
+                        if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE
+                                && replaceElementContentTargets.contains(nodeKey(parent))) {
+                            continue;
+                        }
+                    }
+                    applyPersistentReplaceNode(context, transaction, p, modifiedDocuments);
+                }
+                // Phase 4: replaceElementContent (after replaceNode)
+                for (final UpdatePrimitive p : replaceElementContents) {
+                    applyPersistentReplaceValue(context, transaction, p, modifiedDocuments);
+                }
+                // Delete in reverse document order
+                for (int i = deletes.size() - 1; i >= 0; i--) {
+                    applyPersistentDelete(context, transaction, deletes.get(i), modifiedDocuments);
+                }
+                for (final UpdatePrimitive p : puts) {
+                    applyPersistentPut(context, transaction, p);
+                }
+
+                // Store all modified documents and send notifications
+                final NotificationService notifier2 = broker.getBrokerPool().getNotificationService();
+                final Iterator<DocumentImpl> storeIter = modifiedDocuments.getDocumentIterator();
+                while (storeIter.hasNext()) {
+                    final DocumentImpl doc = storeIter.next();
+                    broker.storeXMLResource(transaction, doc);
+                    notifier2.notifyUpdate(doc, UpdateListener.UPDATE);
+                }
+
+                // Finish triggers
+                final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
+                while (iterator.hasNext()) {
+                    final DocumentImpl doc = iterator.next();
+                    context.addModifiedDoc(doc);
+                    finishTrigger(broker, triggers, doc);
+                }
+                triggers.clear();
+
+                transaction.commit();
+            } catch (final TriggerException | org.exist.storage.txn.TransactionException e) {
+                throw new XPathException((Expression) null, e.getMessage(), e);
+            }
+
+        } catch (final LockException | TriggerException e) {
+            throw new XPathException((Expression) null, e.getMessage(), e);
+        } finally {
+            if (lockedDocumentsLocks != null) {
+                lockedDocumentsLocks.close();
+            }
+        }
+    }
+
+    private void applyPersistentInsert(final XQueryContext context, final Txn transaction,
+                                        final UpdatePrimitive p, final MutableDocumentSet modifiedDocuments) throws XPathException {
+        final StoredNode<?> node = (StoredNode<?>) p.getTargetNode();
+        final DocumentImpl doc = node.getOwnerDocument();
+        checkWritePermission(context, doc, p.getSourceExpression());
+
+        final Sequence contentSeq = deepCopy(context, p.getContent());
+        final NodeList contentList = sequenceToNodeList(contentSeq);
+
+        try {
+            switch (p.getType()) {
+                case INSERT_INTO, INSERT_INTO_AS_LAST:
+                    node.appendChildren(transaction, contentList, -1);
+                    break;
+                case INSERT_INTO_AS_FIRST:
+                    node.appendChildren(transaction, contentList, 1);
+                    break;
+                case INSERT_BEFORE: {
+                    final NodeImpl<?> parent = (NodeImpl<?>) getParent(node);
+                    if (parent != null) {
+                        parent.insertBefore(transaction, contentList, node);
+                    }
+                    break;
+                }
+                case INSERT_AFTER: {
+                    final NodeImpl<?> parent = (NodeImpl<?>) getParent(node);
+                    if (parent != null) {
+                        parent.insertAfter(transaction, contentList, node);
+                    }
+                    break;
+                }
+                case INSERT_ATTRIBUTES: {
+                    final ElementImpl elem = (ElementImpl) node;
+                    for (int i = 0; i < contentList.getLength(); i++) {
+                        final Node attrNode = contentList.item(i);
+                        if (attrNode.getNodeType() == Node.ATTRIBUTE_NODE) {
+                            final Attr attr = (Attr) attrNode;
+                            final String nsUri = attr.getNamespaceURI();
+                            if (nsUri != null && !nsUri.isEmpty()) {
+                                elem.setAttributeNS(nsUri,
+                                        (attr.getPrefix() != null ? attr.getPrefix() + ":" : "")
+                                                + attr.getLocalName(),
+                                        attr.getValue());
+                            } else {
+                                elem.setAttribute(attr.getName(), attr.getValue());
+                            }
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            doc.setLastModified(System.currentTimeMillis());
+            modifiedDocuments.add(doc);
+        } catch (final Exception e) {
+            throw new XPathException(p.getSourceExpression(), e.getMessage(), e);
+        }
+    }
+
+    private void applyPersistentRename(final XQueryContext context, final Txn transaction,
+                                        final UpdatePrimitive p, final MutableDocumentSet modifiedDocuments) throws XPathException {
+        final StoredNode<?> node = (StoredNode<?>) p.getTargetNode();
+        final DocumentImpl doc = node.getOwnerDocument();
+        checkWritePermission(context, doc, p.getSourceExpression());
+
+        try {
+            final NamedNode newNode;
+            switch (node.getNodeType()) {
+                case Node.ELEMENT_NODE:
+                    newNode = new ElementImpl(node.getExpression(), (ElementImpl) node);
+                    break;
+                case Node.ATTRIBUTE_NODE:
+                    newNode = new AttrImpl(node.getExpression(),
+                            (AttrImpl) node);
+                    break;
+                default:
+                    throw new XPathException(p.getSourceExpression(), ErrorCodes.XUTY0012,
+                            "Target of rename must be an element, attribute, or processing instruction node.");
+            }
+            newNode.setNodeName(p.getNewName(), context.getBroker().getBrokerPool().getSymbols());
+
+            final Node parent = getParent(node);
+            if (parent instanceof ElementImpl parentElem) {
+                parentElem.updateChild(transaction, node, newNode);
+            }
+
+            doc.setLastModified(System.currentTimeMillis());
+            modifiedDocuments.add(doc);
+        } catch (final XPathException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new XPathException(p.getSourceExpression(), e.getMessage(), e);
+        }
+    }
+
+    private void applyPersistentReplaceValue(final XQueryContext context, final Txn transaction,
+                                              final UpdatePrimitive p, final MutableDocumentSet modifiedDocuments) throws XPathException {
+        final StoredNode<?> node = (StoredNode<?>) p.getTargetNode();
+        final DocumentImpl doc = node.getOwnerDocument();
+        checkWritePermission(context, doc, p.getSourceExpression());
+
+        try {
+            // Per W3C spec: atomize content, join with single space separator
+            final String newValue = atomizeAndJoin(p.getContent());
+
+            // Validate content constraints per XML spec
+            validateNodeContent(node.getNodeType(), newValue, p.getSourceExpression());
+
+            switch (node.getNodeType()) {
+                case Node.ELEMENT_NODE: {
+                    // Replace all children of element with a single text node
+                    final NodeListImpl content = new NodeListImpl();
+                    content.add(new TextImpl(node.getExpression(), newValue));
+                    ((ElementImpl) node).update(transaction, content);
+                    break;
+                }
+                case Node.TEXT_NODE: {
+                    final ElementImpl parent = (ElementImpl) node.getParentNode();
+                    final TextImpl text =
+                            new TextImpl(node.getExpression(), newValue);
+                    text.setOwnerDocument(doc);
+                    parent.updateChild(transaction, node, text);
+                    break;
+                }
+                case Node.ATTRIBUTE_NODE: {
+                    final AttrImpl oldAttr =
+                            (AttrImpl) node;
+                    final ElementImpl parent = (ElementImpl) ((Attr) node).getOwnerElement();
+                    if (parent != null) {
+                        final AttrImpl newAttr =
+                                new AttrImpl(node.getExpression(),
+                                        oldAttr.getQName(), newValue, context.getBroker().getBrokerPool().getSymbols());
+                        newAttr.setOwnerDocument(doc);
+                        parent.updateChild(transaction, node, newAttr);
+                    }
+                    break;
+                }
+                case Node.COMMENT_NODE: {
+                    final Node parent = node.getParentNode();
+                    final CommentImpl newComment =
+                            new CommentImpl(node.getExpression(), newValue);
+                    if (parent instanceof ElementImpl parentElem) {
+                        parentElem.updateChild(transaction, node, newComment);
+                    } else if (parent instanceof DocumentImpl parentDoc) {
+                        newComment.setOwnerDocument(doc);
+                        parentDoc.updateChild(transaction, node, newComment);
+                    }
+                    break;
+                }
+                case Node.PROCESSING_INSTRUCTION_NODE: {
+                    final Node parent = node.getParentNode();
+                    final ProcessingInstructionImpl newPI =
+                            new ProcessingInstructionImpl(
+                                    node.getExpression(), node.getNodeName(), newValue);
+                    if (parent instanceof ElementImpl parentElem) {
+                        parentElem.updateChild(transaction, node, newPI);
+                    } else if (parent instanceof DocumentImpl parentDoc) {
+                        newPI.setOwnerDocument(doc);
+                        parentDoc.updateChild(transaction, node, newPI);
+                    }
+                    break;
+                }
+                default:
+                    throw new XPathException(p.getSourceExpression(), ErrorCodes.XUTY0007,
+                            "Target of replace value must be an element, attribute, text, comment, or processing instruction node.");
+            }
+
+            doc.setLastModified(System.currentTimeMillis());
+            modifiedDocuments.add(doc);
+        } catch (final XPathException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new XPathException(p.getSourceExpression(), e.getMessage(), e);
+        }
+    }
+
+    private void applyPersistentReplaceNode(final XQueryContext context, final Txn transaction,
+                                             final UpdatePrimitive p, final MutableDocumentSet modifiedDocuments) throws XPathException {
+        final StoredNode<?> node = (StoredNode<?>) p.getTargetNode();
+        final DocumentImpl doc = node.getOwnerDocument();
+        checkWritePermission(context, doc, p.getSourceExpression());
+
+        try {
+            final StoredNode parent = node.getParentStoredNode();
+            if (parent == null) {
+                throw new XPathException(p.getSourceExpression(), ErrorCodes.XUDY0009,
+                        "Target node of replace has no parent.");
+            }
+
+            final Sequence contentSeq = deepCopy(context, p.getContent());
+
+            switch (node.getNodeType()) {
+                case Node.ELEMENT_NODE: {
+                    if (contentSeq.getItemCount() > 0) {
+                        final Item newItem = contentSeq.itemAt(0);
+                        if (Type.subTypeOf(newItem.getType(), Type.NODE)) {
+                            final Node newNode = ((NodeValue) newItem).getNode();
+                            ((ElementImpl) parent).replaceChild(transaction, newNode, node);
+                        }
+                    }
+                    break;
+                }
+                case Node.TEXT_NODE: {
+                    final TextImpl text =
+                            new TextImpl(node.getExpression(), contentSeq.getStringValue());
+                    ((ElementImpl) parent).updateChild(transaction, node, text);
+                    break;
+                }
+                case Node.ATTRIBUTE_NODE: {
+                    if (contentSeq.getItemCount() > 0) {
+                        final Item newItem = contentSeq.itemAt(0);
+                        if (Type.subTypeOf(newItem.getType(), Type.NODE)) {
+                            final Node newNode = ((NodeValue) newItem).getNode();
+                            ((ElementImpl) parent).replaceChild(transaction, newNode, node);
+                        }
+                    }
+                    break;
+                }
+                default: {
+                    if (contentSeq.getItemCount() > 0) {
+                        final Item newItem = contentSeq.itemAt(0);
+                        if (Type.subTypeOf(newItem.getType(), Type.NODE)) {
+                            final Node newNode = ((NodeValue) newItem).getNode();
+                            ((ElementImpl) parent).replaceChild(transaction, newNode, node);
+                        }
+                    }
+                    break;
+                }
+            }
+
+            doc.setLastModified(System.currentTimeMillis());
+            modifiedDocuments.add(doc);
+        } catch (final XPathException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new XPathException(p.getSourceExpression(), e.getMessage(), e);
+        }
+    }
+
+    private void applyPersistentDelete(final XQueryContext context, final Txn transaction,
+                                        final UpdatePrimitive p, final MutableDocumentSet modifiedDocuments) throws XPathException {
+        final StoredNode<?> node = (StoredNode<?>) p.getTargetNode();
+        final DocumentImpl doc = node.getOwnerDocument();
+        checkWritePermission(context, doc, p.getSourceExpression());
+
+        try {
+            final Node parent = getParent(node);
+            if (parent == null) {
+                // Per W3C spec, deleting a parentless node is a no-op
+                return;
+            }
+            if (parent.getNodeType() == Node.ELEMENT_NODE) {
+                ((ElementImpl) parent).removeChild(transaction, node);
+            } else if (parent.getNodeType() == Node.DOCUMENT_NODE) {
+                // Document-level node (comment, PI) — remove directly via broker
+                final DBBroker broker = context.getBroker();
+                final NodePath nodePath = node.getPath();
+                final IndexController indexes = broker.getIndexController();
+                indexes.setDocument(doc);
+                indexes.setMode(ReindexMode.REMOVE_SOME_NODES);
+                broker.removeAllNodes(transaction, node, nodePath, indexes.getStreamListener());
+                broker.endRemove(transaction);
+                broker.flush();
+            } else {
+                throw new XPathException(p.getSourceExpression(),
+                        "Cannot delete node: parent is neither element nor document node.");
+            }
+
+            doc.setLastModified(System.currentTimeMillis());
+            modifiedDocuments.add(doc);
+        } catch (final XPathException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new XPathException(p.getSourceExpression(), e.getMessage(), e);
+        }
+    }
+
+    private void applyPersistentPut(final XQueryContext context, final Txn transaction,
+                                     final UpdatePrimitive p) throws XPathException {
+        // fn:put implementation - store a document at the given URI
+        // TODO: implement fn:put for persistent storage
+        LOG.warn("fn:put is not yet fully implemented for persistent storage. Target: {}",
+                p.getTargetNode());
+    }
+
+    /**
+     * Reset this PUL (clear all primitives).
+     */
+    public void clear() {
+        primitives.clear();
+    }
+
+    // Utility methods
+
+    /**
+     * Return a priority for insert primitive types, controlling application order.
+     * Per W3C spec: INSERT_INTO_AS_FIRST first, INSERT_INTO_AS_LAST last,
+     * INSERT_INTO and others in between.
+     */
+    private static int insertPriority(final UpdatePrimitive.Type type) {
+        return switch (type) {
+            case INSERT_INTO_AS_FIRST -> 0;
+            case INSERT_BEFORE, INSERT_AFTER, INSERT_ATTRIBUTES -> 1;
+            case INSERT_INTO -> 2;
+            case INSERT_INTO_AS_LAST -> 3;
+            default -> 1;
+        };
+    }
+
+    private static boolean isPersistentNode(final Node node) {
+        return node instanceof StoredNode;
+    }
+
+    private static void checkWritePermission(final XQueryContext context, final DocumentImpl doc,
+                                              final Expression expr) throws XPathException {
+        try {
+            if (!doc.getPermissions().validate(context.getSubject(), Permission.WRITE)) {
+                throw new PermissionDeniedException("User '" + context.getSubject().getName()
+                        + "' does not have permission to write to the document '" + doc.getDocumentURI() + "'!");
+            }
+        } catch (final PermissionDeniedException e) {
+            throw new XPathException(expr, e.getMessage(), e);
+        }
+    }
+
+    private static Node getParent(final Node node) {
+        if (node.getNodeType() == Node.ATTRIBUTE_NODE) {
+            return ((Attr) node).getOwnerElement();
+        }
+        return node.getParentNode();
+    }
+
+    /**
+     * Deep copy a sequence, detaching nodes from their source documents.
+     * Reuses the pattern from Modification.deepCopy().
+     */
+    private static Sequence deepCopy(final XQueryContext context, final Sequence inSeq) throws XPathException {
+        if (inSeq == null || inSeq.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        context.pushDocumentContext();
+        final MemTreeBuilder builder = context.getDocumentBuilder();
+        final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(context.getRootExpression(), builder);
+        final Serializer serializer = context.getBroker().borrowSerializer();
+        serializer.setReceiver(receiver);
+
+        try {
+            final Sequence out = new ValueSequence();
+            for (final SequenceIterator i = inSeq.iterate(); i.hasNext(); ) {
+                Item item = i.nextItem();
+                if (item.getType() == Type.DOCUMENT) {
+                    if (((NodeValue) item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        final NodeHandle root = (NodeHandle) ((NodeProxy) item).getOwnerDocument().getDocumentElement();
+                        item = new NodeProxy(context.getRootExpression(), root);
+                    } else {
+                        item = (Item) ((org.w3c.dom.Document) item).getDocumentElement();
+                    }
+                }
+                if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                    if (((NodeValue) item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        final int last = builder.getDocument().getLastNode();
+                        final NodeProxy p = (NodeProxy) item;
+                        serializer.toReceiver(p, false, false);
+                        if (p.getNodeType() == Node.ATTRIBUTE_NODE) {
+                            item = builder.getDocument().getLastAttr();
+                        } else {
+                            item = builder.getDocument().getNode(last + 1);
+                        }
+                    } else {
+                        ((org.exist.dom.memtree.NodeImpl) item).deepCopy();
+                    }
+                }
+                out.add(item);
+            }
+            return out;
+        } catch (final SAXException e) {
+            throw new XPathException(context.getRootExpression(), e.getMessage(), e);
+        } finally {
+            context.getBroker().returnSerializer(serializer);
+            context.popDocumentContext();
+        }
+    }
+
+    private static NodeList sequenceToNodeList(final Sequence seq) throws XPathException {
+        final NodeListImpl nl = new NodeListImpl();
+        for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
+            final Item item = i.nextItem();
+            if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                nl.add(((NodeValue) item).getNode());
+            }
+        }
+        return nl;
+    }
+
+    private static void prepareTrigger(final DBBroker broker, final Int2ObjectMap<DocumentTrigger> triggers,
+                                        final DocumentImpl doc) throws TriggerException {
+        final org.exist.collections.Collection col = doc.getCollection();
+        final DocumentTrigger trigger = new DocumentTriggers(broker, null, col);
+        trigger.beforeUpdateDocument(broker, broker.getCurrentTransaction(), doc);
+        triggers.put(doc.getDocId(), trigger);
+    }
+
+    private static void finishTrigger(final DBBroker broker, final Int2ObjectMap<DocumentTrigger> triggers,
+                                       final DocumentImpl doc) throws TriggerException {
+        final DocumentTrigger trigger = triggers.get(doc.getDocId());
+        if (trigger != null) {
+            trigger.afterUpdateDocument(broker, broker.getCurrentTransaction(), doc);
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/UpdatePrimitive.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/UpdatePrimitive.java
@@ -1,0 +1,144 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.dom.QName;
+import org.exist.xquery.Expression;
+import org.exist.xquery.value.Sequence;
+import org.w3c.dom.Node;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a single update primitive in the W3C XQuery Update Facility 3.0
+ * Pending Update List (PUL).
+ *
+ * Each primitive carries a target node, optional content/value, and the
+ * expression that created it (for error reporting).
+ */
+public class UpdatePrimitive {
+
+    public enum Type {
+        INSERT_INTO,
+        INSERT_INTO_AS_FIRST,
+        INSERT_INTO_AS_LAST,
+        INSERT_BEFORE,
+        INSERT_AFTER,
+        INSERT_ATTRIBUTES,
+        DELETE,
+        REPLACE_NODE,
+        REPLACE_VALUE,
+        RENAME,
+        PUT
+    }
+
+    private final Type type;
+    private final Node targetNode;
+    private final @Nullable Sequence content;
+    private final @Nullable QName newName;
+    private final @Nullable String uri;
+    private final Expression sourceExpr;
+
+    public UpdatePrimitive(final Type type, final Node targetNode, @Nullable final Sequence content,
+                           @Nullable final QName newName, @Nullable final String uri,
+                           final Expression sourceExpr) {
+        this.type = type;
+        this.targetNode = targetNode;
+        this.content = content;
+        this.newName = newName;
+        this.uri = uri;
+        this.sourceExpr = sourceExpr;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Node getTargetNode() {
+        return targetNode;
+    }
+
+    @Nullable
+    public Sequence getContent() {
+        return content;
+    }
+
+    @Nullable
+    public QName getNewName() {
+        return newName;
+    }
+
+    @Nullable
+    public String getUri() {
+        return uri;
+    }
+
+    public Expression getSourceExpression() {
+        return sourceExpr;
+    }
+
+    // Factory methods
+
+    public static UpdatePrimitive insertInto(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_INTO, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive insertIntoAsFirst(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_INTO_AS_FIRST, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive insertIntoAsLast(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_INTO_AS_LAST, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive insertBefore(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_BEFORE, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive insertAfter(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_AFTER, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive insertAttributes(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.INSERT_ATTRIBUTES, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive delete(final Node target, final Expression expr) {
+        return new UpdatePrimitive(Type.DELETE, target, null, null, null, expr);
+    }
+
+    public static UpdatePrimitive replaceNode(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.REPLACE_NODE, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive replaceValue(final Node target, final Sequence content, final Expression expr) {
+        return new UpdatePrimitive(Type.REPLACE_VALUE, target, content, null, null, expr);
+    }
+
+    public static UpdatePrimitive rename(final Node target, final QName newName, final Expression expr) {
+        return new UpdatePrimitive(Type.RENAME, target, null, newName, null, expr);
+    }
+
+    public static UpdatePrimitive put(final Node target, final String uri, final Expression expr) {
+        return new UpdatePrimitive(Type.PUT, target, null, null, uri, expr);
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFDeleteExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFDeleteExpr.java
@@ -1,0 +1,118 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+
+/**
+ * W3C XQuery Update Facility 3.0 - delete expression.
+ *
+ * <pre>
+ * DeleteExpr ::= "delete" ("node" | "nodes") TargetExpr
+ * </pre>
+ */
+public class XQUFDeleteExpr extends AbstractExpression {
+
+    private final Expression target;
+
+    public XQUFDeleteExpr(final XQueryContext context, final Expression target) {
+        super(context);
+        this.target = target;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        if (contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "delete expression is not allowed in a non-updating context");
+        }
+        // Target expression of delete is a non-updating context
+        final AnalyzeContextInfo subInfo = new AnalyzeContextInfo(contextInfo);
+        subInfo.setParent(this);
+        subInfo.addFlag(IN_UPDATE);
+        subInfo.addFlag(NON_UPDATING_CONTEXT);
+        target.analyze(subInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+        final Sequence targetSeq = target.eval(ctxSeq, null);
+
+        if (!targetSeq.isEmpty()) {
+            final PendingUpdateList pul = context.getPendingUpdateList();
+            for (final SequenceIterator i = targetSeq.iterate(); i.hasNext(); ) {
+                final Item item = i.nextItem();
+                if (!Type.subTypeOf(item.getType(), Type.NODE)) {
+                    throw new XPathException(this, ErrorCodes.XUTY0007,
+                            "Target of delete expression must be a node.");
+                }
+                final NodeValue nv = (NodeValue) item;
+                pul.addPrimitive(UpdatePrimitive.delete(nv.getNode(), this));
+            }
+        }
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", Sequence.EMPTY_SEQUENCE);
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        return true;
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        target.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("delete node ");
+        target.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        return "delete node " + target.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFFnPut.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFFnPut.java
@@ -1,0 +1,66 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+/**
+ * W3C XQuery Update Facility 3.0 - fn:put function.
+ *
+ * <pre>
+ * fn:put($node as node(), $uri as xs:string) as empty-sequence()
+ * </pre>
+ *
+ * Adds a put primitive to the PUL for deferred persistence.
+ */
+public class XQUFFnPut extends BasicFunction {
+
+    public static final FunctionSignature SIGNATURE = new FunctionSignature(
+            new QName("put", Function.BUILTIN_FUNCTION_NS, "fn"),
+            "Stores a document node to a specified URI. The actual storage is deferred "
+                    + "to the end of the snapshot (pending update list application).",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                            "The node to store"),
+                    new FunctionParameterSequenceType("uri", Type.STRING, Cardinality.EXACTLY_ONE,
+                            "The URI where the node should be stored")
+            },
+            new SequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE)
+    );
+
+    public XQUFFnPut(final XQueryContext context) {
+        super(context, SIGNATURE);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final NodeValue node = (NodeValue) args[0].itemAt(0);
+        final String uri = args[1].getStringValue();
+
+        final PendingUpdateList pul = context.getPendingUpdateList();
+        pul.addPrimitive(UpdatePrimitive.put(node.getNode(), uri, this));
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFInsertExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFInsertExpr.java
@@ -1,0 +1,307 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Node;
+
+/**
+ * W3C XQuery Update Facility 3.0 - insert expression.
+ *
+ * <pre>
+ * InsertExpr ::= "insert" ("node" | "nodes") SourceExpr InsertExprTargetChoice TargetExpr
+ * InsertExprTargetChoice ::= (("as" ("first" | "last"))? "into") | "after" | "before"
+ * </pre>
+ */
+public class XQUFInsertExpr extends AbstractExpression {
+
+    public static final int INSERT_INTO = 0;
+    public static final int INSERT_INTO_AS_FIRST = 1;
+    public static final int INSERT_INTO_AS_LAST = 2;
+    public static final int INSERT_BEFORE = 3;
+    public static final int INSERT_AFTER = 4;
+
+    private final Expression source;
+    private final Expression target;
+    private final int mode;
+
+    public XQUFInsertExpr(final XQueryContext context, final Expression source,
+                          final Expression target, final int mode) {
+        super(context);
+        this.source = source;
+        this.target = target;
+        this.mode = mode;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        if (contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "insert expression is not allowed in a non-updating context");
+        }
+        // Source and target expressions of insert are non-updating contexts
+        final AnalyzeContextInfo subInfo = new AnalyzeContextInfo(contextInfo);
+        subInfo.setParent(this);
+        subInfo.addFlag(IN_UPDATE);
+        subInfo.addFlag(NON_UPDATING_CONTEXT);
+        source.analyze(subInfo);
+        target.analyze(subInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+
+        // Evaluate source expression (content to insert)
+        final Sequence sourceSeq = source.eval(ctxSeq, null);
+        if (sourceSeq.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        // Evaluate target expression
+        final Sequence targetSeq = target.eval(ctxSeq, null);
+
+        // XUDY0027: target must not be empty
+        if (targetSeq.isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XUDY0027,
+                    "Target of insert expression must not be an empty sequence.");
+        }
+
+        // Target must be a single node
+        if (targetSeq.getItemCount() != 1 || !Type.subTypeOf(targetSeq.itemAt(0).getType(), Type.NODE)) {
+            if (mode == INSERT_INTO || mode == INSERT_INTO_AS_FIRST || mode == INSERT_INTO_AS_LAST) {
+                // XUTY0005: target of insert-into must be single element or document
+                throw new XPathException(this, ErrorCodes.XUTY0005,
+                        "Target of insert into expression must be a single element or document node.");
+            } else {
+                // XUTY0006: target of insert-before/after must be single element/text/comment/PI
+                throw new XPathException(this, ErrorCodes.XUTY0006,
+                        "Target of insert before/after expression must be a single element, text, comment, or processing instruction node.");
+            }
+        }
+
+        final NodeValue targetNode = (NodeValue) targetSeq.itemAt(0);
+        final Node domTarget = targetNode.getNode();
+        final int targetType = domTarget.getNodeType();
+
+        // Validate target and source based on insert mode
+        switch (mode) {
+            case INSERT_INTO:
+            case INSERT_INTO_AS_FIRST:
+            case INSERT_INTO_AS_LAST:
+                // XUTY0005: target must be element or document
+                if (targetType != Node.ELEMENT_NODE && targetType != Node.DOCUMENT_NODE) {
+                    throw new XPathException(this, ErrorCodes.XUTY0005,
+                            "Target of insert into expression must be an element or document node.");
+                }
+
+                // XUTY0004: source must not have attribute after non-attribute
+                {
+                    boolean seenNonAttribute = false;
+                    for (final SequenceIterator i = sourceSeq.iterate(); i.hasNext(); ) {
+                        final Item item = i.nextItem();
+                        if (Type.subTypeOf(item.getType(), Type.NODE)
+                                && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                            if (seenNonAttribute) {
+                                throw new XPathException(this, ErrorCodes.XUTY0004,
+                                        "In the source of an insert expression, attribute nodes must not follow non-attribute nodes.");
+                            }
+                        } else {
+                            seenNonAttribute = true;
+                        }
+                    }
+                }
+
+                // XUTY0022: cannot insert attributes into document node
+                if (targetType == Node.DOCUMENT_NODE) {
+                    for (final SequenceIterator i = sourceSeq.iterate(); i.hasNext(); ) {
+                        final Item item = i.nextItem();
+                        if (Type.subTypeOf(item.getType(), Type.NODE)
+                                && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                            throw new XPathException(this, ErrorCodes.XUTY0022,
+                                    "Cannot insert attribute nodes into a document node.");
+                        }
+                    }
+                }
+                break;
+
+            case INSERT_BEFORE:
+            case INSERT_AFTER:
+                // XUTY0006: target must be element, text, comment, or PI (not document or attribute)
+                if (targetType == Node.DOCUMENT_NODE || targetType == Node.ATTRIBUTE_NODE) {
+                    throw new XPathException(this, ErrorCodes.XUTY0006,
+                            "Target of insert before/after must be an element, text, comment, or processing instruction node.");
+                }
+
+                // XUDY0029: target must have a parent
+                if (domTarget.getParentNode() == null) {
+                    throw new XPathException(this, ErrorCodes.XUDY0029,
+                            "Target of insert before/after must have a parent node.");
+                }
+
+                // Checks when parent is document node
+                if (domTarget.getParentNode().getNodeType() == Node.DOCUMENT_NODE) {
+                    // XUDY0030: cannot insert attribute before/after node whose parent is document
+                    for (final SequenceIterator i = sourceSeq.iterate(); i.hasNext(); ) {
+                        final Item item = i.nextItem();
+                        if (Type.subTypeOf(item.getType(), Type.NODE)
+                                && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                            throw new XPathException(this, ErrorCodes.XUDY0030,
+                                    "Cannot insert attribute node before/after a node whose parent is a document node.");
+                        }
+                    }
+                    // XUDY0027: target is root element or root text of a document
+                    if (targetType == Node.ELEMENT_NODE || targetType == Node.TEXT_NODE) {
+                        throw new XPathException(this, ErrorCodes.XUDY0027,
+                                "Target of insert before/after is a root element or root text node of a document.");
+                    }
+                }
+                break;
+        }
+
+        // Add to PUL
+        final PendingUpdateList pul = context.getPendingUpdateList();
+        final UpdatePrimitive.Type primType = switch (mode) {
+            case INSERT_INTO -> UpdatePrimitive.Type.INSERT_INTO;
+            case INSERT_INTO_AS_FIRST -> UpdatePrimitive.Type.INSERT_INTO_AS_FIRST;
+            case INSERT_INTO_AS_LAST -> UpdatePrimitive.Type.INSERT_INTO_AS_LAST;
+            case INSERT_BEFORE -> UpdatePrimitive.Type.INSERT_BEFORE;
+            case INSERT_AFTER -> UpdatePrimitive.Type.INSERT_AFTER;
+            default -> UpdatePrimitive.Type.INSERT_INTO;
+        };
+
+        // Separate attribute and non-attribute content
+        if (mode == INSERT_INTO || mode == INSERT_INTO_AS_FIRST || mode == INSERT_INTO_AS_LAST) {
+            // For into modes: attributes go as INSERT_ATTRIBUTES on target element
+            if (domTarget.getNodeType() == Node.ELEMENT_NODE) {
+                final ValueSequence attrContent = new ValueSequence();
+                final ValueSequence otherContent = new ValueSequence();
+                for (final SequenceIterator i = sourceSeq.iterate(); i.hasNext(); ) {
+                    final Item item = i.nextItem();
+                    if (Type.subTypeOf(item.getType(), Type.NODE)
+                            && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                        attrContent.add(item);
+                    } else {
+                        otherContent.add(item);
+                    }
+                }
+                if (!attrContent.isEmpty()) {
+                    pul.addPrimitive(new UpdatePrimitive(UpdatePrimitive.Type.INSERT_ATTRIBUTES,
+                            domTarget, attrContent, null, null, this));
+                }
+                if (!otherContent.isEmpty()) {
+                    pul.addPrimitive(new UpdatePrimitive(primType, domTarget, otherContent, null, null, this));
+                }
+            } else {
+                pul.addPrimitive(new UpdatePrimitive(primType, domTarget, sourceSeq, null, null, this));
+            }
+        } else if (mode == INSERT_BEFORE || mode == INSERT_AFTER) {
+            // For before/after modes: per W3C spec, attribute nodes in source are
+            // added to the PARENT element of the target node
+            final ValueSequence attrContent = new ValueSequence();
+            final ValueSequence otherContent = new ValueSequence();
+            for (final SequenceIterator i = sourceSeq.iterate(); i.hasNext(); ) {
+                final Item item = i.nextItem();
+                if (Type.subTypeOf(item.getType(), Type.NODE)
+                        && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                    attrContent.add(item);
+                } else {
+                    otherContent.add(item);
+                }
+            }
+            if (!attrContent.isEmpty()) {
+                // Attributes go to the parent element
+                final Node parentNode = domTarget.getParentNode();
+                pul.addPrimitive(new UpdatePrimitive(UpdatePrimitive.Type.INSERT_ATTRIBUTES,
+                        parentNode, attrContent, null, null, this));
+            }
+            if (!otherContent.isEmpty()) {
+                pul.addPrimitive(new UpdatePrimitive(primType, domTarget, otherContent, null, null, this));
+            }
+        } else {
+            pul.addPrimitive(new UpdatePrimitive(primType, domTarget, sourceSeq, null, null, this));
+        }
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", Sequence.EMPTY_SEQUENCE);
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        return true;
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        source.resetState(postOptimization);
+        target.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("insert node ");
+        source.dump(dumper);
+        switch (mode) {
+            case INSERT_INTO -> dumper.display(" into ");
+            case INSERT_INTO_AS_FIRST -> dumper.display(" as first into ");
+            case INSERT_INTO_AS_LAST -> dumper.display(" as last into ");
+            case INSERT_BEFORE -> dumper.display(" before ");
+            case INSERT_AFTER -> dumper.display(" after ");
+        }
+        target.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("insert node ");
+        sb.append(source.toString());
+        switch (mode) {
+            case INSERT_INTO -> sb.append(" into ");
+            case INSERT_INTO_AS_FIRST -> sb.append(" as first into ");
+            case INSERT_INTO_AS_LAST -> sb.append(" as last into ");
+            case INSERT_BEFORE -> sb.append(" before ");
+            case INSERT_AFTER -> sb.append(" after ");
+        }
+        sb.append(target.toString());
+        return sb.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFRenameExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFRenameExpr.java
@@ -1,0 +1,184 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Node;
+
+/**
+ * W3C XQuery Update Facility 3.0 - rename expression.
+ *
+ * <pre>
+ * RenameExpr ::= "rename" "node" TargetExpr "as" NewNameExpr
+ * </pre>
+ */
+public class XQUFRenameExpr extends AbstractExpression {
+
+    private final Expression target;
+    private final Expression newName;
+
+    public XQUFRenameExpr(final XQueryContext context, final Expression target, final Expression newName) {
+        super(context);
+        this.target = target;
+        this.newName = newName;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        if (contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "rename expression is not allowed in a non-updating context");
+        }
+        // Target and new name expressions are non-updating contexts
+        final AnalyzeContextInfo subInfo = new AnalyzeContextInfo(contextInfo);
+        subInfo.setParent(this);
+        subInfo.addFlag(IN_UPDATE);
+        subInfo.addFlag(NON_UPDATING_CONTEXT);
+        target.analyze(subInfo);
+        newName.analyze(subInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+
+        final Sequence targetSeq = target.eval(ctxSeq, null);
+        if (targetSeq.isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XUDY0027,
+                    "Target of rename expression must not be an empty sequence.");
+        }
+
+        // XUTY0012: target must be a single element, attribute, or PI node
+        if (targetSeq.getItemCount() != 1 || !Type.subTypeOf(targetSeq.itemAt(0).getType(), Type.NODE)) {
+            throw new XPathException(this, ErrorCodes.XUTY0012,
+                    "Target of rename expression must be a single element, attribute, or processing instruction node.");
+        }
+
+        final NodeValue targetNode = (NodeValue) targetSeq.itemAt(0);
+        final int nodeType = targetNode.getNode().getNodeType();
+
+        if (nodeType != Node.ELEMENT_NODE && nodeType != Node.ATTRIBUTE_NODE
+                && nodeType != Node.PROCESSING_INSTRUCTION_NODE) {
+            throw new XPathException(this, ErrorCodes.XUTY0012,
+                    "Target of rename expression must be an element, attribute, or processing instruction node.");
+        }
+
+        // Evaluate new name — must be a single item castable to xs:QName
+        final Sequence nameSeq = newName.eval(ctxSeq, null);
+        if (nameSeq.isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "New name expression in rename must not be empty; expected xs:QName or xs:string.");
+        }
+        if (nameSeq.getItemCount() > 1) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "New name expression in rename must be a single item; got " + nameSeq.getItemCount() + " items.");
+        }
+
+        // Atomize the new name expression per W3C spec
+        final Item nameItem;
+        final Item rawItem = nameSeq.itemAt(0);
+        if (Type.subTypeOf(rawItem.getType(), Type.NODE)) {
+            nameItem = rawItem.atomize();
+        } else {
+            nameItem = rawItem;
+        }
+
+        final QName qname;
+        if (nameItem.getType() == Type.QNAME) {
+            qname = ((QNameValue) nameItem).getQName();
+        } else if (Type.subTypeOf(nameItem.getType(), Type.STRING) || nameItem.getType() == Type.UNTYPED_ATOMIC) {
+            final String nameStr = nameItem.getStringValue().trim();
+            try {
+                qname = QName.parse(context, nameStr);
+            } catch (final QName.IllegalQNameException e) {
+                throw new XPathException(this, ErrorCodes.XQDY0074, "Invalid QName for rename: " + nameStr);
+            }
+            // Validate the name is a valid QName (NCName with optional prefix)
+            if (org.exist.dom.QName.isQName(nameStr) != QName.Validity.VALID.val) {
+                throw new XPathException(this, ErrorCodes.XQDY0074, "Invalid QName for rename: " + nameStr);
+            }
+        } else {
+            // Non-QName/string/untypedAtomic types are a type error (XPTY0004)
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "New name expression in rename must be of type xs:QName or xs:string; got " + Type.getTypeName(nameItem.getType()));
+        }
+
+        // XQDY0064: PI target name must not be "xml" (case-insensitive)
+        if (nodeType == Node.PROCESSING_INSTRUCTION_NODE) {
+            if ("xml".equalsIgnoreCase(qname.getLocalPart())) {
+                throw new XPathException(this, ErrorCodes.XQDY0064,
+                        "Processing instruction target name cannot be 'xml'.");
+            }
+        }
+
+        final PendingUpdateList pul = context.getPendingUpdateList();
+        pul.addPrimitive(UpdatePrimitive.rename(targetNode.getNode(), qname, this));
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", Sequence.EMPTY_SEQUENCE);
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        return true;
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        target.resetState(postOptimization);
+        newName.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("rename node ");
+        target.dump(dumper);
+        dumper.display(" as ");
+        newName.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        return "rename node " + target.toString() + " as " + newName.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFRenameExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFRenameExpr.java
@@ -130,11 +130,10 @@ public class XQUFRenameExpr extends AbstractExpression {
         }
 
         // XQDY0064: PI target name must not be "xml" (case-insensitive)
-        if (nodeType == Node.PROCESSING_INSTRUCTION_NODE) {
-            if ("xml".equalsIgnoreCase(qname.getLocalPart())) {
-                throw new XPathException(this, ErrorCodes.XQDY0064,
-                        "Processing instruction target name cannot be 'xml'.");
-            }
+        if (nodeType == Node.PROCESSING_INSTRUCTION_NODE
+                && "xml".equalsIgnoreCase(qname.getLocalPart())) {
+            throw new XPathException(this, ErrorCodes.XQDY0064,
+                    "Processing instruction target name cannot be 'xml'.");
         }
 
         final PendingUpdateList pul = context.getPendingUpdateList();

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFReplaceNodeExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFReplaceNodeExpr.java
@@ -1,0 +1,183 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Node;
+
+/**
+ * W3C XQuery Update Facility 3.0 - replace node expression.
+ *
+ * <pre>
+ * ReplaceExpr ::= "replace" ("value" "of")? "node" TargetExpr "with" ExprSingle
+ * </pre>
+ *
+ * This class handles "replace node" (not "replace value of node").
+ */
+public class XQUFReplaceNodeExpr extends AbstractExpression {
+
+    private final Expression target;
+    private final Expression replacement;
+
+    public XQUFReplaceNodeExpr(final XQueryContext context, final Expression target, final Expression replacement) {
+        super(context);
+        this.target = target;
+        this.replacement = replacement;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        if (contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "replace expression is not allowed in a non-updating context");
+        }
+        // Target and replacement expressions are non-updating contexts
+        final AnalyzeContextInfo subInfo = new AnalyzeContextInfo(contextInfo);
+        subInfo.setParent(this);
+        subInfo.addFlag(IN_UPDATE);
+        subInfo.addFlag(NON_UPDATING_CONTEXT);
+        target.analyze(subInfo);
+        replacement.analyze(subInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+
+        final Sequence targetSeq = target.eval(ctxSeq, null);
+        if (targetSeq.isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XUDY0027,
+                    "Target of replace expression must not be an empty sequence.");
+        }
+
+        // XUTY0008: target must be a single node
+        if (targetSeq.getItemCount() != 1 || !Type.subTypeOf(targetSeq.itemAt(0).getType(), Type.NODE)) {
+            throw new XPathException(this, ErrorCodes.XUTY0008,
+                    "Target of replace expression must be a single node.");
+        }
+
+        final NodeValue targetNode = (NodeValue) targetSeq.itemAt(0);
+        final Node domNode = targetNode.getNode();
+        final int nodeType = domNode.getNodeType();
+
+        // XUTY0008: target must not be a document node
+        if (nodeType == Node.DOCUMENT_NODE) {
+            throw new XPathException(this, ErrorCodes.XUTY0008,
+                    "Target of replace expression must not be a document node.");
+        }
+
+        // XUTY0006: target must be element, attribute, text, comment, or PI
+        if (nodeType != Node.ELEMENT_NODE && nodeType != Node.ATTRIBUTE_NODE
+                && nodeType != Node.TEXT_NODE && nodeType != Node.COMMENT_NODE
+                && nodeType != Node.PROCESSING_INSTRUCTION_NODE) {
+            throw new XPathException(this, ErrorCodes.XUTY0006,
+                    "Target of replace expression must be an element, attribute, text, comment, or processing instruction node.");
+        }
+
+        // XUDY0009: target must have a parent
+        final boolean hasParent;
+        if (nodeType == Node.ATTRIBUTE_NODE) {
+            hasParent = ((org.w3c.dom.Attr) domNode).getOwnerElement() != null;
+        } else {
+            hasParent = domNode.getParentNode() != null;
+        }
+        if (!hasParent) {
+            throw new XPathException(this, ErrorCodes.XUDY0009,
+                    "Target node of replace expression has no parent.");
+        }
+
+        final Sequence replacementSeq = replacement.eval(ctxSeq, null);
+
+        // Type checking based on target node type
+        if (nodeType == Node.ATTRIBUTE_NODE) {
+            // XUTY0011: replacement of attribute must be attributes
+            for (final SequenceIterator i = replacementSeq.iterate(); i.hasNext(); ) {
+                final Item item = i.nextItem();
+                if (Type.subTypeOf(item.getType(), Type.NODE)
+                        && ((NodeValue) item).getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
+                    throw new XPathException(this, ErrorCodes.XUTY0011,
+                            "Replacement of an attribute node must be attribute node(s).");
+                }
+            }
+        } else {
+            // XUTY0010: replacement of element/text/comment/PI must not be attributes
+            for (final SequenceIterator i = replacementSeq.iterate(); i.hasNext(); ) {
+                final Item item = i.nextItem();
+                if (Type.subTypeOf(item.getType(), Type.NODE)
+                        && ((NodeValue) item).getNode().getNodeType() == Node.ATTRIBUTE_NODE) {
+                    throw new XPathException(this, ErrorCodes.XUTY0010,
+                            "Replacement of an element, text, comment, or PI node must not contain attribute nodes.");
+                }
+            }
+        }
+
+        final PendingUpdateList pul = context.getPendingUpdateList();
+        pul.addPrimitive(UpdatePrimitive.replaceNode(targetNode.getNode(), replacementSeq, this));
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", Sequence.EMPTY_SEQUENCE);
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        return true;
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        target.resetState(postOptimization);
+        replacement.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("replace node ");
+        target.dump(dumper);
+        dumper.display(" with ");
+        replacement.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        return "replace node " + target.toString() + " with " + replacement.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFReplaceValueExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFReplaceValueExpr.java
@@ -1,0 +1,146 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Node;
+
+/**
+ * W3C XQuery Update Facility 3.0 - replace value of node expression.
+ *
+ * <pre>
+ * ReplaceExpr ::= "replace" "value" "of" "node" TargetExpr "with" ExprSingle
+ * </pre>
+ */
+public class XQUFReplaceValueExpr extends AbstractExpression {
+
+    private final Expression target;
+    private final Expression value;
+
+    public XQUFReplaceValueExpr(final XQueryContext context, final Expression target, final Expression value) {
+        super(context);
+        this.target = target;
+        this.value = value;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        if (contextInfo.hasFlag(NON_UPDATING_CONTEXT)) {
+            throw new XPathException(this, ErrorCodes.XUST0001,
+                    "replace value of expression is not allowed in a non-updating context");
+        }
+        // Target and value expressions are non-updating contexts
+        final AnalyzeContextInfo subInfo = new AnalyzeContextInfo(contextInfo);
+        subInfo.setParent(this);
+        subInfo.addFlag(IN_UPDATE);
+        subInfo.addFlag(NON_UPDATING_CONTEXT);
+        target.analyze(subInfo);
+        value.analyze(subInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+
+        final Sequence targetSeq = target.eval(ctxSeq, null);
+        if (targetSeq.isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XUDY0027,
+                    "Target of replace value of expression must not be an empty sequence.");
+        }
+
+        // XUTY0008: target must be a single node of the right type
+        if (targetSeq.getItemCount() != 1 || !Type.subTypeOf(targetSeq.itemAt(0).getType(), Type.NODE)) {
+            throw new XPathException(this, ErrorCodes.XUTY0008,
+                    "Target of replace value of expression must be a single element, attribute, text, comment, or processing instruction node.");
+        }
+
+        final NodeValue targetNode = (NodeValue) targetSeq.itemAt(0);
+        final int nodeType = targetNode.getNode().getNodeType();
+
+        if (nodeType == Node.DOCUMENT_NODE || (nodeType != Node.ELEMENT_NODE && nodeType != Node.ATTRIBUTE_NODE
+                && nodeType != Node.TEXT_NODE && nodeType != Node.COMMENT_NODE
+                && nodeType != Node.PROCESSING_INSTRUCTION_NODE)) {
+            throw new XPathException(this, ErrorCodes.XUTY0008,
+                    "Target of replace value of expression must be a single element, attribute, text, comment, or processing instruction node, not " +
+                    (nodeType == Node.DOCUMENT_NODE ? "a document node" : "node type " + nodeType) + ".");
+        }
+
+        final Sequence valueSeq = value.eval(ctxSeq, null);
+
+        // Per W3C spec, the replacement value is the string value obtained by atomizing
+        // the content expression and joining with single space separator.
+        // We materialize this now (at snapshot time) rather than deferring to PUL application,
+        // to ensure we capture the original value before any other PUL primitives modify the tree.
+        final String stringValue = PendingUpdateList.atomizeAndJoin(valueSeq);
+
+        final PendingUpdateList pul = context.getPendingUpdateList();
+        pul.addPrimitive(UpdatePrimitive.replaceValue(targetNode.getNode(),
+                new StringValue(this, stringValue), this));
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", Sequence.EMPTY_SEQUENCE);
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public boolean isUpdating() {
+        return true;
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        target.resetState(postOptimization);
+        value.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("replace value of node ");
+        target.dump(dumper);
+        dumper.display(" with ");
+        value.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        return "replace value of node " + target.toString() + " with " + value.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFTransformExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFTransformExpr.java
@@ -206,14 +206,24 @@ public class XQUFTransformExpr extends AbstractExpression {
                 Item item = i.nextItem();
                 final boolean isDocument = item.getType() == Type.DOCUMENT;
                 if (isDocument) {
-                    // For document nodes, copy the document element but return
-                    // the wrapping document node to preserve the node type
+                    // For document nodes, copy ALL children (comments, PIs, elements)
+                    // to preserve the complete document structure
                     if (((NodeValue) item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
-                        final NodeHandle root = (NodeHandle) ((NodeProxy) item).getOwnerDocument().getDocumentElement();
-                        item = new NodeProxy(this, root);
+                        final NodeProxy docProxy = (NodeProxy) item;
+                        serializer.toReceiver(docProxy, false, false);
                     } else {
-                        item = (Item) ((Document) item).getDocumentElement();
+                        final Document docNode = (Document) item;
+                        Node child = docNode.getFirstChild();
+                        while (child != null) {
+                            if (child instanceof org.exist.dom.memtree.NodeImpl) {
+                                ((org.exist.dom.memtree.NodeImpl) child).copyTo(context.getBroker(), receiver);
+                            }
+                            child = child.getNextSibling();
+                        }
                     }
+                    item = builder.getDocument();
+                    out.add(item);
+                    continue;
                 }
                 if (Type.subTypeOf(item.getType(), Type.NODE)) {
                     // Collect inherited namespace bindings from the source node's ancestors
@@ -237,10 +247,7 @@ public class XQUFTransformExpr extends AbstractExpression {
                         final org.exist.dom.memtree.NodeImpl memNode = (org.exist.dom.memtree.NodeImpl) item;
                         memNode.copyTo(context.getBroker(), receiver);
                     }
-                    if (isDocument) {
-                        // Return the document node wrapping the copied element
-                        item = builder.getDocument();
-                    } else if (item.getType() == Type.ATTRIBUTE) {
+                    if (item.getType() == Type.ATTRIBUTE) {
                         item = builder.getDocument().getLastAttr();
                     } else {
                         item = builder.getDocument().getNode(last + 1);
@@ -251,6 +258,15 @@ public class XQUFTransformExpr extends AbstractExpression {
                             && item instanceof org.exist.dom.memtree.NodeImpl) {
                         addInheritedNamespaces(builder.getDocument(),
                                 ((org.exist.dom.memtree.NodeImpl) item).getNodeNumber(), inheritedNs);
+                    }
+
+                    // W3C copy-namespaces no-preserve: strip namespace declarations
+                    // not used by element/attribute names from the copied subtree
+                    if (!context.preserveNamespaces()
+                            && item instanceof org.exist.dom.memtree.NodeImpl
+                            && ((org.exist.dom.memtree.NodeImpl) item).getNode().getNodeType() == Node.ELEMENT_NODE) {
+                        builder.getDocument().stripUnusedNamespacesInSubtree(
+                                ((org.exist.dom.memtree.NodeImpl) item).getNodeNumber());
                     }
                 }
                 out.add(item);

--- a/exist-core/src/main/java/org/exist/xquery/xquf/XQUFTransformExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/xquf/XQUFTransformExpr.java
@@ -1,0 +1,366 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.Namespaces;
+import org.exist.dom.QName;
+import org.exist.dom.memtree.DocumentBuilderReceiver;
+import org.exist.dom.memtree.ElementImpl;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.dom.persistent.NodeHandle;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.storage.serializers.Serializer;
+import org.exist.xquery.*;
+import org.exist.xquery.functions.fn.FunInScopePrefixes;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * W3C XQuery Update Facility 3.0 - transform (copy-modify) expression.
+ *
+ * <pre>
+ * TransformExpr ::= "copy" CopyBinding ("," CopyBinding)* "modify" ExprSingle "return" ExprSingle
+ * CopyBinding   ::= "$" VarName ":=" ExprSingle
+ * </pre>
+ *
+ * Also supports the shorthand: transform with { ... } (XQuery Update 3.0 extension)
+ */
+public class XQUFTransformExpr extends AbstractExpression {
+
+    private final List<CopyBinding> copyBindings;
+    private final Expression modifyExpr;
+    private final Expression returnExpr;
+
+    public XQUFTransformExpr(final XQueryContext context, final List<CopyBinding> copyBindings,
+                              final Expression modifyExpr, final Expression returnExpr) {
+        super(context);
+        this.copyBindings = copyBindings;
+        this.modifyExpr = modifyExpr;
+        this.returnExpr = returnExpr;
+    }
+
+    public static class CopyBinding {
+        private final QName varName;
+        private final Expression sourceExpr;
+
+        public CopyBinding(final QName varName, final Expression sourceExpr) {
+            this.varName = varName;
+            this.sourceExpr = sourceExpr;
+        }
+
+        public QName getVarName() {
+            return varName;
+        }
+
+        public Expression getSourceExpr() {
+            return sourceExpr;
+        }
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+        contextInfo.setParent(this);
+
+        // Mark variable scope so copy variables are visible to modify/return expressions
+        final LocalVariable mark = context.markLocalVariables(false);
+        try {
+            // Copy binding source expressions are non-updating contexts (XUST0001)
+            final AnalyzeContextInfo sourceInfo = new AnalyzeContextInfo(contextInfo);
+            sourceInfo.addFlag(NON_UPDATING_CONTEXT);
+            for (final CopyBinding binding : copyBindings) {
+                binding.sourceExpr.analyze(sourceInfo);
+
+                // Declare each copy variable so it's visible during analysis of modify/return
+                final LocalVariable var = new LocalVariable(binding.varName);
+                var.setSequenceType(new SequenceType(Type.NODE, Cardinality.EXACTLY_ONE));
+                context.declareVariableBinding(var);
+            }
+
+            // Modify clause is in an updating context (updating expressions allowed)
+            final AnalyzeContextInfo modifyInfo = new AnalyzeContextInfo(contextInfo);
+            modifyInfo.addFlag(IN_UPDATE);
+            modifyInfo.removeFlag(NON_UPDATING_CONTEXT);
+            modifyExpr.analyze(modifyInfo);
+
+            // XUST0002: modify clause must be updating or vacuous (empty sequence)
+            if (!modifyExpr.isUpdating() && !modifyExpr.isVacuous()) {
+                throw new XPathException(this, ErrorCodes.XUST0002,
+                        "The modify clause of a copy-modify expression must contain an updating expression.");
+            }
+
+            // Return clause is a non-updating context
+            final AnalyzeContextInfo returnInfo = new AnalyzeContextInfo(contextInfo);
+            returnInfo.addFlag(NON_UPDATING_CONTEXT);
+            returnExpr.analyze(returnInfo);
+        } finally {
+            context.popLocalVariables(mark);
+        }
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().start(this);
+        }
+
+        final Sequence ctxSeq = contextItem != null ? contextItem.toSequence() : contextSequence;
+
+        // Save the outer PUL and create a new scope for the modify clause
+        final PendingUpdateList outerPul = context.getPendingUpdateList();
+        final PendingUpdateList innerPul = new PendingUpdateList();
+        context.setPendingUpdateList(innerPul);
+
+        try {
+            // Push a new variable scope for the copy bindings
+            final LocalVariable mark = context.markLocalVariables(false);
+
+            try {
+                // Evaluate each copy binding and deep-copy the source node
+                final List<Node> copiedRoots = new ArrayList<>();
+                for (final CopyBinding binding : copyBindings) {
+                    final Sequence sourceSeq = binding.sourceExpr.eval(ctxSeq, null);
+                    if (sourceSeq.getItemCount() != 1 || !Type.subTypeOf(sourceSeq.itemAt(0).getType(), Type.NODE)) {
+                        throw new XPathException(this, ErrorCodes.XUTY0013,
+                                "Source expression of copy binding must return a single node.");
+                    }
+
+                    // Deep copy the source node into an in-memory tree
+                    final Sequence copied = deepCopyNode(sourceSeq);
+
+                    // Track the copied root node for XUDY0014 checking
+                    copiedRoots.add(((NodeValue) copied.itemAt(0)).getNode());
+
+                    // Bind the variable to the copied node
+                    final LocalVariable var = new LocalVariable(binding.varName);
+                    var.setSequenceType(new SequenceType(Type.NODE, Cardinality.EXACTLY_ONE));
+                    var.setValue(copied);
+                    context.declareVariableBinding(var);
+                }
+
+                // Evaluate the modify clause - updates go to innerPul
+                modifyExpr.eval(ctxSeq, null);
+
+                // XUDY0014: check that all update targets are descendants of copied nodes
+                innerPul.checkTransformTargets(copiedRoots, this);
+
+                // Apply the inner PUL to the copied nodes (in-memory updates)
+                innerPul.apply(context);
+
+                // Evaluate and return the return clause
+                final Sequence result = returnExpr.eval(ctxSeq, null);
+
+                if (context.getProfiler().isEnabled()) {
+                    context.getProfiler().end(this, "", result);
+                }
+
+                return result;
+            } finally {
+                context.popLocalVariables(mark);
+            }
+        } finally {
+            // Restore the outer PUL
+            context.setPendingUpdateList(outerPul);
+        }
+    }
+
+    /**
+     * Deep copy a node sequence into an in-memory tree.
+     * Reuses the serialization approach from Modification.deepCopy().
+     */
+    private Sequence deepCopyNode(final Sequence inSeq) throws XPathException {
+        context.pushDocumentContext();
+        final MemTreeBuilder builder = context.getDocumentBuilder();
+        final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(this, builder);
+        final Serializer serializer = context.getBroker().borrowSerializer();
+        serializer.setReceiver(receiver);
+
+        try {
+            final Sequence out = new ValueSequence();
+            for (final SequenceIterator i = inSeq.iterate(); i.hasNext(); ) {
+                Item item = i.nextItem();
+                final boolean isDocument = item.getType() == Type.DOCUMENT;
+                if (isDocument) {
+                    // For document nodes, copy the document element but return
+                    // the wrapping document node to preserve the node type
+                    if (((NodeValue) item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        final NodeHandle root = (NodeHandle) ((NodeProxy) item).getOwnerDocument().getDocumentElement();
+                        item = new NodeProxy(this, root);
+                    } else {
+                        item = (Item) ((Document) item).getDocumentElement();
+                    }
+                }
+                if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                    // Collect inherited namespace bindings from the source node's ancestors
+                    // BEFORE copying, so we can add them to the copied element afterwards.
+                    // This implements W3C copy-namespaces preserve semantics.
+                    final Map<String, String> inheritedNs;
+                    if (item.getType() == Type.ELEMENT && context.preserveNamespaces()) {
+                        inheritedNs = collectInheritedNamespaces((NodeValue) item);
+                    } else {
+                        inheritedNs = null;
+                    }
+
+                    // Always serialize through MemTreeBuilder to create a true independent copy.
+                    // Using NodeImpl.deepCopy() would mutate the original in place, causing
+                    // the source variable and copy variable to share the same document.
+                    final int last = builder.getDocument().getLastNode();
+                    if (((NodeValue) item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        final NodeProxy p = (NodeProxy) item;
+                        serializer.toReceiver(p, false, false);
+                    } else {
+                        final org.exist.dom.memtree.NodeImpl memNode = (org.exist.dom.memtree.NodeImpl) item;
+                        memNode.copyTo(context.getBroker(), receiver);
+                    }
+                    if (isDocument) {
+                        // Return the document node wrapping the copied element
+                        item = builder.getDocument();
+                    } else if (item.getType() == Type.ATTRIBUTE) {
+                        item = builder.getDocument().getLastAttr();
+                    } else {
+                        item = builder.getDocument().getNode(last + 1);
+                    }
+
+                    // Add inherited namespace bindings to the copied root element
+                    if (inheritedNs != null && !inheritedNs.isEmpty()
+                            && item instanceof org.exist.dom.memtree.NodeImpl) {
+                        addInheritedNamespaces(builder.getDocument(),
+                                ((org.exist.dom.memtree.NodeImpl) item).getNodeNumber(), inheritedNs);
+                    }
+                }
+                out.add(item);
+            }
+            return out;
+        } catch (final SAXException e) {
+            throw new XPathException(this, e.getMessage(), e);
+        } finally {
+            context.getBroker().returnSerializer(serializer);
+            context.popDocumentContext();
+        }
+    }
+
+    @Override
+    public int returnsType() {
+        return returnExpr.returnsType();
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return returnExpr.getCardinality();
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
+        super.resetState(postOptimization);
+        for (final CopyBinding binding : copyBindings) {
+            binding.sourceExpr.resetState(postOptimization);
+        }
+        modifyExpr.resetState(postOptimization);
+        returnExpr.resetState(postOptimization);
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("copy ");
+        for (int i = 0; i < copyBindings.size(); i++) {
+            if (i > 0) {
+                dumper.display(", ");
+            }
+            final CopyBinding binding = copyBindings.get(i);
+            dumper.display("$").display(binding.varName.getLocalPart()).display(" := ");
+            binding.sourceExpr.dump(dumper);
+        }
+        dumper.display(" modify ");
+        modifyExpr.dump(dumper);
+        dumper.display(" return ");
+        returnExpr.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("copy ");
+        for (int i = 0; i < copyBindings.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            final CopyBinding binding = copyBindings.get(i);
+            sb.append("$").append(binding.varName.getLocalPart()).append(" := ");
+            sb.append(binding.sourceExpr.toString());
+        }
+        sb.append(" modify ");
+        sb.append(modifyExpr.toString());
+        sb.append(" return ");
+        sb.append(returnExpr.toString());
+        return sb.toString();
+    }
+
+    /**
+     * Collect namespace bindings inherited from ancestor elements of the given node.
+     * These are namespaces in scope on the node via inheritance but not declared on the node itself.
+     */
+    private Map<String, String> collectInheritedNamespaces(final NodeValue nodeValue) {
+        final Map<String, String> inherited = new LinkedHashMap<>();
+        Node parent = nodeValue.getNode().getParentNode();
+        // Walk up ancestors collecting namespace bindings
+        final Deque<org.w3c.dom.Element> ancestors = new ArrayDeque<>();
+        while (parent != null && parent.getNodeType() == Node.ELEMENT_NODE) {
+            ancestors.push((org.w3c.dom.Element) parent);
+            parent = parent.getParentNode();
+        }
+        // Process top-down so closer ancestors override
+        while (!ancestors.isEmpty()) {
+            FunInScopePrefixes.collectNamespacePrefixes(ancestors.pop(), inherited);
+        }
+        // Remove "xml" prefix — always implicitly in scope
+        inherited.remove("xml");
+        // Remove any bindings that are already declared on the element itself
+        final Map<String, String> selfNs = new LinkedHashMap<>();
+        FunInScopePrefixes.collectNamespacePrefixes((org.w3c.dom.Element) nodeValue.getNode(), selfNs);
+        for (final String prefix : selfNs.keySet()) {
+            inherited.remove(prefix);
+        }
+        return inherited;
+    }
+
+    /**
+     * Add inherited namespace bindings to a copied element node.
+     * Only adds bindings not already declared on the element.
+     */
+    private void addInheritedNamespaces(final org.exist.dom.memtree.DocumentImpl doc,
+                                         final int elementNodeNum,
+                                         final Map<String, String> inheritedNs) {
+        for (final Map.Entry<String, String> entry : inheritedNs.entrySet()) {
+            final String prefix = entry.getKey();
+            final String uri = entry.getValue();
+            if (uri != null && !uri.isEmpty()) {
+                final QName nsQName = new QName(prefix, uri, XMLConstants.XMLNS_ATTRIBUTE);
+                doc.addNamespace(elementNodeNum, nsQName);
+            }
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/lock/ConcurrencyBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/lock/ConcurrencyBenchmark.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
  * </pre>
  */
+@SuppressWarnings("PMD.ClassNamingConventions") // benchmark, not a test class; gated by -Dexist.run.benchmarks=true
 public class ConcurrencyBenchmark {
 
     @ClassRule

--- a/exist-core/src/test/java/org/exist/xquery/lock/ConcurrencyBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/lock/ConcurrencyBenchmark.java
@@ -1,0 +1,375 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.lock;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XQueryService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Concurrency benchmark for measuring the impact of preclaiming locks
+ * on read, write, and mixed workloads.
+ *
+ * <p>Run on both the base branch (develop) and the preclaiming branch
+ * to get before/after comparisons. Results are printed to stdout.</p>
+ *
+ * <p>This class intentionally does <em>not</em> end in {@code *Test} so that
+ * Surefire will not discover it during normal {@code mvn test} runs.
+ * Run explicitly with:</p>
+ * <pre>
+ *   mvn test -pl exist-core -Dtest=ConcurrencyBenchmark \
+ *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
+ * </pre>
+ */
+public class ConcurrencyBenchmark {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static final String COLLECTION_NAME = "benchmark-concurrency";
+    private static final String COLLECTION_PATH = "/db/" + COLLECTION_NAME;
+
+    private static final int NUM_DOCUMENTS = 8;
+    private static final int DURATION_SECONDS = 5;
+    private static final int[] THREAD_COUNTS = {2, 4, 8};
+
+    @BeforeClass
+    public static void assumeBenchmarks() {
+        Assume.assumeTrue("Benchmarks are disabled. Set -Dexist.run.benchmarks=true to enable.",
+                Boolean.getBoolean("exist.run.benchmarks"));
+    }
+
+    @BeforeClass
+    public static void setUp() throws XMLDBException {
+        if (!Boolean.getBoolean("exist.run.benchmarks")) {
+            return;
+        }
+
+        final CollectionManagementService cms =
+                server.getRoot().getService(CollectionManagementService.class);
+        cms.createCollection(COLLECTION_NAME);
+
+        final Collection col = server.getRoot().getChildCollection(COLLECTION_NAME);
+        for (int i = 1; i <= NUM_DOCUMENTS; i++) {
+            final XMLResource res = col.createResource("doc" + i + ".xml", XMLResource.class);
+            res.setContent("<root><counter>0</counter><data>" + "x".repeat(100) + "</data></root>");
+            col.storeResource(res);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws XMLDBException {
+        if (!Boolean.getBoolean("exist.run.benchmarks")) {
+            return;
+        }
+
+        final CollectionManagementService cms =
+                server.getRoot().getService(CollectionManagementService.class);
+        cms.removeCollection(COLLECTION_NAME);
+    }
+
+    // ---- Scenario 1: Concurrent reads ----
+
+    @Test
+    public void concurrentReads() throws Exception {
+        System.out.println("\n=== Concurrent Reads (all threads read same document) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter/text()");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "read-same-doc", threads, opsPerSec);
+        }
+    }
+
+    @Test
+    public void concurrentReadsDistributed() throws Exception {
+        System.out.println("\n=== Concurrent Reads (each thread reads different doc) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                final int docNum = (threadId % NUM_DOCUMENTS) + 1;
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/data/text()");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "read-diff-docs", threads, opsPerSec);
+        }
+    }
+
+    // ---- Scenario 2: Concurrent writes ----
+
+    @Test
+    public void concurrentWritesSameDoc() throws Exception {
+        System.out.println("\n=== Concurrent Writes (all threads update same document) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("update value doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter " +
+                                "with string(number(doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter) + 1)");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "write-same-doc", threads, opsPerSec);
+        }
+    }
+
+    @Test
+    public void concurrentWritesDifferentDocs() throws Exception {
+        System.out.println("\n=== Concurrent Writes (each thread updates its own document) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                final int docNum = (threadId % NUM_DOCUMENTS) + 1;
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("update value doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter " +
+                                "with string(number(doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter) + 1)");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "write-diff-docs", threads, opsPerSec);
+        }
+    }
+
+    // ---- Scenario 3: Mixed read/write ----
+
+    @Test
+    public void mixedReadWrite() throws Exception {
+        System.out.println("\n=== Mixed Read/Write (half readers, half writers, same document) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                final boolean isWriter = (threadId % 2 == 0);
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        if (isWriter) {
+                            qs.query("update value doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter " +
+                                    "with string(number(doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter) + 1)");
+                        } else {
+                            qs.query("doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter/text()");
+                        }
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "mixed-same-doc", threads, opsPerSec);
+        }
+    }
+
+    @Test
+    public void mixedReadWriteDistributed() throws Exception {
+        System.out.println("\n=== Mixed Read/Write (half readers, half writers, different documents) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                final boolean isWriter = (threadId % 2 == 0);
+                final int docNum = (threadId % NUM_DOCUMENTS) + 1;
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        if (isWriter) {
+                            qs.query("update value doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter " +
+                                    "with string(number(doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter) + 1)");
+                        } else {
+                            qs.query("doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter/text()");
+                        }
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "mixed-diff-docs", threads, opsPerSec);
+        }
+    }
+
+    // ---- Scenario 4: Write contention with XQUF (deferred PUL) ----
+
+    @Test
+    public void concurrentXQUFWritesSameDoc() throws Exception {
+        System.out.println("\n=== Concurrent XQUF Writes (all threads update same document via PUL) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("replace value of node doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter " +
+                                "with string(number(doc('" + COLLECTION_PATH + "/doc1.xml')/root/counter) + 1)");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "xquf-write-same-doc", threads, opsPerSec);
+        }
+    }
+
+    @Test
+    public void concurrentXQUFWritesDifferentDocs() throws Exception {
+        System.out.println("\n=== Concurrent XQUF Writes (each thread updates its own document via PUL) ===");
+        printHeader();
+
+        for (final int threads : THREAD_COUNTS) {
+            resetDocuments();
+            final double opsPerSec = runBenchmark(threads, (threadId, barrier, opsCounter, errorCounter) -> {
+                final XQueryService qs = server.getRoot().getService(XQueryService.class);
+                final int docNum = (threadId % NUM_DOCUMENTS) + 1;
+                barrier.await();
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(DURATION_SECONDS);
+                while (System.nanoTime() < deadline) {
+                    try {
+                        qs.query("replace value of node doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter " +
+                                "with string(number(doc('" + COLLECTION_PATH + "/doc" + docNum + ".xml')/root/counter) + 1)");
+                        opsCounter.incrementAndGet();
+                    } catch (final XMLDBException e) {
+                        errorCounter.incrementAndGet();
+                    }
+                }
+            });
+            System.out.printf("  %-24s  threads=%d  ops/sec=%8.0f%n", "xquf-write-diff-docs", threads, opsPerSec);
+        }
+    }
+
+    // ---- Helpers ----
+
+    @FunctionalInterface
+    interface BenchmarkTask {
+        void run(int threadId, CyclicBarrier barrier, AtomicInteger opsCounter, AtomicInteger errorCounter) throws Exception;
+    }
+
+    private double runBenchmark(final int numThreads, final BenchmarkTask task) throws Exception {
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        final AtomicInteger totalOps = new AtomicInteger(0);
+        final AtomicInteger totalErrors = new AtomicInteger(0);
+        final List<Future<?>> futures = new ArrayList<>();
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            futures.add(executor.submit(() -> {
+                task.run(threadId, barrier, totalOps, totalErrors);
+                return null;
+            }));
+        }
+
+        for (final Future<?> f : futures) {
+            f.get(DURATION_SECONDS + 10, TimeUnit.SECONDS);
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        if (totalErrors.get() > 0) {
+            System.out.printf("    (errors: %d)%n", totalErrors.get());
+        }
+
+        return totalOps.get() / (double) DURATION_SECONDS;
+    }
+
+    private void resetDocuments() throws XMLDBException {
+        final Collection col = server.getRoot().getChildCollection(COLLECTION_NAME);
+        for (int i = 1; i <= NUM_DOCUMENTS; i++) {
+            final XMLResource res = col.createResource("doc" + i + ".xml", XMLResource.class);
+            res.setContent("<root><counter>0</counter><data>" + "x".repeat(100) + "</data></root>");
+            col.storeResource(res);
+        }
+    }
+
+    private static void printHeader() {
+        System.out.printf("  %-24s  %8s  %12s%n", "Scenario", "Threads", "Ops/sec");
+        System.out.println("  " + "=".repeat(50));
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/lock/LockTargetCollectorTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/lock/LockTargetCollectorTest.java
@@ -164,6 +164,7 @@ public class LockTargetCollectorTest {
 
     // --- Helper ---
 
+    @SuppressWarnings("PMD.UnusedLocalVariable") // broker acquired for thread-local lifecycle (XQuery.compile depends on it); not referenced explicitly
     private LockTargetCollector collectTargets(final String xquery)
             throws EXistException, PermissionDeniedException, XPathException, IOException, URISyntaxException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();

--- a/exist-core/src/test/java/org/exist/xquery/lock/LockTargetCollectorTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/lock/LockTargetCollectorTest.java
@@ -1,0 +1,182 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.lock;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link LockTargetCollector} — verifies that the expression tree
+ * visitor correctly identifies document and collection targets from XQuery
+ * expressions at compile time.
+ */
+public class LockTargetCollectorTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer =
+            new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void staticDocCall() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "doc('/db/test/data.xml')//item");
+
+        assertFalse(collector.requiresGlobalLock());
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/data.xml")));
+        assertTrue(collector.getCollectionTargets().isEmpty());
+    }
+
+    @Test
+    public void staticCollectionCall() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "collection('/db/test')//item");
+
+        assertFalse(collector.requiresGlobalLock());
+        assertTrue(collector.getCollectionTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test")));
+        assertTrue(collector.getDocumentTargets().isEmpty());
+    }
+
+    @Test
+    public void dynamicDocCallRequiresGlobalLock() throws EXistException,
+            PermissionDeniedException, XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "let $path := '/db/test/data.xml' return doc($path)//item");
+
+        assertTrue(collector.requiresGlobalLock());
+    }
+
+    @Test
+    public void multipleStaticDocCalls() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "doc('/db/test/a.xml')//x | doc('/db/test/b.xml')//y");
+
+        assertFalse("Global lock should not be required for static doc calls",
+                collector.requiresGlobalLock());
+        assertEquals("Should find 2 doc targets, found: " + collector.getDocumentTargets(),
+                2, collector.getDocumentTargets().size());
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/a.xml")));
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/b.xml")));
+    }
+
+    @Test
+    public void mixedStaticAndDynamicRequiresGlobalLock() throws EXistException,
+            PermissionDeniedException, XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "let $p := '/db/dynamic.xml' " +
+                "return (doc('/db/test/static.xml'), doc($p))");
+
+        // Even though one target is static, the dynamic one forces global lock
+        assertTrue(collector.requiresGlobalLock());
+        // Static target should still be collected
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/static.xml")));
+    }
+
+    @Test
+    public void noDocOrCollectionCalls() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "1 + 2");
+
+        assertFalse(collector.requiresGlobalLock());
+        assertTrue(collector.getDocumentTargets().isEmpty());
+        assertTrue(collector.getCollectionTargets().isEmpty());
+        assertFalse(collector.hasTargets());
+    }
+
+    @Test
+    public void docInFLWOR() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "for $x in doc('/db/test/data.xml')//item " +
+                "return $x/name");
+
+        assertFalse(collector.requiresGlobalLock());
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/data.xml")));
+    }
+
+    @Test
+    public void docInConditional() throws EXistException, PermissionDeniedException,
+            XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets(
+                "if (true()) then doc('/db/test/a.xml') else doc('/db/test/b.xml')");
+
+        assertFalse(collector.requiresGlobalLock());
+        assertEquals(2, collector.getDocumentTargets().size());
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/a.xml")));
+        assertTrue(collector.getDocumentTargets().contains(
+                XmldbURI.xmldbUriFor("/db/test/b.xml")));
+    }
+
+    @Test
+    public void zeroArgCollectionRequiresGlobalLock() throws EXistException,
+            PermissionDeniedException, XPathException, IOException, URISyntaxException {
+        final LockTargetCollector collector = collectTargets("collection()");
+
+        assertTrue(collector.requiresGlobalLock());
+    }
+
+    // --- Helper ---
+
+    private LockTargetCollector collectTargets(final String xquery)
+            throws EXistException, PermissionDeniedException, XPathException, IOException, URISyntaxException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xqueryService = pool.getXQueryService();
+            final XQueryContext context = new XQueryContext(pool);
+            final CompiledXQuery compiled = xqueryService.compile(context,
+                    new StringSource(xquery));
+
+            final LockTargetCollector collector = new LockTargetCollector();
+            // CompiledXQuery is implemented by PathExpr which is an Expression
+            collector.collect((Expression) compiled);
+            return collector;
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
@@ -1,0 +1,1973 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xmldb.IndexQueryService;
+import org.junit.*;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for W3C XQuery Update Facility 3.0 expressions.
+ *
+ * Tests insert, delete, replace, replace value of, rename, and copy-modify
+ * expressions against persistent (stored) documents.
+ */
+public class XQUFBasicTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
+
+    private Collection testCollection;
+
+    @Before
+    public void setUp() throws Exception {
+        final CollectionManagementService service =
+                existEmbeddedServer.getRoot().getService(CollectionManagementService.class);
+        testCollection = service.createCollection("test");
+    }
+
+    @After
+    public void tearDown() throws XMLDBException {
+        final CollectionManagementService service =
+                existEmbeddedServer.getRoot().getService(CollectionManagementService.class);
+        service.removeCollection("test");
+        testCollection = null;
+    }
+
+    private XQueryService storeXMLStringAndGetQueryService(final String documentName,
+            final String content) throws XMLDBException {
+        final XMLResource doc = testCollection.createResource(documentName, XMLResource.class);
+        doc.setContent(content);
+        testCollection.storeResource(doc);
+        return testCollection.getService(XQueryService.class);
+    }
+
+    private ResourceSet queryResource(final XQueryService service, final String resource,
+            final String query, final int expected) throws XMLDBException {
+        final ResourceSet result = service.queryResource(resource, query);
+        assertEquals(query, expected, result.getSize());
+        return result;
+    }
+
+    private String queryAndGetString(final XQueryService service, final String query) throws XMLDBException {
+        final ResourceSet result = service.query(query);
+        assertEquals("Expected single result for: " + query, 1L, result.getSize());
+        return result.getResource(0).getContent().toString();
+    }
+
+    // === Insert tests ===
+
+    @Test
+    public void insertNodeInto() throws XMLDBException {
+        final String docName = "insert-into.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        queryResource(service, docName, "insert node <b/> into /root", 0);
+
+        queryResource(service, docName, "/root/b", 1);
+        queryResource(service, docName, "/root/*", 2);
+    }
+
+    @Test
+    public void insertNodesInto() throws XMLDBException {
+        final String docName = "insert-nodes.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        queryResource(service, docName, "insert nodes (<a/>, <b/>) into /root", 0);
+
+        queryResource(service, docName, "/root/*", 2);
+    }
+
+    @Test
+    public void insertNodeBefore() throws XMLDBException {
+        final String docName = "insert-before.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><b/></root>");
+
+        queryResource(service, docName, "insert node <a/> before /root/b", 0);
+
+        // Verify <a/> comes before <b/>
+        final ResourceSet result = service.queryResource(docName, "/root/*[1]");
+        assertEquals(1L, result.getSize());
+        assertEquals("<a/>", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void insertNodeAfter() throws XMLDBException {
+        final String docName = "insert-after.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        queryResource(service, docName, "insert node <b/> after /root/a", 0);
+
+        final ResourceSet result = service.queryResource(docName, "/root/*[2]");
+        assertEquals(1L, result.getSize());
+        assertEquals("<b/>", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void insertNodeAsFirstInto() throws XMLDBException {
+        final String docName = "insert-first.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><b/></root>");
+
+        queryResource(service, docName, "insert node <a/> as first into /root", 0);
+
+        final ResourceSet result = service.queryResource(docName, "/root/*[1]");
+        assertEquals(1L, result.getSize());
+        assertEquals("<a/>", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void insertNodeAsLastInto() throws XMLDBException {
+        final String docName = "insert-last.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        queryResource(service, docName, "insert node <b/> as last into /root", 0);
+
+        final ResourceSet result = service.queryResource(docName, "/root/*[last()]");
+        assertEquals(1L, result.getSize());
+        assertEquals("<b/>", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void insertTextNode() throws XMLDBException {
+        final String docName = "insert-text.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        queryResource(service, docName, "insert node text {'hello'} into /root", 0);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root)");
+        assertEquals(1L, result.getSize());
+        assertEquals("hello", result.getResource(0).getContent().toString());
+    }
+
+    // === Delete tests ===
+
+    @Test
+    public void deleteNode() throws XMLDBException {
+        final String docName = "delete.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/><b/><c/></root>");
+
+        queryResource(service, docName, "delete node /root/b", 0);
+
+        queryResource(service, docName, "/root/*", 2);
+        queryResource(service, docName, "/root/b", 0);
+    }
+
+    @Test
+    public void deleteNodes() throws XMLDBException {
+        final String docName = "delete-nodes.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/><b/><c/></root>");
+
+        queryResource(service, docName, "delete nodes /root/*[position() > 1]", 0);
+
+        queryResource(service, docName, "/root/*", 1);
+        queryResource(service, docName, "/root/a", 1);
+    }
+
+    // === Replace node tests ===
+
+    @Test
+    public void replaceNode() throws XMLDBException {
+        final String docName = "replace.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a>old</a></root>");
+
+        queryResource(service, docName, "replace node /root/a with <b>new</b>", 0);
+
+        queryResource(service, docName, "/root/a", 0);
+        queryResource(service, docName, "/root/b", 1);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root/b)");
+        assertEquals("new", result.getResource(0).getContent().toString());
+    }
+
+    // === Replace value of tests ===
+
+    @Test
+    public void replaceValueOfElement() throws XMLDBException {
+        final String docName = "replace-value.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a>old</a></root>");
+
+        queryResource(service, docName, "replace value of node /root/a with 'new'", 0);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root/a)");
+        assertEquals("new", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void replaceValueOfAttribute() throws XMLDBException {
+        final String docName = "replace-attr-value.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root x='old'/>");
+
+        queryResource(service, docName, "replace value of node /root/@x with 'new'", 0);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root/@x)");
+        assertEquals("new", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void replaceValueOfText() throws XMLDBException {
+        final String docName = "replace-text-value.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root>old</root>");
+
+        queryResource(service, docName, "replace value of node /root/text() with 'new'", 0);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root)");
+        assertEquals("new", result.getResource(0).getContent().toString());
+    }
+
+    // === Rename tests ===
+
+    @Test
+    public void renameElement() throws XMLDBException {
+        final String docName = "rename.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><oldname>content</oldname></root>");
+
+        queryResource(service, docName, "rename node /root/oldname as 'newname'", 0);
+
+        queryResource(service, docName, "/root/oldname", 0);
+        queryResource(service, docName, "/root/newname", 1);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root/newname)");
+        assertEquals("content", result.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void renameAttribute() throws XMLDBException {
+        final String docName = "rename-attr.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root oldattr='value'/>");
+
+        queryResource(service, docName, "rename node /root/@oldattr as 'newattr'", 0);
+
+        queryResource(service, docName, "/root/@oldattr", 0);
+        queryResource(service, docName, "/root/@newattr", 1);
+
+        final ResourceSet result = service.queryResource(docName, "string(/root/@newattr)");
+        assertEquals("value", result.getResource(0).getContent().toString());
+    }
+
+    // === Transform (copy-modify) tests ===
+
+    @Test
+    public void copyModifyReplaceValue() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $node := <root><a>old</a></root> " +
+                "return copy $c := $node " +
+                "modify replace value of node $c/a with 'new' " +
+                "return $c";
+
+        final String result = queryAndGetString(service, query);
+        assertTrue("Expected result to contain 'new', got: " + result,
+                result.contains("new"));
+        assertFalse("Expected result to NOT contain 'old', got: " + result,
+                result.contains("old"));
+    }
+
+    @Test
+    public void copyModifyDoesNotAffectOriginal() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $node := <root><a>original</a></root> " +
+                "let $copy := copy $c := $node " +
+                "             modify replace value of node $c/a with 'modified' " +
+                "             return $c " +
+                "return ($node/a/text(), '|', $copy/a/text())";
+
+        final ResourceSet result = service.query(query);
+        assertEquals(3L, result.getSize());
+        assertEquals("original", result.getResource(0).getContent().toString());
+        assertEquals("modified", result.getResource(2).getContent().toString());
+    }
+
+    @Test
+    public void copyModifyDelete() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $node := <root><a/><b/><c/></root> " +
+                "return copy $c := $node " +
+                "modify delete node $c/b " +
+                "return count($c/*)";
+
+        final String result = queryAndGetString(service, query);
+        assertEquals("2", result);
+    }
+
+    @Test
+    public void copyModifyInsert() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $node := <root><a/></root> " +
+                "return copy $c := $node " +
+                "modify insert node <b/> into $c " +
+                "return count($c/*)";
+
+        final String result = queryAndGetString(service, query);
+        assertEquals("2", result);
+    }
+
+    @Test
+    public void copyModifyRename() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $node := <root><old/></root> " +
+                "return copy $c := $node " +
+                "modify rename node $c/old as 'new' " +
+                "return local-name($c/*[1])";
+
+        final String result = queryAndGetString(service, query);
+        assertEquals("new", result);
+    }
+
+    @Test
+    public void copyModifyMultipleBindings() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $a := <x>1</x> " +
+                "let $b := <y>2</y> " +
+                "return copy $ca := $a, $cb := $b " +
+                "modify (replace value of node $ca with '10', replace value of node $cb with '20') " +
+                "return ($ca, $cb)";
+
+        final ResourceSet result = service.query(query);
+        assertEquals(2L, result.getSize());
+        assertTrue(result.getResource(0).getContent().toString().contains("10"));
+        assertTrue(result.getResource(1).getContent().toString().contains("20"));
+    }
+
+    // === Combined update tests ===
+
+    @Test
+    public void multipleUpdatesInFlwor() throws XMLDBException {
+        final String docName = "multi-update.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName,
+                "<root><item n='1'/><item n='2'/><item n='3'/></root>");
+
+        // Delete all items, then insert a new one
+        queryResource(service, docName, "delete nodes /root/item", 0);
+        queryResource(service, docName, "/root/item", 0);
+
+        queryResource(service, docName, "insert node <item n='new'/> into /root", 0);
+        queryResource(service, docName, "/root/item[@n='new']", 1);
+    }
+
+    // === Error condition tests ===
+
+    @Test(expected = XMLDBException.class)
+    public void replaceNodeDocumentTarget() throws XMLDBException {
+        final String docName = "error-doc-target.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        // Replacing a document node should fail with XUTY0008
+        service.queryResource(docName, "replace node / with <new/>");
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void replaceValueOfDocumentTarget() throws XMLDBException {
+        final String docName = "error-doc-target2.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        service.queryResource(docName, "replace value of node / with 'text'");
+    }
+
+    // === XUST0001 static analysis tests ===
+
+    @Test(expected = XMLDBException.class)
+    public void xust0001InsertInNonUpdatingFunction() throws XMLDBException {
+        final String docName = "xust0001-func.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Non-updating function containing an insert expression should fail with XUST0001
+        service.queryResource(docName,
+                "declare function local:f($e as element()) { insert node <b/> into $e }; " +
+                "local:f(/root)");
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void xust0001DeleteInLogicalOp() throws XMLDBException {
+        final String docName = "xust0001-logical.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Delete expression in logical AND operand should fail with XUST0001
+        service.queryResource(docName, "fn:false() and (delete node /root/a)");
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void xust0001InsertInForInput() throws XMLDBException {
+        final String docName = "xust0001-for.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Insert expression in for clause input should fail with XUST0001
+        service.queryResource(docName, "for $x in (insert node <b/> into /root) return $x");
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void xust0001InsertInFunctionArgument() throws XMLDBException {
+        final String docName = "xust0001-arg.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Insert expression as function argument should fail with XUST0001
+        service.queryResource(docName, "fn:count(insert node <b/> into /root)");
+    }
+
+    @Test
+    public void xust0001MixedConditionalBranches() throws XMLDBException {
+        final String docName = "xust0001-cond.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Mixed updating/non-updating branches should fail with XUST0001
+        try {
+            service.queryResource(docName,
+                    "if (fn:false()) then 'not updating' else insert node <b/> into /root");
+            fail("Expected XMLDBException for XUST0001 but query succeeded");
+        } catch (XMLDBException e) {
+            assertTrue("Expected XUST0001, got: " + e.getMessage(),
+                    e.getMessage().contains("XUST0001"));
+        }
+    }
+
+    @Test
+    public void updatingFunctionKeywordSyntax() throws XMLDBException {
+        final String docName = "updating-func-keyword.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // W3C 1.0 keyword syntax: declare updating function
+        service.queryResource(docName,
+                "declare updating function local:add($e as element()) { " +
+                "  insert node <b/> into $e " +
+                "}; " +
+                "local:add(/root)");
+        queryResource(service, docName, "/root/b", 1);
+    }
+
+    @Test
+    public void updatingFunctionAnnotationSyntax() throws XMLDBException {
+        final String docName = "updating-func-annot.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // W3C 3.0 annotation syntax: declare %updating function
+        service.queryResource(docName,
+                "declare %updating function local:add($e as element()) { " +
+                "  insert node <c/> into $e " +
+                "}; " +
+                "local:add(/root)");
+        queryResource(service, docName, "/root/c", 1);
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void xust0028UpdatingFunctionWithReturnType() throws XMLDBException {
+        final String docName = "xust0028.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        // XUST0028: updating function must not declare a return type
+        service.queryResource(docName,
+                "declare updating function local:f() as item()* { " +
+                "  insert node <a/> into /root " +
+                "}; " +
+                "local:f()");
+    }
+
+    @Test(expected = XMLDBException.class)
+    public void xust0002UpdatingFunctionNonUpdatingBody() throws XMLDBException {
+        final String docName = "xust0002.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root/>");
+
+        // XUST0002: body of updating function must be updating or vacuous
+        service.queryResource(docName,
+                "declare updating function local:f($x as xs:integer) { " +
+                "  $x + 1 " +
+                "}; " +
+                "local:f(1)");
+    }
+
+    @Test
+    public void xust0001InsertInFlworReturnIsAllowed() throws XMLDBException {
+        final String docName = "xust0001-return.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<root><a/></root>");
+
+        // Insert expression in FLWOR return clause IS allowed (at top level)
+        queryResource(service, docName, "for $x in /root/a return insert node <b/> into /root", 0);
+        queryResource(service, docName, "/root/b", 1);
+    }
+
+    @Test(timeout = 10000)
+    public void copyModifyMultipleInsertAfterSameNode() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $doc := <employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee> " +
+                "return copy $c := $doc " +
+                "modify ( " +
+                "  insert node (<type>Part Time</type>,<age>26</age>) after $c/empnum[1], " +
+                "  insert node (<type>Full Time</type>,<age>30</age>) after $c/empnum[1] " +
+                ") return $c";
+
+        final ResourceSet result = service.query(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Should contain Part Time", xml.contains("Part Time"));
+        assertTrue("Should contain Full Time", xml.contains("Full Time"));
+    }
+
+    // === Multi-step update + query tests (complex-deletes regression) ===
+
+    @Test
+    public void deletePIMultiStepPrecedingSiblingTextCount() throws Exception {
+        // Simulates the XQTS multi-step pattern: update query mutates an in-memory doc,
+        // then a separate verification query reads it.
+        // This is the pattern that fails in complex-deletes-q3.
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Parse document externally (like the XQTS runner does with SAXParser)
+        final String xml = "<root>A<!-- c1 -->B<?pi x?>C<child/>D</root>";
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParser saxParser = javax.xml.parsers.SAXParserFactory.newDefaultInstance().newSAXParser();
+        saxParser.getXMLReader().setContentHandler(adapter);
+        saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        // Step 1: Run update query with document as external variable
+        service.declareVariable("doc", doc);
+        service.query("declare variable $doc external; delete nodes $doc//processing-instruction('pi')");
+
+        // Step 2: Run verification query on the same document
+        service.declareVariable("doc", doc);
+        final ResourceSet result = service.query(
+                "declare variable $doc external; count($doc//child/preceding-sibling::text())");
+        assertEquals("Expected single result", 1L, result.getSize());
+        final String count = result.getResource(0).getContent().toString();
+
+        // After deleting the PI between B and C, B+C merge per W3C spec → 2 text nodes: A, BC
+        assertEquals("Text node count after PI deletion", "2", count);
+    }
+
+    @Test
+    public void deletePIMultiStepComplexDeletesQ3() throws Exception {
+        // Full complex-deletes-q3 pattern with doc-level PIs,
+        // using BrokerPool + XQuery service directly with context sequence (like the XQTS runner).
+        final String xml =
+                "<!-- Comment-1 --><?a-pi pi-1?><!-- Comment-2 -->" +
+                "<far-north> text-1A\n" +
+                "    <!-- Comment-3 --> text-1B\n" +
+                "    <?a-pi pi-2?> text-1C\n" +
+                "  <north mark=\"n0\"> text-2A\n" +
+                "    <near-north> text-3A\n" +
+                "      <center mark=\"c0\"> text-4A\n" +
+                "        <near-south-west/> text-4B\n" +
+                "            <!--Comment-5--> text-4C\n" +
+                "            <?a-pi pi-4?> text-4D\n" +
+                "        <near-south> text-5A\n" +
+                "        </near-south> text-4E\n" +
+                "      </center> text-3E\n" +
+                "    </near-north> text-2D\n" +
+                "  </north> text-1D\n" +
+                "</far-north>\n" +
+                "<!-- Comment-6 --><?a-pi pi-6?><!-- Comment-7 -->";
+
+        // Parse using SAXAdapter (same as XQTS runner)
+        final javax.xml.parsers.SAXParserFactory spf = javax.xml.parsers.SAXParserFactory.newInstance();
+        spf.setNamespaceAware(true);
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParser saxParser = spf.newSAXParser();
+        saxParser.getXMLReader().setContentHandler(adapter);
+        saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        // Use BrokerPool + XQuery service directly (like the XQTS runner)
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            // Step 1: Delete all PIs with target "a-pi"
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                ctx.declareVariable("input-context", doc);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "declare variable $input-context external; " +
+                                "delete nodes $input-context//processing-instruction('a-pi')");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Step 2: Snapshot step (like ". " in the XQTS test)
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                ctx.declareVariable("input-context", doc);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx, ". ");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Step 3: Verification query - just count
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "count(.//(north | near-south)/preceding-sibling::text())");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                final String countStr = result.itemAt(0).getStringValue();
+
+                // Also get the individual text values for debug
+                final org.exist.xquery.XQueryContext ctx2 = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled2 = xqueryService.compile(ctx2,
+                        "for $t in .//(north | near-south)/preceding-sibling::text() " +
+                                "return concat('[', $t, ']')");
+                final org.exist.xquery.value.Sequence result2 = xqueryService.execute(broker, compiled2, doc);
+                final StringBuilder texts = new StringBuilder();
+                for (int i = 0; i < result2.getItemCount(); i++) {
+                    if (i > 0) texts.append(", ");
+                    texts.append(result2.itemAt(i).getStringValue());
+                }
+
+                // Also check what .//(north | near-south) returns
+                final org.exist.xquery.XQueryContext ctx3 = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled3 = xqueryService.compile(ctx3,
+                        "for $n in .//(north | near-south) return name($n)");
+                final org.exist.xquery.value.Sequence result3 = xqueryService.execute(broker, compiled3, doc);
+                final StringBuilder names = new StringBuilder();
+                for (int i = 0; i < result3.getItemCount(); i++) {
+                    if (i > 0) names.append(", ");
+                    names.append(result3.itemAt(i).getStringValue());
+                }
+
+                // W3C spec requires text node merging: after deleting PI between text-1B and text-1C,
+                // they merge into one. Same for text-4C and text-4D. So: north has 2 preceding text,
+                // near-south has 3 preceding text = 5 total.
+                assertEquals("count=" + countStr + ", texts=" + texts + ", targets=" + names, "5", countStr);
+                ctx.runCleanupTasks();
+                ctx2.runCleanupTasks();
+                ctx3.runCleanupTasks();
+            }
+        }
+    }
+
+    // === Delete + axis traversal tests (single-query, copy-modify) ===
+
+    @Test
+    public void deletePIPrecedingSiblingTextCount() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Simulate complex-deletes-q3: delete PIs, then count preceding-sibling text nodes
+        final String query =
+                "let $doc := <root>A<!-- c1 -->B<?pi x?>C<child/>D</root> " +
+                "return copy $c := $doc " +
+                "modify delete nodes $c//processing-instruction() " +
+                "return count($c/child/preceding-sibling::text())";
+
+        final String result = queryAndGetString(service, query);
+        // After deleting PI between B and C, B+C merge per W3C spec → 2 text nodes: A, BC
+        assertEquals("2", result);
+    }
+
+    @Test
+    public void deleteElementChildTextCount() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Simulate complex-deletes-q10: delete element, count remaining text children
+        final String query =
+                "let $doc := <root>A<a/>B<b/>C<target/>D</root> " +
+                "return copy $c := $doc " +
+                "modify delete nodes $c/target " +
+                "return count($c/text())";
+
+        final String result = queryAndGetString(service, query);
+        // After deleting <target/>, C+D merge per W3C spec → 3 text nodes: A, B, CD
+        assertEquals("3", result);
+    }
+
+    @Test
+    public void deletePIDescendantAndPrecedingSibling() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Full complex-deletes-q3 pattern: delete PIs, then use //child/preceding-sibling::text()
+        final String query =
+                "let $doc := <root>A<!-- c1 -->B<?mypi x?>C<child/>D</root> " +
+                "return copy $c := $doc " +
+                "modify delete nodes $c//processing-instruction('mypi') " +
+                "return count($c//child/preceding-sibling::text())";
+
+        final String result = queryAndGetString(service, query);
+        // After deleting PI between B and C, B+C merge per W3C spec → 2 text nodes: A, BC
+        assertEquals("2", result);
+    }
+
+    @Test
+    public void deletePIComplexDeletesQ3Pattern() throws XMLDBException {
+        // Exact pattern from complex-deletes-q3 using copy-modify
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Uses the full TopMany.xml-like structure with mixed PIs, comments, text, elements
+        final String query =
+                "let $doc := <far-north> text-1A\n" +
+                "    <!-- Comment-3 --> text-1B\n" +
+                "    <?a-pi pi-2?> text-1C\n" +
+                "  <north mark='n0'> text-2A\n" +
+                "    <near-north> text-3A\n" +
+                "      <center mark='c0'> text-4A\n" +
+                "        <near-south-west/> text-4B\n" +
+                "            <!--Comment-5--> text-4C\n" +
+                "            <?a-pi pi-4?> text-4D\n" +
+                "        <near-south> text-5A\n" +
+                "        </near-south> text-4E\n" +
+                "      </center> text-3E\n" +
+                "    </near-north> text-2D\n" +
+                "  </north> text-1D\n" +
+                "</far-north>\n" +
+                "return copy $c := $doc " +
+                "modify delete nodes $c//processing-instruction('a-pi') " +
+                "return (\n" +
+                "  let $a := $c//(north | near-south)/preceding-sibling::comment()\n" +
+                "  return <result count='{count($a)}'>{$a}</result>,\n" +
+                "  let $a := $c//(north | near-south)/preceding-sibling::text()\n" +
+                "  return <result count='{count($a)}'>{$a}</result>\n" +
+                ")";
+
+        final ResourceSet result = service.query(query);
+        assertEquals("Expected 2 result elements", 2L, result.getSize());
+
+        final String commentResult = result.getResource(0).getContent().toString();
+        System.err.println("deletePI comments: " + commentResult);
+        // With //(north | near-south), both north AND near-south are found as descendants.
+        // north/preceding-sibling::comment() = <!-- Comment-3 --> (1 comment)
+        // near-south/preceding-sibling::comment() = <!--Comment-5--> (1 comment, after PI deletion)
+        // Wait: near-south is at center level. Its preceding siblings include:
+        //   near-south-west, text-4B, <!--Comment-5--> (after PI deletion, text-4C+text-4D merged)
+        // So near-south has 1 preceding-sibling comment.
+        // Total = 2 comments.
+        assertTrue("Comment count should be 2, got: " + commentResult,
+                commentResult.contains("count=\"2\""));
+
+        final String textResult = result.getResource(1).getContent().toString();
+        // After deleting PIs, adjacent text nodes merge per W3C spec:
+        // north: text-1A, (text-1B+text-1C merged) = 2 preceding text siblings
+        // near-south: text-4A, text-4B, (text-4C+text-4D merged) = 3 preceding text siblings
+        // Total = 5
+        assertTrue("Text count should be 5, got: " + textResult, textResult.contains("count=\"5\""));
+    }
+
+    @Test
+    public void deleteAttributesSingleElement() throws XMLDBException {
+        // Simplest case: delete one attribute from one element
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $doc := <a x='1' y='2' z='3'/> " +
+                "return copy $c := $doc " +
+                "modify delete nodes $c/@y " +
+                "return count($c/@*)";
+
+        assertEquals("2", queryAndGetString(service, query));
+    }
+
+    @Test
+    public void deleteAttributesTwoElements() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        // Delete one attr from each of two elements
+        final String query =
+                "let $doc := <root><a x='1' y='2' z='3'/><b p='4' q='5' r='6'/></root> " +
+                "return copy $c := $doc " +
+                "modify delete nodes ($c/a/@y, $c/b/@q) " +
+                "return (count($c/a/@*), count($c/b/@*))";
+
+        final ResourceSet result = testCollection.getService(XQueryService.class).query(query);
+        assertEquals("a should have 2 attrs", "2", result.getResource(0).getContent().toString());
+        assertEquals("b should have 2 attrs", "2", result.getResource(1).getContent().toString());
+    }
+
+    @Test
+    public void deleteAttributesThreeElementsExplicit() throws XMLDBException {
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "let $doc := <root>" +
+                "  <a mark='w0' a1='v1' a2='v2' a3='v3'/>" +
+                "  <b mark='c0' b1='v1' b2='v2' b3='v3'/>" +
+                "  <c mark='s0' c1='v1' c2='v2'/>" +
+                "</root> " +
+                "return copy $c := $doc " +
+                "modify delete nodes ($c/a/@a2, $c/b/@b2, $c/c/@c2) " +
+                "return (count($c/a/@*), count($c/b/@*), count($c/c/@*))";
+
+        final ResourceSet result = service.query(query);
+        assertEquals("a", "3", result.getResource(0).getContent().toString());
+        assertEquals("b", "3", result.getResource(1).getContent().toString());
+        assertEquals("c", "2", result.getResource(2).getContent().toString());
+    }
+
+    // === Insert before — multiple inserts at same target (regression for hang) ===
+
+    @Test(timeout = 10000)
+    public void insertMultipleGroupsBeforeSameTarget() throws XMLDBException {
+        final String docName = "insert-multi-before.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName,
+                "<employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee>");
+
+        // Two insert-before expressions targeting the same node — this should not hang
+        queryResource(service, docName,
+                "let $var := /employee " +
+                "return ( " +
+                "  insert node (<type>Part Time</type>,<age>26</age>) before $var/empnum[1], " +
+                "  insert node (<type>Full Time</type>,<age>30</age>) before $var/empnum[1] " +
+                ")", 0);
+
+        // Verify the inserts happened
+        final ResourceSet result = service.queryResource(docName, "count(/employee/*)");
+        assertEquals(1L, result.getSize());
+        // 3 original + 4 inserted = 7
+        assertEquals("7", result.getResource(0).getContent().toString());
+    }
+
+    @Test(timeout = 10000)
+    public void insertMultipleGroupsBeforeSameTargetInMemory() throws XMLDBException {
+        final String docName = "dummy.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName, "<dummy/>");
+
+        // Test insert into in copy-modify
+        assertEquals("insert into", "2", service.query(
+                "copy $c := <employee><empnum>E1</empnum></employee> " +
+                "modify insert node <type>PT</type> into $c " +
+                "return count($c/*)").getResource(0).getContent().toString());
+
+        // Test insert after in copy-modify
+        assertEquals("insert after", "4", service.query(
+                "copy $c := <employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee> " +
+                "modify insert node <type>PT</type> after $c/empnum[1] " +
+                "return count($c/*)").getResource(0).getContent().toString());
+
+        // Test insert before in copy-modify
+        assertEquals("insert before", "4", service.query(
+                "copy $c := <employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee> " +
+                "modify insert node <type>Part Time</type> before $c/empnum[1] " +
+                "return count($c/*)").getResource(0).getContent().toString());
+
+        // Test insert as first into in copy-modify
+        assertEquals("insert as first", "4", service.query(
+                "copy $c := <employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee> " +
+                "modify insert node <type>PT</type> as first into $c " +
+                "return count($c/*)").getResource(0).getContent().toString());
+
+        // Now test two inserts using comma expression
+        final String query =
+                "let $doc := <employee><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee> " +
+                "return copy $c := $doc " +
+                "modify ( " +
+                "  insert node (<type>Part Time</type>,<age>26</age>) before $c/empnum[1], " +
+                "  insert node (<type>Full Time</type>,<age>30</age>) before $c/empnum[1] " +
+                ") " +
+                "return count($c/*)";
+
+        final ResourceSet result = service.query(query);
+        assertEquals(1L, result.getSize());
+        // 3 original + 4 inserted = 7
+        assertEquals("7", result.getResource(0).getContent().toString());
+    }
+
+    // === XQTS-style in-memory insert-after test (mimics id-insert-expr-021) ===
+
+    @Test
+    public void inMemoryInsertAfterTwoElements() throws Exception {
+        // Parse document using SAXAdapter (same as XQTS runner)
+        final String xml = "<root><a>1</a><b>2</b><c>3</c></root>";
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParser saxParser = javax.xml.parsers.SAXParserFactory.newDefaultInstance().newSAXParser();
+        saxParser.getXMLReader().setContentHandler(adapter);
+        saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            // Step 1: Insert two elements after <a>
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "insert node (<x>10</x>,<y>20</y>) after ./root/a");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Step 2: Query all children of root in order
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "string-join(for $e in ./root/* return concat(name($e), '=', string($e)), ',')");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                final String output = result.itemAt(0).getStringValue();
+                // Expected order: a=1, x=10, y=20, b=2, c=3
+                assertEquals("a=1,x=10,y=20,b=2,c=3", output);
+            }
+        }
+    }
+
+    @Test
+    public void inMemoryInsertAttributeNamespacedElement() throws Exception {
+        // Test 094: insert attribute into element in default namespace
+        // Use real books3.xml content with comments, PIs, entities
+        final java.io.File books3 = new java.io.File(
+                System.getProperty("user.home") + "/workspace/exist-xqts-runner/work/qt4tests-master/upd/TestSources/books3.xml");
+        final byte[] xml;
+        if (books3.exists()) {
+            xml = java.nio.file.Files.readAllBytes(books3.toPath());
+        } else {
+            // Fallback simplified version
+            xml = ("<?xml version=\"1.0\"?>\n" +
+                    "<BOOKLIST xmlns=\"http://ns.example.com/books\">\n" +
+                    "<BOOKS>\n" +
+                    "\t<ITEM CAT=\"MMP\">\n" +
+                    "\t    <!-- the first book -->\n" +
+                    "\t    <?pi data?>\n" +
+                    "\t    <TITLE>Pride and Prejudice</TITLE>\n" +
+                    "\t</ITEM>\n" +
+                    "</BOOKS>\n" +
+                    "<CATEGORIES DESC=\"Miscellaneous categories\">\n" +
+                    "   <CATEGORY CODE=\"P\" DESC=\"Paperback\"/>\n" +
+                    "</CATEGORIES>\n" +
+                    "</BOOKLIST>").getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        }
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParserFactory spf = javax.xml.parsers.SAXParserFactory.newInstance();
+        spf.setNamespaceAware(true);
+        final javax.xml.parsers.SAXParser nsParser = spf.newSAXParser();
+        nsParser.getXMLReader().setContentHandler(adapter);
+        nsParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        nsParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml)));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        // Check document-level children before update
+        int docChildren = 0;
+        org.w3c.dom.Node docChild = doc.getFirstChild();
+        while (docChild != null) {
+            System.out.println("Before update - doc child " + docChildren + ": type=" + docChild.getNodeType()
+                    + " name=" + docChild.getNodeName());
+            docChildren++;
+            docChild = docChild.getNextSibling();
+        }
+        System.out.println("Before update: " + docChildren + " document-level children");
+
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            // Insert ITEMS attribute into BOOKS (count should be 3)
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "declare namespace books='http://ns.example.com/books'; " +
+                        "insert node attribute ITEMS { count(.//books:ITEM) } into .//books:BOOKS");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Check document-level children after update
+            docChildren = 0;
+            docChild = doc.getFirstChild();
+            while (docChild != null) {
+                System.out.println("After update - doc child " + docChildren + ": type=" + docChild.getNodeType()
+                        + " name=" + docChild.getNodeName() + " value='" + (docChild.getNodeValue() != null ? docChild.getNodeValue().replace("\n", "\\n") : "null") + "'");
+                docChildren++;
+                docChild = docChild.getNextSibling();
+            }
+            System.out.println("After update: " + docChildren + " document-level children");
+
+            // First, run the verification query "." and get the result
+            final org.exist.xquery.value.Sequence verifyResult;
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx, " .");
+                verifyResult = xqueryService.execute(broker, compiled, doc);
+                System.out.println("Verify result count: " + verifyResult.getItemCount());
+                System.out.println("Verify result type: " + verifyResult.itemAt(0).getType());
+            }
+
+            // Then serialize via $result external variable (same as XQTS runner)
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                ctx.declareVariable("result", verifyResult);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "declare variable $result external; " +
+                        "let $local:default-serialization := " +
+                        "  <output:serialization-parameters xmlns:output='http://www.w3.org/2010/xslt-xquery-serialization'>" +
+                        "    <output:method value='xml'/>" +
+                        "    <output:indent value='no'/>" +
+                        "    <output:omit-xml-declaration value='yes'/>" +
+                        "  </output:serialization-parameters> " +
+                        "return fn:serialize($result, $local:default-serialization)");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, null);
+                final String serialized = result.itemAt(0).getStringValue();
+                System.out.println("Test 094 serialized length: " + serialized.length());
+                System.out.println("Test 094 first 200: " + serialized.substring(0, Math.min(200, serialized.length())));
+                System.out.println("Test 094 last 100: " + serialized.substring(Math.max(0, serialized.length() - 100)));
+                assertTrue("BOOKS element should have ITEMS attribute",
+                        serialized.contains("ITEMS=\"6\"") || serialized.contains("ITEMS=\"1\"") || serialized.contains("ITEMS=\"3\""));
+                // Check if fn:serialize adds a trailing newline for document nodes
+                System.out.println("Last char code: " + (int) serialized.charAt(serialized.length() - 1));
+                System.out.println("Ends with newline: " + serialized.endsWith("\n"));
+                // Check that wrapping in ignorable-wrapper produces 1 child
+                final String wrapped = "<ignorable-wrapper>" + serialized + "</ignorable-wrapper>";
+                final javax.xml.parsers.DocumentBuilderFactory dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+                dbf.setNamespaceAware(true);
+                final javax.xml.parsers.DocumentBuilder db = dbf.newDocumentBuilder();
+                final org.w3c.dom.Document wrappedDoc = db.parse(new org.xml.sax.InputSource(
+                        new java.io.ByteArrayInputStream(wrapped.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+                final int wrapperChildCount = wrappedDoc.getDocumentElement().getChildNodes().getLength();
+                System.out.println("Wrapper child count: " + wrapperChildCount);
+                if (wrapperChildCount != 1) {
+                    for (int i = 0; i < wrapperChildCount; i++) {
+                        final org.w3c.dom.Node ch = wrappedDoc.getDocumentElement().getChildNodes().item(i);
+                        System.out.println("Wrapper child " + i + ": type=" + ch.getNodeType()
+                                + " name=" + ch.getNodeName()
+                                + " value='" + (ch.getNodeValue() != null ? ch.getNodeValue().substring(0, Math.min(50, ch.getNodeValue().length())).replace("\n", "\\n") : "null") + "'");
+                    }
+                }
+                assertEquals("Wrapper should have exactly 1 child", 1, wrapperChildCount);
+            }
+        }
+    }
+
+    @Test
+    public void inMemoryInsertIntoOrdering() throws Exception {
+        // Test 052: INSERT_INTO should go between INSERT_INTO_AS_FIRST and INSERT_INTO_AS_LAST
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            final String xml = "<root><a/><b/></root>";
+            final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+            final javax.xml.parsers.SAXParser saxParser = javax.xml.parsers.SAXParserFactory.newDefaultInstance().newSAXParser();
+            saxParser.getXMLReader().setContentHandler(adapter);
+            saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+            saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                    new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+            final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+            // Apply multiple inserts: as first, as last, and plain into
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "insert node <first/> as first into ./root," +
+                        "insert node <last/> as last into ./root," +
+                        "insert node <mid/> into ./root");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Check ordering
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "string-join(./root/*/name(), ',')");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                final String output = result.itemAt(0).getStringValue();
+                System.out.println("Test 052 ordering: " + output);
+                // first must be first, last must be last, mid must be between them
+                assertTrue("first should be first", output.startsWith("first,"));
+                assertTrue("last should be last", output.endsWith(",last"));
+                assertFalse("mid should not come after last", output.indexOf("mid") > output.indexOf("last"));
+            }
+        }
+    }
+
+    @Test
+    public void inMemoryInsertAfterDescendantAxis() throws Exception {
+        // Test that //element finds inserted nodes (descendant axis traversal)
+        final String xml = "<employee><hours>70</hours><hours>20</hours></employee>";
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParser saxParser = javax.xml.parsers.SAXParserFactory.newDefaultInstance().newSAXParser();
+        saxParser.getXMLReader().setContentHandler(adapter);
+        saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            // Insert two hours after hours[1]
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "insert node (<hours>15</hours>,<hours>25</hours>) after ./employee/hours[1]");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Query //hours and check order
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "string-join(for $h in .//hours return string($h), ',')");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                final String output = result.itemAt(0).getStringValue();
+                // Expected order: 70, 15, 25, 20
+                assertEquals("70,15,25,20", output);
+            }
+        }
+    }
+
+    @Test
+    public void inMemoryReplaceAttribute() throws Exception {
+        final String xml = "<employee name=\"Jane\" gender=\"female\"><empnum>E1</empnum></employee>";
+        final org.exist.dom.memtree.SAXAdapter adapter = new org.exist.dom.memtree.SAXAdapter();
+        final javax.xml.parsers.SAXParser saxParser = javax.xml.parsers.SAXParserFactory.newDefaultInstance().newSAXParser();
+        saxParser.getXMLReader().setContentHandler(adapter);
+        saxParser.getXMLReader().setProperty("http://xml.org/sax/properties/lexical-handler", adapter);
+        saxParser.getXMLReader().parse(new org.xml.sax.InputSource(
+                new java.io.ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        final org.exist.dom.memtree.DocumentImpl doc = adapter.getDocument();
+
+        final org.exist.storage.BrokerPool pool = org.exist.storage.BrokerPool.getInstance();
+        try (final org.exist.storage.DBBroker broker = pool.getBroker()) {
+            final org.exist.xquery.XQuery xqueryService = pool.getXQueryService();
+
+            // Replace attribute name with name1
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "replace node ./employee/@name with attribute name1 {\"new name\"}");
+                xqueryService.execute(broker, compiled, doc);
+                ctx.runCleanupTasks();
+            }
+
+            // Verify: check the result
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "string(./employee/@name1)");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                assertEquals("new name", result.itemAt(0).getStringValue());
+            }
+
+            // Verify: old attribute is gone
+            {
+                final org.exist.xquery.XQueryContext ctx = new org.exist.xquery.XQueryContext(pool);
+                final org.exist.xquery.CompiledXQuery compiled = xqueryService.compile(ctx,
+                        "count(./employee/@name)");
+                final org.exist.xquery.value.Sequence result = xqueryService.execute(broker, compiled, doc);
+                assertEquals("0", result.itemAt(0).getStringValue());
+            }
+        }
+    }
+
+    /**
+     * Verify that constructed in-memory elements have no parent
+     * (explicitlyCreated=false makes getParentNode() return null),
+     * and that replace node correctly raises XUDY0009.
+     */
+    @Test
+    public void replaceNodeParentlessElementXUDY0009() throws XMLDBException {
+        final XQueryService service = storeXMLStringAndGetQueryService("xudy0009.xml", "<dummy/>");
+        final String query =
+                "let $var := <hours/> " +
+                "return replace node $var with <other/>";
+        try {
+            service.query(query);
+            fail("Expected XUDY0009 error for parentless element");
+        } catch (final XMLDBException e) {
+            assertTrue("Expected XUDY0009 but got: " + e.getMessage(),
+                    e.getMessage().contains("XUDY0009"));
+        }
+    }
+
+    /**
+     * Verify XUTY0008 is raised when replace target is multiple nodes.
+     */
+    @Test
+    public void replaceNodeMultipleTargetsXUTY0008() throws XMLDBException {
+        final XQueryService service = storeXMLStringAndGetQueryService("xuty0008.xml", "<root><a/><b/></root>");
+        final String query =
+                "let $doc := doc('/db/test/xuty0008.xml') " +
+                "return replace node $doc/root/child::* with <c/>";
+        try {
+            service.query(query);
+            fail("Expected XUTY0008 error for multiple targets");
+        } catch (final XMLDBException e) {
+            assertTrue("Expected XUTY0008 but got: " + e.getMessage(),
+                    e.getMessage().contains("XUTY0008"));
+        }
+    }
+
+    // === Compatibility tests: replaceNode + replaceElementContent interaction ===
+
+    @Test
+    public void replaceValueOfElementAndReplaceNodeChildPersistent() throws XMLDBException {
+        // Matches compatibility-027: replace value of node + replace node on child
+        final String docName = "compat027.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName,
+                "<employee name=\"Jane\" gender=\"female\"><empnum>E1</empnum><pnum>P1</pnum><hours>40</hours></employee>");
+
+        // replace value of element replaces ALL children; replaceNode of child should be skipped
+        service.query(
+                "let $var := doc('/db/test/compat027.xml')/employee " +
+                "return ( " +
+                "  replace value of node $var with 'on leave', " +
+                "  replace node $var/empnum with <empnum>on leave</empnum> " +
+                ")");
+
+        final ResourceSet result = service.query("doc('/db/test/compat027.xml')/employee");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Expected text 'on leave' in employee, got: " + xml, xml.contains("on leave"));
+        // The element should have only text content (no child elements) after replaceElementContent
+        assertFalse("Expected no <empnum> child after replaceElementContent, got: " + xml, xml.contains("<empnum"));
+    }
+
+    @Test
+    public void replaceValueOfElementAndInsertChildPersistent() throws XMLDBException {
+        // Matches compatibility-029: replace value of node + insert into
+        final String docName = "compat029.xml";
+        final XQueryService service = storeXMLStringAndGetQueryService(docName,
+                "<employee name=\"Jane\"><empnum>E1</empnum></employee>");
+
+        service.query(
+                "let $var := doc('/db/test/compat029.xml')/employee " +
+                "return ( " +
+                "  replace value of node $var with 'on leave', " +
+                "  insert node <!-- this employee is on leave --> into $var " +
+                ")");
+
+        final ResourceSet result = service.query("doc('/db/test/compat029.xml')/employee");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Expected text 'on leave' in employee, got: " + xml, xml.contains("on leave"));
+        // replaceElementContent should supersede the insert
+        assertFalse("Expected no comment after replaceElementContent, got: " + xml, xml.contains("<!--"));
+    }
+
+    // === Namespace propagation in copy-modify ===
+
+    @Test
+    public void propagateNamespacesInsertInheritsFromCopiedParent() throws XMLDBException {
+        // Simplified propagateNamespaces01: inserted nodes inherit namespaces from copied parent
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "declare copy-namespaces preserve, inherit;\n" +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/>\n" +
+                "modify insert node <w/> into $data\n" +
+                "return namespace-uri-for-prefix('a', $data/w)";
+
+        final ResourceSet result = service.query(query);
+        assertEquals("Expected single result", 1L, result.getSize());
+        final String val = result.getResource(0).getContent().toString();
+        assertEquals("Inserted <w> should inherit xmlns:a from copied <v>", "a-one", val);
+    }
+
+    @Test
+    public void propagateNamespacesFull() throws XMLDBException {
+        // Full propagateNamespaces01 test
+        final XQueryService service = testCollection.getService(XQueryService.class);
+
+        final String query =
+                "declare copy-namespaces preserve, inherit;\n" +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/>\n" +
+                "modify\n" +
+                "  insert node <w><x xmlns:a=\"a-two\"><y xmlns:b=\"b-two\"><z/></y></x></w> into $data\n" +
+                "return\n" +
+                "  let $w := $data/w\n" +
+                "  let $x := $w/x\n" +
+                "  let $y := $x/y\n" +
+                "  let $z := $y/z\n" +
+                "  return\n" +
+                "    <result>\n" +
+                "      <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w>\n" +
+                "      <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x>\n" +
+                "      <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y>\n" +
+                "      <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z>\n" +
+                "    </result>";
+
+        final ResourceSet result = service.query(query);
+        assertEquals("Expected single result", 1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        // Check output contains expected namespace values
+        final String xmlNorm = xml.replaceAll("\\s+", " ").trim();
+        assertTrue("w should have a=a-one, got: " + xmlNorm, xmlNorm.contains("<w>a-one b-one</w>"));
+        assertTrue("x should have a=a-two, got: " + xmlNorm, xmlNorm.contains("<x>a-two b-one</x>"));
+        assertTrue("y should have a=a-two b=b-two, got: " + xmlNorm, xmlNorm.contains("<y>a-two b-two</y>"));
+        assertTrue("z should have a=a-two b=b-two, got: " + xmlNorm, xmlNorm.contains("<z>a-two b-two</z>"));
+    }
+
+    @Test
+    public void propagateNamespaces01XqtsExact() throws XMLDBException {
+        // Exact XQTS propagateNamespaces01 query with boundary-space preserve
+        final XQueryService service = testCollection.getService(XQueryService.class);
+        final String query = "declare copy-namespaces preserve, inherit; " +
+                "declare boundary-space preserve; " +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/> " +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data " +
+                "return let $w := $data/w let $x := $w/x let $y := $x/y let $z := $y/z " +
+                "return <result> " +
+                "<w>{namespace-uri-for-prefix(\"a\", $w), namespace-uri-for-prefix(\"b\",$w)}</w> " +
+                "<x>{namespace-uri-for-prefix(\"a\", $x), namespace-uri-for-prefix(\"b\",$x)}</x> " +
+                "<y>{namespace-uri-for-prefix(\"a\", $y), namespace-uri-for-prefix(\"b\",$y)}</y> " +
+                "<z>{namespace-uri-for-prefix(\"a\", $z), namespace-uri-for-prefix(\"b\",$z)}</z> " +
+                "</result>";
+
+        final ResourceSet result = service.query(query);
+        System.err.println("propagateNamespaces01_xqts_exact: result size = " + result.getSize());
+        for (long i = 0; i < result.getSize(); i++) {
+            System.err.println("Result[" + i + "] = " + result.getResource(i).getContent().toString());
+        }
+        assertEquals("Expected single result", 1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Result should contain w element", xml.contains("<w>"));
+    }
+
+    @Test
+    public void applyUpdates001InMemoryInsertThenDelete() throws XMLDBException {
+        // applyUpdates-001 pattern but with copy-modify (in-memory path)
+        final XQueryService service = testCollection.getService(XQueryService.class);
+        final String query =
+                "copy $data := <employee name=\"Jane Doe 1\" gender=\"female\">\n" +
+                "   <empnum>E1</empnum>\n" +
+                "   <pnum>P1</pnum>\n" +
+                "   <hours>40</hours>\n" +
+                "</employee>\n" +
+                "modify (\n" +
+                "  insert node comment { 'Testing' } into $data/hours,\n" +
+                "  delete node $data/hours/text()\n" +
+                ")\n" +
+                "return $data/hours";
+        final ResourceSet result = service.query(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("applyUpdates001_inMemory result: " + xml);
+        assertTrue("hours should contain comment", xml.contains("<!--Testing-->"));
+        assertFalse("hours should not contain '40'", xml.contains("40"));
+    }
+
+    @Test
+    public void applyUpdates013InMemoryInsertDeleteAttributeSameName() throws XMLDBException {
+        // applyUpdates-013: insert attribute name="Sylvia" and delete @name
+        final XQueryService service = testCollection.getService(XQueryService.class);
+        final String query =
+                "copy $data := <employee name=\"Jane Doe 1\" gender=\"female\">\n" +
+                "   <empnum>E1</empnum>\n" +
+                "   <pnum>P1</pnum>\n" +
+                "   <hours>40</hours>\n" +
+                "</employee>\n" +
+                "modify (\n" +
+                "  insert node attribute name {'Sylvia'} into $data,\n" +
+                "  delete node $data/@name\n" +
+                ")\n" +
+                "return $data";
+        final ResourceSet result = service.query(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("applyUpdates013_inMemory result: " + xml);
+        assertTrue("should have name='Sylvia'", xml.contains("name=\"Sylvia\""));
+        assertFalse("should not have 'Jane Doe 1'", xml.contains("Jane Doe 1"));
+    }
+
+    @Test
+    public void applyUpdates001PersistentInsertThenDelete() throws XMLDBException {
+        // applyUpdates-001: insert comment into hours, delete hours/text()
+        final XQueryService service = storeXMLStringAndGetQueryService("works-mod.xml",
+                "<employee name=\"Jane Doe 1\" gender=\"female\">\n" +
+                "   <empnum>E1</empnum>\n" +
+                "   <pnum>P1</pnum>\n" +
+                "   <hours>40</hours>\n" +
+                "</employee>");
+
+        // Run the update: insert comment into hours AND delete hours/text()
+        service.query(
+                "let $var := doc('/db/test/works-mod.xml')/employee " +
+                "return (\n" +
+                "  insert node comment { 'Testing' } into $var/hours,\n" +
+                "  delete node $var/hours/text()\n" +
+                ")");
+
+        // Verify: hours should have comment but no text node
+        final ResourceSet result = service.query(
+                "doc('/db/test/works-mod.xml')/employee/hours");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("applyUpdates001 result: " + xml);
+        assertTrue("hours should contain comment", xml.contains("<!--Testing-->"));
+        assertFalse("hours should not contain '40'", xml.contains("40"));
+    }
+
+    @Test
+    public void transformExpr034CopyDocumentRename() throws XMLDBException {
+        // id-transform-expr-034: copy a document, rename its root element
+        final String query =
+                "let $doc := document { <works><employee name=\"Jane\"/></works> }\n" +
+                "return copy $var1 := $doc\n" +
+                "       modify rename node $var1/works as \"workers\"\n" +
+                "       return $var1";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Root should be renamed to 'workers'", xml.contains("<workers"));
+        assertTrue("Should preserve children", xml.contains("employee"));
+    }
+
+    @Test
+    public void transformExpr035CopyAttributeReplaceValue() throws XMLDBException {
+        // id-transform-expr-035: copy an attribute, replace its value
+        final String query =
+                "let $var := <employee name=\"Jane Doe 1\"/>\n" +
+                "return copy $var1 := $var/@name\n" +
+                "       modify replace value of node $var1 with \"Ursula Le Guin\"\n" +
+                "       return <newemp>{ $var1 }</newemp>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertEquals("<newemp name=\"Ursula Le Guin\"/>", xml);
+    }
+
+    @Test
+    public void transformExprXUDY0014TargetOutsideCopy() throws XMLDBException {
+        // XUDY0014: update target must be created by the copy clause
+        final String query =
+                "let $outside := <root><a>1</a></root>\n" +
+                "return copy $c := <x><y/></x>\n" +
+                "       modify replace value of node $outside/a with \"2\"\n" +
+                "       return $c";
+        try {
+            existEmbeddedServer.executeQuery(query);
+            fail("Expected XUDY0014");
+        } catch (final org.xmldb.api.base.XMLDBException e) {
+            assertTrue("Should raise XUDY0014", e.getMessage().contains("XUDY0014"));
+        }
+    }
+
+    @Test
+    public void commaExpr015TwoReplaceValuesSnapshotIsolation() throws XMLDBException {
+        // id-comma-expr-015: two replace value ops referencing each other's targets
+        // Tests W3C snapshot semantics: content expressions evaluated BEFORE updates applied
+        final String query =
+                "let $doc := <works>\n" +
+                "  <employee name=\"Jane\">\n" +
+                "    <hours>40</hours>\n" +
+                "  </employee>\n" +
+                "  <employee name=\"John\">\n" +
+                "    <hours>70</hours>\n" +
+                "    <hours>20</hours>\n" +
+                "  </employee>\n" +
+                "</works>\n" +
+                "return copy $c := $doc\n" +
+                "modify (\n" +
+                "  let $var1 := $c/employee[1]\n" +
+                "  let $var2 := $c/employee[2]\n" +
+                "  return (\n" +
+                "    replace value of node $var1/hours[1] with $var2/hours[1],\n" +
+                "    replace value of node $var2/hours[2] with $var1/hours[1]\n" +
+                "  )\n" +
+                ")\n" +
+                "return ($c/employee[1]/hours, $c/employee[2]/hours)";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(3L, result.getSize());
+        // employee[1]/hours[1]: was 40, replaced with $var2/hours[1]=70
+        assertEquals("70", result.getResource(0).getContent().toString().replaceAll("</?hours>", ""));
+        // employee[2]/hours[1]: unchanged = 70
+        assertEquals("70", result.getResource(1).getContent().toString().replaceAll("</?hours>", ""));
+        // employee[2]/hours[2]: was 20, replaced with $var1/hours[1]=40 (original, snapshot)
+        assertEquals("40", result.getResource(2).getContent().toString().replaceAll("</?hours>", ""));
+    }
+
+    @Test
+    public void replaceNode029ReplaceTextNodes() throws XMLDBException {
+        // id-replace-expr-029: replace text nodes
+        final String query =
+                "copy $c := <employee name=\"Jane Doe 1\" gender=\"female\">\n" +
+                "   <empnum>E1</empnum>\n" +
+                "   <pnum>P1</pnum>\n" +
+                "   <hours>40</hours>\n" +
+                "</employee>\n" +
+                "modify (\n" +
+                "  replace node $c/empnum[1]/text() with \"E1000\",\n" +
+                "  replace node $c/hours[1]/text() with 10\n" +
+                ")\n" +
+                "return $c";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("empnum should be E1000", xml.contains("<empnum>E1000</empnum>"));
+        assertTrue("hours should be 10", xml.contains("<hours>10</hours>"));
+    }
+
+    @Test
+    public void deleteMultipleAttributesForLoop() throws XMLDBException {
+        // Delete attributes on multiple elements using for loop (workaround for //(@attr) bug)
+        final String query =
+                "let $doc := <root>\n" +
+                "  <a x=\"1\" y=\"2\" z=\"3\"/>\n" +
+                "  <b x=\"4\" y=\"5\" z=\"6\"/>\n" +
+                "</root>\n" +
+                "return copy $c := $doc\n" +
+                "modify (\n" +
+                "  for $e in $c//* return delete nodes ($e/@y, $e/@z)\n" +
+                ")\n" +
+                "return $c";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        // After deleting @y and @z, only @x should remain
+        assertTrue("a should have only x", xml.contains("<a x=\"1\""));
+        assertFalse("a should not have y", xml.contains("y=\"2\""));
+        assertFalse("a should not have z", xml.contains("z=\"3\""));
+        assertTrue("b should have only x", xml.contains("<b x=\"4\""));
+        assertFalse("b should not have y", xml.contains("y=\"5\""));
+        assertFalse("b should not have z", xml.contains("z=\"6\""));
+    }
+
+    @Test
+    public void deleteDocumentNodeIsNoOp() throws XMLDBException {
+        // complex-deletes-q14: delete document node is a no-op
+        final String query =
+                "let $doc := document { <root><a/><b/></root> }\n" +
+                "return copy $c := $doc\n" +
+                "modify delete nodes $c\n" +
+                "return $c";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("deleteDocumentNode: " + xml);
+        assertTrue("Document should be preserved", xml.contains("<root>"));
+    }
+
+    @Test
+    public void replaceValueOfElementWithMarkup() throws XMLDBException {
+        // complex-replacevalues-q14: replace value with string that looks like markup
+        final String query =
+                "copy $c := <root><target>old</target></root>\n" +
+                "modify replace value of node $c/target with \"<notANode>value</notANode>\"\n" +
+                "return $c/target";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("replaceValueMarkup: " + xml);
+        // The markup string should be escaped text, not parsed as XML
+        assertTrue("Should contain escaped markup",
+                xml.contains("&lt;notANode&gt;value&lt;/notANode&gt;"));
+    }
+
+    /**
+     * Test insert + delete on same parent element in a single PUL.
+     * Reproduces XQTS applyUpdates-001: insert comment into element then delete its text child.
+     * After PUL application, the element should contain only the comment (text deleted).
+     * Verifies that getFirstChildFor can find appended children when positional children are deleted.
+     */
+    @Test
+    public void applyUpdates001InsertCommentDeleteText() throws XMLDBException {
+        final String query =
+                "copy $c := <employee><hours>40</hours></employee>\n" +
+                "modify (\n" +
+                "  insert node comment { 'Testing' } into $c/hours,\n" +
+                "  delete node $c/hours/text()\n" +
+                ")\n" +
+                "return $c/hours";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("applyUpdates001: " + xml);
+        // Should contain the comment but NOT the text "40"
+        assertTrue("Should contain comment", xml.contains("<!--Testing-->"));
+        assertFalse("Should not contain original text '40'", xml.contains("40"));
+    }
+
+    /**
+     * Test delete text + insert comment (reverse order) on same parent.
+     * Reproduces XQTS applyUpdates-002.
+     */
+    @Test
+    public void applyUpdates002DeleteTextInsertComment() throws XMLDBException {
+        final String query =
+                "copy $c := <employee><hours>40</hours></employee>\n" +
+                "modify (\n" +
+                "  delete node $c/hours/text(),\n" +
+                "  insert node comment { 'Testing' } into $c/hours\n" +
+                ")\n" +
+                "return $c/hours";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("applyUpdates002: " + xml);
+        assertTrue("Should contain comment", xml.contains("<!--Testing-->"));
+        assertFalse("Should not contain original text '40'", xml.contains("40"));
+    }
+
+    /**
+     * Test rename on elements accessed via in-memory document navigation.
+     * Reproduces XQTS complex-renames-q4: rename one of multiple matching elements.
+     */
+    @Test
+    public void renameInMemoryElementSingleFromMultiple() throws XMLDBException {
+        final String query =
+                "copy $c := <root><a mark='1'/><a mark='2'/></root>\n" +
+                "modify rename node ($c//a)[1] as 'b'\n" +
+                "return <result>\n" +
+                "  <a-count>{count($c//a)}</a-count>\n" +
+                "  <b-count>{count($c//b)}</b-count>\n" +
+                "</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("renameInMemory: " + xml);
+        assertTrue("Should have 1 'a' element", xml.contains("<a-count>1</a-count>"));
+        assertTrue("Should have 1 'b' element", xml.contains("<b-count>1</b-count>"));
+    }
+
+    /**
+     * Test replace value on in-memory elements via for loop.
+     * Reproduces XQTS complex-replacevalues-q8 pattern.
+     */
+    @Test
+    public void replaceValueInMemoryElementsForLoop() throws XMLDBException {
+        final String query =
+                "copy $c := <root><item>old1</item><item>old2</item></root>\n" +
+                "modify for $a in $c//item return replace value of node $a with 'new'\n" +
+                "return $c";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("replaceValueForLoop: " + xml);
+        assertFalse("Should not contain 'old1'", xml.contains("old1"));
+        assertFalse("Should not contain 'old2'", xml.contains("old2"));
+        assertTrue("Should contain 'new'", xml.contains("<item>new</item>"));
+    }
+
+    /**
+     * Test delete document-level comments using >> (follows) operator.
+     * Reproduces XQTS complex-deletes-q2: delete trailing comments.
+     */
+    @Test
+    public void deleteDocumentCommentsFollowsOperator() throws XMLDBException {
+        // Simulates the structure: document has root element, then comments after it
+        final String query =
+                "let $doc := <root/>\n" +
+                "return\n" +
+                "copy $c := $doc\n" +
+                "modify ()\n" +
+                "return $c";
+        // Basic test: just make sure >> operator works
+        final String followsTest =
+                "let $doc := parse-xml('<root><a/><b/></root>')\n" +
+                "return count($doc/root/*[. >> $doc/root/a])";
+        final ResourceSet result = existEmbeddedServer.executeQuery(followsTest);
+        assertEquals(1L, result.getSize());
+        assertEquals("1", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * Test replace value of element on persistent document via top-level PUL.
+     * Reproduces XQTS complex-replacevalues-q8 on stored documents.
+     */
+    @Test
+    public void replaceValuePersistentForLoop() throws XMLDBException {
+        final XQueryService queryService = storeXMLStringAndGetQueryService(
+                "topMany.xml",
+                "<root><se mark='1se'/><se mark='2se'/></root>");
+        queryService.setProperty("base-uri", testCollection.getName());
+
+        // Update: replace value of all se elements
+        queryService.query(
+                "let $doc := doc('" + testCollection.getName() + "/topMany.xml')\n" +
+                "for $a in $doc//se\n" +
+                "return replace value of node $a with 'content'");
+
+        // Verify
+        final ResourceSet result = queryService.query(
+                "let $doc := doc('" + testCollection.getName() + "/topMany.xml')\n" +
+                "return <result>{$doc//se}</result>");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("replaceValuePersistent: " + xml);
+        assertTrue("First se should have content",
+                xml.contains("<se mark=\"1se\">content</se>"));
+        assertTrue("Second se should have content",
+                xml.contains("<se mark=\"2se\">content</se>"));
+    }
+
+    /**
+     * Test replace value on in-memory document via top-level PUL (not copy-modify).
+     * Simulates what the XQTS runner does: parse XML, apply top-level update, query result.
+     * This is a two-step query: first update, then verify in separate query.
+     */
+    @Test
+    public void replaceValueTopLevelPULInMemoryDoc() throws XMLDBException {
+        // Store the XML in the database first, so we can do a two-step update+verify
+        final XQueryService queryService = storeXMLStringAndGetQueryService(
+                "inmem.xml",
+                "<root><se mark='1se'/><se mark='2se'/></root>");
+        queryService.setProperty("base-uri", testCollection.getName());
+
+        // Step 1: use copy-modify to simulate top-level PUL on in-memory doc
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $doc := parse-xml('<root><se mark=\"1se\"/><se mark=\"2se\"/></root>')\n" +
+                "return\n" +
+                "  copy $c := $doc\n" +
+                "  modify for $a in $c//se return replace value of node $a with 'content'\n" +
+                "  return <result>{$c//se}</result>");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("replaceValueTopLevelPUL: " + xml);
+        assertTrue("First se should have content",
+                xml.contains("<se mark=\"1se\">content</se>"));
+        assertTrue("Second se should have content",
+                xml.contains("<se mark=\"2se\">content</se>"));
+    }
+
+    /**
+     * Test rename on persistent document via top-level PUL.
+     * Reproduces XQTS complex-renames-q2 on stored documents.
+     */
+    @Test
+    public void renamePersistentMultipleElements() throws XMLDBException {
+        final XQueryService queryService = storeXMLStringAndGetQueryService(
+                "topMany.xml",
+                "<root><se mark='1se'/><se mark='2se'/></root>");
+        queryService.setProperty("base-uri", testCollection.getName());
+
+        // Update: rename all se elements to 'renamed'
+        queryService.query(
+                "let $doc := doc('" + testCollection.getName() + "/topMany.xml')\n" +
+                "for $a in $doc//se\n" +
+                "return rename node $a as 'renamed'");
+
+        // Verify
+        final ResourceSet result = queryService.query(
+                "let $doc := doc('" + testCollection.getName() + "/topMany.xml')\n" +
+                "return <result>\n" +
+                "  <se-count>{count($doc//se)}</se-count>\n" +
+                "  <renamed-count>{count($doc//renamed)}</renamed-count>\n" +
+                "</result>");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("renamePersistent: " + xml);
+        assertTrue("Should have 0 'se' elements", xml.contains("<se-count>0</se-count>"));
+        assertTrue("Should have 2 'renamed' elements", xml.contains("<renamed-count>2</renamed-count>"));
+    }
+
+    /**
+     * XQTS update10keywords: XQuery Update keywords can be used as variable names.
+     */
+    @Test
+    public void updateKeywordsAsVariableNames() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $ascending := 1 let $descending := 2 let $greatest := 3 " +
+                "let $least := 4 let $satisfies := 5 let $revalidation := 6 " +
+                "let $skip := 7 let $strict := 8 let $lax := 9 " +
+                "let $insert := 10 let $delete := 11 let $replace := 12 " +
+                "let $rename := 13 let $copy := 14 let $modify := 15 " +
+                "let $value := 16 let $into := 17 let $with := 18 " +
+                "let $after := 19 let $before := 20 let $first := 21 " +
+                "let $last := 22 let $nodes := 23 let $updating := 24 " +
+                "return $ascending + $descending");
+        assertEquals(1L, result.getSize());
+        assertEquals("3", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * XQTS propagateNamespaces01: namespace propagation in copy-modify insert.
+     */
+    @Test
+    public void propagateNamespacesPreserveInherit() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "declare copy-namespaces preserve, inherit;\n" +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/>\n" +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data\n" +
+                "return\n" +
+                "  let $w := $data/w\n" +
+                "  let $x := $w/x\n" +
+                "  let $y := $x/y\n" +
+                "  let $z := $y/z\n" +
+                "  return <result>\n" +
+                "    <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w>\n" +
+                "    <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x>\n" +
+                "    <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y>\n" +
+                "    <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z>\n" +
+                "  </result>");
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("propagateNamespaces: " + xml);
+        // With preserve+inherit, inserted children should inherit parent's namespaces
+        assertTrue("w should inherit a-one", xml.contains("<w>a-one b-one</w>"));
+        assertTrue("x should override a with a-two", xml.contains("<x>a-two b-one</x>"));
+        assertTrue("y should override b with b-two", xml.contains("<y>a-two b-two</y>"));
+        assertTrue("z should inherit from y", xml.contains("<z>a-two b-two</z>"));
+    }
+
+    /**
+     * Simulate XQTS FullAxis complex-replacevalues-q8: replaceValue on multiple sibling
+     * empty elements, then verify with following-sibling axis and predicate filter.
+     */
+    @Test
+    public void replaceValueEmptyElementsFollowingSiblingAxis() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $doc := parse-xml('" +
+                "<center mark=\"c0\">" +
+                "  <near-south> text-5A" +
+                "    <south mark=\"s0\"> text-6A <far-south/> text-6B </south> text-5B" +
+                "  </near-south> text-4E" +
+                "  <south-east mark=\"1se\"/> text-4G" +
+                "  <south-east mark=\"2se\"/> text-4H" +
+                "</center>')\n" +
+                "return\n" +
+                "  copy $c := $doc\n" +
+                "  modify for $a in $c//south-east return replace value of node $a with 'very south east'\n" +
+                "  return (\n" +
+                "    let $a := $c//near-south/following-sibling::node()\n" +
+                "    return <result count=\"{count($a)}\">{$a}</result>,\n" +
+                "    let $a := $c//south-east[. = 'very south east']\n" +
+                "    return <result count=\"{count($a)}\">{$a}</result>\n" +
+                "  )");
+
+        assertEquals(2L, result.getSize());
+        final String r1 = result.getResource(0).getContent().toString();
+        final String r2 = result.getResource(1).getContent().toString();
+        System.err.println("replaceValueFollowingSibling r1: " + r1);
+        System.err.println("replaceValueFollowingSibling r2: " + r2);
+
+        // r2 should find both south-east elements with the replaced text
+        assertTrue("Should find south-east with replaced value",
+                r2.contains("<south-east mark=\"1se\">very south east</south-east>"));
+        assertTrue("Should find both south-east elements",
+                r2.contains("count=\"2\""));
+    }
+
+    /**
+     * Test that //(element | element) union expressions with descendant axis work correctly.
+     * Note: //(@attr) with parenthesized attribute expressions is a pre-existing eXist
+     * limitation where the // axis handling incorrectly overwrites the attribute axis.
+     * The non-parenthesized //@x form works correctly. See PR #6106 for the fix.
+     */
+    @Test
+    public void parenthesizedAttributeUnionWithDescendant() throws XMLDBException {
+        // //@x (non-parenthesized) should work correctly
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $doc := <root>" +
+                "  <a x='1' y='2'/>" +
+                "  <b><c x='3' z='4'/></b>" +
+                "</root>\n" +
+                "return <r>{count($doc//@x)}</r>");
+        assertEquals(1L, result.getSize());
+        assertEquals("//@x should find 2", "<r>2</r>", result.getResource(0).getContent().toString());
+
+        // //(element-name | element-name) should find descendants
+        final ResourceSet result2 = existEmbeddedServer.executeQuery(
+                "let $doc := <root><a><b>1</b><c>2</c></a><d><b>3</b></d></root>\n" +
+                "return <r>{count($doc//(b | c))}</r>");
+        assertEquals(1L, result2.getSize());
+        assertEquals("//(b | c) should find 3 elements", "<r>3</r>",
+                result2.getResource(0).getContent().toString());
+
+        // //(element-union) in nested structure should find all matching descendants
+        final ResourceSet result3 = existEmbeddedServer.executeQuery(
+                "let $doc := <far-north>\n" +
+                "    <!-- Comment-3 -->\n" +
+                "  <north mark='n0'>\n" +
+                "    <near-north>\n" +
+                "      <center mark='c0'>\n" +
+                "        <!--Comment-5-->\n" +
+                "        <near-south/>\n" +
+                "      </center>\n" +
+                "    </near-north>\n" +
+                "  </north>\n" +
+                "</far-north>\n" +
+                "return (\n" +
+                "  <found>{for $n in $doc//(north | near-south) return local-name($n)}</found>,\n" +
+                "  <comments>{count($doc//(north | near-south)/preceding-sibling::comment())}</comments>\n" +
+                ")");
+        assertEquals(2L, result3.getSize());
+        assertTrue("Should find both elements",
+                result3.getResource(0).getContent().toString().contains("north")
+                && result3.getResource(0).getContent().toString().contains("near-south"));
+        assertEquals("Should find 2 preceding-sibling comments",
+                "<comments>2</comments>", result3.getResource(1).getContent().toString());
+    }
+
+    // ---- Mutual exclusion: legacy + XQUF in same module ----
+
+    @Test
+    public void mixedLegacyAndXQUFIsRejected() throws XMLDBException {
+        final XQueryService queryService =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        try {
+            queryService.query(
+                    "let $doc := <root><a/></root> " +
+                    "return (update insert <b/> into $doc, insert node <c/> into $doc)");
+            fail("Should reject mixing legacy and XQUF syntax");
+        } catch (final XMLDBException e) {
+            assertTrue("Should report syntax conflict",
+                    e.getMessage().contains("legacy") || e.getMessage().contains("W3C"));
+        }
+    }
+
+    @Test
+    public void mixedXQUFThenLegacyIsRejected() throws XMLDBException {
+        final XQueryService queryService =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        try {
+            queryService.query(
+                    "let $doc := <root><a/></root> " +
+                    "return (insert node <b/> into $doc, update insert <c/> into $doc)");
+            fail("Should reject mixing XQUF and legacy syntax");
+        } catch (final XMLDBException e) {
+            assertTrue("Should report syntax conflict",
+                    e.getMessage().contains("legacy") || e.getMessage().contains("W3C"));
+        }
+    }
+
+    @Test
+    public void pureXQUFIsAccepted() throws XMLDBException {
+        final XQueryService queryService =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        // Should not throw - pure XQUF is fine
+        queryService.query(
+                "copy $c := <root><a/></root> " +
+                "modify insert node <b/> into $c " +
+                "return $c");
+    }
+
+    @Test
+    public void pureLegacyIsAccepted() throws XMLDBException {
+        final XQueryService queryService =
+                storeXMLStringAndGetQueryService("test-legacy.xml", "<root><a/></root>");
+        // Should not throw - pure legacy is fine
+        queryService.query("update insert <b/> into doc('/db/test/test-legacy.xml')/root");
+    }
+
+}

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
@@ -797,8 +797,6 @@ public class XQUFBasicTest {
 
     @Test
     public void deleteAttributesTwoElements() throws XMLDBException {
-        final XQueryService service = testCollection.getService(XQueryService.class);
-
         // Delete one attr from each of two elements
         final String query =
                 "let $doc := <root><a x='1' y='2' z='3'/><b p='4' q='5' r='6'/></root> " +
@@ -1675,13 +1673,6 @@ public class XQUFBasicTest {
      */
     @Test
     public void deleteDocumentCommentsFollowsOperator() throws XMLDBException {
-        // Simulates the structure: document has root element, then comments after it
-        final String query =
-                "let $doc := <root/>\n" +
-                "return\n" +
-                "copy $c := $doc\n" +
-                "modify ()\n" +
-                "return $c";
         // Basic test: just make sure >> operator works
         final String followsTest =
                 "let $doc := parse-xml('<root><a/><b/></root>')\n" +

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
@@ -1468,7 +1468,7 @@ public class XQUFBasicTest {
         try {
             existEmbeddedServer.executeQuery(query);
             fail("Expected XUDY0014");
-        } catch (final org.xmldb.api.base.XMLDBException e) {
+        } catch (final XMLDBException e) {
             assertTrue("Should raise XUDY0014", e.getMessage().contains("XUDY0014"));
         }
     }

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBasicTest.java
@@ -1970,4 +1970,258 @@ public class XQUFBasicTest {
         queryService.query("update insert <b/> into doc('/db/test/test-legacy.xml')/root");
     }
 
+    // === Namespace propagation diagnostic tests ===
+
+    /**
+     * XQTS propagateNamespaces01: preserve, inherit.
+     * After inserting content into a copied element, namespace bindings
+     * from the parent should propagate to the inserted children.
+     */
+    @Test
+    public void propagateNamespaces01PreserveInherit() throws XMLDBException {
+        final String query =
+                "declare copy-namespaces preserve, inherit; " +
+                "declare boundary-space preserve; " +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/> " +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data " +
+                "return let $w := $data/w let $x := $w/x let $y := $x/y let $z := $y/z " +
+                "return <result> " +
+                "  <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w> " +
+                "  <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x> " +
+                "  <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y> " +
+                "  <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z> " +
+                "</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("propagateNS01 (preserve,inherit): " + xml);
+        // Expected: <w>a-one b-one</w> <x>a-two b-one</x> <y>a-two b-two</y> <z>a-two b-two</z>
+        assertTrue("w should inherit a-one", xml.contains("<w>a-one b-one</w>"));
+        assertTrue("x should have a-two and inherit b-one", xml.contains("<x>a-two b-one</x>"));
+        assertTrue("y should have a-two b-two", xml.contains("<y>a-two b-two</y>"));
+        assertTrue("z should have a-two b-two", xml.contains("<z>a-two b-two</z>"));
+    }
+
+    /**
+     * XQTS propagateNamespaces02: preserve, no-inherit.
+     * Inserted children should NOT inherit ns from insertion target,
+     * but internal ns scoping within inserted content should still work.
+     */
+    @Test
+    public void propagateNamespaces02PreserveNoInherit() throws XMLDBException {
+        final String query =
+                "declare copy-namespaces preserve, no-inherit; " +
+                "declare boundary-space preserve; " +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/> " +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data " +
+                "return let $w := $data/w let $x := $w/x let $y := $x/y let $z := $y/z " +
+                "return <result> " +
+                "  <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w> " +
+                "  <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x> " +
+                "  <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y> " +
+                "  <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z> " +
+                "</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("propagateNS02 (preserve,no-inherit): " + xml);
+        // Expected: <w/> <x>a-two</x> <y>a-two b-two</y> <z>a-two b-two</z>
+        assertTrue("w should be empty (no-inherit blocks parent ns)", xml.contains("<w/>"));
+        assertTrue("x should have own a-two only", xml.contains("<x>a-two</x>"));
+        assertTrue("y should see a-two from x and own b-two", xml.contains("<y>a-two b-two</y>"));
+        assertTrue("z should see a-two b-two from ancestors", xml.contains("<z>a-two b-two</z>"));
+    }
+
+    /**
+     * XQTS propagateNamespaces03: no-preserve, inherit.
+     * Copy strips unused ns from copied element; inserted content
+     * is also deep-copied with no-preserve stripping.
+     */
+    @Test
+    public void propagateNamespaces03NoPreserveInherit() throws XMLDBException {
+        final String query =
+                "declare copy-namespaces no-preserve, inherit; " +
+                "declare boundary-space preserve; " +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/> " +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data " +
+                "return let $w := $data/w let $x := $w/x let $y := $x/y let $z := $y/z " +
+                "return <result> " +
+                "  <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w> " +
+                "  <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x> " +
+                "  <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y> " +
+                "  <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z> " +
+                "</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("propagateNS03 (no-preserve,inherit): " + xml);
+        // Expected: all empty — no-preserve strips unused ns, nothing to propagate
+        assertTrue("w should be empty", xml.contains("<w/>"));
+        assertTrue("x should be empty", xml.contains("<x/>") || xml.contains("<x></x>"));
+        assertTrue("y should be empty", xml.contains("<y/>") || xml.contains("<y></y>"));
+        assertTrue("z should be empty", xml.contains("<z/>") || xml.contains("<z></z>"));
+    }
+
+    /**
+     * XQTS propagateNamespaces04: no-preserve, no-inherit.
+     * Both modes strip — all elements should have no namespace bindings.
+     */
+    @Test
+    public void propagateNamespaces04NoPreserveNoInherit() throws XMLDBException {
+        final String query =
+                "declare copy-namespaces no-preserve, no-inherit; " +
+                "declare boundary-space preserve; " +
+                "copy $data := <v xmlns:a=\"a-one\" xmlns:b=\"b-one\"/> " +
+                "modify insert node <w> <x xmlns:a=\"a-two\"> <y xmlns:b=\"b-two\"><z/></y> </x> </w> into $data " +
+                "return let $w := $data/w let $x := $w/x let $y := $x/y let $z := $y/z " +
+                "return <result> " +
+                "  <w>{namespace-uri-for-prefix('a', $w), namespace-uri-for-prefix('b',$w)}</w> " +
+                "  <x>{namespace-uri-for-prefix('a', $x), namespace-uri-for-prefix('b',$x)}</x> " +
+                "  <y>{namespace-uri-for-prefix('a', $y), namespace-uri-for-prefix('b',$y)}</y> " +
+                "  <z>{namespace-uri-for-prefix('a', $z), namespace-uri-for-prefix('b',$z)}</z> " +
+                "</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("propagateNS04 (no-preserve,no-inherit): " + xml);
+        // Expected: all empty
+        assertTrue("w should be empty", xml.contains("<w/>"));
+        assertTrue("x should be empty", xml.contains("<x/>") || xml.contains("<x></x>"));
+        assertTrue("y should be empty", xml.contains("<y/>") || xml.contains("<y></y>"));
+        assertTrue("z should be empty", xml.contains("<z/>") || xml.contains("<z></z>"));
+    }
+
+    /**
+     * XQTS attribute-errors-q14: Simultaneous attribute replacements
+     * where one replaces @name with @salary and another replaces @gender with @name.
+     */
+    @Test
+    public void attributeReplaceSwap() throws XMLDBException {
+        final String query =
+                "copy $in := <employee name=\"Jane Doe 1\" gender=\"female\">" +
+                "  <empnum>E1</empnum><pnum>P1</pnum>" +
+                "</employee> " +
+                "modify (" +
+                "  replace node $in/@name with attribute {'salary'} {'10'}," +
+                "  replace node $in/@gender with attribute {'name'} {'Blodwyn Jones'}" +
+                ") " +
+                "return $in";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        System.err.println("attrReplaceSwap: " + xml);
+        assertTrue("Should have salary attr", xml.contains("salary=\"10\""));
+        assertTrue("Should have name attr with new value", xml.contains("name=\"Blodwyn Jones\""));
+        assertFalse("Should NOT have gender attr", xml.contains("gender="));
+    }
+
+    // ======================== FullAxis tests ========================
+
+    /**
+     * Baseline: following axis from document element (no updates).
+     */
+    @Test
+    public void followingAxisFromDocElementBaseline() throws XMLDBException {
+        final String query =
+                "let $doc := document { " +
+                "  <!--Comment-1-->, <?a-pi pi-1?>, " +
+                "  <root><child/></root>, " +
+                "  <!--Comment-2-->, <?b-pi pi-2?> " +
+                "} " +
+                "return let $a := $doc/*/following::node() " +
+                "return <result count=\"{count($a)}\">{$a}</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        assertTrue("Should have count 2, got: " + xml, xml.contains("count=\"2\""));
+    }
+
+    /**
+     * Following axis from document element after deleting trailing comments.
+     * Based on XQTS upd-FullAxis/complex-deletes-q2.
+     */
+    @Test
+    public void followingAxisAfterDeleteTrailingComments() throws XMLDBException {
+        final String query =
+                "let $doc := document { " +
+                "  <!--Comment-1-->, <?a-pi pi-1?>, <!--Comment-2-->, " +
+                "  <root><child/></root>, " +
+                "  <!--Comment-3-->, <?b-pi pi-2?>, <!--Comment-4--> " +
+                "} " +
+                "return copy $d := $doc " +
+                "modify delete nodes $d/comment()[. >> $d/*] " +
+                "return let $a := $d/*/following::node() " +
+                "return <result count=\"{count($a)}\">{$a}</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        // After deleting trailing comments, only PI-2 should remain as following
+        assertTrue("Should have count 1, got: " + xml, xml.contains("count=\"1\""));
+        assertTrue("Should contain the PI", xml.contains("pi-2"));
+    }
+
+    /**
+     * Following axis from document element after replacing trailing comment values.
+     * Based on XQTS upd-FullAxis/complex-replacevalues-q2.
+     */
+    @Test
+    public void followingAxisAfterReplaceTrailingCommentValues() throws XMLDBException {
+        final String query =
+                "let $doc := document { " +
+                "  <!--Comment-1-->, <?a-pi pi-1?>, <!--Comment-2-->, " +
+                "  <root><child/></root>, " +
+                "  <!--Comment-3-->, <?b-pi pi-2?>, <!--Comment-4--> " +
+                "} " +
+                "return copy $d := $doc " +
+                "modify ( " +
+                "  for $c in $d/comment()[. >> $d/*] " +
+                "  return replace value of node $c with 'Replaced' " +
+                ") " +
+                "return let $a := $d/*/following::node() " +
+                "return <result count=\"{count($a)}\">{$a}</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        // Trailing comments replaced + PI = 3 following nodes
+        assertTrue("Should have count 3", xml.contains("count=\"3\""));
+        assertTrue("Should contain replaced comment", xml.contains("Replaced"));
+        assertTrue("Should contain the PI", xml.contains("pi-2"));
+    }
+
+    /**
+     * Preceding axis after replacing text nodes with empty strings.
+     * Based on XQTS upd-FullAxis/complex-replacevalues-q7.
+     * Verifies that soft-deleted nodes from mergeAdjacentTextNodes don't crash selectPreceding.
+     */
+    @Test
+    public void precedingAxisAfterReplaceTextWithEmpty() throws XMLDBException {
+        final String query =
+                "let $doc := document { " +
+                "  <root>" +
+                "    <a>text-a</a>" +
+                "    <!--comment-1-->" +
+                "    text-after-comment" +
+                "    <b>" +
+                "      <c>text-c</c>" +
+                "      <?pi-1 data?>" +
+                "      text-after-pi" +
+                "      <target/>" +
+                "    </b>" +
+                "  </root> " +
+                "} " +
+                "return copy $d := $doc " +
+                "modify ( " +
+                "  for $t in $d//text()[preceding-sibling::node()[1]/(self::comment() | self::processing-instruction())] " +
+                "  return replace value of node $t with '' " +
+                ") " +
+                "return let $a := $d//target/preceding::text() " +
+                "return <result count=\"{count($a)}\">{for $t in $a return <t>{$t}</t>}</result>";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        assertEquals(1L, result.getSize());
+        final String xml = result.getResource(0).getContent().toString();
+        // Should not crash with "node not found"
+        assertTrue("Should have text-a in preceding", xml.contains("text-a"));
+        assertTrue("Should have text-c in preceding", xml.contains("text-c"));
+    }
+
 }

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBenchmark.java
@@ -1,0 +1,443 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xquf;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XQueryService;
+
+/**
+ * Performance benchmark for W3C XQuery Update Facility 3.0 operations.
+ *
+ * <p>Measures wall-clock time for W3C XQUF persistent update operations (insert,
+ * delete, replace node, replace value, rename), their legacy eXist-db equivalents
+ * (update insert, update delete, etc.), and in-memory copy-modify (transform)
+ * expressions at various data sizes.</p>
+ *
+ * <p>This class intentionally does <em>not</em> end in {@code *Test} so that
+ * Surefire will not discover it during normal {@code mvn test} runs.
+ * Run explicitly with:</p>
+ * <pre>
+ *   mvn test -pl exist-core -Dtest=XQUFBenchmark \
+ *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
+ * </pre>
+ */
+public class XQUFBenchmark {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static final String COLLECTION_NAME = "benchmark-xquf";
+    private static final String COLLECTION_PATH = "/db/" + COLLECTION_NAME;
+
+    private static final int WARMUP_ITERATIONS = 3;
+    private static final int MEASURE_ITERATIONS = 5;
+    private static final int[] DATA_SIZES = {10, 50, 200};
+
+    @BeforeClass
+    public static void assumeBenchmarks() {
+        Assume.assumeTrue("Benchmarks are disabled. Set -Dexist.run.benchmarks=true to enable.",
+                Boolean.getBoolean("exist.run.benchmarks"));
+    }
+
+    @BeforeClass
+    public static void setUp() throws XMLDBException {
+        if (!Boolean.getBoolean("exist.run.benchmarks")) {
+            return;
+        }
+
+        final CollectionManagementService cms =
+                server.getRoot().getService(CollectionManagementService.class);
+        cms.createCollection(COLLECTION_NAME);
+    }
+
+    @AfterClass
+    public static void tearDown() throws XMLDBException {
+        if (!Boolean.getBoolean("exist.run.benchmarks")) {
+            return;
+        }
+
+        final CollectionManagementService cms =
+                server.getRoot().getService(CollectionManagementService.class);
+        cms.removeCollection(COLLECTION_NAME);
+    }
+
+    // ---- Persistent update benchmarks ----
+
+    @Test
+    public void insertInto() throws XMLDBException {
+        System.out.println("\n=== insert node ... into (persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("insert-into", size, (queryService, docPath) -> {
+                // Reset document with N items
+                storeDocument(size);
+
+                // Insert a new child into each item
+                final String update = String.format(
+                        "for $item in doc('%s/bench.xml')//item " +
+                        "return insert node <added/> into $item",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("insert-into benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void deleteNode() throws XMLDBException {
+        System.out.println("\n=== delete node (persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("delete-node", size, (queryService, docPath) -> {
+                // Reset document with N items, each having a <value> child
+                storeDocument(size);
+
+                // Delete the <value> child from each item
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return delete node $v",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("delete-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void replaceValue() throws XMLDBException {
+        System.out.println("\n=== replace value of node (persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("replace-value", size, (queryService, docPath) -> {
+                // Reset document
+                storeDocument(size);
+
+                // Replace value of each item's @id attribute
+                final String update = String.format(
+                        "for $item in doc('%s/bench.xml')//item " +
+                        "return replace value of node $item/@id with concat('new-', $item/@id)",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("replace-value benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void renameNode() throws XMLDBException {
+        System.out.println("\n=== rename node (persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("rename-node", size, (queryService, docPath) -> {
+                // Reset document
+                storeDocument(size);
+
+                // Rename each <value> element to <renamed>
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return rename node $v as 'renamed'",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("rename-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void replaceNode() throws XMLDBException {
+        System.out.println("\n=== replace node (persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("replace-node", size, (queryService, docPath) -> {
+                // Reset document
+                storeDocument(size);
+
+                // Replace each <value> with a <new-value>
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return replace node $v with <new-value>{string($v)}</new-value>",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("replace-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    // ---- Legacy persistent update benchmarks (DEPRECATED syntax) ----
+
+    @Test
+    public void legacyInsertInto() throws XMLDBException {
+        System.out.println("\n=== update insert ... into (legacy persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("legacy-insert-into", size, (queryService, docPath) -> {
+                storeDocument(size);
+                final String update = String.format(
+                        "for $item in doc('%s/bench.xml')//item " +
+                        "return update insert <added/> into $item",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("legacy-insert-into benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void legacyDeleteNode() throws XMLDBException {
+        System.out.println("\n=== update delete (legacy persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("legacy-delete-node", size, (queryService, docPath) -> {
+                storeDocument(size);
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return update delete $v",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("legacy-delete-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void legacyReplaceValue() throws XMLDBException {
+        System.out.println("\n=== update value (legacy persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("legacy-replace-value", size, (queryService, docPath) -> {
+                storeDocument(size);
+                final String update = String.format(
+                        "for $item in doc('%s/bench.xml')//item " +
+                        "return update value $item/@id with concat('new-', $item/@id)",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("legacy-replace-value benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void legacyRenameNode() throws XMLDBException {
+        System.out.println("\n=== update rename (legacy persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("legacy-rename-node", size, (queryService, docPath) -> {
+                storeDocument(size);
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return update rename $v as 'renamed'",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("legacy-rename-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void legacyReplaceNode() throws XMLDBException {
+        System.out.println("\n=== update replace (legacy persistent) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final double avgMs = runPersistentBenchmark("legacy-replace-node", size, (queryService, docPath) -> {
+                storeDocument(size);
+                final String update = String.format(
+                        "for $v in doc('%s/bench.xml')//item/value " +
+                        "return update replace $v with <new-value>{string($v)}</new-value>",
+                        COLLECTION_PATH);
+                queryService.query(update);
+            });
+            assertTrue("legacy-replace-node benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    // ---- In-memory copy-modify benchmarks ----
+
+    @Test
+    public void copyModifySingle() throws XMLDBException {
+        System.out.println("\n=== copy-modify single node (in-memory) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final String query = String.format(
+                    "let $doc := <root>{ for $i in 1 to %d return <item id='{$i}'><value>{$i}</value></item> }</root> " +
+                    "return copy $c := $doc modify ( replace value of node $c//item[@id = '1']/value with 'modified' ) return $c//item[@id = '1']/value/string()",
+                    size);
+            final double avgMs = runInMemoryBenchmark("copy-modify-single", size, query);
+            assertTrue("copy-modify-single benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void copyModifyMultiple() throws XMLDBException {
+        System.out.println("\n=== copy-modify multiple replaceValue (in-memory) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final String query = String.format(
+                    "let $doc := <root>{ for $i in 1 to %d return <item id='{$i}'><value>{$i}</value></item> }</root> " +
+                    "return copy $c := $doc modify ( " +
+                    "  for $v in $c//item/value return replace value of node $v with concat('m-', $v) " +
+                    ") return count($c//item)",
+                    size);
+            final double avgMs = runInMemoryBenchmark("copy-modify-multi", size, query);
+            assertTrue("copy-modify-multi benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void copyModifyInsertDelete() throws XMLDBException {
+        System.out.println("\n=== copy-modify insert + delete (in-memory) ===");
+        printHeader();
+
+        for (final int size : DATA_SIZES) {
+            final String query = String.format(
+                    "let $doc := <root>{ for $i in 1 to %d return <item id='{$i}'><value>{$i}</value></item> }</root> " +
+                    "return copy $c := $doc modify ( " +
+                    "  insert node <added/> into $c, " +
+                    "  for $v in $c//item[@id = ('1','2','3')]/value return delete node $v " +
+                    ") return count($c//item)",
+                    size);
+            final double avgMs = runInMemoryBenchmark("copy-modify-ins-del", size, query);
+            assertTrue("copy-modify-ins-del benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    @Test
+    public void copyModifyDeepTree() throws XMLDBException {
+        System.out.println("\n=== copy-modify deep tree (in-memory) ===");
+        printHeader();
+
+        // Nested structure: root > section > subsection > item (depth=4)
+        for (final int size : DATA_SIZES) {
+            final String query = String.format(
+                    "let $doc := <root>{ " +
+                    "  for $s in 1 to %d " +
+                    "  return <section id='{$s}'>{ " +
+                    "    for $ss in 1 to 3 " +
+                    "    return <subsection id='{$s}-{$ss}'><item>data</item></subsection> " +
+                    "  }</section> " +
+                    "}</root> " +
+                    "return copy $c := $doc modify ( " +
+                    "  for $item in $c//item return replace value of node $item with 'updated' " +
+                    ") return count($c//item[. = 'updated'])",
+                    size);
+            final double avgMs = runInMemoryBenchmark("copy-modify-deep", size, query);
+            assertTrue("copy-modify-deep benchmark should complete in positive time", avgMs >= 0);
+        }
+    }
+
+    // ---- Helpers ----
+
+    private void storeDocument(final int numItems) throws XMLDBException {
+        final Collection col = server.getRoot().getChildCollection(COLLECTION_NAME);
+        final StringBuilder sb = new StringBuilder("<root>\n");
+        for (int i = 1; i <= numItems; i++) {
+            sb.append(String.format("  <item id='%d'><value>val-%d</value></item>\n", i, i));
+        }
+        sb.append("</root>");
+
+        final XMLResource res = col.createResource("bench.xml", XMLResource.class);
+        res.setContent(sb.toString());
+        col.storeResource(res);
+    }
+
+    @FunctionalInterface
+    interface PersistentOperation {
+        void execute(XQueryService queryService, String docPath) throws XMLDBException;
+    }
+
+    private double runPersistentBenchmark(final String label, final int size,
+                                         final PersistentOperation operation) throws XMLDBException {
+        final XQueryService queryService = server.getRoot().getService(XQueryService.class);
+
+        // warmup
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            operation.execute(queryService, COLLECTION_PATH + "/bench.xml");
+        }
+
+        // measure
+        long totalNs = 0;
+        for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+            final long start = System.nanoTime();
+            operation.execute(queryService, COLLECTION_PATH + "/bench.xml");
+            final long elapsed = System.nanoTime() - start;
+            totalNs += elapsed;
+        }
+
+        final double avgMs = (totalNs / (double) MEASURE_ITERATIONS) / 1_000_000.0;
+        System.out.printf("  %-24s  size=%3d  avg=%8.2f ms%n", label, size, avgMs);
+        return avgMs;
+    }
+
+    private double runInMemoryBenchmark(final String label, final int size,
+                                       final String query) throws XMLDBException {
+        final XQueryService queryService = server.getRoot().getService(XQueryService.class);
+
+        // warmup
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            queryService.query(query);
+        }
+
+        // measure
+        long totalNs = 0;
+        for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+            final long start = System.nanoTime();
+            final ResourceSet result = queryService.query(query);
+            if (result.getSize() != 1) {
+                throw new AssertionError(label + " (size=" + size + "): expected 1 result, got " + result.getSize());
+            }
+            final long elapsed = System.nanoTime() - start;
+            totalNs += elapsed;
+        }
+
+        final double avgMs = (totalNs / (double) MEASURE_ITERATIONS) / 1_000_000.0;
+        System.out.printf("  %-24s  size=%3d  avg=%8.2f ms%n", label, size, avgMs);
+        return avgMs;
+    }
+
+    private static void printHeader() {
+        System.out.printf("  %-24s  %8s  %12s%n", "Operation", "Size", "Avg (ms)");
+        System.out.println("  " + "-".repeat(50));
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBenchmark.java
+++ b/exist-core/src/test/java/org/exist/xquery/xquf/XQUFBenchmark.java
@@ -51,6 +51,7 @@ import org.xmldb.api.modules.XQueryService;
  *       -Dexist.run.benchmarks=true -Ddependency-check.skip=true
  * </pre>
  */
+@SuppressWarnings("PMD.ClassNamingConventions") // benchmark, not a test class; gated by -Dexist.run.benchmarks=true
 public class XQUFBenchmark {
 
     @ClassRule

--- a/exist-core/src/test/xquery/xquery3/bindingConflict.xqm
+++ b/exist-core/src/test/xquery/xquery3/bindingConflict.xqm
@@ -29,6 +29,8 @@ declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 declare namespace myns="http://www.foo.com";
 declare namespace myns2="http://www.foo.net";
 
+(: ===== Legacy update tests (persistent documents) ===== :)
+
 (: insert node into a ns with a conflicting ns in parent tree :)
 declare %test:assertError("XUDY0023")
 function ut:insert-child-namespaced-attr-conflicted() {

--- a/exist-core/src/test/xquery/xquery3/bindingConflictXQUF.xqm
+++ b/exist-core/src/test/xquery/xquery3/bindingConflictXQUF.xqm
@@ -1,0 +1,90 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(: W3C XQUF 3.0 versions of the namespace binding conflict tests.
+ : These use copy/modify/return (in-memory) instead of the legacy
+ : update syntax (persistent). Separated into its own module because
+ : legacy and XQUF syntax cannot be mixed in the same module.
+ :)
+
+module namespace utx="http://exist-db.org/xquery/update/xquf-test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare namespace myns="http://www.foo.com";
+declare namespace myns2="http://www.foo.net";
+
+(: insert node into a ns with a conflicting ns in parent tree :)
+declare %test:assertError("XUDY0023")
+function utx:xquf-insert-child-namespaced-attr-conflicted() {
+    copy $data := <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node <child myns:baz="qux"/> into $data/z
+    return $data
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z blah=""wah""><child xmlns:myns=""http://www.foo.com"" myns:baz=""qux""/></z>")
+function utx:xquf-insert-child-namespaced-attr() {
+    copy $data := <root attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node <child myns:baz="qux"/> into $data/z
+    return $data/z
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z blah=""wah""><myns:child xmlns:myns=""http://www.foo.com"" baz=""qux""/></z>")
+function utx:xquf-insert-namespaced-child() {
+    copy $data := <root attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node <myns:child baz="qux"/> into $data/z
+    return $data/z
+};
+
+declare %test:assertEquals("<z blah=""wah""><myns:child xmlns:myns=""http://www.foo.com"" baz=""qux""><grand xmlns:myns=""http://www.fubar.com""><great xmlns:myns2=""http://www.foo.net"" myns:boz=""chux"" myns2:pip=""dickens""/></grand></myns:child></z>")
+function utx:xquf-insert-namespaced-child-deep() {
+    copy $data := <root attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node <myns:child baz="qux"><grand xmlns:myns="http://www.fubar.com"><great myns:boz="chux" myns2:pip="dickens"/></grand></myns:child> into $data/z
+    return fn:serialize($data/z)
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertError("XUDY0023")
+function utx:xquf-insert-namespaced-child-conflicted() {
+    copy $data := <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node <myns:child baz="qux"/> into $data/z
+    return $data/z
+};
+
+(: insert attr into a ns with a conflicting ns in parent tree :)
+declare %test:assertError("XUDY0023")
+function utx:xquf-insert-namespaced-attr-conflicted() {
+    copy $data := <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node attribute myns:baz { "qux" } into $data/z
+    return $data
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z xmlns:myns=""http://www.foo.com"" blah=""wah"" myns:baz=""qux""/>")
+function utx:xquf-insert-namespaced-attr() {
+    copy $data := <root attr="1"><!-- foobar --><z blah="wah"/></root>
+    modify insert node attribute myns:baz { "qux" } into $data/z
+    return $data/z
+};


### PR DESCRIPTION
## Summary

Implements BaseX-style preclaiming two-phase locking to prevent data corruption during concurrent database operations. Before query evaluation begins, the compiled expression tree is statically analyzed to determine which documents will be accessed. Write locks are acquired on all targets before `eval()` and released after the operation completes.

This ensures that no two queries can concurrently modify the same document, eliminating dirty writes structurally rather than relying on transaction isolation. The preclaiming mechanism protects all write paths — `xmldb:store`, `xmldb:remove`, collection move/rename, legacy `update`, and XQuery Update Facility.

## Evidence: Concurrent Write Corruption Prevention

A real-world corruption scenario was reported by Alexander Henket (Slack, 2026-03-27): "When 4-6 users do more or less heavy writing in the same resource… data meant for one attribute ends up in another."

`ConcurrentWriteCorruptionTest.sustainedConcurrentSharedCounter` reproduces this: 6 threads increment a shared counter attribute for 5 seconds via `update value`.

| Metric | develop (no preclaiming) | With preclaiming |
|--------|--------------------------|-----------------|
| Total operations | 32,165 | 40,317 |
| Final counter value | **NaN (CORRUPTED)** | **40,317 (CORRECT)** |
| Lost updates | **32,165 (100%)** | **0 (0%)** |
| Data corruption | **YES** | **NO** |

On develop, concurrent read-modify-write produced a corrupt intermediate state — one thread read the attribute while another was mid-write, producing NaN. With preclaiming, each query's lock targets are determined statically (`doc('/db/.../counter.xml')`), write locks are acquired before `eval()`, and the read-modify-write becomes atomic.

## MoveResourceTest Contention — Resolved

The initial implementation preclaimed collection-level write locks, which caused deadlock with concurrent collection operations (40% hang rate). The fix: **preclaim only document-level write locks**. Collection-level locks are already handled internally by `NativeBroker` operations.

| Config | MoveResourceTest result |
|--------|------------------------|
| Old preclaiming (collection + document locks) | **2/5 timeout (40% hang)** |
| **This PR (document-level locks only)** | **10/10 pass (0% hang)** |

## What Changed

### New files

- **`LockTargetCollector.java`** — `ExpressionVisitor` that walks the compiled expression tree to find `fn:doc()`, `fn:collection()`, `fn:doc-available()`, and `fn:uri-collection()` calls with static string arguments. Uses `TreeSet<XmldbURI>` for consistent lock ordering (deadlock prevention). Falls back to global lock for dynamic targets.

- **`LockTargetCollectorTest.java`** — 9 unit tests covering static doc/collection detection, dynamic fallback, FLWOR traversal, conditional handling.

- **`ConcurrencyBenchmark.java`** — Measures ops/sec under 8 concurrent scenarios. Guarded by `-Dexist.run.benchmarks=true`.

- **`ConcurrentWriteCorruptionTest.java`** — 6 concurrency tests reproducing real-world data corruption under concurrent writes.

### Modified files

- **`XQueryContext.java`** — Preclaiming infrastructure: `collectLockTargets()`, `preclaimLocks()` (document-level only), `releasePreclaimedLocks()`.

- **`XQuery.java`** — Hooks into `execute()`: collects lock targets, acquires preclaimed locks before `eval()`, releases in `finally` block. Graceful degradation on `LockException`.

## How It Works

```
BEFORE (current):
  compile → analyze → eval() → update/modify [locks acquired HERE] → release
  Problem: another query can read/modify the same document during eval()

AFTER (preclaiming):
  compile → analyze → collectLockTargets() → preclaimLocks() [doc locks HERE] → eval() → update [locks still held] → release
  No concurrent modification possible during eval+update window
```

For dynamic targets (`fn:doc($variable)`), the collector falls back to a global collection write lock on `/db`, which serializes all updating queries — conservative but correct. This matches BaseX's approach.

## Comparison with BaseX

| Aspect | BaseX | eXist (this PR) |
|--------|-------|-----------------|
| Lock determination | `LockVisitor` walks AST | `LockTargetCollector` walks expression tree |
| Lock ordering | Alphabetical by database name | Alphabetical by URI (`TreeSet`) |
| Dynamic fallback | Global lock | Global lock on `/db` |
| Lock granularity | Database level | **Document level** (finer-grained) |

## Design Decisions

- **Document-level locks only**: Collection-level preclaiming caused deadlock with `NativeBroker`'s internal collection lock acquisition. Removed in favor of document-level locks, which are sufficient for preventing concurrent write corruption.
- **TreeSet for lock ordering**: Prevents deadlocks by ensuring all queries acquire locks in the same URI-sorted order.
- **Global lock fallback**: Matches BaseX — if targets can't be determined statically, serialize all updating queries.
- **Graceful degradation**: If preclaim lock acquisition fails (`LockException`), the query proceeds without preclaimed locks rather than failing.

## Scope

### What this prevents
- Read-modify-write corruption (Alexander Henket's scenario)
- Concurrent modification of the same document
- Cross-contamination where "data from one attribute ends up in another"

### Known limitations
- Not full ACID (no journaling/rollback integration)
- `xmldb:store/remove/move` with dynamic targets fall back to global lock
- Future enhancement: literal-argument detection for `xmldb:*` functions

## Test Plan

- [x] 9 LockTargetCollector unit tests pass
- [x] ConcurrentWriteCorruptionTest: NaN corruption → zero corruption
- [x] MoveResourceTest: 10/10 pass (0% hang rate)
- [x] Full exist-core test suite: all tests pass
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>