### PR TITLE
[bugfix] Improve XQTS CI comparison output with gross counts and pass tracking

### DIFF
--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -82,8 +82,10 @@
         <xsl:variable name="skipped" select="sum($testsuite/@skipped/xs:integer(.))" as="xs:integer"/>
         <xsl:variable name="failures" select="sum($testsuite/@failures/xs:integer(.))" as="xs:integer"/>
         <xsl:variable name="errors" select="sum($testsuite/@errors/xs:integer(.))" as="xs:integer"/>
+        <xsl:variable name="pass" select="$tests - $skipped - $failures - $errors" as="xs:integer"/>
+        <xsl:variable name="pass-pct" select="if ($tests eq 0) then 0 else (100 * $pass) div $tests" as="xs:decimal"/>
         <xsl:document>
-            <cr:results tests="{$tests}" pass="{$tests - $skipped - $failures - $errors}" skipped="{$skipped}" failures="{$failures}" errors="{$errors}" time="{sum($testsuite/@time/xs:float(.))}">
+            <cr:results tests="{$tests}" pass="{$pass}" pass-pct="{$pass-pct}" skipped="{$skipped}" failures="{$failures}" errors="{$errors}" time="{sum($testsuite/@time/xs:float(.))}">
                 <cr:skipped>
                     <xsl:sequence select="$testsuite/testcase[skipped]"/>
                 </cr:skipped>
@@ -109,7 +111,14 @@
         <xsl:variable name="current-attr" select="$current-results/@*[local-name(.) eq $attr-name]"/>
         
         <xsl:attribute name="{$attr-name}" select="$current-attr - $previous-attr"/>
-        <xsl:attribute name="{$attr-name}-pct" select="(($current-attr - $previous-attr) div $previous-attr) * 100"/>
+        <xsl:choose>
+            <xsl:when test="$attr-name eq 'pass'">
+                <xsl:attribute name="pass-pct-delta" select="xs:decimal($current-results/@pass-pct) - xs:decimal($previous-results/@pass-pct)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:attribute name="{$attr-name}-pct" select="(($current-attr - $previous-attr) div $previous-attr) * 100"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:function>
 
     <xsl:function name="cr:new-changes">

--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -38,6 +38,11 @@
     <xsl:template name="compare-results" as="document-node(element(cr:comparison))">
         <xsl:variable name="previous-summary" select="cr:summarise-results($xqts.previous.junit-data-path)" as="document-node(element(cr:results))"/>
         <xsl:variable name="current-summary" select="cr:summarise-results($xqts.current.junit-data-path)" as="document-node(element(cr:results))"/>
+        <xsl:variable name="new-changes" as="element()+">
+            <xsl:for-each select="('pass', 'skipped', 'failures', 'errors')">
+                <xsl:sequence select="cr:new-changes($previous-summary/cr:results, $current-summary/cr:results, .)"/>
+            </xsl:for-each>
+        </xsl:variable>
         <xsl:document>
             <cr:comparison>
                 <cr:previous>
@@ -52,14 +57,17 @@
                 </cr:current>
                 <cr:change>
                     <cr:results>
-                        <xsl:for-each select="('tests', 'skipped', 'failures', 'errors', 'time')">
-                            <xsl:sequence select="cr:calculate-change($previous-summary/cr:results, $current-summary/cr:results, .)"/>
+                        <xsl:for-each select="('tests', 'pass', 'skipped', 'failures', 'errors')">
+                            <xsl:variable name="attr-name" select="." as="xs:string"/>
+                            <xsl:sequence select="cr:calculate-change($previous-summary/cr:results, $current-summary/cr:results, $attr-name)"/>
+                            <xsl:if test="$attr-name = ('pass', 'skipped', 'failures', 'errors')">
+                                <xsl:attribute name="{$attr-name}-new" select="count($new-changes[local-name(.) eq $attr-name]/testcase)"/>
+                            </xsl:if>
                         </xsl:for-each>
+                        <xsl:sequence select="cr:calculate-change($previous-summary/cr:results, $current-summary/cr:results, 'time')"/>
                     </cr:results>
                     <cr:new>
-                        <xsl:for-each select="('pass', 'skipped', 'failures', 'errors')">
-                            <xsl:sequence select="cr:new-changes($previous-summary/cr:results, $current-summary/cr:results, .)"/>
-                        </xsl:for-each>
+                        <xsl:sequence select="$new-changes"/>
                     </cr:new>
                 </cr:change>
             </cr:comparison>
@@ -70,8 +78,12 @@
         <xsl:param name="junit-data-path" as="xs:string" required="yes"/>
         <xsl:variable name="collection-uri" select="concat($junit-data-path, '?select=*.xml')"/>
         <xsl:variable name="testsuite" select="collection($collection-uri)/testsuite"/>
+        <xsl:variable name="tests" select="sum($testsuite/@tests/xs:integer(.))" as="xs:integer"/>
+        <xsl:variable name="skipped" select="sum($testsuite/@skipped/xs:integer(.))" as="xs:integer"/>
+        <xsl:variable name="failures" select="sum($testsuite/@failures/xs:integer(.))" as="xs:integer"/>
+        <xsl:variable name="errors" select="sum($testsuite/@errors/xs:integer(.))" as="xs:integer"/>
         <xsl:document>
