### PR TITLE
[bugfix] Fix negative double/float comparison in value index

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
+++ b/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
@@ -93,15 +93,19 @@ public class ValueIndexFactory {
         }
         /* xs:double */
         else if (type == Type.DOUBLE) {
-            final long bits = ByteConversion.byteToLong(data, start +
-                    (ValueIndexFactory.LENGTH_VALUE_TYPE)) ^ 0x8000000000000000L;
+            long bits = ByteConversion.byteToLong(data, start +
+                    (ValueIndexFactory.LENGTH_VALUE_TYPE));
+            // Reverse the sortable encoding: if high bit is set, it was positive (flip sign bit);
+            // if high bit is clear, it was negative (flip all bits)
+            bits = bits < 0 ? bits ^ 0x8000000000000000L : ~bits;
             final double d = Double.longBitsToDouble(bits);
             return new DoubleValue(d);
         }
         /* xs:float */
         else if (type == Type.FLOAT) {
-            final int bits = ByteConversion.byteToInt(data, start +
-                    (ValueIndexFactory.LENGTH_VALUE_TYPE)) ^ 0x80000000;
+            int bits = ByteConversion.byteToInt(data, start +
+                    (ValueIndexFactory.LENGTH_VALUE_TYPE));
+            bits = bits < 0 ? bits ^ 0x80000000 : ~bits;
             final float f = Float.intBitsToFloat(bits);
             return new FloatValue(f);
         }
