### PR TITLE
[bugfix] range:eq: per-item BOOLEAN-mode evaluation drops value comparison after preSelect

### DIFF
--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
@@ -442,11 +442,10 @@ public class Lookup extends Function implements Optimizable, IndexUseReporter {
 //            LOG.info("eval plain took " + (System.currentTimeMillis() - start));
         } else {
             contextStep.setPreloadedData(preselectResult.getDocumentSet(), preselectResult);
-            // Use effectiveContextSequence (the per-item context when contextItem is set) so
-            // BOOLEAN-mode per-item predicate evaluation actually checks the per-item node.
-            // With contextSequence (the full preloaded set), every per-item call returned the
-            // same non-empty NodeSet, silently dropping the value comparison from a for-bound
-            // variable: //x[@indexed = $v] over-returned by ~scale factor for each outer iter.
+            // Use effectiveContextSequence instead of contextSequence here. With contextSequence
+            // (the full preloaded set), a lookup inside a predicate would "see" the entire nodeSet
+            // for each iteration in a query like //x[@indexed-attribute = $v] and return duplicate
+            // hits.
             result = getArgument(0).eval(effectiveContextSequence, contextItem).toNodeSet();
         }
         return result;

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
@@ -441,10 +441,13 @@ public class Lookup extends Function implements Optimizable, IndexUseReporter {
             }
 //            LOG.info("eval plain took " + (System.currentTimeMillis() - start));
         } else {
-//            long start = System.currentTimeMillis();
             contextStep.setPreloadedData(preselectResult.getDocumentSet(), preselectResult);
-            result = getArgument(0).eval(contextSequence, null).toNodeSet();
-            //LOG.info("eval took " + (System.currentTimeMillis() - start));
+            // Use effectiveContextSequence (the per-item context when contextItem is set) so
+            // BOOLEAN-mode per-item predicate evaluation actually checks the per-item node.
+            // With contextSequence (the full preloaded set), every per-item call returned the
+            // same non-empty NodeSet, silently dropping the value comparison from a for-bound
+            // variable: //x[@indexed = $v] over-returned by ~scale factor for each outer iter.
+            result = getArgument(0).eval(effectiveContextSequence, contextItem).toNodeSet();
         }
         return result;
     }

