### PR TITLE
Fix BlobStoreImpl non-daemon threads causing CI test hangs

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
@@ -327,12 +327,14 @@ public class BlobStoreImpl implements BlobStore {
                 this::abnormalPersistentWriterShutdown);
         this.persistentWriterThread = new Thread(blobStoreThreadGroup, persistentWriter,
                 nameInstanceThread(database, "blob-store.persistent-writer"));
+        persistentWriterThread.setDaemon(true);
         persistentWriterThread.start();
 
         // startup the blob vacuum thread
         this.blobVacuum = new BlobVacuum(vacuumQueue);
         this.blobVacuumThread = new Thread(blobStoreThreadGroup, blobVacuum,
                 nameInstanceThread(database, "blob-store.vacuum"));
+        blobVacuumThread.setDaemon(true);
         blobVacuumThread.start();
 
         // we are now open!

--- a/exist-core/src/test/java/org/exist/storage/BrokerPoolShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BrokerPoolShutdownTest.java
@@ -1,0 +1,71 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Verifies that BrokerPool shutdown doesn't leave non-daemon threads
+ * that would prevent JVM exit (cause of CI hangs).
+ */
+public class BrokerPoolShutdownTest {
+
+    @Test
+    public void shutdownLeavesNoNonDaemonExistThreads() throws Exception {
+        // Start a BrokerPool
+        final ExistEmbeddedServer server = new ExistEmbeddedServer(true, true);
+        server.startDb();
+
+        // Shut it down
+        server.stopDb();
+
+        // Give threads a moment to terminate
+        Thread.sleep(2000);
+
+        // Check for non-daemon eXist threads still alive
+        final Thread[] threads = new Thread[Thread.activeCount() * 2];
+        Thread.enumerate(threads);
+        final List<Thread> leaks = Arrays.stream(threads)
+            .filter(t -> t != null)
+            .filter(t -> !t.isDaemon())
+            .filter(t -> t.isAlive())
+            .filter(t -> {
+                final String name = t.getName().toLowerCase();
+                return name.contains("exist") || name.contains("db.exist")
+                    || name.contains("broker") || name.contains("blob");
+            })
+            .collect(Collectors.toList());
+
+        if (!leaks.isEmpty()) {
+            final String details = leaks.stream()
+                .map(t -> t.getName() + " (state=" + t.getState() + ")")
+                .collect(Collectors.joining(", "));
+            fail("Non-daemon eXist threads survived shutdown: " + details);
+        }
+    }
+}

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -837,6 +837,7 @@
                         </dependency>
                     </dependencies>
                     <configuration>
+                        <forkedProcessExitTimeoutInSeconds>60</forkedProcessExitTimeoutInSeconds>
                         <forkCount>2C</forkCount>
                         <!--  Setting `reuseForks` to `true` greatly speeds up execution of the test suite.
                               However it can make it hard to diagnose problems if tests leak state; If you experience


### PR DESCRIPTION
## Summary

- BlobStoreImpl's PersistentWriter and BlobVacuum threads were non-daemon threads that blocked JVM exit when BrokerPool shutdown failed to join them cleanly
- This caused ~20% of CI runs to hang indefinitely after all tests had completed
- Follow-up to #6167 which fixed the same issue for StatusReporter

## What Changed

**`BlobStoreImpl.java`**: Added `setDaemon(true)` to both `persistentWriterThread` and `blobVacuumThread` before starting them. These threads still participate in normal shutdown via poison pill / interrupt, but the JVM can now exit even if those shutdown paths fail.

**`exist-parent/pom.xml`**: Added `forkedProcessExitTimeoutInSeconds=60` to the surefire configuration as a safety net — surefire will kill forked test JVMs that fail to exit within 60 seconds.

**`BrokerPoolShutdownTest.java`** (new): Regression test that starts a BrokerPool, shuts it down, and asserts that no non-daemon eXist-related threads remain alive. Catches future regressions where new non-daemon threads are introduced.

## Evidence

A controlled hang experiment (5 serial trials × 4 configs) identified BlobStore threads as the remaining hang cause after #6167. jstack captures showed `BlobStoreImpl$PersistentWriter` and `BlobStoreImpl$BlobVacuum` parked on blocking queue operations after all tests completed.

## Test Plan

- [x] `BrokerPoolShutdownTest` passes
- [x] Full exist-core test suite: 6,543 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)