### PR TITLE
[bugfix] Replace silent exception swallowing with proper logging

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -461,8 +461,13 @@ public class MutableCollection implements Collection {
                         child.allDocs(broker, docs, recursive, lockMap);
                     }
                 } catch(final PermissionDeniedException pde) {
-                    //SKIP to next collection
-                    //TODO create an audit log??!
+                    // The caller is permitted to read this collection, but lacks read
+                    // permission on a sub-collection. Skip it and continue: the result is
+                    // a partial document set, not an error.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Skipping sub-collection {} during allDocs traversal of {}: {}",
+                                subCol, path, pde.getMessage());
+                    }
                 }
             }
         }
@@ -496,8 +501,13 @@ public class MutableCollection implements Collection {
                         child.allDocs(broker, docs, recursive, lockMap, lockType);
                     }
                 } catch (final PermissionDeniedException pde) {
-                    //SKIP to next collection
-                    //TODO create an audit log??!
+                    // The caller is permitted to read this collection, but lacks read
+                    // permission on a sub-collection. Skip it and continue: the result is
+                    // a partial document set, not an error.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Skipping sub-collection {} during allDocs traversal of {}: {}",
+                                uri, path, pde.getMessage());
+                    }
                 }
             }
         }

--- a/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
@@ -642,8 +642,7 @@ public class HttpRequestWrapper implements RequestWrapper {
                     try {
                         values[position] = getPartContentAsString(part, formEncoding);
                     } catch (final IOException e) {
-                        LOG.warn(e);
-                        e.printStackTrace();
+                        LOG.warn("Failed to read multipart form field as string", e);
                     }
 
                 } else {
@@ -664,8 +663,7 @@ public class HttpRequestWrapper implements RequestWrapper {
                 try {
                     values[0] = getPartContentAsString(part, formEncoding);
                 } catch (final IOException e) {
-                    LOG.warn(e);
-                    e.printStackTrace();
+                    LOG.warn("Failed to read multipart form field as string", e);
                 }
 
             } else {

--- a/exist-core/src/main/java/org/exist/source/SourceFactory.java
+++ b/exist-core/src/main/java/org/exist/source/SourceFactory.java
@@ -98,6 +98,10 @@ public class SourceFactory {
                 }
             } catch (final IllegalArgumentException e) {
                 // this is allowed if the location is already an absolute URI, below we will try using other schemes
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("xmldb URI parse failed for contextPath={}, location={}: {}",
+                            contextPath, location, e.getMessage());
+                }
                 pathUri = null;
             }
 
@@ -137,6 +141,10 @@ public class SourceFactory {
                 final URL url = new URL(location);
                 source = new URLSource(url);
             } catch (final MalformedURLException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Source location is not a well-formed URL, returning null: {} ({})",
+                            location, e.getMessage());
+                }
                 return null;
             }
         }
@@ -163,7 +171,11 @@ public class SourceFactory {
         try {
             return new ClassLoaderSource(ClassLoaderSource.PROTOCOL + childLocation.toString().replace('\\', '/'));
         } catch (final IOException e) {
-            // no-op, we will try again below
+            // child resolution missed; fall through to sibling resolution below
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Classpath source not resolvable as child of {}: {} ({})",
+                        rootPath, childLocation, e.getMessage());
+            }
         }
 
         // 2) try resolving location as sibling
