### PR TITLE
[bugfix] Upgrade jansi - revise pom

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -221,19 +221,12 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>4.0.12</version>
-            <classifier>jdk11</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jline</groupId>
-            <artifactId>jansi</artifactId>
             <version>${jansi.version}</version>
+            <classifier>jdk11</classifier>
             <!--
                 Optionally used by jline at runtime on Linux and macOS,
                 and required by jline at runtime on Windows.
             -->
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
fix for last PR #6250 

but it looks that we need indeed both...
---
https://www.perplexity.ai/search/059316bd-32b0-4eff-bd2a-02ad85066f56

In JLine 4, `jline.jar` and `jansi.jar` (both `org.jline` artifacts) are **different modules** with different responsibilities, even though they share or relate to the same native code.

## What `jline.jar` (v4) does

- `jline.jar` is the **core JLine library** that provides terminal abstractions, line editing, history, completion, and prompt handling for console‑like applications.[3][7]
- It depends on a “terminal provider” (JNA, JNI, Jansi, FFM, etc.) but does **not** itself contain the low‑level ANSI or console‑native logic; it just orchestrates the terminal and input layer.[10]

## What `jansi.jar` (v4) does

- `jansi.jar` is the **ANSI‑forwarding / console I/O layer** that handles ANSI escape sequences, color formatting, and low‑level access to the native console (e.g., `libjansi`‑style native bits).[2][7]
- In JLine 3/4, Jansi has been merged and refined into JLine’s own stack, so `org.jline:jansi` (or `jline-jansi-core`) is the focused ANSI/console module that JLine can plug in as a terminal provider.[2][3]

## Why they seem similar

- Both JLine and Jansi can **load the same native library** (`libjansi`‑style) on the OS, so the native part is shared, which is why you see “same native libs”.[16][2]
- JLine 4.x uses Jansi as one of several possible **terminal providers** (Jansi, JNI, FFM, JNA), so you see both jars when you have `jline` plus `jansi`‑based terminal support on the classpath.[10]

## Practical takeaway

- If you only need **ANSI coloring** (e.g., `Ansi.ansi()`‑style output), `jansi.jar` is enough by itself.
- If you need **interactive console behavior** (line editing, history, prompts, etc.), you **must** also depend on `jline.jar` (or the JLine‑provided terminal‑builder APIs) and wire it to a terminal provider (often Jansi‑based).[3][10]

So: `jline.jar` = high‑level terminal/console framework; `jansi.jar` = the low‑level ANSI/console‑native layer they both can share.

Sources
[1] Releases · fusesource/jansi https://github.com/fusesource/jansi/releases
[2] jline3/README.md at master · jline/jline3 https://github.com/jline/jline3/blob/master/README.md
[3] JLine is a Java library for handling console input. https://github.com/jline/jline3
[4] JLine 3: finalize jna vs. jansi choice, including legalities · Issue #677 · scala/scala-dev https://github.com/scala/scala-dev/issues/677
[5] Snippets https://central.sonatype.com/artifact/org.jline/jline-terminal-jansi
[6] org.jline:jansi on Maven https://libraries.io/maven/org.jline:jansi/3.27.1
[7] JLine Architecture https://jline.org/docs/architecture/
[8] JLine http://jline.org/jline2/dependencies.html
[9] jline - Maven Repository https://mvnrepository.com/artifact/jline/jline
[10] Terminal Providers - JLine https://jline.org/docs/modules/terminal-providers/
[11] jline-terminal-jansi 3.30.5 javadoc (org.jline) https://javadoc.io/doc/org.jline/jline-terminal-jansi/latest/index.html
[12] org.jline:jansi 3.30.6 on Maven - Libraries.io - security ... https://libraries.io/maven/org.jline:jansi
[13] jline-native 3.27.1 javadoc (org.jline) https://www.javadoc.io/doc/org.jline/jline-native
[14] JLine3 "Unable to create a system terminal" after build https://stackoverflow.com/questions/50737843/jline3-unable-to-create-a-system-terminal-after-build/50740881
[15] Maven Central: org.jline:jline:3.23.0 https://central.sonatype.com/artifact/org.jline/jline/3.23.0
[16] UnsatisfiedLinkError when using terminal-jansi on Linux · Issue #112 · jline/jline3 https://github.com/jline/jline3/issues/112
