### PR TITLE
[ci] Add weekly Prethink context refresh workflow

### DIFF
--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'zulu'
+          distribution: 'liberica'
 
       - name: Install Moderne CLI
         run: |

--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -1,0 +1,48 @@
+name: Update Prethink Context
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  workflow_dispatch:       # Manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  prethink:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: Install Moderne CLI
+        run: |
+          curl -sSL https://pkgs.moderne.io/moderne-cli/latest/linux/mod > mod
+          chmod +x mod
+          sudo mv mod /usr/local/bin/
+
+      - name: Configure Moderne
+        run: |
+          mod config moderne edit https://app.moderne.io --token ${{ secrets.MODERNE_TOKEN }}
+          mod config recipes jar install io.moderne.recipe:rewrite-prethink:LATEST
+
+      - name: Build LSTs
+        run: mod build .
+
+      - name: Run Prethink (deterministic, no AI)
+        run: mod run . --recipe io.moderne.prethink.UpdatePrethinkContextNoAiStarter
+
+      - name: Apply changes
+        run: mod git apply . --last-recipe-run
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .moderne/context/ AGENTS.md
+          git diff --staged --quiet || git commit -m "[ci] Update Prethink context"
+          git push


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [Moderne Prethink](https://docs.moderne.io/user-documentation/recipes/prethink) weekly to refresh pre-analyzed codebase metadata in `.moderne/context/`.

This is a follow-up to #6141 which adds the initial `AGENTS.md` guide and Prethink context.

## What it does

- Runs every Monday at 6am UTC (+ manual trigger via `workflow_dispatch`)
- Uses the deterministic recipe (`UpdatePrethinkContextNoAiStarter`) — no AI API calls, pure code analysis
- Updates `.moderne/context/` files: architecture diagrams, class descriptions, dependency trees, coding conventions, error handling patterns, test coverage mappings
- Auto-commits changes to `develop`

## Prerequisites

- `MODERNE_TOKEN` secret must be added to GitHub Actions settings
- Free for open-source repositories (no paid Moderne license needed)

## Test Plan

- [x] Add `MODERNE_TOKEN` secret
- [ ] Trigger manual run via Actions tab
- [ ] Verify `.moderne/context/` files are updated
- [x] Review by @duncdrum

🤖 Generated with [Claude Code](https://claude.com/claude-code)