@@ -229,7 +241,11 @@ public class SourceFactory {
                 source = new FileSource(p, checkXQEncoding);
             }
         } catch (final InvalidPathException e) {
-            // continue trying
+            // not a valid path on this filesystem; fall through to next resolution attempt
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                        contextPath, location, e.getMessage());
+            }
         }
 
         if (source == null) {
@@ -240,7 +256,11 @@ public class SourceFactory {
                     source = new FileSource(p2, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -252,7 +272,11 @@ public class SourceFactory {
                     source = new FileSource(p3, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -267,7 +291,11 @@ public class SourceFactory {
                     source = new FileSource(p4, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -282,7 +310,11 @@ public class SourceFactory {
                     source = new FileSource(p5, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -296,7 +328,11 @@ public class SourceFactory {
                     try {
                         p6 = Paths.get(new URI(contextPath)).resolveSibling(locationPath);
                     } catch (final URISyntaxException e) {
-                        // continue trying
+                        // contextPath is not a parseable URI; fall through to plain-path handling
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("contextPath is not a parseable URI (contextPath={}): {}",
+                                    contextPath, e.getMessage());
+                        }
                     }
                 }
 
@@ -309,7 +345,11 @@ public class SourceFactory {
                     source = new FileSource(p6, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -323,7 +363,11 @@ public class SourceFactory {
                     try {
                         p7 = Paths.get(new URI(contextPath)).resolve(locationPath);
                     } catch (final URISyntaxException e) {
-                        // continue trying
+                        // contextPath is not a parseable URI; fall through to plain-path handling
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("contextPath is not a parseable URI (contextPath={}): {}",
+                                    contextPath, e.getMessage());
+                        }
                     }
                 }
 
@@ -336,7 +380,11 @@ public class SourceFactory {
                     source = new FileSource(p7, checkXQEncoding);
                 }
             } catch (final InvalidPathException e) {
-                // continue trying
+                // not a valid path on this filesystem; fall through to next resolution attempt
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("File source path invalid (contextPath={}, location={}): {}",
+                            contextPath, location, e.getMessage());
+                }
             }
         }
 
@@ -354,7 +402,11 @@ public class SourceFactory {
             } catch (final EXistException e) {
                 LOG.warn(e);
             } catch (final InvalidPathException e) {
-                // continue and abort below
+                // fall through; getSource_fromFile will return null and the caller can fail loudly
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("File source path invalid against EXIST_HOME (location={}): {}",
+                            locationPath, e.getMessage());
+                }
             }
         }
 

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -742,7 +742,6 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
 
                 transact.commit(txn);
             } catch(final Exception e) {
-                e.printStackTrace();
                 final String msg = "Initialisation of system collections failed: " + e.getMessage();
                 LOG.error(msg, e);
                 throw new EXistException(msg, e);

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -3979,8 +3979,7 @@ public class NativeBroker implements DBBroker {
                 }
             }
         } catch(final DBException dbe) {
-            dbe.printStackTrace();
-            LOG.error(dbe);
+            LOG.error("DBException during NativeBroker sync", dbe);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/btree/BTree.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/BTree.java
@@ -729,7 +729,7 @@ public class BTree extends Paged implements Lockable {
                 idx = idx < 0 ? - (idx + 1) : idx + 1;
                 node = node.getChildNode(idx);
             } catch (final Exception e) {
-                e.printStackTrace();
+                LOG.error("Error while scanning page {}", node.page.getPageNum(), e);
                 throw new IOException("Error while scanning page " + node.page.getPageNum());
             }
         }
@@ -814,8 +814,7 @@ public class BTree extends Paged implements Lockable {
                 try {
                     dump(writer);
                 } catch (final Exception e) {
-                    LOG.warn(e);
-                    e.printStackTrace();
+                    LOG.warn("Failed to dump BTree state during recovery", e);
                 }
                 LOG.warn(writer.toString());
                 throw new LogException("Critical error during recovery");
@@ -1255,8 +1254,8 @@ public class BTree extends Paged implements Lockable {
                         p += valSize - prefixLen;
                         keys[i] = new Value(t);
                     } catch (final Exception e) {
-                        e.printStackTrace();
-                        LOG.error("prefixLen = {}; i = {}; nKeys = {}", prefixLen, i, nKeys);
+                        LOG.error("Failed to read BTree key prefix (prefixLen={}; i={}; nKeys={})",
+                                prefixLen, i, nKeys, e);
                         throw new IOException(e.getMessage());
                     }
                 } else {

--- a/exist-core/src/main/java/org/exist/storage/btree/Paged.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/Paged.java
@@ -189,7 +189,7 @@ public abstract class Paged implements AutoCloseable {
             fileHeader.write();
             return true;
         } catch (final Exception e) {
-            e.printStackTrace();
+            LOG.error("Error creating paged file {}", FileUtils.fileName(file), e);
             throw new DBException(0, "Error creating " + FileUtils.fileName(file));
         }
     }
@@ -361,7 +361,7 @@ public abstract class Paged implements AutoCloseable {
                 return false;
             }
         } catch (final Exception e) {
-            e.printStackTrace();
+            LOG.error("Error opening paged file {}", FileUtils.fileName(file), e);
             throw new DBException(0, "Error opening " + FileUtils.fileName(file) + ": " + e.getMessage());
         }
     }

