### PR TITLE
[bugfix] WhereClause: descend into where-expression during AST visitor walks (closes GH-2204)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/WhereClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/WhereClause.java
@@ -152,6 +152,11 @@ public class WhereClause extends AbstractFLWORClause {
     }
 
     @Override
+    public void accept(final ExpressionVisitor visitor) {
+        visitor.visitWhereClause(this);
+    }
+
+    @Override
     public void dump(ExpressionDumper dumper) {
         dumper.display("where", whereExpr.getLine());
         dumper.startIndent();


### PR DESCRIPTION
## Summary

`WhereClause` was missing an `accept(ExpressionVisitor)` override. The other FLWOR clause classes (`ForExpr`, `LetExpr`, `WindowExpr`, `OrderByClause`, `GroupByClause`) all override `accept` to dispatch to their corresponding `visitXxx` methods; `WhereClause` was the lone sibling falling through to `AbstractExpression.accept` &rarr; the generic `visit()` &rarr; `processWrappers()` &mdash; which only descends into `Atomize`, `DynamicCardinalityCheck`, `DynamicNameCheck`, `DynamicTypeCheck`, `UntypedValueCheck`, `PathExpr`. `WhereClause` is none of those, so the visitor stopped there.

Concretely: the Optimizer pass that wraps optimizable `LocationStep` predicates in `#exist:optimize#` pragmas never reached predicates inside a `where` clause. Indexed predicate functions therefore missed the bulk-evaluation path and fell through to per-tuple EBV evaluation &mdash; with `ngram:contains`, that's roughly N nodes &times; M outer iterations of `eval()` calls.

## The fix

Five lines in `exist-core/src/main/java/org/exist/xquery/WhereClause.java`:

```java
@Override
public void accept(final ExpressionVisitor visitor) {
    visitor.visitWhereClause(this);
}
```

`DefaultExpressionVisitor.visitWhereClause` already exists and descends into `whereExpr` and `returnExpr` correctly &mdash; only the entry point was missing.

## Diagnostic numbers

Reproducer (the GH-2204 shape, three Shakespeare plays, 5 search terms):

```xquery
for $q in ('Denmark', 'England', 'Norway', 'Polonius', 'France')
where collection('/db/test')//LINE[ngram:contains(., $q)]
return $q
```

Counters added during diagnosis (not in this PR):

| | LocationSteps visited | Optimize.eval | preSelect | NGramSearch.eval | uncached | time |
|---|---|---|---|---|---|---|
| before | **0** | **0** | **0** | **47,460** | **47,460** | **1882 ms** |
| after | 2 | 15 | 15 | 77 | 0 | **6 ms** |

That's a **~313x speedup** at termCount=5; **~600x** at termCount=100. Same correct results in both cases.

## Benchmark evidence

The full benchmark methodology and JMH numbers across all four index APIs (`ngram:contains`, `range:eq`, `range:field-eq`, `ft:query`) live in `exist-indexes-jmh` &mdash; see #6296. The benchmark module is independently useful as the regression-test harness for any future FLWOR / index-optimization work; the numbers there directly motivated this fix.

## Test plan

- [x] `extensions/indexes/ngram` &mdash; 39 tests pass (6 skipped, 0 failures)
- [x] `extensions/indexes/range` &mdash; 422 tests pass (3 skipped, 0 failures)
- [x] `extensions/indexes/lucene` &mdash; 659 tests pass (40 skipped, 0 failures)
- [x] `exist-core` `XQuery3Tests` + `XPathQueryTest` + `OptimizerTest` &mdash; 1140 tests pass (5 skipped, 0 failures)
- [x] The existing `for-variable-in-where-clause` and `for-variable-in-field-eq` regression tests added in #6093 / #6286 still pass with this fix
- [x] Codacy PMD: no new findings on the changed file
- [x] License check passes

## Impact on related PRs

- **#6295** (Juri's "reinstate batch operations" revert) is no longer needed in any form. The perf win it was reaching for arrives via this fix without the correctness regression that revert introduced. The two `%test:pending` markers in #6295 can be dropped because the underlying tests pass against this branch.
- **#6093 and #6286** added per-index `dependsOnLocalVar` / `dependsOnVar` guards in `range:eq`, `range:field-eq`, `ngram:contains`, and `ft:query`. With this fix, those guards become redundant &mdash; they were defending against the missed-optimization case this PR removes. The guards still work and tests still pass with them in place; a follow-up cleanup PR can remove them if desired, but it isn't required.

## Spec / issue references

- Closes https://github.com/eXist-db/exist/issues/2204
Closes https://github.com/eXist-db/exist/issues/5352
- See PR #6296 for the JMH benchmark module that surfaces the numbers and serves as the regression harness for any future FLWOR / index work

[This PR was prepared with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)