### PR TITLE
[bugfix] Validate json-to-xml escape option type (FOJS0005)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -107,6 +107,7 @@ public class JSON extends BasicFunction {
     public static final String OPTION_DUPLICATES_USE_FIRST = "use-first";
     public static final String OPTION_DUPLICATES_USE_LAST = "use-last";
     public static final String OPTION_LIBERAL = "liberal";
+    public static final String OPTION_ESCAPE = "escape";
     public static final String OPTION_UNESCAPE = "unescape";
     public static final QName KEY = new QName("key",null);
 
@@ -133,6 +134,15 @@ public class JSON extends BasicFunction {
             final Sequence duplicateOpt = options.get(new StringValue(OPTION_DUPLICATES));
             if (duplicateOpt.hasOne()) {
                 handleDuplicates = duplicateOpt.itemAt(0).getStringValue();
+            }
+            final Sequence escapeOpt = options.get(new StringValue(OPTION_ESCAPE));
+            if (escapeOpt.hasOne()) {
+                try {
+                    escapeOpt.itemAt(0).convertTo(Type.BOOLEAN);
+                } catch (final XPathException e) {
+                    throw new XPathException(this, ErrorCodes.FOJS0005,
+                            "Value of option 'escape' is not a valid xs:boolean: " + escapeOpt.itemAt(0).getStringValue());
+                }
             }
         }
 

--- a/exist-core/src/test/xquery/xquery3/json-to-xml.xql
+++ b/exist-core/src/test/xquery/xquery3/json-to-xml.xql
@@ -58,7 +58,6 @@ function jsonxml:json-to-xml-error-1() {
 
 
 declare
-    %test:pending("not implemented yet")
     %test:assertError("err:FOJS0005")
 function jsonxml:json-to-xml-error-2() {
     json-to-xml('{"x": "\\", "y": "\u0025"}', map{'escape': 'invalid-value'})


### PR DESCRIPTION
## Summary

The `json-to-xml()` function now validates that the `escape` option value is castable to `xs:boolean`, raising FOJS0005 if not. Previously, invalid option values were silently ignored.

The actual escape behavior (preserving JSON escape sequences in output) is not yet implemented — only the type validation. The `%test:pending` on the escape behavior test (`json-to-xml-3`) remains.

Split out from #6153 per reviewer request.

## Test plan

- [x] `json-to-xml-error-2` test (FOJS0005) now passes
- [x] `json-to-xml-3` (escape behavior) remains pending
- [x] All other json-to-xml tests pass — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)