--- a/exist-core/src/main/java/org/exist/storage/dom/DOMFile.java
+++ b/exist-core/src/main/java/org/exist/storage/dom/DOMFile.java
@@ -1887,8 +1887,7 @@ public class DOMFile extends BTree implements Lockable {
             return true;
         } catch (final BTreeException | IOException e) {
             //TODO : rethrow exception ? -pb
-            LOG.error(e);
-            e.printStackTrace();
+            LOG.error("Failed to update value in DOMFile", e);
             return false;
         }
     }
@@ -3060,9 +3059,8 @@ public class DOMFile extends BTree implements Lockable {
                 this.page = getPage(pos);
                 load(page);
             } catch (final IOException ioe) {
-                LOG.error(ioe);
-                ioe.printStackTrace();
                 //TODO  :throw exception ? -pb
+                LOG.error("Failed to load DOMPage at position {}", pos, ioe);
             }
         }
         
@@ -3196,8 +3194,7 @@ public class DOMFile extends BTree implements Lockable {
                     return;
                 }
             } catch (final IOException ioe) {
-                LOG.error(ioe);
-                ioe.printStackTrace();
+                LOG.error("Failed to read DOMPage data from page {}", page != null ? page.getPageNum() : -1, ioe);
             }
             saved = true;
         }

--- a/exist-core/src/main/java/org/exist/storage/index/BFile.java
+++ b/exist-core/src/main/java/org/exist/storage/index/BFile.java
@@ -680,13 +680,11 @@ public class BFile extends BTree {
                 addValue(transaction, key, p);
                 return p;
             } catch (final IOException ioe) {
-                ioe.printStackTrace();
-                LOG.warn(ioe);
+                LOG.warn("Failed to store value while updating key in BFile", ioe);
                 return UNKNOWN_ADDRESS;
             }
         } catch (final BTreeException | IOException e) {
-            e.printStackTrace();
-            LOG.warn(e);
+            LOG.warn("Failed to update value in BFile", e);
             return UNKNOWN_ADDRESS;
         }
     }

