### PR TITLE
Add bounded timeouts to BlobStore shutdown join() calls

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
@@ -447,13 +447,21 @@ public class BlobStoreImpl implements BlobStore {
             if (persistentWriter != null) {
                 persistQueue.put(PersistentWriter.POISON_PILL);
             }
-            persistentWriterThread.join();
+            persistentWriterThread.join(30_000);
+            if (persistentWriterThread.isAlive()) {
+                LOG.warn("BlobStore PersistentWriter did not terminate within 30s, interrupting");
+                persistentWriterThread.interrupt();
+                persistentWriterThread.join(5_000);
+            }
 
             // shutdown the vacuum
             if (blobVacuum != null) {
                 blobVacuumThread.interrupt();
             }
-            blobVacuumThread.join();
+            blobVacuumThread.join(30_000);
+            if (blobVacuumThread.isAlive()) {
+                LOG.warn("BlobStore BlobVacuum did not terminate within 30s");
+            }
         } catch (final InterruptedException e) {
             // Restore the interrupted status
             Thread.currentThread().interrupt();
@@ -523,7 +531,10 @@ public class BlobStoreImpl implements BlobStore {
             if (blobVacuum != null) {
                 blobVacuumThread.interrupt();
             }
-            blobVacuumThread.join();
+            blobVacuumThread.join(30_000);
+            if (blobVacuumThread.isAlive()) {
+                LOG.warn("BlobStore BlobVacuum did not terminate within 30s during abnormal shutdown");
+            }
 
         } catch (final InterruptedException e) {
             // Restore the interrupted status


### PR DESCRIPTION
## Summary

`BlobStoreImpl.normalClose()` and `abnormalPersistentWriterShutdown()` called `Thread.join()` with no timeout on the PersistentWriter and BlobVacuum threads. If either thread failed to terminate promptly, the shutdown would hang indefinitely — causing CI test suite timeouts when the surefire fork couldn't exit.

This supersedes #6179, which incorrectly made BlobStore threads daemon threads. As @adamretter (author of BlobStore) correctly pointed out, these threads must remain non-daemon to ensure pending blob writes complete. The fix is bounded `join()` timeouts during shutdown — giving threads 30s to drain before proceeding.

## What changed

**`BlobStoreImpl.java`** — Added 30-second bounded timeouts to all three `Thread.join()` calls:

- `normalClose()` — PersistentWriter: `join(30_000)`, then `interrupt()` + `join(5_000)` if still alive
- `normalClose()` — BlobVacuum: `join(30_000)` with warning if still alive
- `abnormalPersistentWriterShutdown()` — BlobVacuum: `join(30_000)` with warning if still alive

## Why this is safe

The existing shutdown mechanisms are correct and unchanged:
1. PersistentWriter receives a `POISON_PILL` via the persist queue → drains remaining items and exits
2. BlobVacuum receives `interrupt()` → wakes from `PriorityBlockingQueue.take()` and exits

In practice, both threads respond within milliseconds. The 30s timeout is a safety net — it only fires if something goes wrong, ensuring shutdown completes instead of hanging forever.

## Test results

- 27/27 BlobStore-specific tests pass
- 3/3 full test suite trials: BUILD SUCCESS, clean exit (3:26–4:23)

## Test plan

- [x] `BlobStoreImplTest` — 27 tests, 0 failures
- [x] Full `mvn test -pl exist-core` — 3 trials, all pass, no hangs
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)