-            <cr:results tests="{sum($testsuite/@tests/xs:integer(.))}" skipped="{sum($testsuite/@skipped/xs:integer(.))}" failures="{sum($testsuite/@failures/xs:integer(.))}" errors="{sum($testsuite/@errors/xs:integer(.))}" time="{sum($testsuite/@time/xs:float(.))}">
+            <cr:results tests="{$tests}" pass="{$tests - $skipped - $failures - $errors}" skipped="{$skipped}" failures="{$failures}" errors="{$errors}" time="{sum($testsuite/@time/xs:float(.))}">
                 <cr:skipped>
                     <xsl:sequence select="$testsuite/testcase[skipped]"/>
                 </cr:skipped>


### PR DESCRIPTION
## Summary

The XQTS CI comparison currently shows only net deltas under
`cr:change/cr:results`, which is misleading: a `failures: -6` delta
can hide 12 new failures alongside 18 newly passing tests. Per
@line-o's suggestion in #6272, this PR adds gross counts and pass
tracking so the comparison is unambiguous.

Closes https://github.com/eXist-db/exist/issues/6272

## What Changed

`exist-xqts/src/main/xslt/compare-results.xslt`:

- Added `pass` attribute to `cr:summarise-results` output (derived as
  `tests - skipped - failures - errors`).
- Added absolute `pass-pct` (`100 * pass div tests`) to both
  `cr:previous/cr:results` and `cr:current/cr:results` so the pass
  rate is visible at a glance on each side of the comparison.
- Under `cr:change/cr:results`, added `pass` (delta in pass count)
  and `pass-pct-delta` (`current.pass-pct - previous.pass-pct`,
  expressed in percentage points) — replacing the previous
  `pass-pct`, which was a relative-change percent of the pass count
  and hard to interpret.
- Added gross counts to `cr:change/cr:results`: `pass-new`,
  `skipped-new`, `failures-new`, `errors-new`. These count the
  testcases under `cr:new/cr:<category>` (i.e. testcases that didn't
  exist under that category in the previous run).
- The `cr:new` block is now computed once into a variable and reused
  for both the gross-count attributes and the emitted detail elements,
  per @line-o's preferred single-loop approach.
- Existing net-delta attributes (`tests`, `tests-pct`, `skipped`,
  `skipped-pct`, `failures`, `failures-pct`, `errors`, `errors-pct`,
  `time`, `time-pct`) are preserved unchanged for backward compatibility.

## Sample Output

Comparing two QT4 result sets where the current run added 51 new
tests and saw a substantial number of category transitions:

```xml
<cr:comparison>
  <cr:previous>
    <cr:results tests="36965" pass="31674" pass-pct="85.69"
                skipped="1118" failures="3433" errors="740"
                time="232.4"/>
  </cr:previous>
  <cr:current>
    <cr:results tests="37016" pass="32169" pass-pct="86.91"
                skipped="871" failures="3237" errors="739"
                time="256.4"/>
  </cr:current>
  <cr:change>
    <cr:results tests="51" tests-pct="0.14"
                pass="495" pass-pct-delta="1.22" pass-new="972"
                skipped="-247" skipped-pct="-22.09" skipped-new="0"
                failures="-196" failures-pct="-5.71" failures-new="178"
                errors="-1" errors-pct="-0.14" errors-new="6"
                time="23.99" time-pct="10.33"/>
    <cr:new>
      <cr:pass>...972 testcases...</cr:pass>
      <cr:skipped/>
      <cr:failures>...178 testcases...</cr:failures>
      <cr:errors>...6 testcases...</cr:errors>
    </cr:new>
  </cr:change>
</cr:comparison>
```

Reading at a glance:

- `cr:previous/@pass-pct="85.69"` and `cr:current/@pass-pct="86.91"` —
  absolute pass rates on each side.
- `cr:change/@pass="495"` — net 495 more tests passing this run.
- `cr:change/@pass-pct-delta="1.22"` — pass rate rose by 1.22
  percentage points.
- `cr:change/@failures="-196"` looks like progress, but
  `cr:change/@failures-new="178"` shows 178 tests started failing in
  this run — surfacing regressions that were previously masked.

## Test Plan

- [x] Ran the XSLT locally with `Saxon-HE 9.9.1-8` against synthetic
  and real QT4 result sets and verified output structure.
- [x] Verified `cr:previous/@pass-pct` and `cr:current/@pass-pct`
  show absolute pass percentages.
- [x] Verified `cr:change/@pass-pct-delta` equals
  `current.pass-pct - previous.pass-pct`.
- [x] Verified `pass-new`, `failures-new`, `errors-new`,
  `skipped-new` match the counts of `<testcase>` elements in their
  corresponding `cr:new/cr:<category>` blocks.
- [x] Existing net-delta attributes (`tests`, `tests-pct`,
  `skipped`, `skipped-pct`, `failures`, `failures-pct`, `errors`,
  `errors-pct`, `time`, `time-pct`) unchanged in shape/semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
