### PR TITLE
[ci] Fix composite action secrets access for GitHub Packages auth

### DIFF
--- a/.github/actions/maven-github-settings/action.yml
+++ b/.github/actions/maven-github-settings/action.yml
@@ -2,6 +2,10 @@
 # Required for resolving from maven.pkg.github.com/eXist-db/exist and exist-xqts-runner.
 name: Maven GitHub Packages settings
 description: Create settings.xml with github and github-xqts-runner servers
+inputs:
+  token:
+    description: 'GitHub token for package authentication'
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -16,12 +20,12 @@ runs:
             <server>
               <id>github</id>
               <username>${OWNER}</username>
-              <password>${{ secrets.GITHUB_TOKEN }}</password>
+              <password>${{ inputs.token }}</password>
             </server>
             <server>
               <id>github-xqts-runner</id>
               <username>${OWNER}</username>
-              <password>${{ secrets.GITHUB_TOKEN }}</password>
+              <password>${{ inputs.token }}</password>
             </server>
           </servers>
         </settings>

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -23,6 +23,8 @@ jobs:
           java-version: '21'
       - uses: ./.github/actions/maven-cache
       - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy SNAPSHOT maven artefacts
         timeout-minutes: 40
         env:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,6 +32,8 @@ jobs:
           java-version: ${{ env.DEV_JDK }}
       - uses: ./.github/actions/maven-cache
       - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set week for OWASP cache key
         run: echo "WEEK=$(date +%Y-%U)" >> $GITHUB_ENV
       - name: Restore OWASP dependency-check cache

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -17,6 +17,8 @@ jobs:
           java-version: '21'
       - uses: ./.github/actions/maven-cache
       - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Maven XQTS Build
         timeout-minutes: 25
         env:


### PR DESCRIPTION
## Summary

- Fix `maven-github-settings` composite action to accept the GitHub token as an input parameter instead of accessing `secrets.GITHUB_TOKEN` directly (which doesn't work in composite actions)
- Update all three calling workflows (`ci-test`, `ci-snapshots`, `ci-xqts`) to pass the token via `with`

## Problem

Composite actions [cannot access the `secrets` context](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action#using-inputs-and-outputs-in-a-composite-action). The `${{ secrets.GITHUB_TOKEN }}` reference in the action silently resolves to an empty string, breaking GitHub Packages authentication for Maven dependency resolution.

Appears to have been broken since commit dd71b1afbf (Feb 13, 2026).

## Changes

| File | Change |
|------|--------|
| `.github/actions/maven-github-settings/action.yml` | Add `inputs.token` parameter; use `${{ inputs.token }}` instead of `${{ secrets.GITHUB_TOKEN }}` |
| `.github/workflows/ci-test.yml` | Pass `token: ${{ secrets.GITHUB_TOKEN }}` to the action |
| `.github/workflows/ci-snapshots.yml` | Pass `token: ${{ secrets.GITHUB_TOKEN }}` to the action |
| `.github/workflows/ci-xqts.yml` | Pass `token: ${{ secrets.GITHUB_TOKEN }}` to the action |

## Test plan

- [x] CI workflows should now authenticate correctly with GitHub Packages

[This PR was co-authored with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)