@@ -176,7 +180,11 @@ public class ValueIndexFactory {
         else if (value.getType() == Type.DOUBLE) {
             final byte[] data = new byte[offset + ValueIndexFactory.LENGTH_VALUE_TYPE + 8];
             data[offset] = (byte) Type.DOUBLE;
-            final long bits = Double.doubleToLongBits(((DoubleValue) value).getValue()) ^ 0x8000000000000000L;
+            long bits = Double.doubleToLongBits(((DoubleValue) value).getValue());
+            // Encode doubles for correct unsigned byte-order comparison:
+            // positive: flip sign bit so positives sort after negatives;
+            // negative: flip all bits to invert magnitude ordering
+            bits = bits >= 0 ? bits ^ 0x8000000000000000L : ~bits;
             ByteConversion.longToByte(bits, data, offset + ValueIndexFactory.LENGTH_VALUE_TYPE);
             return data;
         }
@@ -184,7 +192,8 @@ public class ValueIndexFactory {
         else if (value.getType() == Type.FLOAT) {
             final byte[] data = new byte[offset + ValueIndexFactory.LENGTH_VALUE_TYPE + 4];
             data[offset] = (byte) Type.FLOAT;
-            final int bits = Float.floatToIntBits(((FloatValue) value).getValue()) ^ 0x80000000;
+            int bits = Float.floatToIntBits(((FloatValue) value).getValue());
+            bits = bits >= 0 ? bits ^ 0x80000000 : ~bits;
             ByteConversion.intToByteH(bits, data, offset + ValueIndexFactory.LENGTH_VALUE_TYPE);
             return data;
         }

--- a/exist-core/src/test/java/org/exist/storage/ValueIndexFactoryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ValueIndexFactoryTest.java
@@ -22,7 +22,6 @@
 package org.exist.storage;
 
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 
 import org.exist.EXistException;
 import static org.junit.Assert.assertEquals;
@@ -30,72 +29,49 @@ import static org.junit.Assert.assertTrue;
 
 import org.exist.storage.btree.Value;
 import org.exist.xquery.value.DecimalValue;
-import org.junit.Ignore;
+import org.exist.xquery.value.DoubleValue;
 import org.junit.Test;
 
 
 public class ValueIndexFactoryTest {
 
-    @Ignore
     @Test
-    public void negativeNumbersComparison() {
+    public void negativeNumbersComparison() throws EXistException {
 
         // -8.6...
-        final ByteBuffer data1 = encode(-8.612328);
+        final byte[] data1 = encodeDouble(-8.612328);
 
         // 1.0
-        final ByteBuffer data2 = encode(1.0);
-
-//        // print data
-//        print(data1);
-//        print(data2);
+        final byte[] data2 = encodeDouble(1.0);
 
         // -8.6 < 1.0
-        assertTrue(data1.compareTo(data2) <= -1);
-
-        // -8.6 < 1.0
-        assertEquals("v1 < v2", -1, new Value(data1.array()).compareTo(new Value(data2.array())));
+        assertTrue("v1 < v2", new Value(data1).compareTo(new Value(data2)) < 0);
     }
 
     @Test
-    public void numbersComparison() {
+    public void numbersComparison() throws EXistException {
 
-        // -8.6...
-        final ByteBuffer data1 = encode(8.612328);
+        // 8.6...
+        final byte[] data1 = encodeDouble(8.612328);
 
         // 1.0
-        final ByteBuffer data2 = encode(1.0);
+        final byte[] data2 = encodeDouble(1.0);
 
-//        // print data
-//        print(data1);
-//        print(data2);
-
-        // -8.6 < 1.0
-        assertTrue(data1.compareTo(data2) >= 1);
-
-        // -8.6 < 1.0
-        assertEquals("v1 < v2", 1, new Value(data1.array()).compareTo(new Value(data2.array())));
+        // 8.6 > 1.0
+        assertTrue("v1 > v2", new Value(data1).compareTo(new Value(data2)) > 0);
     }
 
-    @Ignore
     @Test
-    public void negativeNumbersComparison2() {
+    public void negativeNumbersComparison2() throws EXistException {
 
-        // -8.6...
-        final ByteBuffer data1 = encode(8.612328);
+        // 8.6...
+        final byte[] data1 = encodeDouble(8.612328);
 
-        // 1.0
-        final ByteBuffer data2 = encode(-1.0);
+        // -1.0
+        final byte[] data2 = encodeDouble(-1.0);
 
-//        // print data
-//        print(data1);
-//        print(data2);
-
-        // -8.6 < 1.0
-        assertTrue(data1.compareTo(data2) >= 1);
-
-        // -8.6 < 1.0
-        assertEquals("v1 < v2", 1, new Value(data1.array()).compareTo(new Value(data2.array())));
+        // 8.6 > -1.0
+        assertTrue("v1 > v2", new Value(data1).compareTo(new Value(data2)) > 0);
     }
 
     @Test
@@ -109,11 +85,34 @@ public class ValueIndexFactoryTest {
 
         assertEquals(dec, ((DecimalValue)value).getValue());
     }
-	
-    private ByteBuffer encode(final double number) {
-        final ByteBuffer buf = ByteBuffer.allocate(8);
-        buf.putDouble(number);
-        buf.flip();
-        return buf;
+
+    @Test
+    public void roundTripDouble() throws EXistException {
+        final double[] values = {-8.612328, -1.0, 0.0, 1.0, 8.612328};
+        for (final double d : values) {
+            final byte[] data = ValueIndexFactory.serialize(new DoubleValue(d), 0);
+            final Indexable value = ValueIndexFactory.deserialize(data, 0, data.length);
+            assertTrue(value instanceof DoubleValue);
+            assertEquals(d, ((DoubleValue) value).getValue(), 0.0);
+        }
+    }
+
+    @Test
+    public void doubleOrderingComprehensive() throws EXistException {
+        final double[] ordered = {-8.612328, -1.0, 0.0, 1.0, 8.612328};
+        final byte[][] encoded = new byte[ordered.length][];
+        for (int i = 0; i < ordered.length; i++) {
+            encoded[i] = encodeDouble(ordered[i]);
+        }
+        for (int i = 0; i < ordered.length; i++) {
+            for (int j = i + 1; j < ordered.length; j++) {
+                assertTrue(ordered[i] + " < " + ordered[j],
+                        new Value(encoded[i]).compareTo(new Value(encoded[j])) < 0);
+            }
+        }
+    }
+
+    private byte[] encodeDouble(final double number) throws EXistException {
+        return ValueIndexFactory.serialize(new DoubleValue(number), 0);
     }
 }


### PR DESCRIPTION
## Summary

The value index serialization for `xs:double` and `xs:float` used `bits ^ SIGN_BIT` for all IEEE 754 values regardless of sign. This only produces correct unsigned byte ordering for positive values. For negative values, the magnitude bits must also be flipped.

Applied the standard IEEE 754 sortable encoding:
- Positive values: flip sign bit (so positives sort after negatives)
- Negative values: flip all bits (to invert magnitude ordering)

Two previously `@Ignore`'d tests (`negativeNumbersComparison`, `negativeNumbersComparison2`) now pass and have been re-enabled, plus two new tests added for round-trip verification and comprehensive ordering.

**Note:** existing range indexes containing negative `xs:double` or `xs:float` values will need to be reindexed after this fix.

Closes #6161

Split out from #6153 per reviewer request.

## Test plan

- [x] `ValueIndexFactoryTest` — 6 tests, 0 failures
- [x] Full `exist-core` test suite — 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)