### PR TITLE
[bugfix] Run DatabaseResources query cleanup in a finally block

### DIFF
--- a/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
+++ b/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
@@ -135,6 +135,10 @@ public class DatabaseResources {
     }
 
     public Sequence executeQuery(final String queryPath, final Map<String, String> params, final Subject user) {
+        return executeQuery(new XQueryContext(brokerPool), queryPath, params, user);
+    }
+
+    Sequence executeQuery(final XQueryContext context, final String queryPath, final Map<String, String> params, final Subject user) {
 
         final String namespace = params.get(TARGETNAMESPACE);
         final String publicId = params.get(PUBLICID);
@@ -146,7 +150,6 @@ public class DatabaseResources {
         }
 
         Sequence result = null;
-        final XQueryContext context = new XQueryContext(brokerPool);
         try (final DBBroker broker = brokerPool.get(Optional.ofNullable(user))) {
 
             final XQuery xquery = brokerPool.getXQueryService();

--- a/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
+++ b/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
@@ -34,6 +34,7 @@ import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.BinaryValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 
@@ -173,8 +174,20 @@ public class DatabaseResources {
         } catch (final EXistException | XPathException | IOException | PermissionDeniedException ex) {
             logger.error("Problem executing xquery", ex);
             result = null;
-            context.runCleanupTasks();
-
+        } finally {
+            // Don't close BinaryValues that are part of the result the caller
+            // will read; mirrors the predicate used by LocalXPathQueryService.
+            final Sequence resSeq = result;
+            context.runCleanupTasks(o -> {
+                if (resSeq != null && o instanceof BinaryValue) {
+                    for (int i = 0; i < resSeq.getItemCount(); i++) {
+                        if (resSeq.itemAt(i) == o) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            });
         }
         return result;
     }

--- a/exist-core/src/test/java/org/exist/validation/internal/DatabaseResourcesTest.java
+++ b/exist-core/src/test/java/org/exist/validation/internal/DatabaseResourcesTest.java
@@ -1,0 +1,66 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.validation.internal;
+
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.exist.TestUtils.ADMIN_DB_PWD;
+import static org.exist.TestUtils.ADMIN_DB_USER;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DatabaseResourcesTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void cleanupRunsOnSuccessPath() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final Subject admin = pool.getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+
+        final DatabaseResources resources = new DatabaseResources(pool);
+        final XQueryContext context = new XQueryContext(pool);
+
+        final AtomicBoolean cleaned = new AtomicBoolean(false);
+        context.registerCleanupTask((ctx, predicate) -> cleaned.set(true));
+
+        final Map<String, String> params = new HashMap<>();
+        params.put(DatabaseResources.COLLECTION, "/db");
+        params.put(DatabaseResources.TARGETNAMESPACE, "http://example.org/no-such-namespace");
+
+        final Sequence result = resources.executeQuery(context, DatabaseResources.FIND_XSD, params, admin);
+
+        assertNotNull("query should succeed (return an empty sequence, not null)", result);
+        assertTrue("registered cleanup task must run on the success path", cleaned.get());
+    }
+}


### PR DESCRIPTION
## Summary

`DatabaseResources.executeQuery()` -- used by the validation system to
look up grammar/catalog locations from the database -- only invoked
`context.runCleanupTasks()` from its `catch` block. On the common
success path the per-call `XQueryContext` was never cleaned up, so any
`BinaryValue` streams it held stayed open until GC.

This PR moves the cleanup into a `finally` block, using the same
result-aware predicate as `LocalXPathQueryService.execute()` so we
don't close `BinaryValue`s that are part of the result the caller is
about to read.

## What Changed

- `exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java`
  - Move `context.runCleanupTasks(...)` from the `catch` block into a
    new `finally` block so it runs on both success and error paths.
  - Pass a predicate that excludes any `BinaryValue` instance present
    in the result `Sequence`, mirroring the established pattern at
    `LocalXPathQueryService.java:216`.
  - Add `org.exist.xquery.value.BinaryValue` import.
  - Extract a package-private `executeQuery(XQueryContext, ...)`
    overload so a regression test can register a sentinel
    `CleanupTask` on the same context the query runs under. The
    public `executeQuery(...)` overload still creates a fresh context
    and is the only entry point production callers use.

- `exist-core/src/test/java/org/exist/validation/internal/DatabaseResourcesTest.java` (new)
  - `cleanupRunsOnSuccessPath` registers an
    `AtomicBoolean`-flipping `CleanupTask` on a caller-supplied
    `XQueryContext`, runs `FIND_XSD` against `/db` (returns an empty
    sequence -- success path, no exception), and asserts the task
    fired. The test fails against the previous catch-only placement
    ("registered cleanup task must run on the success path") and
    passes with the finally block.

## Reproducer / Issue Reference

Per @line-o's question: there is no existing issue whose reproducer
calls `DatabaseResources`. Issue #5345 (temp-file leak from
`util:string-to-binary` -> `compression:deflate` ->
`response:stream-binary`) flows through `RESTServer` /
`RpcConnection`, not the validation code path that
`DatabaseResources` serves -- @line-o's intuition was correct. The
test added here serves as the reproducer.