--- a/exist-core/src/main/java/org/exist/storage/lock/FileLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/FileLock.java
@@ -114,8 +114,7 @@ public class FileLock {
             try {
                 read();
             } catch (final IOException e) {
-                message("Failed to read lock file", null);
-                e.printStackTrace();
+                message("Failed to read lock file", e);
             }
             
             //Check if there's a heart-beat. If not, remove the stale .lck file and try again

--- a/exist-core/src/main/java/org/exist/storage/statistics/IndexStatisticsWorker.java
+++ b/exist-core/src/main/java/org/exist/storage/statistics/IndexStatisticsWorker.java
@@ -21,6 +21,8 @@
  */
 package org.exist.storage.statistics;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.DocumentSet;
@@ -61,6 +63,9 @@ import java.util.Map;
 /**
  */
 public class IndexStatisticsWorker implements IndexWorker {
+
+    private static final Logger LOG = LogManager.getLogger(IndexStatisticsWorker.class);
+
     private final IndexStatistics index;
     private final StatisticsListener listener = new StatisticsListener();
 
@@ -197,7 +202,7 @@ public class IndexStatisticsWorker implements IndexWorker {
                 }
             }
         } catch (final IOException | XMLStreamException e) {
-            e.printStackTrace();
+            LOG.warn("Failed to update index statistics for document", e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -211,7 +211,7 @@ public class ModuleContext extends XQueryContext {
                     }
                 }
             } catch (final URISyntaxException e) {
-                e.printStackTrace();
+                LOG.warn("Failed to derive module load path from parent context", e);
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -507,7 +507,7 @@ public class XQueryContext implements BinaryValueManager, Context {
             try {
                 declareNamespace(prefix, copyFrom.staticNamespaces.get(prefix));
             } catch (final XPathException ex) {
-                ex.printStackTrace();
+                LOG.warn("Failed to copy namespace declaration for prefix '{}'", prefix, ex);
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/Stream.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/Stream.java
@@ -113,7 +113,7 @@ public class Stream extends StrictResponseFunction {
                     serializer.toSAX(inputNode, 1, inputNode.getItemCount(), false, false, 0, 0);
 
                 } catch (final SAXException e) {
-                    e.printStackTrace();
+                    logger.error("SAX error while serializing response stream", e);
                     throw new IOException(e);
                 } finally {
                     serializerPool.returnObject(sax);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1165,7 +1165,13 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                         // clean attributes
                         attribs.clear();
                     } catch (PermissionDeniedException e) {
-                        // not allowed to read the document: ignore the match.
+                        // The current user is not allowed to read this matching document.
+                        // We must drop it from the result set rather than leak its contents,
+                        // but log so partial-result situations are diagnosable.
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Lucene search hit dropped due to permission denial on document {}: {}",
+                                    fDocUri, e.getMessage());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Replace silent exception swallowing and `printStackTrace()` calls with proper SLF4J/Log4j logging across storage, HTTP, and XQuery production paths. Identified by a Moderne Prethink hotspot scan (107 ignored-exception sites and 111 `printStackTrace` sites in `main/` code).

In production deployments where stderr is not captured, lost stack traces materially hurt incident response. Silent catch blocks make wrong-answer bugs invisible: queries return partial results without any indication that documents were skipped, modules failed to load, or search hits were dropped.

## What Changed

### Silent exception swallowing -> logged

- **`MutableCollection.allDocs` (x2)** — `PermissionDeniedException` on recursive sub-collection traversal now logs the skipped collection URI at DEBUG. Behaviour is unchanged (sub-collections without read permission remain filtered from the result), but partial-result situations are now diagnosable.
- **`SourceFactory`** — 11 silent catch blocks across the module source resolution fallback chain (xmldb / file / classpath / URL) now log at DEBUG/TRACE with `contextPath` and `location`. Previously, `module not found` errors gave no clue which lookup steps had been attempted.
- **`LuceneIndexWorker.BinarySearchLeafCollector.collect`** — `PermissionDeniedException` during result-collection now logs the dropped document URI. Previously, search hits the user lacked permission to read were silently dropped with no trace.

### `printStackTrace()` -> `LOG.error/warn(...)`

| Layer | Files |
|---|---|
| storage | `BFile`, `DOMFile` (x3), `Paged` (x2), `BTree` (x3), `NativeBroker`, `BrokerPool`, `FileLock`, `IndexStatisticsWorker` |
| http | `HttpRequestWrapper` (x2) |
| xquery | `XQueryContext`, `ModuleContext`, `functions/response/Stream` |

Where a redundant `LOG.warn(e)` already followed `printStackTrace()`, both calls are collapsed into a single `LOG` call with a descriptive message.  `IndexStatisticsWorker` had no `Logger`; one is added.

### Sites intentionally NOT changed

- CLI tools (`Repair`) where `printStackTrace()` writes to stderr that the operator expects to see.
- `ConsistencyCheckTask.error` which writes `printStackTrace(printWriter)` to a captured audit log.
- `TryCatchExpression` / `HTTPUtils.printStackTraceHTML` where `printStackTrace(printWriter)` renders an error-message string for downstream callers.

## Test Plan

- [x] `mvn install -pl exist-core -am` succeeds
- [x] `mvn install -pl extensions/indexes/lucene -am` succeeds
- [x] `exist-core` full unit test suite passes (4:38)
- [x] `extensions/indexes/lucene` tests in isolation: 659 passed, 0 failures, 0 errors
- [x] All other reactor modules pass on resume; only `exist-xqts` fails with an unrelated GitHub Packages 401 for `org.eclipse.emf` metadata (pre-existing local-build infrastructure issue, not caused by this change).

## Source

- Prethink hotspot report: priorities 1–4 from the report's "Recommended Investigation Priority" list.

[This response was co-authored with Claude Code. -Joe]