### PR TITLE
[feature] Add repo:resource-available() function

### DIFF
--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ExpathPackageModule.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ExpathPackageModule.java
@@ -60,6 +60,7 @@ public class ExpathPackageModule extends AbstractInternalModule {
         new FunctionDef(InstallFunction.signatureInstallFromDB, InstallFunction.class),
         new FunctionDef(RemoveFunction.signature, RemoveFunction.class),
         new FunctionDef(GetResource.signature, GetResource.class),
+        new FunctionDef(ResourceAvailable.signature, ResourceAvailable.class),
         new FunctionDef(GetAppRoot.signature, GetAppRoot.class)
     };
 

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
@@ -1,0 +1,100 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.expathrepo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import javax.xml.transform.stream.StreamSource;
+
+import org.exist.dom.QName;
+import org.exist.repo.ExistRepository;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.*;
+import org.expath.pkg.repo.Package;
+import org.expath.pkg.repo.PackageException;
+import org.expath.pkg.repo.Packages;
+import org.expath.pkg.repo.Storage;
+
+/**
+ * repo:resource-available($pkgName, $resource) as xs:boolean
+ *
+ * Returns true if the specified resource exists in the named EXPath package,
+ * false otherwise. Companion to repo:get-resource(), analogous to
+ * fn:doc-available() for fn:doc().
+ */
+public class ResourceAvailable extends BasicFunction {
+
+    public final static FunctionSignature signature =
+        new FunctionSignature(
+            new QName("resource-available", ExpathPackageModule.NAMESPACE_URI, ExpathPackageModule.PREFIX),
+            "Returns true if the specified resource exists in the named EXPath package, false otherwise.",
+            new SequenceType[] {
+                new FunctionParameterSequenceType("pkgName", Type.STRING, Cardinality.EXACTLY_ONE, "package name"),
+                new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "resource path")
+            },
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
+                "true if the resource exists in the package, false otherwise"));
+
+    public ResourceAvailable(final XQueryContext context) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final String pkgName = args[0].getStringValue();
+        final String path = args[1].getStringValue();
+
+        final Optional<ExistRepository> repo = context.getRepository();
+        if (repo.isPresent()) {
+            try {
+                for (final Packages pp : repo.get().getParentRepo().listPackages()) {
+                    final Package pkg = pp.latest();
+                    if (pkg.getName().equals(pkgName)) {
+                        try {
+                            // resolveResource opens a stream — close it immediately
+                            final StreamSource source = (StreamSource) pkg.getResolver().resolveResource(path);
+                            final InputStream is = source.getInputStream();
+                            if (is != null) {
+                                is.close();
+                            }
+                            return BooleanValue.TRUE;
+                        } catch (final Storage.NotExistException e) {
+                            return BooleanValue.FALSE;
+                        } catch (final IOException e) {
+                            return BooleanValue.FALSE;
+                        }
+                    }
+                }
+            } catch (final PackageException e) {
+                throw new XPathException(this, "Caught package error while checking resource availability", e);
+            }
+        }
+        // Package not found
+        return BooleanValue.FALSE;
+    }
+}

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
@@ -70,29 +70,29 @@ public class ResourceAvailable extends BasicFunction {
         final String path = args[1].getStringValue();
 
         final Optional<ExistRepository> repo = context.getRepository();
-        if (repo.isPresent()) {
-            try {
-                for (final Packages pp : repo.get().getParentRepo().listPackages()) {
-                    final Package pkg = pp.latest();
-                    if (pkg.getName().equals(pkgName)) {
-                        try {
-                            // resolveResource opens a stream — close it immediately
-                            final StreamSource source = (StreamSource) pkg.getResolver().resolveResource(path);
-                            final InputStream is = source.getInputStream();
-                            if (is != null) {
-                                is.close();
-                            }
-                            return BooleanValue.TRUE;
-                        } catch (final Storage.NotExistException e) {
-                            return BooleanValue.FALSE;
-                        } catch (final IOException e) {
-                            return BooleanValue.FALSE;
+        if (!repo.isPresent()) {
+            return BooleanValue.FALSE;
+        }
+
+        try {
+            for (final Packages pp : repo.get().getParentRepo().listPackages()) {
+                final Package pkg = pp.latest();
+                if (pkg.getName().equals(pkgName)) {
+                    try {
+                        // resolveResource opens a stream — close it immediately
+                        final StreamSource source = (StreamSource) pkg.getResolver().resolveResource(path);
+                        final InputStream is = source.getInputStream();
+                        if (is != null) {
+                            is.close();
                         }
+                        return BooleanValue.TRUE;
+                    } catch (final Storage.NotExistException | IOException e) {
+                        return BooleanValue.FALSE;
                     }
                 }
-            } catch (final PackageException e) {
-                throw new XPathException(this, "Caught package error while checking resource availability", e);
             }
+        } catch (final PackageException e) {
+            throw new XPathException(this, "Caught package error while checking resource availability", e);
         }
         // Package not found
         return BooleanValue.FALSE;

--- a/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/resource-available.xql
+++ b/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/resource-available.xql
@@ -1,0 +1,95 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for repo:resource-available().
+ : https://github.com/eXist-db/exist/issues/3904
+ :)
+module namespace ra="http://exist-db.org/test/resource-available";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+import module namespace repo="http://exist-db.org/xquery/repo";
+import module namespace compression="http://exist-db.org/xquery/compression";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+
+declare variable $ra:pkg-name := "http://exist-db.org/test/resource-available-test";
+
+declare variable $ra:expathxml :=
+    <package xmlns="http://expath.org/ns/pkg" name="{$ra:pkg-name}" abbrev="ra-test" version="1.0.0" spec="1.0">
+        <title>Resource Available Test</title>
+    </package>;
+
+declare variable $ra:repoxml :=
+    <meta xmlns="http://exist-db.org/xquery/repo">
+        <description>Resource Available Test</description>
+        <type>library</type>
+        <target/>
+    </meta>;
+
+declare variable $ra:entries := (
+    <entry name="expath-pkg.xml" type="xml">{$ra:expathxml}</entry>,
+    <entry name="repo.xml" type="xml">{$ra:repoxml}</entry>,
+    <entry name="test-data.xml" type="xml"><test><data/></test></entry>
+);
+
+declare
+    %test:setUp
+function ra:setup() {
+    xmldb:create-collection("/db", "ra-test"),
+    let $zip := compression:zip($ra:entries, false())
+    let $stored := xmldb:store("/db/ra-test", "ra-test-1.0.xar", $zip)
+    return repo:install-and-deploy-from-db($stored)
+};
+
+declare
+    %test:tearDown
+function ra:cleanup() {
+    if (repo:list() = $ra:pkg-name) then (
+        repo:undeploy($ra:pkg-name),
+        repo:remove($ra:pkg-name)
+    ) else (),
+    if (xmldb:collection-available("/db/ra-test")) then
+        xmldb:remove("/db/ra-test")
+    else ()
+};
+
+(: A resource that was included in the package should be available :)
+declare
+    %test:assertTrue
+function ra:existing-resource() {
+    repo:resource-available($ra:pkg-name, "expath-pkg.xml")
+};
+
+(: A resource not in the package should not be available :)
+declare
+    %test:assertFalse
+function ra:missing-resource() {
+    repo:resource-available($ra:pkg-name, "nonexistent-file-xyz.xml")
+};
+
+(: A non-existing package should return false :)
+declare
+    %test:assertFalse
+function ra:missing-package() {
+    repo:resource-available("http://example.com/no-such-package-42", "anything.xml")
+};


### PR DESCRIPTION
## Summary

Add `repo:resource-available($pkgName, $resource)` that returns `true` if the specified resource exists in the named EXPath package, `false` otherwise. This is the companion to `repo:get-resource()`, analogous to `fn:doc-available()` for `fn:doc()`.

## Motivation

Since PR #3896, `repo:get-resource()` throws `FODC0002` when the resource doesn't exist. There's currently no way to check if a resource exists without catching the error. Tools like exist-api need to probe for resources like `exist.xml`, `repo.xml`, etc. in installed packages.

## What Changed

- **`ResourceAvailable.java`** (new): Implementation modeled on `GetResource.java`. Uses `pkg.getResolver().resolveResource(path)` and catches `Storage.NotExistException` to return false. Closes the `StreamSource` input stream immediately since only existence is needed.
- **`ExpathPackageModule.java`**: Register the new function.
- **`resource-available.xql`** (new): 3 XQSuite tests covering missing resource, missing package, and existing resource scenarios.

## Test plan

- [x] `mvn test -pl extensions/modules/expathrepo -am` — 8 tests pass (5 existing + 3 new)
- [x] CI green

Closes https://github.com/eXist-db/exist/issues/3904

🤖 Generated with [Claude Code](https://claude.ai/code)