### PR TITLE
[ci] Fix Moderne CLI install URL (pkgs.moderne.io → app.moderne.io/cli)

### DIFF
--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -21,9 +21,8 @@ jobs:
 
       - name: Install Moderne CLI
         run: |
-          curl -sSL https://pkgs.moderne.io/moderne-cli/latest/linux/mod > mod
-          chmod +x mod
-          sudo mv mod /usr/local/bin/
+          curl -sSL https://app.moderne.io/cli | bash
+          echo "$HOME/.moderne/cli/bin" >> $GITHUB_PATH
 
       - name: Configure Moderne
         run: |


### PR DESCRIPTION
## Summary

- Fixes the broken `Install Moderne CLI` step in `.github/workflows/prethink.yml`
- The `pkgs.moderne.io` hostname no longer resolves (DNS failure, exit code 6)
- Replaces it with the official install script at `https://app.moderne.io/cli`, which downloads the mod wrapper from Maven Central

## What Changed

**`.github/workflows/prethink.yml`**
- Replaced `curl -sSL https://pkgs.moderne.io/moderne-cli/latest/linux/mod > mod` with `curl -sSL https://app.moderne.io/cli | bash`
- Adds `~/.moderne/cli/bin` to `$GITHUB_PATH` so subsequent steps can invoke `mod`

## Test Plan

- [x] Install step confirmed working via manual `workflow_dispatch` run on fork
- [x] `mod` CLI installs successfully and proceeds to Configure and Build LSTs steps
- [ ] Full end-to-end run (requires `MODERNE_TOKEN` secret in `eXist-db/exist` Actions secrets)

> **Note:** `MODERNE_TOKEN` needs to be added to this repo's Actions secrets (Settings → Secrets and variables → Actions) for the full workflow to complete. The token can be found at https://app.moderne.io/settings/access-token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)