### PR TITLE
[fix] reinstate batch operations for ngram:contains

### DIFF
--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -566,22 +566,11 @@ public class NGramSearch extends Function implements Optimizable {
     @Override
 	public int getDependencies() {
         final Expression stringArg = getArgument(0);
-        if (Type.subTypeOf(stringArg.returnsType(), Type.NODE)
-            && !Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
-            // Check if any other argument depends on a local iteration variable.
-            // If so, the expression cannot be bulk-evaluated during ForExpr preEval
-            // because the variable value changes per iteration. (GH-2204)
-            // Only LOCAL_VARS (same for/let scope) prevent bulk evaluation;
-            // CONTEXT_VARS (outer scope) are static and safe to preselect.
-            for (int i = 1; i < getArgumentCount(); i++) {
-                if (Dependency.dependsOnLocalVar(getArgument(i))) {
-                    return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
-                }
-            }
-            return Dependency.CONTEXT_SET;
-        } else {
+        if (!Type.subTypeOf(stringArg.returnsType(), Type.NODE)
+                || Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
             return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
         }
+        return Dependency.CONTEXT_SET;
     }
 
     @Override

--- a/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
@@ -543,6 +543,7 @@ public class CustomIndexTest {
      * must not raise XPTY0004.
      */
     @Test
+    @Ignore("skip until better solution is found")
     public void ngramContainsWithForVariable() throws PermissionDeniedException, XPathException, EXistException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {

--- a/extensions/indexes/ngram/src/test/xquery/ngram/for-variable.xql
+++ b/extensions/indexes/ngram/src/test/xquery/ngram/for-variable.xql
@@ -100,6 +100,7 @@ function fv:tearDown() {
  : collection variable. This is the pattern from the original bug report.
  :)
 declare
+    %test:pending
     %test:assertEquals("Chair", "Table")
 function fv:for-variable-in-where-clause() {
     for $q in doc($fv:COLLECTION || "/queries.xml")//q


### PR DESCRIPTION
### Description:

This PR reverts parts of #6286 and #6093
Merging this PR means we need to reopen #2204

`ngram:contains#2` would fail to use batch operation mode when in a predicate.

The easiest way to reproduce it is in function documentation search.

### Reference:

reopen #2204

### Type of tests:

None added. @joewiz  was so kind to create benchmarks and share analysis in #6296