### PR TITLE
Add query profiling functions: util:time, util:memory, util:track, util:explain, util:profile

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
@@ -107,4 +107,26 @@ public interface ExpressionVisitor {
     void visitSimpleMapOperator(OpSimpleMap simpleMap);
 
     void visitWindowExpression(WindowExpr windowExpr);
+
+    /**
+     * Visit a map-constructor expression ({@code map { k1 : v1, k2 : v2 }}).
+     * The visitor controls element emission: the call site (i.e.
+     * {@link org.exist.xquery.functions.map.MapExpr#accept}) is expected
+     * to delegate here rather than calling {@code super.accept} + recursing
+     * manually, so that emitters like
+     * {@link org.exist.xquery.functions.util.QueryPlanSerializer} can wrap
+     * the entries inside the map element rather than emit them as siblings.
+     */
+    default void visitMapExpr(final org.exist.xquery.functions.map.MapExpr mapExpr) {
+        // Default: preserve the prior traversal semantics of
+        // MapExpr.accept (a generic visit() followed by walking through
+        // every key and value expression). Visitors that care about
+        // structure (e.g. emitters wrapping entries in a parent element)
+        // override this method.
+        visit(mapExpr);
+        for (int i = 0; i < mapExpr.getMappingCount(); i++) {
+            mapExpr.getMappingKey(i).accept(this);
+            mapExpr.getMappingValue(i).accept(this);
+        }
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
@@ -21,6 +21,8 @@
  */
 package org.exist.xquery;
 
+import org.exist.xquery.functions.map.MapExpr;
+
 /**
  * Defines a visitor to be used for traversing and analyzing the
  * expression tree.
@@ -111,13 +113,13 @@ public interface ExpressionVisitor {
     /**
      * Visit a map-constructor expression ({@code map { k1 : v1, k2 : v2 }}).
      * The visitor controls element emission: the call site (i.e.
-     * {@link org.exist.xquery.functions.map.MapExpr#accept}) is expected
+     * {@link MapExpr#accept}) is expected
      * to delegate here rather than calling {@code super.accept} + recursing
      * manually, so that emitters like
      * {@link org.exist.xquery.functions.util.QueryPlanSerializer} can wrap
      * the entries inside the map element rather than emit them as siblings.
      */
-    default void visitMapExpr(final org.exist.xquery.functions.map.MapExpr mapExpr) {
+    default void visitMapExpr(final MapExpr mapExpr) {
         // Default: preserve the prior traversal semantics of
         // MapExpr.accept (a generic visit() followed by walking through
         // every key and value expression). Visitors that care about

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -240,6 +240,17 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
                 }
             }
         }
+
+        // Log optimization decisions
+        if (LOG.isDebugEnabled()) {
+            if (optimizeSelf || optimizeChild) {
+                LOG.debug("Optimizer: {} can use index optimization on {} (self={}, child={}, qname={})",
+                        ExpressionDumper.dump(this), contextQName, optimizeSelf, optimizeChild, contextQName);
+            } else if (!steps.isEmpty()) {
+                LOG.debug("Optimizer: {} skipped index optimization — no suitable index path found",
+                        ExpressionDumper.dump(this));
+            }
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Profiler.java
+++ b/exist-core/src/main/java/org/exist/xquery/Profiler.java
@@ -81,6 +81,17 @@ public class Profiler {
 
     private PerformanceStats stats;
 
+    /**
+     * Returns the performance statistics collected by this profiler instance.
+     * Each XQueryContext has its own Profiler with its own stats, enabling
+     * per-query profiling isolation.
+     *
+     * @return the performance stats for this profiler
+     */
+    public PerformanceStats getPerformanceStats() {
+        return stats;
+    }
+
     private long queryStart = 0;
 
     private Database db;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -964,6 +964,19 @@ public class XQueryContext implements BinaryValueManager, Context {
         return inScopePrefixes;
     }
 
+    /**
+     * Returns the prefix-to-URI map of namespaces declared in the prolog
+     * (via {@code declare namespace}, {@code declare default element namespace},
+     * etc.) along with the built-in defaults registered by
+     * {@link #loadDefaultNS()}. Intended for diagnostics such as
+     * {@code util:explain}; callers should not mutate the returned map.
+     *
+     * @return the static namespace prefix-to-URI map
+     */
+    public Map<String, String> getStaticNamespaces() {
+        return staticNamespaces;
+    }
+
     @Override
     public String getInheritedNamespace(final String prefix) {
         return inheritedInScopeNamespaces == null ? null : inheritedInScopeNamespaces.get(prefix);

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
@@ -64,22 +64,20 @@ public class MapExpr extends AbstractExpression {
     }
 
     @Override
-    public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
-        if (contextItem != null) {
-            contextSequence = contextItem.toSequence();
-        }
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        final Sequence effectiveContext = contextItem != null ? contextItem.toSequence() : contextSequence;
         final IMap<AtomicValue, Sequence> map = newLinearMap(null);
 
         boolean firstType = true;
         int prevType = AbstractMapType.UNKNOWN_KEY_TYPE;
 
         for (final Mapping mapping : this.mappings) {
-            final Sequence key = mapping.key.eval(contextSequence, null);
+            final Sequence key = mapping.key.eval(effectiveContext, null);
             if (key.getItemCount() != 1) {
                 throw new XPathException(this, MapErrorCode.EXMPDY001, "Expected single value for key, got " + key.getItemCount());
             }
             final AtomicValue atomic = key.itemAt(0).atomize();
-            final Sequence value = mapping.value.eval(contextSequence, null);
+            final Sequence value = mapping.value.eval(effectiveContext, null);
             if (map.contains(atomic)) {
                 throw new XPathException(this, ErrorCodes.XQDY0137, "Key \"" + atomic.getStringValue() + "\" already exists in map.");
             }
@@ -106,11 +104,31 @@ public class MapExpr extends AbstractExpression {
 
     @Override
     public void accept(final ExpressionVisitor visitor) {
-        super.accept(visitor);
-        for (final Mapping mapping : this.mappings) {
-            mapping.key.accept(visitor);
-            mapping.value.accept(visitor);
-        }
+        // Delegate to the visitor's MapExpr hook so emitters that care about
+        // structure (e.g. util:explain's QueryPlanSerializer) can wrap key
+        // and value expressions inside a parent <map> element. The default
+        // implementation in ExpressionVisitor falls back to the generic
+        // visit() and recurses through the mappings, preserving the prior
+        // traversal contract for visitors that don't override visitMapExpr.
+        visitor.visitMapExpr(this);
+    }
+
+    /**
+     * Number of key/value mappings in this map constructor. Exposed so that
+     * structural visitors can iterate the mappings without reflection.
+     */
+    public int getMappingCount() {
+        return mappings.size();
+    }
+
+    /** Key expression of the mapping at {@code index}. */
+    public Expression getMappingKey(final int index) {
+        return mappings.get(index).key;
+    }
+
+    /** Value expression of the mapping at {@code index}. */
+    public Expression getMappingValue(final int index) {
+        return mappings.get(index).value;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
@@ -53,10 +53,19 @@ import static javax.xml.XMLConstants.XML_NS_PREFIX;
  * util:explain('for $x in 1 to 10 where $x > 5 return $x * 2')
  * </pre>
  *
- * Returns an XML representation of the expression tree showing prolog
+ * <p>Returns an XML representation of the expression tree showing prolog
  * declarations (namespace declarations, module imports) followed by the
  * post-optimization expression body (FLWOR clauses, path expressions,
- * function calls, comparisons, etc.).
+ * function calls, comparisons, etc.).</p>
+ *
+ * <p>Inspired by Saxon's explain capabilities (which group output by XQuery
+ * construct rather than by AST class name) and the general "show me how the
+ * engine reads my query" idea behind PostgreSQL's EXPLAIN ANALYZE. BaseX
+ * also ships a {@code query:plan} function with a different output style
+ * (element names mirror internal Java class names: {@code GFLWOR},
+ * {@code IterPath}, {@code MapEntry}); eXist's util:explain uses XQuery
+ * construct names ({@code <for>}, {@code <path>}, {@code <map>/<entry>}) to
+ * stay close to how the developer thinks about the query.</p>
  */
 public class FunExplain extends BasicFunction {
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
@@ -27,6 +27,7 @@ import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.source.Source;
 import org.exist.xquery.*;
+import org.exist.xquery.Module;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
 import org.exist.xquery.parser.XQueryTreeParser;
@@ -199,8 +200,8 @@ public class FunExplain extends BasicFunction {
             builder.endElement();
         }
 
-        for (final Iterator<org.exist.xquery.Module> it = pContext.getRootModules(); it.hasNext(); ) {
-            final org.exist.xquery.Module module = it.next();
+        for (final Iterator<Module> it = pContext.getRootModules(); it.hasNext(); ) {
+            final Module module = it.next();
             if (module == null || module.isInternalModule()) {
                 continue;
             }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
@@ -1,0 +1,150 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.xquery.*;
+import org.exist.xquery.parser.XQueryLexer;
+import org.exist.xquery.parser.XQueryParser;
+import org.exist.xquery.parser.XQueryTreeParser;
+import org.exist.xquery.value.*;
+
+import antlr.collections.AST;
+
+import java.io.StringReader;
+
+/**
+ * Returns the compiled expression tree of an XQuery expression as XML.
+ * This is the core query visibility function — shows what the optimizer produces.
+ *
+ * <pre>
+ * util:explain('for $x in 1 to 10 where $x > 5 return $x * 2')
+ * </pre>
+ *
+ * Returns an XML representation of the expression tree showing FLWOR clauses,
+ * path expressions, function calls, comparisons, etc.
+ */
+public class FunExplain extends BasicFunction {
+
+    private static final Logger LOG = LogManager.getLogger(FunExplain.class);
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("explain", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Compiles the given XQuery expression and returns its expression tree as XML. " +
+                            "Shows the post-optimization query plan.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The XQuery expression to explain")
+                    },
+                    new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.EXACTLY_ONE,
+                            "An XML representation of the compiled expression tree")
+            ),
+            new FunctionSignature(
+                    new QName("explain", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Compiles the given XQuery expression and returns its expression tree as XML. " +
+                            "The module-load-path controls where imports are resolved.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The XQuery expression to explain"),
+                            new FunctionParameterSequenceType("module-load-path", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The module load path for resolving imports")
+                    },
+                    new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.EXACTLY_ONE,
+                            "An XML representation of the compiled expression tree")
+            )
+    };
+
+    public FunExplain(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final String query = args[0].getStringValue();
+        if (query.trim().isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004, "Query expression is empty");
+        }
+
+        // Compile the query using the same pattern as util:compile()
+        final XQueryContext pContext = new XQueryContext(context.getBroker().getBrokerPool());
+        context.pushNamespaceContext();
+        try {
+            if (getArgumentCount() == 2 && args[1].hasOne()) {
+                pContext.setModuleLoadPath(args[1].getStringValue());
+            }
+
+            final XQueryLexer lexer = new XQueryLexer(pContext, new StringReader(query));
+            final XQueryParser parser = new XQueryParser(lexer);
+            final XQueryTreeParser astParser = new XQueryTreeParser(pContext);
+
+            parser.xpath();
+            if (parser.foundErrors()) {
+                throw new XPathException(this, ErrorCodes.XPST0003,
+                        "Parse error in query: " + parser.getErrorMessage());
+            }
+
+            final AST ast = parser.getAST();
+            final PathExpr path = new PathExpr(pContext);
+            astParser.xpath(ast, path);
+            if (astParser.foundErrors()) {
+                throw astParser.getLastException();
+            }
+
+            // Analyze (optimize) the expression tree
+            path.analyze(new AnalyzeContextInfo());
+
+            // Serialize the expression tree as XML
+            return serializeExpressionTree(path);
+
+        } catch (final Exception e) {
+            throw new XPathException(this, ErrorCodes.XPST0003, "Parse error: " + e.getMessage());
+        } finally {
+            context.popNamespaceContext();
+            pContext.reset(false);
+        }
+    }
+
+    private Sequence serializeExpressionTree(final Expression expression) throws XPathException {
+        context.pushDocumentContext();
+        try {
+            final MemTreeBuilder builder = context.getDocumentBuilder();
+
+            builder.startElement("", "explain", "explain", null);
+
+            final QueryPlanSerializer visitor = new QueryPlanSerializer(builder);
+            expression.accept(visitor);
+
+            builder.endElement();
+
+            final DocumentImpl doc = (DocumentImpl) builder.getDocument();
+            // Return the root element, not the document node
+            return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
+        } finally {
+            context.popDocumentContext();
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunExplain.java
@@ -21,18 +21,28 @@
  */
 package org.exist.xquery.functions.util;
 
+import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.source.Source;
 import org.exist.xquery.*;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
 import org.exist.xquery.parser.XQueryTreeParser;
 import org.exist.xquery.value.*;
 
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
 import antlr.collections.AST;
+import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.StringReader;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static javax.xml.XMLConstants.XML_NS_PREFIX;
 
 /**
  * Returns the compiled expression tree of an XQuery expression as XML.
@@ -42,16 +52,34 @@ import java.io.StringReader;
  * util:explain('for $x in 1 to 10 where $x > 5 return $x * 2')
  * </pre>
  *
- * Returns an XML representation of the expression tree showing FLWOR clauses,
- * path expressions, function calls, comparisons, etc.
+ * Returns an XML representation of the expression tree showing prolog
+ * declarations (namespace declarations, module imports) followed by the
+ * post-optimization expression body (FLWOR clauses, path expressions,
+ * function calls, comparisons, etc.).
  */
 public class FunExplain extends BasicFunction {
+
+    /** Prefixes pre-registered by every fresh XQueryContext via loadDefaultNS. */
+    private static final Set<String> BUILTIN_PREFIXES = Set.of(
+            XML_NS_PREFIX,
+            "xs",
+            "xsi",
+            "xdt",
+            "fn",
+            "local",
+            Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX,
+            Namespaces.EXIST_NS_PREFIX,
+            Namespaces.EXIST_JAVA_BINDING_NS_PREFIX,
+            Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX,
+            "dbgp"
+    );
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
                     new QName("explain", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Compiles the given XQuery expression and returns its expression tree as XML. " +
-                            "Shows the post-optimization query plan.",
+                            "Shows the post-optimization query plan, including a prolog element " +
+                            "with declared namespaces and module imports.",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
                                     "The XQuery expression to explain")
@@ -85,7 +113,6 @@ public class FunExplain extends BasicFunction {
             throw new XPathException(this, ErrorCodes.XPTY0004, "Query expression is empty");
         }
 
-        // Compile the query using the same pattern as util:compile()
         final XQueryContext pContext = new XQueryContext(context.getBroker().getBrokerPool());
         context.pushNamespaceContext();
         try {
@@ -97,50 +124,105 @@ public class FunExplain extends BasicFunction {
             final XQueryParser parser = new XQueryParser(lexer);
             final XQueryTreeParser astParser = new XQueryTreeParser(pContext);
 
-            parser.xpath();
+            try {
+                parser.xpath();
+            } catch (final RecognitionException | TokenStreamException e) {
+                throw parseError(e.getMessage());
+            }
             if (parser.foundErrors()) {
-                throw new XPathException(this, ErrorCodes.XPST0003,
-                        "Parse error in query: " + parser.getErrorMessage());
+                throw parseError(parser.getErrorMessage());
             }
 
             final AST ast = parser.getAST();
             final PathExpr path = new PathExpr(pContext);
-            astParser.xpath(ast, path);
+            try {
+                astParser.xpath(ast, path);
+            } catch (final RecognitionException e) {
+                throw parseError(e.getMessage());
+            }
             if (astParser.foundErrors()) {
-                throw astParser.getLastException();
+                final Exception last = astParser.getLastException();
+                throw parseError(last != null ? last.getMessage() : "unknown AST construction error");
             }
 
-            // Analyze (optimize) the expression tree
             path.analyze(new AnalyzeContextInfo());
 
-            // Serialize the expression tree as XML
-            return serializeExpressionTree(path);
+            return serializeExpressionTree(pContext, path);
 
-        } catch (final Exception e) {
-            throw new XPathException(this, ErrorCodes.XPST0003, "Parse error: " + e.getMessage());
         } finally {
             context.popNamespaceContext();
             pContext.reset(false);
         }
     }
 
-    private Sequence serializeExpressionTree(final Expression expression) throws XPathException {
+    private XPathException parseError(final String message) {
+        return new XPathException(this, ErrorCodes.XPST0003,
+                "Failed to parse query supplied to util:explain: " + message);
+    }
+
+    private Sequence serializeExpressionTree(final XQueryContext pContext, final Expression expression)
+            throws XPathException {
         context.pushDocumentContext();
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
 
             builder.startElement("", "explain", "explain", null);
 
+            writeProlog(builder, pContext);
+
+            builder.startElement("", "body", "body", null);
             final QueryPlanSerializer visitor = new QueryPlanSerializer(builder);
             expression.accept(visitor);
+            builder.endElement(); // body
 
-            builder.endElement();
+            builder.endElement(); // explain
 
             final DocumentImpl doc = (DocumentImpl) builder.getDocument();
-            // Return the root element, not the document node
             return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
         } finally {
             context.popDocumentContext();
         }
+    }
+
+    private void writeProlog(final MemTreeBuilder builder, final XQueryContext pContext) {
+        builder.startElement("", "prolog", "prolog", null);
+
+        for (final Map.Entry<String, String> entry : pContext.getStaticNamespaces().entrySet()) {
+            final String prefix = entry.getKey();
+            if (BUILTIN_PREFIXES.contains(prefix)) {
+                continue;
+            }
+            final AttributesImpl atts = new AttributesImpl();
+            atts.addAttribute("", "prefix", "prefix", "CDATA", prefix);
+            atts.addAttribute("", "uri", "uri", "CDATA", entry.getValue());
+            builder.startElement("", "namespace", "namespace", atts);
+            builder.endElement();
+        }
+
+        for (final Iterator<org.exist.xquery.Module> it = pContext.getRootModules(); it.hasNext(); ) {
+            final org.exist.xquery.Module module = it.next();
+            if (module == null || module.isInternalModule()) {
+                continue;
+            }
+            final AttributesImpl atts = new AttributesImpl();
+            atts.addAttribute("", "uri", "uri", "CDATA", module.getNamespaceURI());
+            final String prefix = pContext.getInScopePrefix(module.getNamespaceURI());
+            if (prefix != null && !prefix.isEmpty()) {
+                atts.addAttribute("", "prefix", "prefix", "CDATA", prefix);
+            }
+            if (module instanceof final ExternalModule external) {
+                final Source source = external.getSource();
+                if (source != null) {
+                    final String location = source.pathOrShortIdentifier();
+                    if (location != null) {
+                        atts.addAttribute("", "location", "location", "CDATA", location);
+                    }
+                }
+            }
+            builder.startElement("", "module-import", "module-import", atts);
+            builder.endElement();
+        }
+
+        builder.endElement(); // prolog
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunIndexReport.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunIndexReport.java
@@ -35,46 +35,38 @@ import antlr.collections.AST;
 import java.io.StringReader;
 
 /**
- * Returns the compiled expression tree of an XQuery expression as XML.
- * This is the core query visibility function — shows what the optimizer produces.
+ * Execute a query with profiling and report which indexes were used.
+ * Returns an XML report showing index type, usage count, and elapsed time.
  *
  * <pre>
- * util:explain('for $x in 1 to 10 where $x > 5 return $x * 2')
+ * util:index-report('collection("/db/data")//book[@year > 2020]')
  * </pre>
  *
- * Returns an XML representation of the expression tree showing FLWOR clauses,
- * path expressions, function calls, comparisons, etc.
+ * Returns:
+ * <pre>
+ * &lt;index-report xmlns="http://exist-db.org/xquery/profiling"&gt;
+ *   &lt;index type="range" source="..." elapsed="0.5" calls="42" optimization-level="BASIC"/&gt;
+ *   &lt;optimization type="RANGE_IDX" source="..." line="1" column="15"/&gt;
+ * &lt;/index-report&gt;
+ * </pre>
  */
-public class FunExplain extends BasicFunction {
+public class FunIndexReport extends BasicFunction {
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("explain", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Compiles the given XQuery expression and returns its expression tree as XML. " +
-                            "Shows the post-optimization query plan.",
+                    new QName("index-report", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Executes the given query with profiling enabled and returns an XML report " +
+                            "showing which indexes were used and which optimizations were applied.",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "The XQuery expression to explain")
+                                    "The XQuery expression to analyze for index usage")
                     },
                     new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.EXACTLY_ONE,
-                            "An XML representation of the compiled expression tree")
-            ),
-            new FunctionSignature(
-                    new QName("explain", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Compiles the given XQuery expression and returns its expression tree as XML. " +
-                            "The module-load-path controls where imports are resolved.",
-                    new SequenceType[]{
-                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "The XQuery expression to explain"),
-                            new FunctionParameterSequenceType("module-load-path", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "The module load path for resolving imports")
-                    },
-                    new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.EXACTLY_ONE,
-                            "An XML representation of the compiled expression tree")
+                            "An XML report of index usage and optimizations")
             )
     };
 
-    public FunExplain(final XQueryContext context, final FunctionSignature signature) {
+    public FunIndexReport(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
@@ -85,14 +77,19 @@ public class FunExplain extends BasicFunction {
             throw new XPathException(this, ErrorCodes.XPTY0004, "Query expression is empty");
         }
 
-        // Compile the query using the same pattern as util:compile()
         final XQueryContext pContext = new XQueryContext(context.getBroker().getBrokerPool());
         context.pushNamespaceContext();
-        try {
-            if (getArgumentCount() == 2 && args[1].hasOne()) {
-                pContext.setModuleLoadPath(args[1].getStringValue());
-            }
 
+        try {
+            // Enable profiling with full verbosity
+            final Profiler profiler = pContext.getProfiler();
+            profiler.configure(new Option(
+                    this,
+                    new QName("profiling", "http://exist-db.org/xquery/util", "exist"),
+                    "enabled=yes verbosity=10"
+            ));
+
+            // Compile
             final XQueryLexer lexer = new XQueryLexer(pContext, new StringReader(query));
             final XQueryParser parser = new XQueryParser(lexer);
             final XQueryTreeParser astParser = new XQueryTreeParser(pContext);
@@ -110,37 +107,35 @@ public class FunExplain extends BasicFunction {
                 throw astParser.getLastException();
             }
 
-            // Analyze (optimize) the expression tree
             path.analyze(new AnalyzeContextInfo());
 
-            // Serialize the expression tree as XML
-            return serializeExpressionTree(path);
+            // Execute to trigger index usage
+            path.eval(null, null);
 
+            // Serialize the per-query profiler stats as the index report
+            final PerformanceStats stats = profiler.getPerformanceStats();
+            context.pushDocumentContext();
+            try {
+                final MemTreeBuilder builder = context.getDocumentBuilder();
+                if (stats instanceof PerformanceStatsImpl) {
+                    ((PerformanceStatsImpl) stats).serialize(builder);
+                } else {
+                    builder.startElement("", "index-report", "index-report", null);
+                    builder.endElement();
+                }
+                final DocumentImpl doc = (DocumentImpl) builder.getDocument();
+                return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
+            } finally {
+                context.popDocumentContext();
+            }
+
+        } catch (final XPathException e) {
+            throw e;
         } catch (final Exception e) {
-            throw new XPathException(this, ErrorCodes.XPST0003, "Parse error: " + e.getMessage());
+            throw new XPathException(this, ErrorCodes.FOER0000, "Error profiling query: " + e.getMessage());
         } finally {
             context.popNamespaceContext();
             pContext.reset(false);
-        }
-    }
-
-    private Sequence serializeExpressionTree(final Expression expression) throws XPathException {
-        context.pushDocumentContext();
-        try {
-            final MemTreeBuilder builder = context.getDocumentBuilder();
-
-            builder.startElement("", "explain", "explain", null);
-
-            final QueryPlanSerializer visitor = new QueryPlanSerializer(builder);
-            expression.accept(visitor);
-
-            builder.endElement();
-
-            final DocumentImpl doc = (DocumentImpl) builder.getDocument();
-            // Return the root element, not the document node
-            return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
-        } finally {
-            context.popDocumentContext();
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunIndexReport.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunIndexReport.java
@@ -117,8 +117,8 @@ public class FunIndexReport extends BasicFunction {
             context.pushDocumentContext();
             try {
                 final MemTreeBuilder builder = context.getDocumentBuilder();
-                if (stats instanceof PerformanceStatsImpl) {
-                    ((PerformanceStatsImpl) stats).serialize(builder);
+                if (stats instanceof final PerformanceStatsImpl statsImpl) {
+                    statsImpl.serialize(builder);
                 } else {
                     builder.startElement("", "index-report", "index-report", null);
                     builder.endElement();

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunMemory.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunMemory.java
@@ -1,0 +1,106 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+/**
+ * Pass-through profiling function that measures memory usage of an expression.
+ * Returns the expression result unchanged, logging the memory delta.
+ *
+ * <p>Inspired by BaseX's prof:memory().</p>
+ *
+ * <pre>
+ * util:memory(parse-json(unparsed-text("/db/large.json")))
+ * util:memory(parse-json(unparsed-text("/db/large.json")), "JSON parse")
+ * </pre>
+ */
+public class FunMemory extends BasicFunction {
+
+    private static final Logger LOG = LogManager.getLogger(FunMemory.class);
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("memory", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures the memory usage of the given expression and logs it. Returns the result unchanged.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure")
+                    },
+                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
+                            "The result of the expression, unchanged")
+            ),
+            new FunctionSignature(
+                    new QName("memory", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures the memory usage of the given expression and logs it with a label. Returns the result unchanged.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure"),
+                            new FunctionParameterSequenceType("label", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "A label for the log message")
+                    },
+                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
+                            "The result of the expression, unchanged")
+            )
+    };
+
+    public FunMemory(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Runtime runtime = Runtime.getRuntime();
+        final long memBefore = runtime.totalMemory() - runtime.freeMemory();
+
+        // The expression has already been evaluated — args[0] contains the result
+        final Sequence result = args[0];
+
+        final long memAfter = runtime.totalMemory() - runtime.freeMemory();
+        final long memDelta = memAfter - memBefore;
+
+        final String label = getArgumentCount() == 2
+                ? args[1].getStringValue()
+                : "util:memory()";
+
+        LOG.info("{} \u2014 {}", label, formatBytes(memDelta));
+
+        return result;
+    }
+
+    static String formatBytes(final long bytes) {
+        final long abs = Math.abs(bytes);
+        if (abs < 1024) {
+            return bytes + " B";
+        } else if (abs < 1024 * 1024) {
+            return String.format("%.1f KB", bytes / 1024.0);
+        } else if (abs < 1024 * 1024 * 1024) {
+            return String.format("%.1f MB", bytes / (1024.0 * 1024));
+        } else {
+            return String.format("%.2f GB", bytes / (1024.0 * 1024 * 1024));
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunMemory.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunMemory.java
@@ -33,12 +33,15 @@ import org.exist.xquery.value.*;
  *
  * <p>Inspired by BaseX's prof:memory().</p>
  *
+ * <p>The argument expression is evaluated lazily inside the measurement block so
+ * that util:time and util:memory compose naturally.</p>
+ *
  * <pre>
  * util:memory(parse-json(unparsed-text("/db/large.json")))
  * util:memory(parse-json(unparsed-text("/db/large.json")), "JSON parse")
  * </pre>
  */
-public class FunMemory extends BasicFunction {
+public class FunMemory extends Function {
 
     private static final Logger LOG = LogManager.getLogger(FunMemory.class);
 
@@ -72,23 +75,30 @@ public class FunMemory extends BasicFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        final String label = getArgumentCount() == 2
+                ? getArgument(1).eval(contextSequence, contextItem).getStringValue()
+                : "util:memory()";
+
         final Runtime runtime = Runtime.getRuntime();
         final long memBefore = runtime.totalMemory() - runtime.freeMemory();
-
-        // The expression has already been evaluated — args[0] contains the result
-        final Sequence result = args[0];
-
+        final Sequence result = getArgument(0).eval(contextSequence, contextItem);
         final long memAfter = runtime.totalMemory() - runtime.freeMemory();
         final long memDelta = memAfter - memBefore;
 
-        final String label = getArgumentCount() == 2
-                ? args[1].getStringValue()
-                : "util:memory()";
-
-        LOG.info("{} \u2014 {}", label, formatBytes(memDelta));
+        LOG.info("{} — {}", label, formatBytes(memDelta));
 
         return result;
+    }
+
+    @Override
+    public int returnsType() {
+        return getArgument(0).returnsType();
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return getArgument(0).getCardinality();
     }
 
     static String formatBytes(final long bytes) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
@@ -1,0 +1,217 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.source.StringSource;
+import org.exist.storage.DBBroker;
+import org.exist.xquery.*;
+import org.exist.xquery.functions.map.MapType;
+import org.exist.xquery.parser.XQueryLexer;
+import org.exist.xquery.parser.XQueryParser;
+import org.exist.xquery.parser.XQueryTreeParser;
+import org.exist.xquery.value.*;
+
+import antlr.collections.AST;
+
+import java.io.StringReader;
+
+/**
+ * Execute a query with profiling enabled and return structured profiling data.
+ * Combines timing, memory measurement, expression tree, and index/optimization
+ * statistics into a single map result.
+ *
+ * <pre>
+ * let $p := util:profile('collection("/db/data")//book[year > 2020]')
+ * return (
+ *   $p?result,          (: the query result :)
+ *   $p?time,            (: xs:dayTimeDuration :)
+ *   $p?memory,          (: xs:integer bytes :)
+ *   $p?plan,            (: element(explain) — expression tree :)
+ *   $p?stats            (: element() — profiler statistics XML :)
+ * )
+ * </pre>
+ */
+public class FunProfile extends BasicFunction {
+
+    private static final Logger LOG = LogManager.getLogger(FunProfile.class);
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("profile", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Executes the given query with profiling enabled and returns a map with " +
+                            "the result, timing, memory, expression tree, and profiler statistics.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The XQuery expression to profile")
+                    },
+                    new FunctionReturnSequenceType(Type.MAP_ITEM, Cardinality.EXACTLY_ONE,
+                            "A map with keys: result, time, memory, plan, stats")
+            ),
+            new FunctionSignature(
+                    new QName("profile", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Executes the given query with profiling enabled and returns a map with " +
+                            "the result, timing, memory, expression tree, and profiler statistics.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The XQuery expression to profile"),
+                            new FunctionParameterSequenceType("module-load-path", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The module load path for resolving imports")
+                    },
+                    new FunctionReturnSequenceType(Type.MAP_ITEM, Cardinality.EXACTLY_ONE,
+                            "A map with keys: result, time, memory, plan, stats")
+            )
+    };
+
+    public FunProfile(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final String query = args[0].getStringValue();
+        if (query.trim().isEmpty()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004, "Query expression is empty");
+        }
+
+        final DBBroker broker = context.getBroker();
+        final XQueryContext pContext = new XQueryContext(broker.getBrokerPool());
+        context.pushNamespaceContext();
+
+        try {
+            if (getArgumentCount() == 2 && args[1].hasOne()) {
+                pContext.setModuleLoadPath(args[1].getStringValue());
+            }
+
+            // Enable profiling on the context
+            final Profiler profiler = pContext.getProfiler();
+            profiler.configure(new Option(
+                    this,
+                    new QName("profiling", "http://exist-db.org/xquery/util", "exist"),
+                    "enabled=yes verbosity=10"
+            ));
+
+            // Compile the query
+            final XQueryLexer lexer = new XQueryLexer(pContext, new StringReader(query));
+            final XQueryParser parser = new XQueryParser(lexer);
+            final XQueryTreeParser astParser = new XQueryTreeParser(pContext);
+
+            parser.xpath();
+            if (parser.foundErrors()) {
+                throw new XPathException(this, ErrorCodes.XPST0003,
+                        "Parse error in query: " + parser.getErrorMessage());
+            }
+
+            final AST ast = parser.getAST();
+            final PathExpr path = new PathExpr(pContext);
+            astParser.xpath(ast, path);
+            if (astParser.foundErrors()) {
+                throw astParser.getLastException();
+            }
+
+            // Analyze (optimize)
+            path.analyze(new AnalyzeContextInfo());
+
+            // Generate the expression plan BEFORE execution
+            final Sequence plan = serializeExpressionTree(path);
+
+            // Execute with timing and memory measurement
+            final Runtime runtime = Runtime.getRuntime();
+            final long memBefore = runtime.totalMemory() - runtime.freeMemory();
+            final long startNanos = System.nanoTime();
+
+            final Sequence result = path.eval(null, null);
+
+            final long elapsedNanos = System.nanoTime() - startNanos;
+            final long memAfter = runtime.totalMemory() - runtime.freeMemory();
+            final long memDelta = memAfter - memBefore;
+
+            // Capture profiler stats as XML
+            final Sequence statsXml = serializeProfilerStats(pContext);
+
+            // Build the result map
+            final MapType resultMap = new MapType(this, context);
+
+            resultMap.add(new StringValue("result"), result);
+
+            try {
+                resultMap.add(new StringValue("time"),
+                        new DayTimeDurationValue(this, elapsedNanos / 1_000_000));
+            } catch (final XPathException e) {
+                resultMap.add(new StringValue("time"),
+                        new IntegerValue(this, elapsedNanos / 1_000_000));
+            }
+
+            resultMap.add(new StringValue("memory"), new IntegerValue(this, memDelta));
+            resultMap.add(new StringValue("plan"), plan);
+            resultMap.add(new StringValue("stats"), statsXml);
+
+            return resultMap;
+
+        } catch (final Exception e) {
+            if (e instanceof XPathException) {
+                throw (XPathException) e;
+            }
+            throw new XPathException(this, ErrorCodes.XPST0003, "Error profiling query: " + e.getMessage());
+        } finally {
+            context.popNamespaceContext();
+            pContext.reset(false);
+        }
+    }
+
+    private Sequence serializeExpressionTree(final Expression expression) throws XPathException {
+        context.pushDocumentContext();
+        try {
+            final MemTreeBuilder builder = context.getDocumentBuilder();
+            builder.startElement("", "explain", "explain", null);
+            final QueryPlanSerializer visitor = new QueryPlanSerializer(builder);
+            expression.accept(visitor);
+            builder.endElement();
+            final DocumentImpl doc = (DocumentImpl) builder.getDocument();
+            return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
+        } finally {
+            context.popDocumentContext();
+        }
+    }
+
+    private Sequence serializeProfilerStats(final XQueryContext pContext) throws XPathException {
+        final PerformanceStats stats = pContext.getBroker().getBrokerPool().getPerformanceStats();
+        context.pushDocumentContext();
+        try {
+            final MemTreeBuilder builder = context.getDocumentBuilder();
+            if (stats instanceof PerformanceStatsImpl) {
+                ((PerformanceStatsImpl) stats).serialize(builder);
+            } else {
+                builder.startElement("", "stats", "stats", null);
+                builder.endElement();
+            }
+            final DocumentImpl doc = (DocumentImpl) builder.getDocument();
+            return (org.exist.dom.memtree.ElementImpl) doc.getDocumentElement();
+        } finally {
+            context.popDocumentContext();
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
@@ -21,12 +21,9 @@
  */
 package org.exist.xquery.functions.util;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.source.StringSource;
 import org.exist.storage.DBBroker;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.map.MapType;
@@ -56,8 +53,6 @@ import java.io.StringReader;
  * </pre>
  */
 public class FunProfile extends BasicFunction {
-
-    private static final Logger LOG = LogManager.getLogger(FunProfile.class);
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
@@ -171,10 +166,9 @@ public class FunProfile extends BasicFunction {
 
             return resultMap;
 
+        } catch (final XPathException e) {
+            throw e;
         } catch (final Exception e) {
-            if (e instanceof XPathException) {
-                throw (XPathException) e;
-            }
             throw new XPathException(this, ErrorCodes.XPST0003, "Error profiling query: " + e.getMessage());
         } finally {
             context.popNamespaceContext();
@@ -197,8 +191,14 @@ public class FunProfile extends BasicFunction {
         }
     }
 
+    /**
+     * Serialize the per-query profiler's performance stats as XML.
+     * Uses the profiled query's own Profiler instance (not the global
+     * BrokerPool stats) to ensure per-query isolation under concurrent load.
+     */
     private Sequence serializeProfilerStats(final XQueryContext pContext) throws XPathException {
-        final PerformanceStats stats = pContext.getBroker().getBrokerPool().getPerformanceStats();
+        // Read from the per-query profiler's stats, not the global BrokerPool stats
+        final PerformanceStats stats = pContext.getProfiler().getPerformanceStats();
         context.pushDocumentContext();
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunProfile.java
@@ -202,8 +202,8 @@ public class FunProfile extends BasicFunction {
         context.pushDocumentContext();
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
-            if (stats instanceof PerformanceStatsImpl) {
-                ((PerformanceStatsImpl) stats).serialize(builder);
+            if (stats instanceof final PerformanceStatsImpl statsImpl) {
+                statsImpl.serialize(builder);
             } else {
                 builder.startElement("", "stats", "stats", null);
                 builder.endElement();

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunTime.java
@@ -33,12 +33,16 @@ import org.exist.xquery.value.*;
  *
  * <p>Inspired by BaseX's prof:time().</p>
  *
+ * <p>The argument expression is evaluated lazily inside the timing block so that
+ * util:time and util:memory compose: util:time(util:memory($expr)) measures the
+ * full evaluation cost of $expr.</p>
+ *
  * <pre>
  * util:time(collection("/db/data")//title)
  * util:time(collection("/db/data")//title, "title lookup")
  * </pre>
  */
-public class FunTime extends BasicFunction {
+public class FunTime extends Function {
 
     private static final Logger LOG = LogManager.getLogger(FunTime.class);
 
@@ -72,28 +76,34 @@ public class FunTime extends BasicFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
-        final long startNanos = System.nanoTime();
-
-        // The expression has already been evaluated by the function call mechanism —
-        // args[0] contains the result
-        final Sequence result = args[0];
-
-        final long elapsedNanos = System.nanoTime() - startNanos;
-        final double elapsedMs = elapsedNanos / 1_000_000.0;
-
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        // Evaluate the label first (eager) so that timing covers only the expression of interest.
         final String label = getArgumentCount() == 2
-                ? args[1].getStringValue()
+                ? getArgument(1).eval(contextSequence, contextItem).getStringValue()
                 : "util:time()";
 
-        LOG.info("{} \u2014 {}", label, formatDuration(elapsedMs));
+        final long startNanos = System.nanoTime();
+        final Sequence result = getArgument(0).eval(contextSequence, contextItem);
+        final long elapsedNanos = System.nanoTime() - startNanos;
+
+        LOG.info("{} — {}", label, formatDuration(elapsedNanos / 1_000_000.0));
 
         return result;
     }
 
+    @Override
+    public int returnsType() {
+        return getArgument(0).returnsType();
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return getArgument(0).getCardinality();
+    }
+
     static String formatDuration(final double ms) {
         if (ms < 1.0) {
-            return String.format("%.1f\u00B5s", ms * 1000);
+            return String.format("%.1fµs", ms * 1000);
         } else if (ms < 1000.0) {
             return String.format("%.1fms", ms);
         } else {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunTime.java
@@ -1,0 +1,103 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+/**
+ * Pass-through profiling function that measures execution time of an expression.
+ * Returns the expression result unchanged, logging the elapsed time.
+ *
+ * <p>Inspired by BaseX's prof:time().</p>
+ *
+ * <pre>
+ * util:time(collection("/db/data")//title)
+ * util:time(collection("/db/data")//title, "title lookup")
+ * </pre>
+ */
+public class FunTime extends BasicFunction {
+
+    private static final Logger LOG = LogManager.getLogger(FunTime.class);
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("time", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures the execution time of the given expression and logs it. Returns the result unchanged.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure")
+                    },
+                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
+                            "The result of the expression, unchanged")
+            ),
+            new FunctionSignature(
+                    new QName("time", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures the execution time of the given expression and logs it with a label. Returns the result unchanged.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure"),
+                            new FunctionParameterSequenceType("label", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "A label for the log message")
+                    },
+                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
+                            "The result of the expression, unchanged")
+            )
+    };
+
+    public FunTime(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final long startNanos = System.nanoTime();
+
+        // The expression has already been evaluated by the function call mechanism —
+        // args[0] contains the result
+        final Sequence result = args[0];
+
+        final long elapsedNanos = System.nanoTime() - startNanos;
+        final double elapsedMs = elapsedNanos / 1_000_000.0;
+
+        final String label = getArgumentCount() == 2
+                ? args[1].getStringValue()
+                : "util:time()";
+
+        LOG.info("{} \u2014 {}", label, formatDuration(elapsedMs));
+
+        return result;
+    }
+
+    static String formatDuration(final double ms) {
+        if (ms < 1.0) {
+            return String.format("%.1f\u00B5s", ms * 1000);
+        } else if (ms < 1000.0) {
+            return String.format("%.1fms", ms);
+        } else {
+            return String.format("%.2fs", ms / 1000);
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunTrack.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunTrack.java
@@ -1,0 +1,115 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.functions.map.MapType;
+import org.exist.xquery.value.*;
+
+
+/**
+ * Profiling function that measures execution time and memory, returning
+ * a map with the measurements and the expression result.
+ *
+ * <p>Inspired by BaseX's prof:track().</p>
+ *
+ * <pre>
+ * let $r := util:track(collection("/db/data")//title)
+ * return (
+ *   "Time: " || $r?time,
+ *   "Memory: " || $r?memory || " bytes",
+ *   "Items: " || count($r?value)
+ * )
+ * </pre>
+ */
+public class FunTrack extends BasicFunction {
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("track", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures execution time and memory of the given expression. " +
+                            "Returns map { 'time': xs:dayTimeDuration, 'memory': xs:integer, 'value': item()* }.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure")
+                    },
+                    new FunctionReturnSequenceType(Type.MAP_ITEM, Cardinality.EXACTLY_ONE,
+                            "A map with keys 'time' (xs:dayTimeDuration), 'memory' (xs:integer bytes), 'value' (the result)")
+            ),
+            new FunctionSignature(
+                    new QName("track", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Measures execution time and memory of the given expression with a label. " +
+                            "Returns map { 'time': xs:dayTimeDuration, 'memory': xs:integer, 'value': item()*, 'label': xs:string }.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("expr", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                                    "The expression to measure"),
+                            new FunctionParameterSequenceType("label", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "A label for identifying this measurement")
+                    },
+                    new FunctionReturnSequenceType(Type.MAP_ITEM, Cardinality.EXACTLY_ONE,
+                            "A map with keys 'time', 'memory', 'value', and 'label'")
+            )
+    };
+
+    public FunTrack(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Runtime runtime = Runtime.getRuntime();
+        final long memBefore = runtime.totalMemory() - runtime.freeMemory();
+        final long startNanos = System.nanoTime();
+
+        // The expression has already been evaluated — args[0] contains the result
+        final Sequence result = args[0];
+
+        final long elapsedNanos = System.nanoTime() - startNanos;
+        final long memAfter = runtime.totalMemory() - runtime.freeMemory();
+        final long memDelta = memAfter - memBefore;
+
+        // Build the result map
+        final MapType map = new MapType(this, context);
+
+        // time as xs:dayTimeDuration (millisecond precision)
+        try {
+            map.add(new StringValue("time"), new DayTimeDurationValue(this, elapsedNanos / 1_000_000));
+        } catch (final XPathException e) {
+            // Fallback: store milliseconds as integer
+            map.add(new StringValue("time"), new IntegerValue(this, elapsedNanos / 1_000_000));
+        }
+
+        // memory as xs:integer (bytes)
+        map.add(new StringValue("memory"), new IntegerValue(this, memDelta));
+
+        // value: the expression result
+        map.add(new StringValue("value"), result);
+
+        // optional label
+        if (getArgumentCount() == 2) {
+            map.add(new StringValue("label"), new StringValue(args[1].getStringValue()));
+        }
+
+        return map;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/FunTrack.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/FunTrack.java
@@ -33,6 +33,8 @@ import org.exist.xquery.value.*;
  *
  * <p>Inspired by BaseX's prof:track().</p>
  *
+ * <p>The argument expression is evaluated lazily inside the measurement block.</p>
+ *
  * <pre>
  * let $r := util:track(collection("/db/data")//title)
  * return (
@@ -42,7 +44,7 @@ import org.exist.xquery.value.*;
  * )
  * </pre>
  */
-public class FunTrack extends BasicFunction {
+public class FunTrack extends Function {
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
@@ -76,38 +78,34 @@ public class FunTrack extends BasicFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        final String label = getArgumentCount() == 2
+                ? getArgument(1).eval(contextSequence, contextItem).getStringValue()
+                : null;
+
         final Runtime runtime = Runtime.getRuntime();
         final long memBefore = runtime.totalMemory() - runtime.freeMemory();
         final long startNanos = System.nanoTime();
 
-        // The expression has already been evaluated — args[0] contains the result
-        final Sequence result = args[0];
+        final Sequence result = getArgument(0).eval(contextSequence, contextItem);
 
         final long elapsedNanos = System.nanoTime() - startNanos;
         final long memAfter = runtime.totalMemory() - runtime.freeMemory();
         final long memDelta = memAfter - memBefore;
 
-        // Build the result map
         final MapType map = new MapType(this, context);
 
-        // time as xs:dayTimeDuration (millisecond precision)
         try {
             map.add(new StringValue("time"), new DayTimeDurationValue(this, elapsedNanos / 1_000_000));
         } catch (final XPathException e) {
-            // Fallback: store milliseconds as integer
             map.add(new StringValue("time"), new IntegerValue(this, elapsedNanos / 1_000_000));
         }
 
-        // memory as xs:integer (bytes)
         map.add(new StringValue("memory"), new IntegerValue(this, memDelta));
-
-        // value: the expression result
         map.add(new StringValue("value"), result);
 
-        // optional label
-        if (getArgumentCount() == 2) {
-            map.add(new StringValue("label"), new StringValue(args[1].getStringValue()));
+        if (label != null) {
+            map.add(new StringValue("label"), new StringValue(label));
         }
 
         return map;

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
@@ -65,18 +65,6 @@ public class QueryPlanSerializer extends DefaultExpressionVisitor {
         builder.endElement();
     }
 
-    private void textElement(final String name, final String text) {
-        startElement(name);
-        builder.characters(text);
-        endElement();
-    }
-
-    private void addLocation(final Expression expr) {
-        if (expr.getLine() > 0) {
-            // Line/column info is on the element already started by the caller
-        }
-    }
-
     private String[][] locationAttrs(final Expression expr) {
         if (expr.getLine() > 0) {
             return new String[][]{

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
@@ -92,14 +92,21 @@ public class QueryPlanSerializer extends DefaultExpressionVisitor {
     @Override
     public void visit(final Expression expression) {
         final String className = expression.getClass().getSimpleName();
-        if (className.isEmpty()) {
-            startElement("expression", mergeAttrs(
-                    new String[][]{{"class", expression.getClass().getName()}},
-                    locationAttrs(expression)));
-        } else {
-            startElement("expression", mergeAttrs(
-                    new String[][]{{"type", className}},
-                    locationAttrs(expression)));
+        final String[][] attrs = className.isEmpty()
+                ? new String[][]{{"class", expression.getClass().getName()}}
+                : new String[][]{{"type", className}};
+        startElement("expression", mergeAttrs(attrs, locationAttrs(expression)));
+        // Comprehensive fallback: any expression that exposes sub-expressions
+        // via getSubExpressionCount / getSubExpression renders them nested
+        // here, rather than as siblings of a self-closed <expression/>.
+        // Specific visit*() methods (visitPathExpr, visitForExpression, ...)
+        // override this entirely and emit their own wrapper element.
+        final int subCount = expression.getSubExpressionCount();
+        for (int i = 0; i < subCount; i++) {
+            final Expression sub = expression.getSubExpression(i);
+            if (sub != null) {
+                sub.accept(this);
+            }
         }
         endElement();
     }
@@ -372,6 +379,22 @@ public class QueryPlanSerializer extends DefaultExpressionVisitor {
         startElement("simple-map", locationAttrs(simpleMap));
         simpleMap.getLeft().accept(this);
         simpleMap.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitMapExpr(final org.exist.xquery.functions.map.MapExpr mapExpr) {
+        startElement("map", locationAttrs(mapExpr));
+        for (int i = 0; i < mapExpr.getMappingCount(); i++) {
+            startElement("entry");
+            startElement("key");
+            mapExpr.getMappingKey(i).accept(this);
+            endElement();
+            startElement("value");
+            mapExpr.getMappingValue(i).accept(this);
+            endElement();
+            endElement();
+        }
         endElement();
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
@@ -25,8 +25,11 @@ import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.xquery.*;
 import org.exist.xquery.value.AtomicValue;
 import org.exist.xquery.value.Sequence;
+import org.xml.sax.helpers.AttributesImpl;
 
 import javax.annotation.Nullable;
+
+import static org.exist.xquery.Constants.AXISSPECIFIERS;
 
 /**
  * Serializes a compiled XQuery expression tree as XML.
@@ -52,7 +55,7 @@ public class QueryPlanSerializer extends DefaultExpressionVisitor {
     }
 
     private void startElement(final String name, final String[][] attrs) {
-        final org.xml.sax.helpers.AttributesImpl atts = new org.xml.sax.helpers.AttributesImpl();
+        final AttributesImpl atts = new AttributesImpl();
         for (final String[] attr : attrs) {
             if (attr[1] != null) {
                 atts.addAttribute("", attr[0], attr[0], "CDATA", attr[1]);
@@ -129,7 +132,7 @@ public class QueryPlanSerializer extends DefaultExpressionVisitor {
     public void visitLocationStep(final LocationStep locationStep) {
         startElement("step", mergeAttrs(
                 new String[][]{
-                        {"axis", org.exist.xquery.Constants.AXISSPECIFIERS[locationStep.getAxis()]},
+                        {"axis", AXISSPECIFIERS[locationStep.getAxis()]},
                         {"test", locationStep.getTest().toString()}
                 },
                 locationAttrs(locationStep)));

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/QueryPlanSerializer.java
@@ -1,0 +1,389 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.xquery.*;
+import org.exist.xquery.value.AtomicValue;
+import org.exist.xquery.value.Sequence;
+
+import javax.annotation.Nullable;
+
+/**
+ * Serializes a compiled XQuery expression tree as XML.
+ * Extends DefaultExpressionVisitor to walk the tree and emit XML elements
+ * for each expression type.
+ *
+ * <p>Output namespace: http://exist-db.org/xquery/profiling</p>
+ */
+public class QueryPlanSerializer extends DefaultExpressionVisitor {
+
+    public static final String NAMESPACE = "http://exist-db.org/xquery/profiling";
+
+    private final MemTreeBuilder builder;
+
+    public QueryPlanSerializer(final MemTreeBuilder builder) {
+        this.builder = builder;
+    }
+
+    // === Helper methods ===
+
+    private void startElement(final String name) {
+        builder.startElement("", name, name, null);
+    }
+
+    private void startElement(final String name, final String[][] attrs) {
+        final org.xml.sax.helpers.AttributesImpl atts = new org.xml.sax.helpers.AttributesImpl();
+        for (final String[] attr : attrs) {
+            if (attr[1] != null) {
+                atts.addAttribute("", attr[0], attr[0], "CDATA", attr[1]);
+            }
+        }
+        builder.startElement("", name, name, atts);
+    }
+
+    private void endElement() {
+        builder.endElement();
+    }
+
+    private void textElement(final String name, final String text) {
+        startElement(name);
+        builder.characters(text);
+        endElement();
+    }
+
+    private void addLocation(final Expression expr) {
+        if (expr.getLine() > 0) {
+            // Line/column info is on the element already started by the caller
+        }
+    }
+
+    private String[][] locationAttrs(final Expression expr) {
+        if (expr.getLine() > 0) {
+            return new String[][]{
+                    {"line", String.valueOf(expr.getLine())},
+                    {"column", String.valueOf(expr.getColumn())}
+            };
+        }
+        return new String[0][];
+    }
+
+    private String[][] mergeAttrs(final String[][]... attrSets) {
+        int total = 0;
+        for (final String[][] set : attrSets) total += set.length;
+        final String[][] result = new String[total][];
+        int idx = 0;
+        for (final String[][] set : attrSets) {
+            System.arraycopy(set, 0, result, idx, set.length);
+            idx += set.length;
+        }
+        return result;
+    }
+
+    // === Visitor methods ===
+
+    @Override
+    public void visit(final Expression expression) {
+        final String className = expression.getClass().getSimpleName();
+        if (className.isEmpty()) {
+            startElement("expression", mergeAttrs(
+                    new String[][]{{"class", expression.getClass().getName()}},
+                    locationAttrs(expression)));
+        } else {
+            startElement("expression", mergeAttrs(
+                    new String[][]{{"type", className}},
+                    locationAttrs(expression)));
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitPathExpr(final PathExpr expression) {
+        if (expression.getLength() == 1) {
+            // Unwrap single-step path expressions
+            expression.getExpression(0).accept(this);
+            return;
+        }
+        startElement("path", locationAttrs(expression));
+        for (int i = 0; i < expression.getLength(); i++) {
+            expression.getExpression(i).accept(this);
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitLocationStep(final LocationStep locationStep) {
+        startElement("step", mergeAttrs(
+                new String[][]{
+                        {"axis", org.exist.xquery.Constants.AXISSPECIFIERS[locationStep.getAxis()]},
+                        {"test", locationStep.getTest().toString()}
+                },
+                locationAttrs(locationStep)));
+        @Nullable final Predicate[] predicates = locationStep.getPredicates();
+        if (predicates != null) {
+            for (final Predicate pred : predicates) {
+                pred.accept(this);
+            }
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitFilteredExpr(final FilteredExpression filtered) {
+        startElement("filter", locationAttrs(filtered));
+        filtered.getExpression().accept(this);
+        for (final Predicate pred : filtered.getPredicates()) {
+            pred.accept(this);
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitPredicate(final Predicate predicate) {
+        startElement("predicate", locationAttrs(predicate));
+        predicate.getExpression(0).accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitFunctionCall(final FunctionCall call) {
+        final String name = call.getFunction().getName().getStringValue();
+        startElement("function-call", mergeAttrs(
+                new String[][]{
+                        {"name", name},
+                        {"arity", String.valueOf(call.getArgumentCount())}
+                },
+                locationAttrs(call)));
+        for (int i = 0; i < call.getArgumentCount(); i++) {
+            call.getArgument(i).accept(this);
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitBuiltinFunction(final Function function) {
+        startElement("builtin-function", mergeAttrs(
+                new String[][]{
+                        {"name", function.getName().getStringValue()},
+                        {"arity", String.valueOf(function.getArgumentCount())}
+                },
+                locationAttrs(function)));
+        for (int i = 0; i < function.getArgumentCount(); i++) {
+            function.getArgument(i).accept(this);
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitUserFunction(final UserDefinedFunction function) {
+        startElement("user-function", new String[][]{
+                {"name", function.getName().getStringValue()},
+                {"arity", String.valueOf(function.getSignature().getArgumentCount())}
+        });
+        function.getFunctionBody().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitForExpression(final ForExpr forExpr) {
+        startElement("for", mergeAttrs(
+                new String[][]{{"variable", "$" + forExpr.getVariable().getStringValue()}},
+                locationAttrs(forExpr)));
+        startElement("in");
+        forExpr.getInputSequence().accept(this);
+        endElement();
+        forExpr.getReturnExpression().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitLetExpression(final LetExpr letExpr) {
+        startElement("let", mergeAttrs(
+                new String[][]{{"variable", "$" + letExpr.getVariable().getStringValue()}},
+                locationAttrs(letExpr)));
+        startElement("value");
+        letExpr.getInputSequence().accept(this);
+        endElement();
+        letExpr.getReturnExpression().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitWhereClause(final WhereClause where) {
+        startElement("where", locationAttrs(where));
+        where.getWhereExpr().accept(this);
+        endElement();
+        where.getReturnExpression().accept(this);
+    }
+
+    @Override
+    public void visitOrderByClause(final OrderByClause orderBy) {
+        startElement("order-by", locationAttrs(orderBy));
+        for (final OrderSpec spec : orderBy.getOrderSpecs()) {
+            startElement("order-spec");
+            spec.getSortExpression().accept(this);
+            endElement();
+        }
+        endElement();
+        orderBy.getReturnExpression().accept(this);
+    }
+
+    @Override
+    public void visitGroupByClause(final GroupByClause groupBy) {
+        startElement("group-by", locationAttrs(groupBy));
+        for (final GroupSpec spec : groupBy.getGroupSpecs()) {
+            startElement("group-spec");
+            spec.getGroupExpression().accept(this);
+            endElement();
+        }
+        endElement();
+        groupBy.getReturnExpression().accept(this);
+    }
+
+    @Override
+    public void visitGeneralComparison(final GeneralComparison comparison) {
+        startElement("comparison", mergeAttrs(
+                new String[][]{{"operator", comparison.toString().contains("=") ? "eq" : "cmp"}},
+                locationAttrs(comparison)));
+        comparison.getLeft().accept(this);
+        comparison.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitAndExpr(final OpAnd and) {
+        startElement("and", locationAttrs(and));
+        and.getLeft().accept(this);
+        and.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitOrExpr(final OpOr or) {
+        startElement("or", locationAttrs(or));
+        or.getLeft().accept(this);
+        or.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitConditional(final ConditionalExpression conditional) {
+        startElement("if", locationAttrs(conditional));
+        startElement("test");
+        conditional.getTestExpr().accept(this);
+        endElement();
+        startElement("then");
+        conditional.getThenExpr().accept(this);
+        endElement();
+        startElement("else");
+        conditional.getElseExpr().accept(this);
+        endElement();
+        endElement();
+    }
+
+    @Override
+    public void visitCastExpr(final CastExpression expression) {
+        startElement("cast", mergeAttrs(
+                new String[][]{{"cardinality", expression.getCardinality().getHumanDescription()}},
+                locationAttrs(expression)));
+        endElement();
+    }
+
+    @Override
+    public void visitUnionExpr(final Union union) {
+        startElement("union", locationAttrs(union));
+        union.getLeft().accept(this);
+        union.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitIntersectionExpr(final Intersect intersect) {
+        startElement("intersect", locationAttrs(intersect));
+        intersect.getLeft().accept(this);
+        intersect.getRight().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitVariableReference(final VariableReference ref) {
+        startElement("variable", mergeAttrs(
+                new String[][]{{"name", "$" + ref.getName().toString()}},
+                locationAttrs(ref)));
+        endElement();
+    }
+
+    @Override
+    public void visitVariableDeclaration(final VariableDeclaration decl) {
+        startElement("variable-declaration", mergeAttrs(
+                new String[][]{{"name", "$" + decl.getName().toString()}},
+                locationAttrs(decl)));
+        decl.getExpression().ifPresent(e -> e.accept(this));
+        endElement();
+    }
+
+    @Override
+    public void visitDocumentConstructor(final DocumentConstructor constructor) {
+        startElement("document-constructor", locationAttrs(constructor));
+        constructor.getContent().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitElementConstructor(final ElementConstructor constructor) {
+        startElement("element-constructor", locationAttrs(constructor));
+        constructor.getNameExpr().accept(this);
+        if (constructor.getContent() != null) {
+            constructor.getContent().accept(this);
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitTextConstructor(final DynamicTextConstructor constructor) {
+        startElement("text-constructor", locationAttrs(constructor));
+        constructor.getContent().accept(this);
+        endElement();
+    }
+
+    @Override
+    public void visitTryCatch(final TryCatchExpression tryCatch) {
+        startElement("try-catch", locationAttrs(tryCatch));
+        startElement("try");
+        tryCatch.getTryTargetExpr().accept(this);
+        endElement();
+        for (final TryCatchExpression.CatchClause clause : tryCatch.getCatchClauses()) {
+            startElement("catch");
+            clause.getCatchExpr().accept(this);
+            endElement();
+        }
+        endElement();
+    }
+
+    @Override
+    public void visitSimpleMapOperator(final OpSimpleMap simpleMap) {
+        startElement("simple-map", locationAttrs(simpleMap));
+        simpleMap.getLeft().accept(this);
+        simpleMap.getRight().accept(this);
+        endElement();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -164,7 +164,8 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(FunExplain.signatures[0], FunExplain.class),
             new FunctionDef(FunExplain.signatures[1], FunExplain.class),
             new FunctionDef(FunProfile.signatures[0], FunProfile.class),
-            new FunctionDef(FunProfile.signatures[1], FunProfile.class)
+            new FunctionDef(FunProfile.signatures[1], FunProfile.class),
+            new FunctionDef(FunIndexReport.signatures[0], FunIndexReport.class)
             // --- End Query Profiling Functions ---
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -160,7 +160,9 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(FunMemory.signatures[0], FunMemory.class),
             new FunctionDef(FunMemory.signatures[1], FunMemory.class),
             new FunctionDef(FunTrack.signatures[0], FunTrack.class),
-            new FunctionDef(FunTrack.signatures[1], FunTrack.class)
+            new FunctionDef(FunTrack.signatures[1], FunTrack.class),
+            new FunctionDef(FunExplain.signatures[0], FunExplain.class),
+            new FunctionDef(FunExplain.signatures[1], FunExplain.class)
             // --- End Query Profiling Functions ---
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -152,7 +152,16 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(Base64Functions.signatures[3], Base64Functions.class),
             new FunctionDef(BaseConversionFunctions.FNS_INT_TO_OCTAL, BaseConversionFunctions.class),
             new FunctionDef(BaseConversionFunctions.FNS_OCTAL_TO_INT, BaseConversionFunctions.class),
-            new FunctionDef(LineNumber.signature, LineNumber.class)
+            new FunctionDef(LineNumber.signature, LineNumber.class),
+
+            // --- Query Profiling Functions ---
+            new FunctionDef(FunTime.signatures[0], FunTime.class),
+            new FunctionDef(FunTime.signatures[1], FunTime.class),
+            new FunctionDef(FunMemory.signatures[0], FunMemory.class),
+            new FunctionDef(FunMemory.signatures[1], FunMemory.class),
+            new FunctionDef(FunTrack.signatures[0], FunTrack.class),
+            new FunctionDef(FunTrack.signatures[1], FunTrack.class)
+            // --- End Query Profiling Functions ---
     };
 
     static {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -162,7 +162,9 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(FunTrack.signatures[0], FunTrack.class),
             new FunctionDef(FunTrack.signatures[1], FunTrack.class),
             new FunctionDef(FunExplain.signatures[0], FunExplain.class),
-            new FunctionDef(FunExplain.signatures[1], FunExplain.class)
+            new FunctionDef(FunExplain.signatures[1], FunExplain.class),
+            new FunctionDef(FunProfile.signatures[0], FunProfile.class),
+            new FunctionDef(FunProfile.signatures[1], FunProfile.class)
             // --- End Query Profiling Functions ---
     };
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/QueryPlanSerializerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/QueryPlanSerializerTest.java
@@ -1,0 +1,173 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.util;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Structural-shape tests for {@code util:explain}.
+ *
+ * <p>Each test invokes {@code util:explain(...)} on a small XQuery and
+ * asserts that the returned XML correctly <em>nests</em> sub-expressions
+ * under their parent, rather than emitting them as siblings. The original
+ * defect (issue #6208 review, 2026-06-01): the default
+ * {@code QueryPlanSerializer.visit(Expression)} closed the
+ * {@code <expression>} element immediately, so any expression whose
+ * {@code accept(visitor)} called {@code super.accept} and then recursed
+ * into children produced sibling-children output that's hard to read.</p>
+ *
+ * <p>The tests use {@code matches(...)} on the string output rather than
+ * structural XPath because {@code util:explain} returns a constructed
+ * in-memory document and we want to be resilient to incidental attribute
+ * order.</p>
+ */
+public class QueryPlanSerializerTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer embedded =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /**
+     * Juri's Case 1: {@code map { $p : $i }} as the for-loop body. The
+     * map's key + value must appear as children of the map element, not
+     * as siblings of a self-closed {@code <expression type="MapExpr"/>}.
+     */
+    @Test
+    public void mapConstructorNestsKeysAndValuesAsChildren() throws XMLDBException {
+        final String xml = explain("for $i at $p in (1,2,3) return map { $p : $i }");
+        // The defect emitted <expression type="MapExpr"/> followed by two
+        // <variable> siblings. The fix must produce a map element with
+        // key/value sub-elements.
+        assertContains(xml, "MapExpr — body must nest its entries", "<map");
+        assertNotContains(xml, "MapExpr — must NOT be self-closed",
+                "<expression type=\"MapExpr\"/>");
+        // The two variables (key $p, value $i) must appear inside the map.
+        assertTrue("map body must contain key + value variable refs: " + xml,
+                xml.matches("(?s).*<map[^>]*>.*\\$p.*\\$i.*</map>.*"));
+    }
+
+    /**
+     * Juri's Case 2: {@code //p[@id]}'s {@code <expression type="RootNode"/>}
+     * + descendant-step pair under {@code <path>}. RootNode is a leaf step
+     * in the AST (the descendant step is a sibling, not a child, in the
+     * PathExpr's step list) so the bare {@code <expression type="RootNode"/>}
+     * IS structurally accurate; what mattered for Juri was that the
+     * downstream descendant step is rendered correctly. Verify the path
+     * contains both the RootNode reference and the descendant step.
+     */
+    @Test
+    public void rootNodePathHasBothSteps() throws XMLDBException {
+        final String xml = explain("//p[@id]");
+        assertContains(xml, "path wraps the steps", "<path");
+        assertContains(xml, "descendant step is emitted",
+                "axis=\"descendant\"");
+        assertContains(xml, "predicate is nested under the step",
+                "<predicate");
+    }
+
+    /** Conditional expression must nest condition / then / else as children. */
+    @Test
+    public void conditionalNestsBranches() throws XMLDBException {
+        final String xml = explain("if (1 eq 1) then 'a' else 'b'");
+        // A conditional currently goes through visitConditional which is
+        // already wired correctly; this test pins that behaviour.
+        assertContains(xml, "conditional emits a <if> wrapper", "<if");
+    }
+
+    /** Try-catch must nest the try body and the catch body. */
+    @Test
+    public void tryCatchNestsBodies() throws XMLDBException {
+        final String xml = explain(
+                "xquery version \"3.1\"; try { 1 div 0 } catch * { 'err' }");
+        assertContains(xml, "try-catch emits a <try-catch>", "<try-catch");
+    }
+
+    /** FunctionCall must nest its arguments under the call element. */
+    @Test
+    public void functionCallNestsArguments() throws XMLDBException {
+        final String xml = explain("concat('a', 'b', 'c')");
+        // visitBuiltinFunction already emits <builtin-function> with argument
+        // children — verify that's still the case.
+        assertContains(xml, "function call emits a <builtin-function>",
+                "<builtin-function");
+    }
+
+    /** Simple-map operator (! operator) must nest left + right. */
+    @Test
+    public void simpleMapNestsLeftAndRight() throws XMLDBException {
+        final String xml = explain("(1,2,3) ! (. + 1)");
+        // visitSimpleMapOperator should emit a <simple-map> (or similar)
+        // wrapper with both operands as children.
+        assertContains(xml, "simple-map emits a wrapper", "<simple-map");
+    }
+
+    /** Variable reference must render as a single self-closed element. */
+    @Test
+    public void variableReferenceRendersAsLeaf() throws XMLDBException {
+        final String xml = explain("let $x := 1 return $x");
+        // <variable> exists for both the let-binding and the reference.
+        assertContains(xml, "variable reference present", "$x");
+    }
+
+    /**
+     * Comprehensive sanity: a constructor that has children (MapExpr's
+     * key/value pairs) MUST NOT render as a self-closed
+     * {@code <expression type="MapExpr"/>}. The defect signature: the
+     * default {@code visit()} emitted the type attribute and closed the
+     * element before children could nest.
+     */
+    @Test
+    public void containerExpressionsNestTheirChildren() throws XMLDBException {
+        final String xml = explain(
+                "for $i at $p in //p[@id] return map { $p : $i }");
+        assertNotContains(xml, "MapExpr container must not self-close",
+                "<expression type=\"MapExpr\"/>");
+        // True AST leaves (RootNode is a singleton root reference with no
+        // sub-expressions, ContextItemExpression, etc.) MAY self-close —
+        // that is structurally correct and not part of the defect.
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private static String explain(final String xqueryText) throws XMLDBException {
+        final String esc = xqueryText.replace("\\", "\\\\").replace("\"", "\"\"");
+        final ResourceSet rs = embedded.executeQuery(
+                "util:explain(\"" + esc + "\")");
+        return (String) rs.getResource(0).getContent();
+    }
+
+    private static void assertContains(final String xml, final String message, final String needle) {
+        assertTrue(message + " — not found in: " + xml, xml.contains(needle));
+    }
+
+    private static void assertNotContains(final String xml, final String message, final String needle) {
+        assertTrue(message + " — but found in: " + xml, !xml.contains(needle));
+    }
+}

--- a/exist-core/src/test/xquery/util/profiling.xql
+++ b/exist-core/src/test/xquery/util/profiling.xql
@@ -1,3 +1,24 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
 xquery version "3.1";
 
 (:~
@@ -228,4 +249,20 @@ declare
 function prof:profile-stats-is-element() {
     let $result := util:profile('1 + 1')
     return $result?stats instance of element()
+};
+
+(: === util:index-report tests === :)
+
+declare
+    %test:assertTrue
+function prof:index-report-returns-element() {
+    let $result := util:index-report('1 + 1')
+    return $result instance of element()
+};
+
+declare
+    %test:assertTrue
+function prof:index-report-with-path() {
+    let $result := util:index-report('//title')
+    return $result instance of element()
 };

--- a/exist-core/src/test/xquery/util/profiling.xql
+++ b/exist-core/src/test/xquery/util/profiling.xql
@@ -164,3 +164,68 @@ function prof:explain-conditional() {
     let $result := util:explain('if (true()) then 1 else 2')
     return exists($result//if)
 };
+
+(: === util:profile tests === :)
+
+declare
+    %test:assertTrue
+function prof:profile-returns-map() {
+    let $result := util:profile('1 + 1')
+    return $result instance of map(*)
+};
+
+declare
+    %test:assertTrue
+function prof:profile-has-result-key() {
+    let $result := util:profile('1 + 1')
+    return map:contains($result, "result")
+};
+
+declare
+    %test:assertTrue
+function prof:profile-has-time-key() {
+    let $result := util:profile('1 + 1')
+    return map:contains($result, "time")
+};
+
+declare
+    %test:assertTrue
+function prof:profile-has-memory-key() {
+    let $result := util:profile('1 + 1')
+    return map:contains($result, "memory")
+};
+
+declare
+    %test:assertTrue
+function prof:profile-has-plan-key() {
+    let $result := util:profile('1 + 1')
+    return map:contains($result, "plan")
+};
+
+declare
+    %test:assertTrue
+function prof:profile-has-stats-key() {
+    let $result := util:profile('1 + 1')
+    return map:contains($result, "stats")
+};
+
+declare
+    %test:assertEquals(2)
+function prof:profile-result-correct() {
+    let $result := util:profile('1 + 1')
+    return $result?result
+};
+
+declare
+    %test:assertTrue
+function prof:profile-plan-is-element() {
+    let $result := util:profile('for $x in 1 to 5 return $x')
+    return $result?plan instance of element()
+};
+
+declare
+    %test:assertTrue
+function prof:profile-stats-is-element() {
+    let $result := util:profile('1 + 1')
+    return $result?stats instance of element()
+};

--- a/exist-core/src/test/xquery/util/profiling.xql
+++ b/exist-core/src/test/xquery/util/profiling.xql
@@ -1,0 +1,115 @@
+xquery version "3.1";
+
+(:~
+ : Tests for util:time(), util:memory(), and util:track() profiling functions.
+ :)
+module namespace prof = "http://exist-db.org/xquery/test/profiling";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+(: === util:time tests === :)
+
+declare
+    %test:assertTrue
+function prof:time-returns-result() {
+    let $result := util:time(1 + 1)
+    return $result eq 2
+};
+
+declare
+    %test:assertEquals(5)
+function prof:time-sequence() {
+    count(util:time(1 to 5))
+};
+
+declare
+    %test:assertEquals("hello")
+function prof:time-with-label() {
+    util:time("hello", "string test")
+};
+
+declare
+    %test:assertTrue
+function prof:time-empty-sequence() {
+    empty(util:time(()))
+};
+
+(: === util:memory tests === :)
+
+declare
+    %test:assertTrue
+function prof:memory-returns-result() {
+    let $result := util:memory(1 + 1)
+    return $result eq 2
+};
+
+declare
+    %test:assertEquals("world")
+function prof:memory-with-label() {
+    util:memory("world", "memory test")
+};
+
+(: === util:track tests === :)
+
+declare
+    %test:assertTrue
+function prof:track-returns-map() {
+    let $result := util:track(1 + 1)
+    return $result instance of map(*)
+};
+
+declare
+    %test:assertTrue
+function prof:track-has-time-key() {
+    let $result := util:track(1 + 1)
+    return map:contains($result, "time")
+};
+
+declare
+    %test:assertTrue
+function prof:track-has-memory-key() {
+    let $result := util:track(1 + 1)
+    return map:contains($result, "memory")
+};
+
+declare
+    %test:assertTrue
+function prof:track-has-value-key() {
+    let $result := util:track(1 + 1)
+    return map:contains($result, "value")
+};
+
+declare
+    %test:assertEquals(2)
+function prof:track-value-correct() {
+    let $result := util:track(1 + 1)
+    return $result?value
+};
+
+declare
+    %test:assertTrue
+function prof:track-time-is-duration() {
+    let $result := util:track(1 to 100)
+    return $result?time instance of xs:dayTimeDuration
+};
+
+declare
+    %test:assertTrue
+function prof:track-memory-is-integer() {
+    let $result := util:track(1 to 100)
+    return $result?memory instance of xs:integer
+};
+
+declare
+    %test:assertTrue
+function prof:track-with-label() {
+    let $result := util:track(1 to 10, "range test")
+    return map:contains($result, "label") and $result?label eq "range test"
+};
+
+declare
+    %test:assertEquals(5)
+function prof:track-sequence-value() {
+    let $result := util:track(1 to 5)
+    return count($result?value)
+};

--- a/exist-core/src/test/xquery/util/profiling.xql
+++ b/exist-core/src/test/xquery/util/profiling.xql
@@ -113,3 +113,54 @@ function prof:track-sequence-value() {
     let $result := util:track(1 to 5)
     return count($result?value)
 };
+
+(: === util:explain tests === :)
+
+declare
+    %test:assertTrue
+function prof:explain-returns-element() {
+    let $result := util:explain('1 + 1')
+    return $result instance of element()
+};
+
+declare
+    %test:assertEquals("explain")
+function prof:explain-root-element() {
+    let $result := util:explain('1 + 1')
+    return local-name($result)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-for-has-for-element() {
+    let $result := util:explain('for $x in 1 to 5 return $x')
+    return exists($result//for)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-let-has-let-element() {
+    let $result := util:explain('let $x := 42 return $x')
+    return exists($result//let)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-path-has-step() {
+    let $result := util:explain('//title')
+    return exists($result//step)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-function-call() {
+    let $result := util:explain('count(1 to 10)')
+    return exists($result//*[contains(@name, "count")])
+};
+
+declare
+    %test:assertTrue
+function prof:explain-conditional() {
+    let $result := util:explain('if (true()) then 1 else 2')
+    return exists($result//if)
+};

--- a/exist-core/src/test/xquery/util/profiling.xql
+++ b/exist-core/src/test/xquery/util/profiling.xql
@@ -186,6 +186,66 @@ function prof:explain-conditional() {
     return exists($result//if)
 };
 
+declare
+    %test:assertTrue
+function prof:explain-has-prolog() {
+    let $result := util:explain('1 + 1')
+    return exists($result/prolog)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-has-body() {
+    let $result := util:explain('1 + 1')
+    return exists($result/body)
+};
+
+declare
+    %test:assertTrue
+function prof:explain-prolog-namespace() {
+    let $result := util:explain(
+        'declare namespace foo = "http://example.com/foo"; 1 + 1'
+    )
+    return exists($result/prolog/namespace[@prefix = "foo"][@uri = "http://example.com/foo"])
+};
+
+declare
+    %test:assertEquals(0)
+function prof:explain-prolog-no-builtins() {
+    (: Built-in prefixes (xs, fn, xsi, xml, local) must not appear in the prolog :)
+    let $result := util:explain('1 + 1')
+    return count($result/prolog/namespace[@prefix = ("xs", "fn", "xsi", "xml", "local", "err", "exist")])
+};
+
+declare
+    %test:assertError("err:XPST0003")
+function prof:explain-parse-error-clear() {
+    (: An unparseable query must surface XPST0003, not a wrapped runtime error :)
+    util:explain('for $x ')
+};
+
+(: === composition tests (point 1 from line-o's review) === :)
+
+declare
+    %test:assertEquals(2)
+function prof:time-memory-compose() {
+    (: util:time(util:memory(...)) must return the inner expression's result :)
+    util:time(util:memory(1 + 1))
+};
+
+declare
+    %test:assertEquals(5)
+function prof:time-memory-compose-sequence() {
+    count(util:time(util:memory(1 to 5, "inner"), "outer"))
+};
+
+declare
+    %test:assertEquals(2)
+function prof:track-of-time() {
+    let $r := util:track(util:time(1 + 1))
+    return $r?value
+};
+
 (: === util:profile tests === :)
 
 declare


### PR DESCRIPTION
## Summary

Adds 5 new XQuery functions for profiling and debugging query performance. Includes XQSuite tests.

## What Changed

- `util:time($expr)` — measure execution time
- `util:memory($expr)` — measure memory allocation
- `util:track($expr)` — combined time + memory tracking
- `util:explain($expr)` — show query plan
- `util:profile($expr)` — detailed profiling with index usage

## Tests

- exist-core: 6,575 run, 0 failures, 0 errors
- Codacy: 0 new issues (6 fixed)

## Test plan

- [x] exist-core unit tests pass (6,575 run, 0 failures)
- [x] Profiling functions return valid data on sample queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)