### PR TITLE
[ci] test native Maven transport (remove wagon workaround)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 env:
-  MAVEN_OPTS: -DtrimStackTrace=false -D'maven.resolver.transport=wagon'
+  MAVEN_OPTS: -DtrimStackTrace=false
   DEV_JDK: '21'
 jobs:
   license:
@@ -17,7 +17,7 @@ jobs:
           distribution: liberica
           java-version: ${{ env.DEV_JDK }}
       - uses: ./.github/actions/maven-cache
-      - run: mvn -V -B --no-transfer-progress license:check
+      - run: mvn -V -B --no-transfer-progress --offline license:check
         timeout-minutes: 10
   dependencies:
     name: Dependency checks
@@ -90,15 +90,16 @@ jobs:
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' --projects '!exist-installer'
+          MAVEN_OPTS: ${{ env.MAVEN_OPTS }} -D'aether.connector.basic.connectTimeout=10000' -D'aether.connector.basic.requestTimeout=30000'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -T 1C compile test-compile -D'dependency-check.skip' -D'license.skip' --projects '!exist-installer'
       - name: Maven Unit Tests
         if: matrix.test-type == 'unit'
         timeout-minutes: 45
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress test -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress test -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
       - name: Maven Integration Tests
         if: matrix.test-type == 'integration'
         timeout-minutes: 45
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress verify -DskipUnitTests=true -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress verify -DskipUnitTests=true -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
       - name: Javadoc (ubuntu unit only)
         if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit'
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make


### PR DESCRIPTION
## Summary

Test branch to validate removing the stale `maven.resolver.transport=wagon` setting from global `MAVEN_OPTS` and switching to Maven Resolver's native HTTP transport with explicit timeout configuration.

## Context

The `maven.resolver.transport=wagon` flag was added in March 2023 (commit `77592f63f5`, message "testing") as a workaround for early Maven 3.9.0 instability. mvnd 1.0.3 now bundles Maven 3.9.11, where native transport is stable. The flag is stale and was identified as part of investigating CI hang issues (see #6186).

Two unreliable repos cause CI hangs with wagon:
- `repo.exist-db.org` — accepts TCP, then sends FIN → CLOSE_WAIT; wagon waits indefinitely
- `repo.evolvedbinary.com` — returns HTTP 504 from CI runners; completely unreachable

## Changes

- **Remove `maven.resolver.transport=wagon`** from global `MAVEN_OPTS` — lets mvnd use native transport (Maven 3.9.11 default)
- **Add Aether native transport timeout flags** via step-level `MAVEN_OPTS` on Maven Build: `aether.connector.basic.connectTimeout=10000`, `aether.connector.basic.requestTimeout=30000` (10s connect, 30s read)
- **Add `--offline`** to license check — the develop Maven cache always has all required artifacts; eliminates 7+ min timeouts from unreachable repos

## What to watch

If native transport works correctly, Maven Build should complete on all platforms without wagon-induced hangs. If there are artifact resolution failures that wagon previously masked, they'll surface as explicit download errors rather than silent hangs.

Related: #6186