--- a/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
+++ b/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
@@ -122,12 +122,11 @@ public class ForBoundXmlIdRegressionTest {
      * @return {@code [literalHits, forBoundHits]}
      */
     private long[] runScenario(final XmldbURI col, final int nKeys) throws Exception {
-        final String keysExpr = "(for $i in 0 to %d return \"id\" || $i)".formatted(nKeys - 1);
         final String literal = """
                 collection("%s")//*[@xml:id = "id0"]""".formatted(col);
         final String forBound = """
-                for $v in %s
-                return collection("%s")//*[@xml:id = $v]""".formatted(keysExpr, col);
+                for $v in (for $i in 0 to %d return "id" || $i)
+                return collection("%s")//*[@xml:id = $v]""".formatted(nKeys - 1, col);
 
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {

--- a/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
+++ b/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
@@ -37,6 +37,8 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Sequence;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -83,16 +85,35 @@ public class ForBoundXmlIdRegressionTest {
     private static final int N_ITEMS = 100;
     private static final int N_KEYS = 5;
 
+    private static final XmldbURI COL_LEGACY = XmldbURI.ROOT_COLLECTION_URI.append("forbound-xmlid-L");
+    private static final XmldbURI COL_RANGE = XmldbURI.ROOT_COLLECTION_URI.append("forbound-xmlid-N");
+
+    @BeforeClass
+    public static void setupCollections() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            createCollectionAndStore(pool, broker, COL_LEGACY, CONFIG_LEGACY_ONLY);
+            createCollectionAndStore(pool, broker, COL_RANGE, CONFIG_RANGE_INDEX);
+        }
+    }
+
+    @AfterClass
+    public static void teardownCollections() {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        cleanup(pool, COL_LEGACY);
+        cleanup(pool, COL_RANGE);
+    }
+
     @Test
     public void legacyAutoIndexOnlyReturnsExpectedHits() throws Exception {
-        final long[] hits = runScenario("L", CONFIG_LEGACY_ONLY, N_KEYS);
+        final long[] hits = runScenario(COL_LEGACY, N_KEYS);
         assertEquals("L literal expected 1 hit", 1, hits[0]);
         assertEquals("L for-bound expected " + N_KEYS + " hits", N_KEYS, hits[1]);
     }
 
     @Test
     public void rangeIndexConfiguredReturnsCorrectHits() throws Exception {
-        final long[] hits = runScenario("N", CONFIG_RANGE_INDEX, N_KEYS);
+        final long[] hits = runScenario(COL_RANGE, N_KEYS);
         assertEquals("N literal expected 1 hit", 1, hits[0]);
         assertEquals("N for-bound expected " + N_KEYS + " hits", N_KEYS, hits[1]);
     }
@@ -100,25 +121,17 @@ public class ForBoundXmlIdRegressionTest {
     /**
      * @return {@code [literalHits, forBoundHits]}
      */
-    private long[] runScenario(final String tag, final String configXml, final int nKeys) throws Exception {
+    private long[] runScenario(final XmldbURI col, final int nKeys) throws Exception {
+        final String keysExpr = "(for $i in 0 to %d return \"id\" || $i)".formatted(nKeys - 1);
+        final String literal = """
+                collection("%s")//*[@xml:id = "id0"]""".formatted(col);
+        final String forBound = """
+                for $v in %s
+                return collection("%s")//*[@xml:id = $v]""".formatted(keysExpr, col);
+
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        final XmldbURI col = XmldbURI.ROOT_COLLECTION_URI.append("forbound-xmlid-" + tag);
-        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            createCollectionAndStore(pool, broker, col, configXml);
-        }
-
-        final String keysExpr = IntStream.range(0, nKeys)
-                .mapToObj(i -> "\"id" + i + "\"")
-                .collect(Collectors.joining(",", "(", ")"));
-
-        final String literal = "collection(\"" + col + "\")//*[@xml:id = \"id0\"]";
-        final String forBound = "for $v in " + keysExpr
-                + " return collection(\"" + col + "\")//*[@xml:id = $v]";
-
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             return new long[] { run(broker, literal), run(broker, forBound) };
-        } finally {
-            cleanup(pool, col);
         }
     }
 
@@ -131,8 +144,8 @@ public class ForBoundXmlIdRegressionTest {
         return r.getItemCount();
     }
 
-    private void createCollectionAndStore(final BrokerPool pool, final DBBroker broker,
-                                          final XmldbURI col, final String configXml) throws Exception {
+    private static void createCollectionAndStore(final BrokerPool pool, final DBBroker broker,
+                                                 final XmldbURI col, final String configXml) throws Exception {
         final TransactionManager tm = pool.getTransactionManager();
         try (final Txn txn = tm.beginTransaction()) {
             final Collection collection = broker.getOrCreateCollection(txn, col);
@@ -154,7 +167,7 @@ public class ForBoundXmlIdRegressionTest {
         }
     }
 
-    private void cleanup(final BrokerPool pool, final XmldbURI col) {
+    private static void cleanup(final BrokerPool pool, final XmldbURI col) {
         final TransactionManager tm = pool.getTransactionManager();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
              final Txn txn = tm.beginTransaction();

--- a/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
+++ b/extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java
@@ -1,0 +1,168 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.range;
+
+import org.exist.collections.Collection;
+import org.exist.collections.CollectionConfigurationManager;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test: range index lookup with for-bound value comparand.
+ *
+ * Before the fix, {@code //*[@indexed = $v]} with {@code $v} bound by a {@code for}
+ * expression and {@code @indexed} configured with a Lucene-backed range index returned
+ * every element with {@code @indexed} (one row per outer iter) instead of the matching
+ * elements only. The literal-key form {@code //*[@indexed = "X"]} was unaffected.
+ *
+ * Root cause: Lookup.eval's preselect-result branch evaluated the path expression
+ * against {@code contextSequence} (the full preloaded set) instead of against the
+ * per-item {@code effectiveContextSequence}, so BOOLEAN-mode per-item predicate
+ * evaluation returned the same non-empty NodeSet for every context item.
+ */
+public class ForBoundXmlIdRegressionTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private static final String CONFIG_LEGACY_ONLY = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+              <index/>
+            </collection>""";
+
+    private static final String CONFIG_RANGE_INDEX = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0"
+                        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                        xmlns:xml="http://www.w3.org/XML/1998/namespace">
+              <index>
+                <range>
+                  <create qname="@xml:id" type="xs:string"/>
+                </range>
+              </index>
+            </collection>""";
+
+    private static final int N_ITEMS = 100;
+    private static final int N_KEYS = 5;
+
+    @Test
+    public void legacyAutoIndexOnlyReturnsExpectedHits() throws Exception {
+        final long[] hits = runScenario("L", CONFIG_LEGACY_ONLY, N_KEYS);
+        assertEquals("L literal expected 1 hit", 1, hits[0]);
+        assertEquals("L for-bound expected " + N_KEYS + " hits", N_KEYS, hits[1]);
+    }
+
+    @Test
+    public void rangeIndexConfiguredReturnsCorrectHits() throws Exception {
+        final long[] hits = runScenario("N", CONFIG_RANGE_INDEX, N_KEYS);
+        assertEquals("N literal expected 1 hit", 1, hits[0]);
+        assertEquals("N for-bound expected " + N_KEYS + " hits", N_KEYS, hits[1]);
+    }
+
+    /**
+     * @return {@code [literalHits, forBoundHits]}
+     */
+    private long[] runScenario(final String tag, final String configXml, final int nKeys) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final XmldbURI col = XmldbURI.ROOT_COLLECTION_URI.append("forbound-xmlid-" + tag);
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            createCollectionAndStore(pool, broker, col, configXml);
+        }
+
+        final String keysExpr = IntStream.range(0, nKeys)
+                .mapToObj(i -> "\"id" + i + "\"")
+                .collect(Collectors.joining(",", "(", ")"));
+
+        final String literal = "collection(\"" + col + "\")//*[@xml:id = \"id0\"]";
+        final String forBound = "for $v in " + keysExpr
+                + " return collection(\"" + col + "\")//*[@xml:id = $v]";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            return new long[] { run(broker, literal), run(broker, forBound) };
+        } finally {
+            cleanup(pool, col);
+        }
+    }
+
+    private long run(final DBBroker broker, final String query) throws XPathException, PermissionDeniedException {
+        final BrokerPool pool = broker.getBrokerPool();
+        final XQuery xqs = pool.getXQueryService();
+        final XQueryContext ctx = new XQueryContext(pool);
+        final CompiledXQuery compiled = xqs.compile(ctx, query);
+        final Sequence r = xqs.execute(broker, compiled, null);
+        return r.getItemCount();
+    }
+
+    private void createCollectionAndStore(final BrokerPool pool, final DBBroker broker,
+                                          final XmldbURI col, final String configXml) throws Exception {
+        final TransactionManager tm = pool.getTransactionManager();
+        try (final Txn txn = tm.beginTransaction()) {
+            final Collection collection = broker.getOrCreateCollection(txn, col);
+            broker.saveCollection(txn, collection);
+            final CollectionConfigurationManager cm = pool.getConfigurationManager();
+            cm.addConfiguration(txn, broker, collection, configXml);
+
+            final String items = IntStream.range(0, N_ITEMS)
+                    .mapToObj(i -> "<item xml:id=\"id" + i + "\">v" + i + "</item>")
+                    .collect(Collectors.joining());
+            final String doc = """
+                    <root xmlns:xml="http://www.w3.org/XML/1998/namespace">%s</root>"""
+                    .formatted(items);
+
+            broker.storeDocument(txn, XmldbURI.create("data.xml"),
+                    new StringInputSource(doc), MimeType.XML_TYPE, collection);
+            broker.reindexCollection(txn, collection.getURI());
+            tm.commit(txn);
+        }
+    }
+
+    private void cleanup(final BrokerPool pool, final XmldbURI col) {
+        final TransactionManager tm = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = tm.beginTransaction();
+             final Collection c = broker.openCollection(col, org.exist.storage.lock.Lock.LockMode.WRITE_LOCK)) {
+            if (c != null) broker.removeCollection(txn, c);
+            tm.commit(txn);
+        } catch (Exception e) {
+            System.err.println("cleanup failed for " + col + ": " + e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a high-severity correctness bug in `range:eq` (and the `[@indexed = $v]` predicate it backs): when the value comparand is a **for-bound** variable AND the indexed attribute has a `<range>` block configured, every element under the context passes the predicate per outer for-iter, not just the matching ones. The literal-key form (`[@indexed = "X"]`) is unaffected.

Closes #6307.

## What changed

**`extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java`** — one-line fix in `eval`'s preselect-result branch (line 446). Substitutes `effectiveContextSequence` and `contextItem` for `contextSequence` and `null` in the `getArgument(0).eval(...)` call. The fresh-eval branch in the same method already uses `effectiveContextSequence`; the preselect-result branch had been missing it.

**`extensions/indexes/range/src/test/java/org/exist/xquery/modules/range/ForBoundXmlIdRegressionTest.java`** — new JUnit regression test, runs by default. Two scenarios (legacy auto-index only; legacy + range index configured), each asserting both the literal-key and for-bound shapes return the expected hit counts. Fails on `develop` (505 hits where 5 expected); passes with this fix.

## Mechanism

In BOOLEAN-mode per-item predicate evaluation, the inner `Lookup.eval` is called once per context node with `contextItem` set. The pre-fix code evaluated the path expression against `contextSequence` (the full 101-element preloaded set), so every per-item call returned the same non-empty NodeSet (the `@xml:id` of the single value-matching preloaded element). `effectiveBooleanValue` was true for every element, silently dropping the `$v` binding.

The fix uses `effectiveContextSequence` (= `contextItem.toSequence()` when `contextItem` is set; otherwise = `contextSequence`). For the literal-key NODE-mode path, `contextItem == null` so the change is a no-op. For the for-bound BOOLEAN-mode path, the per-item context is now correctly threaded through.

The for-bound trace (captured via instrumentation, then reverted) shows 1 `preSelect` + 1 NODE-mode `eval` + 101 BOOLEAN-mode `eval(contextItem=set)` calls per outer iter; pre-fix every per-item call returned 1 item, post-fix only the matching item's per-item call returns non-empty.

## Sibling-bug audit

The other Optimizable index functions were audited and do **not** reproduce the same defect:

- **`FieldLookup.eval`** (range:field-eq) — different `selectAncestorDescendant` pattern; targeted regression test passes.
- **`NGramSearch.eval`** (ngram:contains) — reassigns `contextSequence = contextItem.toSequence()` at the top of `eval` (line 242-243), achieving the same effect as using `effectiveContextSequence`.
- **`Query.eval`** (lucene:query) — same top-of-eval reassignment (line 293-295), plus the #3114 predicate-presence guard.
- **`QueryField.eval`** (lucene:query-field) — same module pattern as `Query.eval`.

`Lookup.java` was the outlier. Fix is therefore scoped to `Lookup.java`.

## Related

- #2204 / `d9b2d4d3c2` (in develop) — fixed the WhereClause path. Same family, different code path.
- `718d5b02ed` on `bugfix/ngram-predicate-perf` — sibling fix for ngram/ft. Different code path again.
- This PR is the third sibling: predicate-Optimize-pragma path, `Lookup.eval` preselect-result branch.

## Test plan

- [x] Regression test `ForBoundXmlIdRegressionTest` fails on `develop`, passes with this commit.
- [x] Full range-index test suite (`mvn test -pl extensions/indexes/range`): **424 tests, 0 failures, 0 errors, 3 pre-existing skips**. Includes the existing `for-variable.xql` GH-2204 coverage.
- [ ] CI green on this PR (will appear after submit).
- [ ] No QT4 / XQTS 3.1 regressions vs `develop` (the rewrite-to-Lookup path is gated on a `<range>` block being configured, and the change is a no-op for the literal-key NODE-mode path).

## Risk

Low. The change matches the pattern used in the same method's fresh-eval branch (lines 411, 417, 422). For NODE-mode (literal-key) paths the change is a no-op because `effectiveContextSequence == contextSequence` when `contextItem == null`. The 422 existing range-index tests (XQSuite + JUnit) all pass, including configured-range tests, field tests, and for-variable-from-#2204 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)