### PR TITLE
[optimize] Unwrap parenthesised single-step expressions in Optimizer

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -157,6 +157,57 @@ public class Optimizer extends DefaultExpressionVisitor {
     }
 
     @Override
+    public void visitPathExpr(final PathExpr pathExpr) {
+        super.visitPathExpr(pathExpr);
+
+        // Unwrap parenthesised single-step expressions: `//(name)` -> `//name`,
+        // `$nodes/(child)` -> `$nodes/child`, etc. The parser produces a
+        // wrapping PathExpr for any parenthesised step expression without
+        // outer predicates. At runtime the engine treats such wrapped steps
+        // as generic expressions and materialises the descendant axis instead
+        // of using the structural index by qname. Lifting the inner
+        // LocationStep out of the wrapping PathExpr restores the optimised
+        // path and gets the same downstream optimiser treatment as the
+        // unparenthesised form.
+        //
+        // The wrapping PathExpr by definition has no predicates of its own
+        // (predicates would have produced a FilteredExpression, handled by
+        // visitFilteredExpr below) so the unwrap is semantics-preserving.
+        //
+        // Note: the union-of-steps case `//(A | B)` is a related but distinct
+        // shape and is not handled here -- distributing the parent path over
+        // the union branches requires rewriting the outer PathExpr's steps in
+        // bulk, which the current PathExpr API doesn't support cleanly. That
+        // case is tracked separately; for now users can write `//A | //B`.
+        boolean rewroteAny = true;
+        while (rewroteAny) {
+            rewroteAny = false;
+            for (int i = 0; i < pathExpr.getLength(); i++) {
+                final Expression step = pathExpr.getExpression(i);
+                // Exact class check: PathExpr has many semantically-loaded
+                // subclasses (UnaryExpr, BinaryOp, OpNumeric, ConcatExpr,
+                // EnclosedExpr, LogicalOp, RangeExpression, ...) that we must
+                // never unwrap. Only the parser's generic PathExpr-as-parens
+                // wrapper has class == PathExpr.class.
+                if (step.getClass() == PathExpr.class
+                        && step instanceof final PathExpr inner
+                        && inner.getLength() == 1
+                        && inner.getExpression(0) instanceof final LocationStep innerStep) {
+                    pathExpr.replace(inner, innerStep);
+                    innerStep.setParent(pathExpr);
+                    hasOptimized = true;
+                    // Re-visit the unwrapped step so it gets the same optimiser
+                    // treatment as if the user had written it without parens.
+                    visitLocationStep(innerStep);
+                    rewroteAny = true;
+                    // Restart the loop because the step at index i changed.
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
     public void visitFilteredExpr(final FilteredExpression filtered) {
         super.visitFilteredExpr(filtered);
 


### PR DESCRIPTION
## Summary

The parser wraps any parenthesised step expression without outer predicates in a `PathExpr`. At runtime the engine treats such wrapped steps as generic expressions and materialises the descendant axis instead of dispatching by qname through the structural index. For common shapes like `//(name)` this is roughly 35x slower than the bare form `//name`.

This PR adds a `visitPathExpr` override to `Optimizer` that detects a step whose runtime class is exactly `PathExpr` and which contains a single `LocationStep`, and unwraps it.

## Why exact-class check matters

Many semantically loaded expression types extend `PathExpr`:

- `UnaryExpr` (negation, e.g. `-x`)
- `BinaryOp` and subclasses
- `OpNumeric` (arithmetic)
- `ConcatExpr`
- `EnclosedExpr`
- `LogicalOp`
- `RangeExpression`
- ...and more

A generic `instanceof PathExpr` check would match all of these and incorrectly unwrap them, dropping their semantics. A first version of this patch had that bug -- caught by `XQuery3Tests.bang.precedence1` failing because `(-.)` (a `UnaryExpr` containing a `.` LocationStep) was being unwrapped to just `.`, dropping the unary minus. The exact-class `step.getClass() == PathExpr.class` check is essential.

## Numbers

Synthetic xqdoc-shaped corpus (200 modules x 30 functions = 6,000 functions, ngram-indexed) on develop @ 675a2ddcb5:

```
                                          before    after
//xqdoc:function                            3 ms     3 ms     <-- baseline (no parens, no change)
//(xqdoc:function)                        104 ms    37 ms     <-- ~3x speedup
```

The remaining gap to the bare form is the engine still evaluating two steps (`descendant-or-self::node() / child::name`) rather than the fused single `descendant::name` that the parser produces for `//name` directly. Closing that gap requires path-fusion in the engine and is independent of this change.

## Scope: what's not in this PR

The related **union-of-steps case** `//(A | B)` is _not_ addressed here. Distributing the parent path over union branches (`//A | //B`) requires rewriting the outer `PathExpr`'s steps in bulk, which the current `PathExpr` API doesn't support cleanly. For the function-documentation app's queries specifically, the workaround is to write `$app:data//A | $app:data//B` instead of `$app:data//(A | B)` -- I'll open a PR against `function-documentation` separately.

The follow-up to handle the union case in eXist's optimizer is tracked as future work; the rewrite is more invasive (needs either a `PathExpr.replaceAllSteps` API or a different rewriting strategy that walks up to the outer `PathExpr`'s parent).

## Test plan

- [x] `exist-core` `OptimizerTest` (7 tests, 0 failures)
- [x] `exist-core` `XPathQueryTest` (150 tests, 0 failures)
- [x] `exist-core` `xquery.xquery3.XQuery3Tests` (1011 tests, 0 failures) -- including `bang.precedence1` which catches the wrong-class-check bug
- [x] `extensions/indexes/ngram` (39 tests, 0 failures)
- [x] `extensions/indexes/range` (428 tests, 0 failures)
- [x] `extensions/indexes/lucene` (659 tests, 0 failures)
- [x] Codacy PMD: no new findings on the changed file (3 pre-existing findings unrelated to this change)
- [x] License check passes
- [x] Synthetic `FundocsSearchDiagnostic` shows the 104ms -> 37ms speedup on `//(name)` shape

## Investigation context

This change came out of @line-o's residual-perf question on PR #6295 after #6300 merged. Diagnosis comment with the full data is at https://github.com/eXist-db/exist/pull/6295#issuecomment-4387895437. The key finding: the slowness in the function-documentation app's search queries had nothing to do with ngram or its `getDependencies()` guard. It was the parenthesised-step shape `//(...)` defeating the structural-index fast path.

This PR addresses the simple-parens half of that shape. The union-of-steps half is the follow-up; the function-documentation app can be made fast immediately by rewriting to the split-paths form.

[This PR was prepared with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)