### PR TITLE
[bugfix] Make zip test with illegal filenames pass consistently.

### DIFF
--- a/extensions/modules/compression/src/test/xquery/modules/compression/unzip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/unzip-tests.xql
@@ -83,7 +83,7 @@ function uz:fnUzipUtf8ContentWrongEncoding() {
 
 declare
     %test:user("guest", "guest")
-	%test:assertError("(?:MALFORMED)|(?:malformed)")
+	%test:assertError("(?:MALFORMED|malformed|invalid LOC header)")
 function uz:fnUzipCp437ContentWrongEncoding() {
     (: This case is not working because the Unicode extended filename table is not present in non unicode encoded Zip :)
     compression:unzip($uz:myStaticCP437ContentBase64, util:function(xs:QName("local:entry-filter"), 3), (), util:function(xs:QName("local:entry-data"), 4), (), "UTF8")


### PR DESCRIPTION
Modified unzip-tests.xql to relax the error expectation for uz: fnUzipCp437ContentWrongEncoding: Updated the %test: assertError regex to include invalid LOC header, which is the standard error message thrown by java.util.zip.ZipInputStream (specifically ZipException) in Java 17+ and 21 when encountering malformed encoding in ZIP

Somehow this issue irregularly appeared for local builds java21/25 only.