### PR TITLE
[bugfix] Harden BrokerPool shutdown sequence (audit fixes C2-C5)

### DIFF
--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -483,6 +483,10 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
                 try {
                     Runtime.getRuntime().addShutdownHook(shutdownHookThread);
                     logger.debug("BrokerPoolsAndJetty.ShutdownHook hook registered");
+                    // Avoid C2 race: deregister the default BrokerPools static hook so that only
+                    // BrokerPoolsAndJetty.ShutdownHook runs at JVM shutdown. The default hook would
+                    // otherwise call BrokerPool.stopAll(true) concurrently with this hook.
+                    BrokerPool.deregisterDefaultShutdownHook();
                 } catch (final IllegalArgumentException | IllegalStateException e) {
                     // Hook already registered, or Shutdown in progress
                     logger.error("Unable to add BrokerPoolsAndJetty.ShutdownHook hook: {}", e.getMessage(), e);
@@ -562,9 +566,9 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
                 logger.warn("Unable to remove BrokerPoolsAndJetty.ShutdownHook hook: {}", e.getMessage());
             }
         });
-        
+
         BrokerPool.stopAll(false);
-        
+
         while (status != STATUS_STOPPED) {
             try {
                 wait();

--- a/exist-core/src/main/java/org/exist/scheduler/Scheduler.java
+++ b/exist-core/src/main/java/org/exist/scheduler/Scheduler.java
@@ -43,6 +43,21 @@ public interface Scheduler {
      */
     void shutdown(final boolean waitForJobsToComplete);
 
+    /**
+     * Shutdown the running Scheduler with a maximum wait time.
+     *
+     * Equivalent to {@link #shutdown(boolean) shutdown(true)} but bounded by {@code timeoutMs}:
+     * if the underlying scheduler has not finished joining its worker threads before the
+     * deadline, currently executing jobs are interrupted and the scheduler is then forcibly
+     * stopped via {@code shutdown(false)}. This protects JVM shutdown from blocking
+     * indefinitely on a stuck Quartz job (audit finding C3, 2026-04-29).
+     *
+     * @param timeoutMs maximum time to wait for jobs to complete, in milliseconds.
+     *                  A non-positive value falls back to {@link #shutdown(boolean) shutdown(false)}
+     *                  (no wait).
+     */
+    void shutdown(final long timeoutMs);
+
     boolean isShutdown();
 
     /**

--- a/exist-core/src/main/java/org/exist/scheduler/impl/QuartzSchedulerImpl.java
+++ b/exist-core/src/main/java/org/exist/scheduler/impl/QuartzSchedulerImpl.java
@@ -190,6 +190,69 @@ public class QuartzSchedulerImpl implements Scheduler, BrokerPoolService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Shutdown sequence:
+     * <ol>
+     *   <li>Spawn a daemon worker that calls {@code scheduler.shutdown(true)} (waits for jobs).</li>
+     *   <li>Wait up to {@code timeoutMs} for that worker to finish.</li>
+     *   <li>If the deadline expires, log every currently-executing job, attempt
+     *       {@code interrupt(jobKey)} on each (no-op for non-{@code InterruptableJob} bodies),
+     *       then call {@code scheduler.shutdown(false)} from the calling thread to release
+     *       the blocked worker. The worker thread's {@code shutdown(true)} will then return
+     *       once the underlying scheduler signals stop.</li>
+     * </ol>
+     */
+    @Override
+    public void shutdown(final long timeoutMs) {
+        if (timeoutMs <= 0) {
+            shutdown(false);
+            return;
+        }
+
+        final org.quartz.Scheduler quartz = getScheduler();
+        if (quartz == null) {
+            return;
+        }
+
+        final Thread shutdownWorker = new Thread(() -> {
+            try {
+                quartz.shutdown(true);
+            } catch (final SchedulerException se) {
+                LOG.warn("Unable to cleanly shutdown the Scheduler: {}", se.getMessage(), se);
+            }
+        }, nameInstanceThread(brokerPool, "scheduler-shutdown-watchdog"));
+        shutdownWorker.setDaemon(true);
+        shutdownWorker.start();
+
+        try {
+            shutdownWorker.join(timeoutMs);
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for Scheduler shutdown");
+        }
+
+        if (shutdownWorker.isAlive()) {
+            LOG.warn("Scheduler did not stop within {} ms; escalating to forced shutdown", timeoutMs);
+            try {
+                final List<JobExecutionContext> running = quartz.getCurrentlyExecutingJobs();
+                for (final JobExecutionContext jec : running) {
+                    final JobKey key = jec.getJobDetail().getKey();
+                    LOG.warn("Forcing interrupt of running scheduler job: {}", key);
+                    try {
+                        quartz.interrupt(key);
+                    } catch (final UnableToInterruptJobException uije) {
+                        LOG.warn("Job {} is not interruptible: {}", key, uije.getMessage());
+                    }
+                }
+                quartz.shutdown(false);
+            } catch (final SchedulerException se) {
+                LOG.warn("Unable to force-shutdown the Scheduler: {}", se.getMessage(), se);
+            }
+        }
+    }
+
     @Override
     public boolean isShutdown() {
         try {

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1631,8 +1631,18 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
 
             processMonitor.stopRunningJobs();
 
-            //Shutdown the scheduler
-            scheduler.shutdown(true);
+            // C3 fix (shutdown lifecycle audit, 2026-04-29):
+            // Bound scheduler shutdown so a stuck Quartz job cannot hang the JVM. Wait up to
+            // half of maxShutdownWait for jobs to complete; if the deadline expires, the
+            // implementation logs and force-interrupts running jobs, then shutdown(false)s.
+            // A non-positive maxShutdownWait disables the bound (semantics preserved for
+            // configurations that explicitly opted out via wait-before-shutdown).
+            final long schedulerTimeoutMs = maxShutdownWait > 0 ? maxShutdownWait / 2 : -1L;
+            if (schedulerTimeoutMs > 0) {
+                scheduler.shutdown(schedulerTimeoutMs);
+            } else {
+                scheduler.shutdown(true);
+            }
 
             try {
                 statusReporter = new StatusReporter(SIGNAL_SHUTDOWN);
@@ -1668,12 +1678,17 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                             } catch (final InterruptedException e) {
                                 Thread.currentThread().interrupt();
                                 LOG.warn("Interrupted while waiting for active brokers to return during shutdown");
+                                // C4 fix (shutdown lifecycle audit, 2026-04-29):
+                                // Surface holders so unflushed transactions are visible in the log
+                                // before we proceed into broker.shutdown() with leases still open.
+                                logActiveBrokerHolders("interrupt");
                                 break;
                             }
 
                             //...or force the shutdown
                             if (maxShutdownWait > -1 && System.currentTimeMillis() - waitStart > maxShutdownWait) {
                                 LOG.warn("Not all threads returned. Forcing shutdown ...");
+                                logActiveBrokerHolders("timeout");
                                 break;
                             }
                         }
@@ -1779,6 +1794,12 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                 // interrupt any remaining threads in the instance thread group
                 // to prevent the JVM from hanging on non-daemon threads
                 try {
+                    // C5 fix (shutdown lifecycle audit, 2026-04-29):
+                    // Surface any threads that survived the structured shutdown so leaks are
+                    // diagnosable. Each named thread here is a candidate for an explicit
+                    // BrokerPoolService.shutdown() rather than relying on this blanket
+                    // ThreadGroup.interrupt() fallback.
+                    logSurvivingInstanceThreads();
                     instanceThreadGroup.interrupt();
                 } catch (final SecurityException e) {
                     LOG.warn("Could not interrupt instance thread group: {}", e.getMessage());
@@ -1890,6 +1911,60 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
             System.err.println(s);
         } catch(final IOException e) {
             LOG.error(e);
+        }
+    }
+
+    /**
+     * Enumerate threads still alive in {@code instanceThreadGroup} immediately before the
+     * blanket {@code interrupt()} fallback, and log them by name and daemon status.
+     *
+     * Audit finding C5 (2026-04-29): {@code ThreadGroup.interrupt()} is a band-aid for any
+     * subsystem that did not register an explicit shutdown via {@code BrokerPoolService}.
+     * Logging the survivors makes the leak visible so it can be fixed at source rather than
+     * masked by the interrupt.
+     */
+    private void logSurvivingInstanceThreads() {
+        try {
+            final Thread[] active = new Thread[instanceThreadGroup.activeCount() + 8];
+            final int found = instanceThreadGroup.enumerate(active, true);
+            for (int i = 0; i < found; i++) {
+                final Thread t = active[i];
+                if (t == null || t == Thread.currentThread() || !t.isAlive()) {
+                    continue;
+                }
+                LOG.warn("Thread '{}' (state={}, daemon={}) still alive in instance thread group at shutdown — will be interrupted",
+                        t.getName(), t.getState(), t.isDaemon());
+            }
+        } catch (final SecurityException e) {
+            LOG.warn("Could not enumerate instance thread group at shutdown: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Log every thread that still holds an active broker, with its current stack trace.
+     *
+     * Used by the shutdown sequence (audit finding C4) when the {@code activeBrokers} drain
+     * is interrupted or times out — proceeding with {@code broker.shutdown()} while leases
+     * are still open risks unflushed dirty pages, so making the holders visible is critical
+     * for diagnosing the cause on next start.
+     *
+     * @param reason short tag included in the log message ({@code "interrupt"} or {@code "timeout"}).
+     */
+    private void logActiveBrokerHolders(final String reason) {
+        if (activeBrokers.isEmpty()) {
+            return;
+        }
+        LOG.warn("FORCED SHUTDOWN ({}) with {} active broker(s) — recovery may be required on next start",
+                reason, activeBrokers.size());
+        for (final Map.Entry<Thread, DBBroker> entry : activeBrokers.entrySet()) {
+            final Thread holder = entry.getKey();
+            final StringBuilder sb = new StringBuilder();
+            sb.append("Thread '").append(holder.getName()).append("' (state=").append(holder.getState())
+                    .append(", daemon=").append(holder.isDaemon()).append(") still holds a broker:\n");
+            for (final StackTraceElement frame : holder.getStackTrace()) {
+                sb.append("\tat ").append(frame).append('\n');
+            }
+            LOG.warn(sb.toString());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/BrokerPools.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPools.java
@@ -61,19 +61,45 @@ abstract class BrokerPools {
     public static String DEFAULT_INSTANCE_NAME = "exist";
 
     // register a shutdown hook
+    @GuardedBy("BrokerPools.class") private static Thread defaultShutdownHook;
+
     static {
+        final Thread hook = newGlobalThread("BrokerPools.ShutdownHook", () -> {
+            // Make sure that all instances are cleanly shut down.
+            LOG.info("Executing shutdown thread");
+            BrokerPools.stopAll(true);
+        });
         try {
-            Runtime.getRuntime().addShutdownHook(newGlobalThread("BrokerPools.ShutdownHook", () -> {
-                /**
-                 * Make sure that all instances are cleanly shut down.
-                 */
-                LOG.info("Executing shutdown thread");
-                BrokerPools.stopAll(true);
-            }));
+            Runtime.getRuntime().addShutdownHook(hook);
+            defaultShutdownHook = hook;
             LOG.debug("BrokerPools.ShutdownHook hook registered");
         } catch (final IllegalArgumentException e) {
             // hook already registered
             LOG.warn("Unable to add BrokerPools.ShutdownHook hook: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Deregister the default {@code BrokerPools.ShutdownHook}.
+     *
+     * Used by {@link org.exist.jetty.JettyStart} when it registers its own shutdown hook
+     * that subsumes the default one. Avoids the C2 race where two shutdown hooks both
+     * call {@link #stopAll(boolean)} concurrently and reach for {@code server.stop()}
+     * in non-deterministic order.
+     *
+     * Safe to call multiple times. If the JVM is already shutting down, the deregistration
+     * fails silently — the hook will run and is a no-op against an empty {@code instances} map.
+     */
+    public static synchronized void deregisterDefaultShutdownHook() {
+        if (defaultShutdownHook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(defaultShutdownHook);
+                LOG.debug("BrokerPools.ShutdownHook hook unregistered");
+            } catch (final IllegalStateException e) {
+                // JVM is already shutting down; not safe (and not necessary) to remove
+                LOG.debug("Could not unregister BrokerPools.ShutdownHook (shutdown in progress)");
+            }
+            defaultShutdownHook = null;
         }
     }
 


### PR DESCRIPTION
## Summary

Hardens the BrokerPool shutdown sequence against four critical issues identified in an internal shutdown/lifecycle audit (2026-04-29). These manifest as occasional hangs or NPEs on restart and explain some flaky CI test reports.

- **C2** — Eliminate JVM shutdown-hook race between `BrokerPools.ShutdownHook` and `JettyStart`'s `BrokerPoolAndJettyShutdownHook`. JettyStart now deregisters the default static hook when it registers its own.
- **C3** — Bound Quartz scheduler shutdown with a watchdog so a stuck job cannot hang the JVM. New `Scheduler.shutdown(long timeoutMs)` overload force-interrupts running jobs and falls back to `shutdown(false)` after `maxShutdownWait/2`.
- **C4** — On `activeBrokers` drain interrupt or timeout, log every thread that still holds a broker (state + stack trace) before proceeding into `broker.shutdown()`. Surfaces unflushed-transaction risk for diagnosis.
- **C5** — Before the blanket `instanceThreadGroup.interrupt()` fallback, enumerate and log threads still alive in the group. Subsystems lacking an explicit shutdown path become visible instead of being silently masked.

## What's NOT in this PR

**C1** (Jetty stops AFTER BrokerPool nulls fields, in-flight requests NPE) is intentionally deferred. Reordering Jetty stop to run synchronously inside `BrokerPool.shutdown` deadlocks Jetty 11's stop sequence in the test infrastructure — `RemoteSecurityManagerRoundtripTest` reliably reproduces the hang on `restart()`. It will require a deeper rework of the `JettyStart` status protocol (decoupling lifecycle event delivery from the `synchronized this` monitor) and is best addressed in a follow-up.

## Files changed

| File | Change |
|---|---|
| `BrokerPools.java` | Made the static shutdown hook deregisterable (new `deregisterDefaultShutdownHook()`). |
| `JettyStart.java` | Calls `BrokerPool.deregisterDefaultShutdownHook()` after registering its own JVM hook. |
| `Scheduler.java` | New `void shutdown(long timeoutMs)` interface method. |
| `QuartzSchedulerImpl.java` | Watchdog implementation for the timed shutdown — logs running jobs, attempts `interrupt(jobKey)`, then `shutdown(false)`. |
| `BrokerPool.java` | Uses `scheduler.shutdown(maxShutdownWait/2)` (C3); new `logActiveBrokerHolders(reason)` invoked from drain interrupt/timeout (C4); new `logSurvivingInstanceThreads()` invoked before `instanceThreadGroup.interrupt()` (C5). |

## Test plan

- [x] Targeted shutdown tests: `ShutdownTest`, `DirtyShutdownTest`, `BrokerPoolTest`, `ConcurrentBrokerPoolTest`, `RemoteSecurityManagerRoundtripTest` (12 tests, all green).
- [x] Full `mvn test -Ddependency-check.skip=true -Dlicense.skip=true -Ddocker=false`: every reactor module with test code reports `Failures: 0, Errors: 0`. The only build failure is `exist-xqts` failing dependency resolution against GitHub Packages (`401 Unauthorized` for `exist-xqts-runner_2.13`) — an infrastructure auth issue unrelated to this change.
- [ ] Manual SIGTERM / Docker-restart verification: not run against this branch (no behavior change at the JVM-hook level for embedded mode); reviewers welcome to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)