### PR TITLE
[bugfix] Fix race condition in OrderedValueSequence parallel clear

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
@@ -212,6 +212,14 @@ public class OrderedValueSequence extends AbstractSequence {
 //		FastQSort.sort(items, 0, count - 1);
 
         Arrays.parallelSort(items, 0, count);
+
+        // Clear the shared BitSets once — they are shared across all entries,
+        // so clearing them per-entry in a parallel stream caused a race condition
+        // (concurrent BitSet.clear() corrupts internal wordsInUse counter).
+        for (final BitSet bitSet : encounteredPrimitiveTypesForOrderSpecs) {
+            bitSet.clear();
+        }
+        // Null out per-entry values to release memory (each entry has its own list, so this is safe in parallel)
         Arrays.stream(items, 0, count).parallel().forEach(Entry::clear);
     }
 
@@ -555,9 +563,6 @@ public class OrderedValueSequence extends AbstractSequence {
         }
 
         public void clear() {
-            for (final BitSet encounteredPrimitiveTypesForOrderSpec : encounteredPrimitiveTypesForOrderSpecs) {
-                encounteredPrimitiveTypesForOrderSpec.clear();
-            }
             values = null;
         }
     }


### PR DESCRIPTION
## Summary

- Fix non-deterministic `ArrayIndexOutOfBoundsException: Index -1` in FLWOR `order by` evaluation
- Root cause: `BitSet.clear()` called concurrently from parallel stream on shared mutable instances
- Moved shared `BitSet` clearing into sequential loop; parallel `forEach` now only nulls per-entry values

## Root Cause

`OrderedValueSequence.sort()` used `Arrays.stream(items, 0, count).parallel().forEach(Entry::clear)`. All `Entry` objects share references to the same `List<BitSet> encounteredPrimitiveTypesForOrderSpecs`. `Entry.clear()` called `BitSet.clear()` which is not thread-safe — concurrent decrements of `wordsInUse` corrupt the field, producing `words[-1]` access.

This is the same bug family as the known `groupby.collation` flaky test (documented in CLAUDE.md).

## Test plan

- [x] OrderedValueSequenceTest — 987 tests × 5 runs = 4,935 executions, 0 failures
- [x] OptimizerTest — passes
- [x] XQuery3Tests — passes
- [ ] Full `mvn test -pl exist-core` — no regressions expected (one-line behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>