### PR TITLE
[bugfix] Fix index optimization regression for static outer variables

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Dependency.java
+++ b/exist-core/src/main/java/org/exist/xquery/Dependency.java
@@ -109,4 +109,16 @@ public class Dependency {
     public final static boolean dependsOnVar(Expression expr) {
         return ((expr.getDependencies() & VARS) != 0);
     }
+
+    /**
+     * Returns true if the expression depends on a variable declared in the
+     * same for/let iteration scope (LOCAL_VARS). Variables from outer scopes
+     * (CONTEXT_VARS) are static relative to the current iteration and do not
+     * prevent bulk evaluation.
+     *
+     * @see #dependsOnVar(Expression) which checks both LOCAL_VARS and CONTEXT_VARS
+     */
+    public static boolean dependsOnLocalVar(Expression expr) {
+        return ((expr.getDependencies() & LOCAL_VARS) != 0);
+    }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -389,11 +389,13 @@ public class Query extends Function implements Optimizable {
         final Expression stringArg = getArgument(0);
         if (Type.subTypeOf(stringArg.returnsType(), Type.NODE) &&
                 !Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
-            // Check if any other argument depends on local/context variables.
+            // Check if any other argument depends on a local iteration variable.
             // If so, the expression cannot be bulk-evaluated during ForExpr preEval
             // because the variable value changes per iteration. (GH-2204)
+            // Only LOCAL_VARS (same for/let scope) prevent bulk evaluation;
+            // CONTEXT_VARS (outer scope) are static and safe to preselect.
             for (int i = 1; i < getArgumentCount(); i++) {
-                if (Dependency.dependsOnVar(getArgument(i))) {
+                if (Dependency.dependsOnLocalVar(getArgument(i))) {
                     return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
                 }
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -167,11 +167,13 @@ public class QueryField extends Query implements Optimizable {
 
     @Override
     public int getDependencies() {
-        // Check if any argument depends on local/context variables.
+        // Check if any argument depends on a local iteration variable.
         // If so, the expression cannot be bulk-evaluated during ForExpr preEval
         // because the variable value changes per iteration. (GH-2204)
+        // Only LOCAL_VARS (same for/let scope) prevent bulk evaluation;
+        // CONTEXT_VARS (outer scope) are static and safe to preselect.
         for (int i = 0; i < getArgumentCount(); i++) {
-            if (Dependency.dependsOnVar(getArgument(i))) {
+            if (Dependency.dependsOnLocalVar(getArgument(i))) {
                 return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
             }
         }

--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -568,11 +568,13 @@ public class NGramSearch extends Function implements Optimizable {
         final Expression stringArg = getArgument(0);
         if (Type.subTypeOf(stringArg.returnsType(), Type.NODE)
             && !Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
-            // Check if any other argument depends on local/context variables.
+            // Check if any other argument depends on a local iteration variable.
             // If so, the expression cannot be bulk-evaluated during ForExpr preEval
             // because the variable value changes per iteration. (GH-2204)
+            // Only LOCAL_VARS (same for/let scope) prevent bulk evaluation;
+            // CONTEXT_VARS (outer scope) are static and safe to preselect.
             for (int i = 1; i < getArgumentCount(); i++) {
-                if (Dependency.dependsOnVar(getArgument(i))) {
+                if (Dependency.dependsOnLocalVar(getArgument(i))) {
                     return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
                 }
             }


### PR DESCRIPTION
## Summary

Fixes the performance regression reported by @line-o where `ngram:contains()` with a static outer variable (e.g., `$q` from `let $q := request:get-parameter(...)`) took 10+ seconds instead of milliseconds.

The same fix applies to `ft:query` and `ft:query-field` — all three share the same `getDependencies()` pattern from the GH-2204 fix.

## Root Cause

The GH-2204 fix (commit d9b2d4d3c2) added a `Dependency.dependsOnVar()` check to prevent bulk index evaluation when a search argument changes per FLWOR iteration. But `dependsOnVar()` checks **both** `LOCAL_VARS` (iteration-scoped) and `CONTEXT_VARS` (outer-scoped). A static outer variable like `$q` reports `CONTEXT_VARS`, which is safe for bulk evaluation — the value doesn't change per context item.

When `dependsOnVar()` returned true for `$q`, `getDependencies()` reported `CONTEXT_ITEM` dependency, pushing the predicate into per-item BOOLEAN evaluation instead of the bulk NODE/preSelect index path.

## Fix

- Added `Dependency.dependsOnLocalVar()` — checks only `LOCAL_VARS` (same for/let scope)
- Changed `NGramSearch.getDependencies()`, `Query.getDependencies()`, and `QueryField.getDependencies()` to use `dependsOnLocalVar()` instead of `dependsOnVar()`
- The GH-2204 protection for FLWOR iteration variables is preserved

## What Changed

| File | Change |
|------|--------|
| `Dependency.java` | Added `dependsOnLocalVar()` method |
| `NGramSearch.java` | `dependsOnVar` → `dependsOnLocalVar` |
| `Query.java` | `dependsOnVar` → `dependsOnLocalVar` |
| `QueryField.java` | `dependsOnVar` → `dependsOnLocalVar` |

## Test Plan

- [x] NGram tests: 39 pass (0 failures)
- [x] Lucene tests: 594 pass (0 failures)
- [x] EnforceIndexUseTest: 2 pass
- [x] Full CI-equivalent test suite: 0 test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)