### PR TITLE
[optimize] XQuery local-variable resolution and dead cache removal

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocalVariable.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocalVariable.java
@@ -35,6 +35,22 @@ public class LocalVariable extends VariableImpl {
 	protected LocalVariable before = null;
 	protected LocalVariable after = null;
 
+	/**
+	 * For O(1) variable resolution: the previous LocalVariable with the same
+	 * {@link #getQName()} that was the topmost binding before this one was
+	 * declared. Used by {@link XQueryContext#popLocalVariables} to restore the
+	 * shadowed binding when this variable goes out of scope.
+	 */
+	LocalVariable prevSameName = null;
+
+	/**
+	 * The {@link #contextStack} marker that was on top when this variable was
+	 * declared. A variable is visible in the current scope iff
+	 * {@code markedUnder == contextStack.peek()}; the previous linked-list
+	 * walk used to express this by stopping at {@code contextStack.peek()}.
+	 */
+	LocalVariable markedUnder = null;
+
     public LocalVariable(QName qname) {
         super(qname);
     }

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -57,9 +57,6 @@ public class LocationStep extends Step {
     protected UpdateListener listener = null;
     protected Expression parent = null;
 
-    // Fields for caching the last result
-    protected CachedResult cached = null;
-
     //private int parentDeps = Dependency.UNKNOWN_DEPENDENCY;
     private boolean preloadedData = false;
     protected boolean optimized = false;
@@ -350,30 +347,6 @@ public class LocationStep extends Step {
         if (contextItem != null) {
             contextSequence = contextItem.toSequence();
         }
-        /*
-         * if(contextSequence == null) //Commented because this the high level
-         * result nodeset is *really* null result = NodeSet.EMPTY_SET; //Try to
-         * return cached results else
-         */
-        // TODO: disabled cache for now as it may cause concurrency issues
-        // better use compile-time inspection and maybe a pragma to mark those
-        // sections in the query that can be safely cached
-        // if (cached != null && cached.isValid(contextSequence, contextItem)) {
-        //
-        // // WARNING : commented since predicates are *also* applied below !
-        // // -pb
-        // /*
-        // * if (predicates.size() > 0) { applyPredicate(contextSequence,
-        // * cached.getResult()); } else {
-        // */
-        // result = cached.getResult();
-        // if (context.getProfiler().isEnabled()) {
-        // LOG.debug("Using cached results");
-        // }
-        // context.getProfiler().message(this, Profiler.OPTIMIZATIONS,
-        // "Using cached results", result);
-        //
-        // // }
 
         Sequence result;
         if (needsComputation()) {
@@ -455,11 +428,8 @@ public class LocationStep extends Step {
         } else {
             result = NodeSet.EMPTY_SET;
         }
-        // Caches the result
         if (axis != Constants.SELF_AXIS && contextSequence != null
                 && contextSequence.isCacheable()) {
-            // TODO : cache *after* removing duplicates ? -pb
-            cached = new CachedResult(contextSequence, contextItem, result);
             registerUpdateListener();
         }
         // Remove duplicate nodes
@@ -1214,7 +1184,6 @@ public class LocationStep extends Step {
             listener = new UpdateListener() {
                 @Override
                 public void documentUpdated(final DocumentImpl document, final int event) {
-                    cached = null;
                     if (document == null || event == UpdateListener.ADD || event == UpdateListener.REMOVE) {
                         // clear all
                         currentDocs = null;
@@ -1272,7 +1241,6 @@ public class LocationStep extends Step {
             currentSet = null;
             currentDocs = null;
             optimized = false;
-            cached = null;
             listener = null;
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
@@ -28,7 +28,9 @@ import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author wolf
@@ -36,6 +38,7 @@ import java.util.List;
 public class UserDefinedFunction extends Function implements Cloneable {
 
     private final List<QName> parameters = new ArrayList<>(5);
+    private final Set<QName> parameterNames = new HashSet<>();
     protected boolean visited = false;
     private Expression body;
     private Sequence[] currentArguments = null;
@@ -67,7 +70,7 @@ public class UserDefinedFunction extends Function implements Cloneable {
     }
 
     public void addVariable(QName varName) throws XPathException {
-        if (parameters.contains(varName)) {
+        if (!parameterNames.add(varName)) {
             throw new XPathException(this, ErrorCodes.XQST0039, "function " + getName() + " already has a parameter with the name " + varName);
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2501,22 +2501,24 @@ public class XQueryContext implements BinaryValueManager, Context {
      * @param resultSeq the result sequence
      */
     public void popLocalVariables(@Nullable final LocalVariable var, @Nullable final Sequence resultSeq) {
-        if (var != null) {
-            // Restore localVariableLookup bindings in REVERSE-of-declaration order
-            // so each var's prevSameName chain unwinds correctly. (Walking forward
-            // would leave the map pointing at a popped variable when multiple vars
-            // share a name within the popped scope.)
-            for (LocalVariable cursor = lastVar; cursor != null && cursor != var; cursor = cursor.before) {
-                if (localVariableLookup.get(cursor.getQName()) == cursor) {
-                    if (cursor.prevSameName != null) {
-                        localVariableLookup.put(cursor.getQName(), cursor.prevSameName);
-                    } else {
-                        localVariableLookup.remove(cursor.getQName());
-                    }
+        // Restore localVariableLookup bindings in REVERSE-of-declaration order
+        // so each var's prevSameName chain unwinds correctly. (Walking forward
+        // would leave the map pointing at a popped variable when multiple vars
+        // share a name within the popped scope.) Runs whether or not {@code var}
+        // is null: when {@code var == null}, every binding from {@code lastVar}
+        // back to the start is being popped, so the whole chain must unwind.
+        for (LocalVariable cursor = lastVar; cursor != null && cursor != var; cursor = cursor.before) {
+            if (localVariableLookup.get(cursor.getQName()) == cursor) {
+                if (cursor.prevSameName != null) {
+                    localVariableLookup.put(cursor.getQName(), cursor.prevSameName);
+                } else {
+                    localVariableLookup.remove(cursor.getQName());
                 }
-                cursor.prevSameName = null;
             }
+            cursor.prevSameName = null;
+        }
 
+        if (var != null) {
             // clear all variables registered after var. they should be out of scope.
             LocalVariable outOfScope = var.after;
             while (outOfScope != null) {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -188,11 +188,13 @@ public class XQueryContext implements BinaryValueManager, Context {
     // The last element in the linked list of local in-scope variables
     private LocalVariable lastVar = null;
 
-    // O(1) lookup table from QName to the most-recently-declared LocalVariable
-    // with that name. Maintained alongside the {@link #lastVar} linked list:
-    // declareVariableBinding adds, popLocalVariables restores the prevSameName
-    // chain. Visibility is enforced in resolveLocalVariable by comparing
-    // {@link LocalVariable#markedUnder} to {@code contextStack.peek()}.
+    /**
+     * O(1) lookup table from QName to the most-recently-declared LocalVariable
+     * with that name. Maintained alongside the {@link #lastVar} linked list:
+     * declareVariableBinding adds, popLocalVariables restores the prevSameName
+     * chain. Visibility is enforced in resolveLocalVariable by comparing
+     * {@link LocalVariable#markedUnder} to {@code contextStack.peek()}.
+     */
     // Shared by reference with copies of this context (see copyFields,
     // updateContext) just like {@link #contextStack} and {@link #lastVar}.
     private Map<QName, LocalVariable> localVariableLookup = new HashMap<>();
@@ -2044,7 +2046,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         if (var == null) {
             return null;
         }
-        // Visibility: var is visible iff it was declared under the current
+        // Visibility: var is visible if it was declared under the current
         // contextStack mark — the same boundary the linked-list walk used to
         // express by stopping at {@code contextStack.peek()}.
         if (var.markedUnder != contextStack.peek()) {
@@ -2497,16 +2499,16 @@ public class XQueryContext implements BinaryValueManager, Context {
     /**
      * Restore the local variable stack to the position marked by variable var.
      *
+     * <p>Walks {@link #lastVar} backward to {@code var} (or to the start when
+     * {@code var} is {@code null}), unwinding each variable's
+     * {@code prevSameName} chain into {@link #localVariableLookup} in
+     * REVERSE-of-declaration order so that names with multiple bindings in the
+     * popped scope settle on the still-visible binding, not on a popped one.
+     *
      * @param var       only clear variables after this variable, or null
      * @param resultSeq the result sequence
      */
     public void popLocalVariables(@Nullable final LocalVariable var, @Nullable final Sequence resultSeq) {
-        // Restore localVariableLookup bindings in REVERSE-of-declaration order
-        // so each var's prevSameName chain unwinds correctly. (Walking forward
-        // would leave the map pointing at a popped variable when multiple vars
-        // share a name within the popped scope.) Runs whether or not {@code var}
-        // is null: when {@code var == null}, every binding from {@code lastVar}
-        // back to the start is being popped, so the whole chain must unwind.
         for (LocalVariable cursor = lastVar; cursor != null && cursor != var; cursor = cursor.before) {
             if (localVariableLookup.get(cursor.getQName()) == cursor) {
                 if (cursor.prevSameName != null) {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -188,6 +188,15 @@ public class XQueryContext implements BinaryValueManager, Context {
     // The last element in the linked list of local in-scope variables
     private LocalVariable lastVar = null;
 
+    // O(1) lookup table from QName to the most-recently-declared LocalVariable
+    // with that name. Maintained alongside the {@link #lastVar} linked list:
+    // declareVariableBinding adds, popLocalVariables restores the prevSameName
+    // chain. Visibility is enforced in resolveLocalVariable by comparing
+    // {@link LocalVariable#markedUnder} to {@code contextStack.peek()}.
+    // Shared by reference with copies of this context (see copyFields,
+    // updateContext) just like {@link #contextStack} and {@link #lastVar}.
+    private Map<QName, LocalVariable> localVariableLookup = new HashMap<>();
+
     private Deque<LocalVariable> contextStack = new ArrayDeque<>();
 
     private final Deque<FunctionSignature> callStack = new ArrayDeque<>();
@@ -658,6 +667,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         this.watchdog = from.watchdog;
         this.lastVar = from.lastVar;
         this.contextStack = from.contextStack;
+        this.localVariableLookup = from.localVariableLookup;
         this.inScopeNamespaces = from.inScopeNamespaces;
         this.inScopePrefixes = from.inScopePrefixes;
         this.inheritedInScopeNamespaces = from.inheritedInScopeNamespaces;
@@ -728,6 +738,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         ctx.lastVar = this.lastVar;
         ctx.variableStackSize = getCurrentStackSize();
         ctx.contextStack = this.contextStack;
+        ctx.localVariableLookup = this.localVariableLookup;
         ctx.staticNamespaces = new HashMap<>(this.staticNamespaces);
         ctx.staticPrefixes = new HashMap<>(this.staticPrefixes);
 
@@ -1426,6 +1437,7 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         if (!isShared) {
             lastVar = null;
+            localVariableLookup.clear();
         }
 
         // clear inline functions using closures
@@ -1891,6 +1903,8 @@ public class XQueryContext implements BinaryValueManager, Context {
         }
         lastVar = var;
         var.setStackPosition(getCurrentStackSize());
+        var.markedUnder = contextStack.peek();
+        var.prevSameName = localVariableLookup.put(var.getQName(), var);
         return var;
     }
 
@@ -2024,16 +2038,19 @@ public class XQueryContext implements BinaryValueManager, Context {
     }
 
     protected Variable resolveLocalVariable(final QName qname) throws XPathException {
-        final LocalVariable end = contextStack.peek();
-        for (LocalVariable var = lastVar; var != null; var = var.before) {
-            if (var == end) {
-                return null;
-            }
-            if (qname.equals(var.getQName())) {
-                return var;
-            }
+        // O(1) fast path. The linked-list walk previously here is O(N) per
+        // call and O(N²) when a body of N variables is analyzed.
+        final LocalVariable var = localVariableLookup.get(qname);
+        if (var == null) {
+            return null;
         }
-        return null;
+        // Visibility: var is visible iff it was declared under the current
+        // contextStack mark — the same boundary the linked-list walk used to
+        // express by stopping at {@code contextStack.peek()}.
+        if (var.markedUnder != contextStack.peek()) {
+            return null;
+        }
+        return var;
     }
 
     /**
@@ -2485,6 +2502,21 @@ public class XQueryContext implements BinaryValueManager, Context {
      */
     public void popLocalVariables(@Nullable final LocalVariable var, @Nullable final Sequence resultSeq) {
         if (var != null) {
+            // Restore localVariableLookup bindings in REVERSE-of-declaration order
+            // so each var's prevSameName chain unwinds correctly. (Walking forward
+            // would leave the map pointing at a popped variable when multiple vars
+            // share a name within the popped scope.)
+            for (LocalVariable cursor = lastVar; cursor != null && cursor != var; cursor = cursor.before) {
+                if (localVariableLookup.get(cursor.getQName()) == cursor) {
+                    if (cursor.prevSameName != null) {
+                        localVariableLookup.put(cursor.getQName(), cursor.prevSameName);
+                    } else {
+                        localVariableLookup.remove(cursor.getQName());
+                    }
+                }
+                cursor.prevSameName = null;
+            }
+
             // clear all variables registered after var. they should be out of scope.
             LocalVariable outOfScope = var.after;
             while (outOfScope != null) {


### PR DESCRIPTION
## Summary

Two independent XQuery engine optimizations with no regressions across XQuery3Tests (1227 tests, identical baseline failures), QT4 fn-* / HOF / XQUF sets, and app-XMark.

### 1. `XQueryContext.resolveLocalVariable` — O(N) → O(1)

The previous implementation walked a linked list of `LocalVariable`s backward from `lastVar`, stopping at the current `contextStack` mark. For a function body of N parameters analyzing N variable references this is O(N²). For the 123,456-arity reference in QT4 `misc-HigherOrderFunctions/hof-025`, this lookup alone cost 22.6s.

A `{QName → LocalVariable}` HashMap now points to the most recently declared binding for each name. Each `LocalVariable` carries:

- `prevSameName` — the binding shadowed by this declaration; used by `popLocalVariables` to unwind the chain when the variable goes out of scope.
- `markedUnder` — the `contextStack` frame this variable was declared under. A binding is in scope iff `markedUnder == contextStack.peek()`.

The HashMap is shared by reference with context copies (`copyFields`, `updateContext`) alongside `lastVar` and `contextStack`, so module and forked contexts see the same in-scope variables.

### 2. `UserDefinedFunction.addVariable` — O(N) → O(1)

The duplicate-parameter check used `parameters.contains`, an O(N) ArrayList scan, making parameter-list construction O(N²). For hof-025 this loop alone cost ~8s. A HashSet<QName> alongside the ordered List gives O(1) duplicate detection while preserving insertion order.

### 3. `LocationStep`: remove dead `CachedResult` write

The `CachedResult` write inside `LocationStep.eval` was a leftover from a removed code path. Its result was never read. Removed.

## XQTS impact (QT4 vs `qt4-rd-2026-04-26` baseline)

| Test set | Before | After | Speedup |
|----------|--------|-------|---------|
| `misc-HigherOrderFunctions` | 36.81s | 1.49s | 24x (-4 failures) |
| `hof-025` alone | 33.81s | 0.25s | 135x |
| `app-XMark` | 29.64s | 13.13s | 2.3x (FLWOR var-resolution) |
| `fn-fold-left` | 6.23s | 3.73s | 1.7x |
| `fn-fold-right` | 3.45s | 1.09s | 3.2x |
| `upd-*` (16 sets) | — | — | 1.5x–4.7x, no regressions |

XQuery3Tests JUnit: 1227 tests, identical failure set.

## Note on a third optimization

A companion optimization for `fn:divide-decimals` exists in our integration branches but depends on `FnDivideDecimals.java`, which lives on `v2/xq4-core-functions`. It will be reapplied here once that branch merges.

## Test plan

- [x] `mvn install -pl exist-core -am -DskipTests` passes
- [x] `mvn test -pl exist-core -Dtest=xquery.xquery3.XQuery3Tests` — 1227 tests, baseline failures only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)