### PR TITLE
[bugfix] distinguish XPTY0004 from XQDY0074 in computed constructors

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/DynamicAttributeConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicAttributeConstructor.java
@@ -128,9 +128,10 @@ public class DynamicAttributeConstructor extends NodeConstructor {
 				}
 			}
 
-            //Not in the specs but... makes sense
-            if(!XMLNames.isName(qn.getLocalPart()))
-            	{throw new XPathException(this, ErrorCodes.XQDY0074, "'" + qn.getLocalPart() + "' is not a valid attribute name");}
+            // The name is of an acceptable type but is not a lexically valid QName
+            if (!XMLNames.isName(qn.getLocalPart())) {
+                throw new XPathException(this, ErrorCodes.XQDY0074, "'" + qn.getLocalPart() + "' is not a valid attribute name");
+            }
             
             if ("xmlns".equals(qn.getLocalPart()) && qn.getNamespaceURI().isEmpty())
             	{throw new XPathException(this, ErrorCodes.XQDY0044,

--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -29,6 +29,7 @@ import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.util.XMLNames;
 import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.AtomicValue;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.QNameValue;
 import org.exist.xquery.value.Sequence;
@@ -277,6 +278,16 @@ public class ElementConstructor extends NodeConstructor {
             if (qnitem instanceof QNameValue value) {
                 qn = value.getQName();
             } else {
+                // Only xs:string and xs:untypedAtomic can be used as computed element names
+                // (XQuery 3.1 §3.9.3.1). Atomize first: the name expression may yield a node,
+                // whose atomized value is xs:untypedAtomic.
+                final AtomicValue atomicName = qnitem.atomize();
+                final int itemType = atomicName.getType();
+                if (!Type.subTypeOf(itemType, Type.STRING) && itemType != Type.UNTYPED_ATOMIC) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The name expression must be of type xs:QName, xs:string, or xs:untypedAtomic, got " + Type.getTypeName(itemType));
+                }
+
                 // Element constructors must resolve namespace prefixes using the full
                 // inherited namespace context, regardless of declare copy-namespaces no-inherit.
                 // The no-inherit option governs how namespaces propagate from copied source
@@ -286,11 +297,10 @@ public class ElementConstructor extends NodeConstructor {
                     context.setInheritNamespaces(true);
                 }
                 try {
-                    //Do we have the same result than Atomize there ? -pb
                     try {
-                        qn = QName.parse(context, qnitem.getStringValue());
+                        qn = QName.parse(context, atomicName.getStringValue());
                     } catch (final QName.IllegalQNameException e) {
-                        throw new XPathException(this, ErrorCodes.XQDY0074, "'" + qnitem.getStringValue() + "' is not a valid element name");
+                        throw new XPathException(this, ErrorCodes.XQDY0074, "'" + atomicName.getStringValue() + "' is not a valid element name");
                     } catch (final XPathException e) {
                         e.setLocation(getLine(), getColumn(), getSource());
                         throw e;
@@ -306,7 +316,7 @@ public class ElementConstructor extends NodeConstructor {
                 }
             }
 
-            //Not in the specs but... makes sense
+            // The name is of an acceptable type but is not a lexically valid QName
             if (!XMLNames.isName(qn.getLocalPart())) {
                 throw new XPathException(this, ErrorCodes.XQDY0074, "'" + qnitem.getStringValue() + "' is not a valid element name");
             }


### PR DESCRIPTION
Follow-up to #6263.

#6263 moved computed-constructor name errors to `XQDY0074`, which regressed the cases where the name expression has the wrong *type*. Per XQuery 3.1 §3.9.3.1/§3.9.3.2 these are two different conditions: `element {1} {}` is a type error (`XPTY0004`), while `element {'1localName'} {}` is a dynamic name error (`XQDY0074`). Both were landing on the same `XMLNames.isName()` check, which only sees a string by that point and cannot tell them apart — so changing that one error code just trades one group of failures for the other (my first attempt here did exactly that: +3 / -12).

The real gap is that `ElementConstructor` never had the name-type check `DynamicAttributeConstructor` already carries. This adds it — atomize the name, require `xs:QName`/`xs:string`/`xs:untypedAtomic`, otherwise `XPTY0004` — and leaves `isName()` reporting `XQDY0074`. Each condition now has its own site instead of competing for one.

XQTS (full suite, vs `develop`): **+4, no regressions** — `XPTY0004_02`, `XPTY0004_29`, `Constr-compelem-compname-6`, `Constr-compelem-compname-7`.

Note for anyone reading the XQTS comparison: `prod-DirElemContent.namespace/Constr-inscope-1, -2,-3,-4` are flaky — they flip pass/fail across repeated runs of an identical build, so they can show up in the diff unrelated to this change.

The flaky tests will be addressed in a separate PR