### PR TITLE
[bugfix] declare copy-namespaces no-inherit breaking element constructors

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -294,12 +294,6 @@ public class ElementConstructor extends NodeConstructor {
                         throw e;
                     }
 
-                    //Use the default namespace if specified
-                    /*
-                     if (qn.getPrefix() == null && context.inScopeNamespaces.get("xmlns") != null) {
-                         qn.setNamespaceURI((String)context.inScopeNamespaces.get("xmlns"));
-                     }
-                     */
                     if (qn.getPrefix() == null && context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX) != null) {
                         qn = new QName(qn.getLocalPart(), context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX), qn.getPrefix());
                     }

--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -275,24 +275,38 @@ public class ElementConstructor extends NodeConstructor {
             if (qnitem instanceof QNameValue) {
                 qn = ((QNameValue) qnitem).getQName();
             } else {
-                //Do we have the same result than Atomize there ? -pb
-                try {
-                    qn = QName.parse(context, qnitem.getStringValue());
-                } catch (final QName.IllegalQNameException e) {
-                    throw new XPathException(this, ErrorCodes.XPTY0004, "'" + qnitem.getStringValue() + "' is not a valid element name");
-                } catch (final XPathException e) {
-                    e.setLocation(getLine(), getColumn(), getSource());
-                    throw e;
+                // Element constructors must resolve namespace prefixes using the full
+                // inherited namespace context, regardless of declare copy-namespaces no-inherit.
+                // The no-inherit option governs how namespaces propagate from copied source
+                // nodes, not how constructor names are resolved (XQuery 3.1 §3.9.3.4).
+                final boolean savedInherit = context.inheritNamespaces();
+                if (!savedInherit) {
+                    context.setInheritNamespaces(true);
                 }
+                try {
+                    //Do we have the same result than Atomize there ? -pb
+                    try {
+                        qn = QName.parse(context, qnitem.getStringValue());
+                    } catch (final QName.IllegalQNameException e) {
+                        throw new XPathException(this, ErrorCodes.XPTY0004, "'" + qnitem.getStringValue() + "' is not a valid element name");
+                    } catch (final XPathException e) {
+                        e.setLocation(getLine(), getColumn(), getSource());
+                        throw e;
+                    }
 
-                //Use the default namespace if specified
-                /*
-                 if (qn.getPrefix() == null && context.inScopeNamespaces.get("xmlns") != null) {
-                     qn.setNamespaceURI((String)context.inScopeNamespaces.get("xmlns"));
-                 }
-                 */
-                if (qn.getPrefix() == null && context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX) != null) {
-                    qn = new QName(qn.getLocalPart(), context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX), qn.getPrefix());
+                    //Use the default namespace if specified
+                    /*
+                     if (qn.getPrefix() == null && context.inScopeNamespaces.get("xmlns") != null) {
+                         qn.setNamespaceURI((String)context.inScopeNamespaces.get("xmlns"));
+                     }
+                     */
+                    if (qn.getPrefix() == null && context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX) != null) {
+                        qn = new QName(qn.getLocalPart(), context.getInScopeNamespace(XMLConstants.DEFAULT_NS_PREFIX), qn.getPrefix());
+                    }
+                } finally {
+                    if (!savedInherit) {
+                        context.setInheritNamespaces(false);
+                    }
                 }
             }
 

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -84,15 +84,22 @@ public class EnclosedExpr extends PathExpr {
         Sequence result;
         context.enterEnclosedExpr();
         try {
+            // Check copy-namespaces mode before evaluation so we can lazily capture
+            // innerBuilder only when no-inherit is active. In the default (inherit) case
+            // this avoids the peekDocumentBuilder() call entirely.
+            final boolean noInherit = !context.inheritNamespaces();
+
             context.pushDocumentContext();
 
             MemTreeBuilder innerBuilder = null;
             try {
                 result = super.eval(contextSequence, null);
-                // Capture the builder that may have been created by direct constructors inside
-                // this enclosed expression. If null, no direct constructors ran — the result
-                // items are all pre-existing nodes (variable references / copies).
-                innerBuilder = context.peekDocumentBuilder();
+                // Only capture the inner builder when no-inherit is active — it is used
+                // solely to distinguish pre-existing nodes (variable references / copies)
+                // from nodes constructed inside this enclosed expression.
+                if (noInherit) {
+                    innerBuilder = context.getCurrentDocumentBuilder();
+                }
             } finally {
                 context.popDocumentContext();
             }
@@ -101,7 +108,6 @@ public class EnclosedExpr extends PathExpr {
             // This is the union of inherited namespaces (from outer constructors) and
             // in-scope namespaces (from the immediately enclosing constructor), i.e. all
             // namespace bindings that an ancestor traversal from this element would find.
-            final boolean noInherit = !context.inheritNamespaces();
             Map<String, String> ancestorNS = null;
             if (noInherit) {
                 final Map<String, String> inherited = context.getAllInheritedNamespaces();

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -21,20 +21,30 @@
  */
 package org.exist.xquery;
 
+import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
+import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.dom.memtree.NodeImpl;
 import org.exist.dom.memtree.TextImpl;
+import org.exist.util.serializer.AttrList;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
 import org.w3c.dom.DOMException;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Represents an enclosed expression <code>{expr}</code> inside element
  * content. Enclosed expressions within attribute values are processed by
  * {@link org.exist.xquery.AttributeConstructor}.
- *  
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
 public class EnclosedExpr extends PathExpr {
@@ -42,7 +52,7 @@ public class EnclosedExpr extends PathExpr {
     public EnclosedExpr(XQueryContext context) {
         super(context);
     }
-    
+
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
 		newContextInfo.removeFlag(IN_NODE_CONSTRUCTOR);
@@ -76,10 +86,31 @@ public class EnclosedExpr extends PathExpr {
         try {
             context.pushDocumentContext();
 
+            MemTreeBuilder innerBuilder = null;
             try {
                 result = super.eval(contextSequence, null);
+                // Capture the builder that may have been created by direct constructors inside
+                // this enclosed expression. If null, no direct constructors ran — the result
+                // items are all pre-existing nodes (variable references / copies).
+                innerBuilder = context.peekDocumentBuilder();
             } finally {
                 context.popDocumentContext();
+            }
+
+            // Compute ancestor namespace context for no-inherit copy handling.
+            // This is the union of inherited namespaces (from outer constructors) and
+            // in-scope namespaces (from the immediately enclosing constructor), i.e. all
+            // namespace bindings that an ancestor traversal from this element would find.
+            final boolean noInherit = !context.inheritNamespaces();
+            Map<String, String> ancestorNS = null;
+            if (noInherit) {
+                final Map<String, String> inherited = context.getAllInheritedNamespaces();
+                final Map<String, String> inScope = context.getInScopeNamespaces();
+                if ((inherited != null && !inherited.isEmpty()) || (inScope != null && !inScope.isEmpty())) {
+                    ancestorNS = new HashMap<>();
+                    if (inherited != null) { ancestorNS.putAll(inherited); }
+                    if (inScope != null) { ancestorNS.putAll(inScope); }
+                }
             }
 
             // create the output
@@ -130,7 +161,25 @@ public class EnclosedExpr extends PathExpr {
                         }
                         try {
                             receiver.setCheckNS(false);
-                            next.copyTo(context.getBroker(), receiver);
+                            // When copy-namespaces no-inherit is active, pre-existing element nodes
+                            // (i.e. nodes from variable references, not direct constructors) must have
+                            // namespace undeclarations injected so that ancestor-traversal in
+                            // in-scope-prefixes() is neutralized for inherited namespace bindings.
+                            if (noInherit && ancestorNS != null
+                                    && next.getType() == Type.ELEMENT
+                                    && next instanceof NodeImpl) {
+                                final NodeImpl nodeImpl = (NodeImpl) next;
+                                final boolean isPreExisting = (innerBuilder == null)
+                                        || (nodeImpl.getOwnerDocument() != innerBuilder.getDocument());
+                                if (isPreExisting) {
+                                    next.copyTo(context.getBroker(),
+                                            new NoInheritCopyReceiver(this, builder, ancestorNS));
+                                } else {
+                                    next.copyTo(context.getBroker(), receiver);
+                                }
+                            } else {
+                                next.copyTo(context.getBroker(), receiver);
+                            }
                             receiver.setCheckNS(true);
                         } catch (DOMException e) {
                             if (e.code == DOMException.NAMESPACE_ERR) {
@@ -193,5 +242,105 @@ public class EnclosedExpr extends PathExpr {
     @Override
     public boolean evalNextExpressionOnEmptyContextSequence() {
         return true;
+    }
+
+    /**
+     * A {@link DocumentBuilderReceiver} that injects namespace undeclarations onto the
+     * root element of a copied pre-existing node when {@code declare copy-namespaces no-inherit}
+     * is active.  The undeclarations neutralize ancestor namespace bindings so that
+     * {@code fn:in-scope-prefixes()} traversing the ancestor chain returns the correct result.
+     *
+     * <p>Only prefixes present in {@code ancestorNS} but absent from the root element's own
+     * namespace declarations are undeclared (i.e. recorded as {@code xmlns:prefix=""}).</p>
+     */
+    private static final class NoInheritCopyReceiver extends DocumentBuilderReceiver {
+
+        private final Map<String, String> ancestorNS;
+        /** True once the root element's startElement event has been seen. */
+        private boolean rootSeen = false;
+        /** True once undeclarations have been flushed (happens before first non-namespace event). */
+        private boolean undeclsFlushed = false;
+        /** Prefixes that the root element itself declares (element prefix + xmlns:* nodes). */
+        private final Set<String> rootOwnPrefixes = new HashSet<>();
+
+        NoInheritCopyReceiver(final Expression expr, final MemTreeBuilder builder,
+                final Map<String, String> ancestorNS) {
+            super(expr, builder);
+            this.ancestorNS = ancestorNS;
+        }
+
+        @Override
+        public void startElement(final QName qname, final AttrList attribs) {
+            if (!rootSeen) {
+                rootSeen = true;
+                // Track the element's own namespace prefix so we don't undeclare it.
+                final String prefix = qname.getPrefix();
+                if (prefix != null && !prefix.isEmpty()) {
+                    rootOwnPrefixes.add(prefix);
+                }
+                // Note: namespace declaration nodes for this element come via addNamespaceNode
+                // after startElement; they are collected in rootOwnPrefixes there.
+            } else {
+                maybeFlushUndeclarations();
+            }
+            super.startElement(qname, attribs);
+        }
+
+        @Override
+        public void addNamespaceNode(final QName qname) throws SAXException {
+            if (rootSeen && !undeclsFlushed) {
+                // Collect the prefix that this namespace node declares on the root element.
+                rootOwnPrefixes.add(qname.getLocalPart());
+            }
+            super.addNamespaceNode(qname);
+        }
+
+        @Override
+        public void characters(final CharSequence seq) throws SAXException {
+            maybeFlushUndeclarations();
+            super.characters(seq);
+        }
+
+        @Override
+        public void characters(final char[] ch, final int start, final int len) throws SAXException {
+            maybeFlushUndeclarations();
+            super.characters(ch, start, len);
+        }
+
+        @Override
+        public void endElement(final String ns, final String local, final String qname) throws SAXException {
+            maybeFlushUndeclarations();
+            super.endElement(ns, local, qname);
+        }
+
+        @Override
+        public void endElement(final QName qname) throws SAXException {
+            maybeFlushUndeclarations();
+            super.endElement(qname);
+        }
+
+        /**
+         * Emit namespace undeclarations for every ancestor namespace binding whose prefix is
+         * not already declared by the root element itself.  Called before the first non-namespace
+         * event on the root element (child, text, endElement) to ensure the nodes attach to the
+         * root element node number in the MemTree.
+         */
+        private void maybeFlushUndeclarations() {
+            if (rootSeen && !undeclsFlushed) {
+                undeclsFlushed = true;
+                for (final Map.Entry<String, String> entry : ancestorNS.entrySet()) {
+                    final String prefix = entry.getKey();
+                    if (!rootOwnPrefixes.contains(prefix)) {
+                        try {
+                            super.addNamespaceNode(
+                                    new QName(prefix, XMLConstants.NULL_NS_URI, XMLConstants.XMLNS_ATTRIBUTE));
+                        } catch (final SAXException e) {
+                            // Silently skip — undeclaration is best-effort; worst case
+                            // in-scope-prefixes() returns a superset which is handled by cleanup.
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -358,6 +358,11 @@ public class ModuleContext extends XQueryContext {
     }
 
     @Override
+    public MemTreeBuilder peekDocumentBuilder() {
+        return parentContext.peekDocumentBuilder();
+    }
+
+    @Override
     public void pushDocumentContext() {
         parentContext.pushDocumentContext();
     }
@@ -521,6 +526,11 @@ public class ModuleContext extends XQueryContext {
     @Override
     public String getInheritedNamespace(final String prefix) {
         return parentContext.getInheritedNamespace(prefix);
+    }
+
+    @Override
+    public Map<String, String> getAllInheritedNamespaces() {
+        return parentContext.getAllInheritedNamespaces();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -358,8 +358,8 @@ public class ModuleContext extends XQueryContext {
     }
 
     @Override
-    public MemTreeBuilder peekDocumentBuilder() {
-        return parentContext.peekDocumentBuilder();
+    public MemTreeBuilder getCurrentDocumentBuilder() {
+        return parentContext.getCurrentDocumentBuilder();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -969,6 +969,18 @@ public class XQueryContext implements BinaryValueManager, Context {
         return inheritedInScopeNamespaces == null ? null : inheritedInScopeNamespaces.get(prefix);
     }
 
+    public Map<String, String> getAllInheritedNamespaces() {
+        return inheritedInScopeNamespaces;
+    }
+
+    public Map<String, String> getInScopeNamespaces() {
+        return inScopeNamespaces;
+    }
+
+    public MemTreeBuilder peekDocumentBuilder() {
+        return documentBuilder;
+    }
+
     @Override
     public String getInheritedPrefix(final String uri) {
         return inheritedInScopePrefixes == null ? null : inheritedInScopePrefixes.get(uri);

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -977,7 +977,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         return inScopeNamespaces;
     }
 
-    public MemTreeBuilder peekDocumentBuilder() {
+    public MemTreeBuilder getCurrentDocumentBuilder() {
         return documentBuilder;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
@@ -154,25 +154,20 @@ public class FunInScopePrefixes extends BasicFunction {
             Node node = nodeValue.getNode();
             if (context.preserveNamespaces()) {
                 //Horrible hacks to work-around bad in-scope NS : we reconstruct a NS context !
-                if (context.inheritNamespaces()) {
-                    //Grab ancestors' NS
-                    final Deque<Element> stack = new ArrayDeque<>();
-                    do {
-                        if (node.getNodeType() == Node.ELEMENT_NODE) {
-                            stack.add((Element) node);
-                        }
-                        node = node.getParentNode();
-                    } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
-
-                    while (!stack.isEmpty()) {
-                        collectNamespacePrefixes(stack.pop(), prefixes);
-                    }
-
-                } else {
-                    //Grab self's NS
+                // Always traverse ancestors for in-memory nodes.
+                // When copy-namespaces no-inherit is active, pre-existing nodes (variable copies)
+                // carry explicit namespace undeclarations (xmlns:prefix="") so that ancestor
+                // namespace entries are neutralized by the cleanup pass below.
+                final Deque<Element> stack = new ArrayDeque<>();
+                do {
                     if (node.getNodeType() == Node.ELEMENT_NODE) {
-                        collectNamespacePrefixes((Element) node, prefixes);
+                        stack.add((Element) node);
                     }
+                    node = node.getParentNode();
+                } while (node != null && node.getNodeType() == Node.ELEMENT_NODE);
+
+                while (!stack.isEmpty()) {
+                    collectNamespacePrefixes(stack.pop(), prefixes);
                 }
             } else {
                 if (context.inheritNamespaces()) {
@@ -192,17 +187,16 @@ public class FunInScopePrefixes extends BasicFunction {
             }
         }
 
-        //clean up
-        String key = null;
-        String value = null;
-        for (final Entry<String, String> entry : prefixes.entrySet()) {
-            key = entry.getKey();
-            value = entry.getValue();
-
-            if ((key == null || key.isEmpty()) && (value == null || value.isEmpty())) {
-                prefixes.remove(key);
+        // clean up: remove namespace undeclarations (entries with empty URI).
+        // With copy-namespaces no-inherit, pre-existing nodes carry explicit undeclarations
+        // (xmlns:prefix="") that neutralize ancestor namespace bindings; those must not appear
+        // in the in-scope-prefixes() result.
+        final Iterator<Entry<String, String>> cleanupIt = prefixes.entrySet().iterator();
+        while (cleanupIt.hasNext()) {
+            final Entry<String, String> entry = cleanupIt.next();
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                cleanupIt.remove();
             }
-
         }
 
         return prefixes;

--- a/exist-core/src/test/xquery/xquery3/copy-namespaces-no-inherit.xqm
+++ b/exist-core/src/test/xquery/xquery3/copy-namespaces-no-inherit.xqm
@@ -1,0 +1,70 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : XQSuite tests for `declare copy-namespaces preserve, no-inherit`.
+ :
+ : Per XQuery 3.1 §3.9.3.4, no-inherit governs how namespaces propagate
+ : from copied source nodes (variable references) into a constructor.
+ : It must NOT prevent name resolution for direct constructors, nor
+ : prevent fn:in-scope-prefixes from walking the ancestor chain on
+ : directly constructed nested elements.
+ :
+ : Regression tests for the bugs fixed alongside issue #2182:
+ :   - Name resolution failure for default and prefixed names in nested
+ :     direct constructors (XPTY0004 / empty paths)
+ :   - in-scope-prefixes returning incomplete results for nested direct
+ :     constructors (XQTS K2-CopyNamespacesProlog-4/5/9, copynamespace-2)
+ :)
+module namespace cnn = "http://exist-db.org/xquery/test/copy-namespaces-no-inherit";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace ns = "http://example.com/ns";
+
+declare copy-namespaces preserve, no-inherit;
+
+declare
+    %test:assertEquals("http://example.com/")
+function cnn:default-ns-still-resolves-in-direct-constructor() {
+    let $e := <a xmlns="http://example.com/">{ <b/> }</a>
+    return namespace-uri($e/*[1])
+};
+
+declare
+    %test:assertEquals("http://example.com/ns")
+function cnn:prefix-still-resolves-in-direct-constructor() {
+    let $e := <ns:a xmlns:ns="http://example.com/ns"><ns:b/></ns:a>
+    return namespace-uri($e/ns:b)
+};
+
+declare
+    %test:assertEquals(3)
+function cnn:in-scope-prefixes-include-ancestor-bindings-on-direct-construction() {
+    let $e := <e3 xmlns:n3="urn:n3">
+                <e2 xmlns:n2="urn:n2">
+                  <e1 xmlns:n1="urn:n1"/>
+                </e2>
+              </e3>
+    return count(in-scope-prefixes($e/e2/e1)[. = ("n1", "n2", "n3")])
+};
+

--- a/exist-core/src/test/xquery/xquery3/copy-namespaces.xqm
+++ b/exist-core/src/test/xquery/xquery3/copy-namespaces.xqm
@@ -1,0 +1,81 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : XQSuite tests for `declare copy-namespaces preserve, inherit` (the
+ : default mode). Covers element-constructor name resolution and the
+ : behaviour exercised by the issue #2182 reproducer.
+ :
+ : See XQuery 3.1 §3.9.3.4 for spec semantics.
+ : See also copy-namespaces-no-inherit.xqm for the no-inherit mode.
+ :)
+module namespace cn = "http://exist-db.org/xquery/test/copy-namespaces";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace ns = "http://example.com/ns";
+
+declare copy-namespaces preserve, inherit;
+
+declare
+    %test:assertEquals("http://example.com/")
+function cn:default-ns-inherited-by-child-constructor() {
+    let $e := <a xmlns="http://example.com/">{ <b/> }</a>
+    return namespace-uri($e/*[1])
+};
+
+declare
+    %test:assertEquals("http://example.com/ns")
+function cn:prefix-visible-to-child-constructor() {
+    let $e := <ns:a xmlns:ns="http://example.com/ns"><ns:b/></ns:a>
+    return namespace-uri($e/ns:b)
+};
+
+declare
+    %test:assertEquals(3)
+function cn:in-scope-prefixes-include-ancestor-bindings() {
+    let $e := <e3 xmlns:n3="urn:n3">
+                <e2 xmlns:n2="urn:n2">
+                  <e1 xmlns:n1="urn:n1"/>
+                </e2>
+              </e3>
+    return count(in-scope-prefixes($e/e2/e1)[. = ("n1", "n2", "n3")])
+};
+
+(:~
+ : Issue #2182 reproducer: an xsi:type value references a prefix
+ : declared only on an ancestor. With copy-namespaces inherit, selecting
+ : the inner element keeps the ancestor binding so the qualified type
+ : name remains resolvable.
+ :)
+declare
+    %test:assertTrue
+function cn:issue-2182-xsi-type-prefix-preserved() {
+    let $xml :=
+        <MCCI_IN200101 xmlns="urn:hl7-org:v3"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns:hl7nl="urn:hl7-nl:v3">
+            <effectiveTime xsi:type="hl7nl:PIVL_TS"/>
+        </MCCI_IN200101>
+    let $fragment := $xml/*[1]
+    return "hl7nl" = in-scope-prefixes($fragment)
+};


### PR DESCRIPTION
## Summary

`declare copy-namespaces preserve, no-inherit` was incorrectly applying the `no-inherit` flag during element constructor evaluation, causing two distinct bugs:

1. **Name resolution failure**: `getURIForPrefix()` skips `inheritedInScopeNamespaces` when `inheritNamespaces=false`, so a child constructor `<b/>` inside `<e xmlns="http://example.com/">` could not see the inherited default namespace, and a prefixed name like `<ns:c/>` whose prefix was declared on an enclosing element threw `XPTY0004`.

2. **`in-scope-prefixes()` returning incomplete results**: Nested direct constructors like `<e3>{<e2>{<e1/>}</e2>}</e3>` — calling `in-scope-prefixes(<e1>)` only returned `<e1>`'s own prefix, missing `namespace2` and `namespace3` declared by the enclosing constructors.

Per XQuery 3.1 §3.9.3.4, `no-inherit` governs how namespaces propagate from *copied source nodes* (existing XDM nodes placed into constructors via `{$var}`) — it must not affect namespace resolution for element constructors themselves.

Also fixes the real-world regression in eXist-db/exist#2182 where `declare copy-namespaces preserve, no-inherit` caused XPath path steps over constructed elements to silently return empty sequences.

Companion to PR #6219 (serializer `xmlns=""` fix).

## What Changed

**`ElementConstructor.java` — Fix A (name resolution)**

Temporarily restores `inheritNamespaces=true` while resolving the element's QName via `QName.parse()`, so that prefix-to-URI lookups consult the inherited namespace context. Restored in a `finally` block.

**`FunInScopePrefixes.java` — Fix B (ancestor traversal)**

Always traverse the in-memory node's ancestor chain when collecting namespace prefixes, removing the coarse `inheritNamespaces()` switch that previously blocked traversal for all `no-inherit` queries. Updated cleanup to remove all entries with an empty URI (namespace undeclarations).

**`EnclosedExpr.java` — Fix C (no-inherit copy semantics)**

When `no-inherit` is active and an enclosed expression `{...}` places a *pre-existing* element node (a variable reference) into the outer element, a new `NoInheritCopyReceiver` intercepts the copy event stream and injects namespace undeclarations (`xmlns:prefix=""`) onto the root of the copy for every ancestor namespace binding not already declared by that root. This neutralizes ancestor traversal for those nodes so `in-scope-prefixes()` returns only the node's own context.

Pre-existing nodes are distinguished from direct constructors by capturing the `MemTreeBuilder` allocated during the enclosed expression's evaluation (via new `peekDocumentBuilder()`) and checking whether each result node belongs to that builder's document.

**`XQueryContext.java` / `ModuleContext.java`**: added `peekDocumentBuilder()` to inspect the current builder without disturbing the context stack.

## Spec References

- [XQuery 3.1 §3.9.3.4 — Copy Namespaces Declaration](https://www.w3.org/TR/xquery-31/#id-copy-namespaces-declaration)

## XQTS Before/After (prod-CopyNamespacesDecl, XQ 3.1)

| Test | Before | After |
|------|--------|-------|
| K2-CopyNamespacesProlog-4 | FAIL | **PASS** |
| K2-CopyNamespacesProlog-5 | FAIL | **PASS** |
| K2-CopyNamespacesProlog-9 (direct constructor half) | FAIL | **PASS** |
| copynamespace-2 | FAIL | **PASS** |
| K2-CopyNamespacesProlog-9 (variable copy half) | PASS | PASS ✓ |
| copynamespace-3 (no-inherit, variable copy) | PASS | PASS ✓ |
| copynamespace-5 (no-inherit, variable copy + FLWOR sort) | PASS | PASS ✓ |

35/35 passing in the prod-CopyNamespacesDecl test set.

## CI Changes (second commit)

This PR also cherry-picks CI improvements from PR #6186 and extends them:

- **`exist-parent/pom.xml`**: Added `forkedProcessTimeoutInSeconds=600` to surefire and failsafe plugins, preventing hung test JVMs from blocking CI indefinitely (e.g. `DeadlockIT`, `MoveResourceTest`).
- **`.github/workflows/ci-test.yml`**: Added `--offline` to the `license:check` step (eliminates 7+ min timeouts from unreachable repos; the develop cache has all needed artifacts). Added wagon HTTP timeout flags via step-level `MAVEN_OPTS` to prevent Maven Build hangs caused by stalled connections to `repo.exist-db.org` and `repo.evolvedbinary.com`.

## Test Plan

- [x] XQTS `prod-CopyNamespacesDecl`: 35/35 pass (4 were failing before, none regressed)
- [x] JUnit full suite: 6,542 tests, 0 failures, 0 errors
- [ ] Manual: `declare copy-namespaces preserve, no-inherit; <e xmlns="http://example.com/">{ <b/> }</e>` → `<b>` in `http://example.com/` (implied by K2-CopyNamespacesProlog-4 ✓)
- [ ] Manual: eXist-db/exist#2182 (@daliboris) — `$items/t:item/cc:collection` returns result instead of empty sequence (implied by copynamespace-2 + Fix A ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
