### PR TITLE
fn:json-doc: resolve URIs from dynamically available text resources

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -39,8 +39,7 @@ import org.exist.xquery.value.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.FunctionDSL.*;
 import static org.exist.xquery.functions.fn.FnModule.functionSignatures;
 
@@ -228,7 +227,7 @@ public class JSON extends BasicFunction {
                 url = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + url;
             }
             // Check dynamically available text resources first (e.g., XQTS test resources)
-            try (final Reader dynamicTextResource = context.getDynamicallyAvailableTextResource(url, StandardCharsets.UTF_8)) {
+            try (final Reader dynamicTextResource = context.getDynamicallyAvailableTextResource(url, UTF_8)) {
                 if (dynamicTextResource != null) {
                     final StringBuilder sb = new StringBuilder();
                     final char[] buf = new char[4096];

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -38,6 +38,8 @@ import org.exist.xquery.value.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import static org.exist.xquery.FunctionDSL.*;
 import static org.exist.xquery.functions.fn.FnModule.functionSignatures;
@@ -225,6 +227,24 @@ public class JSON extends BasicFunction {
             if (url.indexOf(':') == Constants.STRING_NOT_FOUND) {
                 url = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + url;
             }
+            // Check dynamically available text resources first (e.g., XQTS test resources)
+            try (final Reader dynamicTextResource = context.getDynamicallyAvailableTextResource(url, StandardCharsets.UTF_8)) {
+                if (dynamicTextResource != null) {
+                    final StringBuilder sb = new StringBuilder();
+                    final char[] buf = new char[4096];
+                    int read;
+                    while ((read = dynamicTextResource.read(buf)) != -1) {
+                        sb.append(buf, 0, read);
+                    }
+                    try (final JsonParser parser = factory.createParser(sb.toString())) {
+                        final Item result = readValue(context, parser, handleDuplicates);
+                        return result == null ? Sequence.EMPTY_SEQUENCE : result.toSequence();
+                    } catch (final IOException jsonErr) {
+                        throw new XPathException(this, ErrorCodes.FOJS0001, jsonErr.getMessage());
+                    }
+                }
+            }
+
             final Source source = SourceFactory.getSource(context.getBroker(), "", url, false);
             if (source == null) {
                 throw new XPathException(this, ErrorCodes.FOUT1170, "failed to load json doc from URI " + url);


### PR DESCRIPTION
## Summary

- `fn:json-doc()` now checks dynamically available text resources before falling through to `SourceFactory.getSource()`, mirroring the pattern used by `fn:doc()` (via `DocUtils`) and `fn:unparsed-text()`
- This enables XQTS `fn-json-doc` tests to pass: the test runner registers environment `<resource>` elements as text resources with their catalog URIs; previously `fn:json-doc()` only tried `SourceFactory`, which attempted (and failed) to fetch the test URIs over HTTP
- XQTS results: **52 of 76** `fn-json-doc` tests now pass (up from ~8); remaining 24 failures are pre-existing issues (Unicode surrogate handling, `xs:double` vs `xs:decimal`, duplicate-key handling, etc.)

## Test plan

- [x] Verified `exist-core` compiles cleanly on `develop`
- [x] Ran XQTS `fn-json-doc` test set against modified build: 52/76 passing
- [x] Confirmed remaining failures are unrelated to resource resolution
- [ ] Verify no regressions in other `fn:json-doc`-related test sets (`fn-json-to-xml`, `fn-parse-json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)