### PR TITLE
[ci] Add maven-github-settings to prethink workflow

### DIFF
--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -29,6 +29,10 @@ jobs:
           mod config moderne edit https://app.moderne.io --token ${{ secrets.MODERNE_TOKEN }}
           mod config recipes jar install io.moderne.recipe:rewrite-prethink:LATEST
 
+      - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build LSTs
         run: mod build .
 


### PR DESCRIPTION
## Summary

Fixes the Prethink context refresh workflow, which has been failing on every run since it was introduced.

## Root cause

The Moderne CLI's `mod build .` step runs `mvn package io.moderne:modmaven:compileLst` internally to compile a Lossless Semantic Tree (LST). This Maven build requires authentication to resolve packages from `maven.pkg.github.com/eXist-db/exist`. Without a `settings.xml` providing those credentials, dependency resolution fails and the build exits after ~3.5 minutes with `"The Maven build failed"`.

All other CI workflows include `.github/actions/maven-github-settings` for exactly this reason. The prethink workflow was missing it.

## What Changed

- `.github/workflows/prethink.yml`: add `maven-github-settings` step (with `GITHUB_TOKEN`) immediately before `mod build .`

## Test Plan

- [ ] Trigger workflow manually after merge — `mod build .` should progress past "Resolving dependencies" and produce a successful LST

Closes the failure reported by @dizzzz on #6237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)