`DatabaseResources` is reached only via the validation system
(`grammar` / catalog lookup during XML parsing), and the bundled
queries (`find_schema_by_targetNamespace.xq`,
`find_catalogs_with_dtd.xq`) don't themselves create `BinaryValue`s,
so the user-visible impact in shipped code is limited. The fix
nonetheless closes a structural leak: any future query routed
through `DatabaseResources` would have leaked any registered
`BinaryValue` streams on every successful call.

## Scope Note

This PR addresses one verified bug. The wider scan that prompted the
work flagged additional sites, but on inspection most are already
correct or are intentional design choices:

- `XQuery.execute(DBBroker, String, Sequence)` and
  `XQuery.execute(DBBroker, File, Sequence)` -- the commented-out
  cleanup carries an explicit `NOTE(AR)` comment about the binary
  value lifecycle. Re-enabling cleanup unconditionally would
  re-introduce the documented bug; a safe fix needs a broader
  refactor.
- `Launcher.java` (12 sites), `RpcConnection.java` queueLock,
  `Leasable.java`, both `Modification.java` classes, `RESTServer.java`
  query blocks, `XIncludeFilter.java` -- all already wrap
  `lock()`/`runCleanupTasks()` in `try-finally`.
- `InspectModule`, `ModuleFunctions`, `LoadXQueryModule` -- delegate
  cleanup of their `tempContext` via `addImportedContext()`, so the
  parent context's `runCleanupTasks` cleans them too.

Those are not addressed here.

## Test Plan

- [x] `mvn install -pl exist-core -am -DskipTests` succeeds
- [x] New `DatabaseResourcesTest.cleanupRunsOnSuccessPath` fails on
      the catch-only placement and passes on the finally placement.
- [x] Validation suite remains green:
      `mvn test -pl exist-core -Dtest='DatabaseResourcesTest,*ValidationTest,*ValidationModeTest,DatabaseInsertResourcesWithValidationTest,DatabaseInsertResourcesNoValidationTest,DtdEntityTest,DatabaseCollectionTest,GrammarPoolTest,CollectionConfigurationValidationModeTest,CollectionConfigurationTest'`
      -> 48 run, 0 failures, 0 errors, 3 pre-existing skips.
- [x] Full CI test suite (`mvn test -Ddependency-check.skip=true
      -Dlicense.skip=true -Ddocker=false`) passes for all 56 test
      modules (Core: 3m33s, all extensions/indexes/modules clean).
      The `exist-xqts` module fails at dependency resolution
      (GitHub Packages 401 for `exist-xqts-runner_2.13` -- a local
      auth gap, unrelated to this change).