### PR TITLE
[optimize] Distribute outer path over union-step branches

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ExtensionExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExtensionExpression.java
@@ -49,6 +49,10 @@ public class ExtensionExpression extends AbstractExpression {
         this.innerExpression = inner;
     }
 
+    public Expression getExpression() {
+        return innerExpression;
+    }
+
     public void addPragma(final Pragma pragma) {
         if (pragmas == null) {
             pragmas = new Pragma[1];

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -205,9 +205,48 @@ public class Optimizer extends DefaultExpressionVisitor {
      */
     @Override
     public void visitPathExpr(final PathExpr pathExpr) {
+        // Case B runs BEFORE super.visitPathExpr descends. If we let super
+        // run first, visitLocationStep would wrap each branch's predicated
+        // LocationStep in an ExtensionExpression(#exist:optimize#) pragma at
+        // its current parent (the parens-PathExpr) before distribution.
+        // After distribution, the pragma stays on each branch's step but it
+        // was set up against the parens-context, where the contextSequence
+        // at eval time is huge (every descendant of the outer prefix). The
+        // pragma's preSelect+findAncestors path then can't preselect
+        // efficiently and falls through to a generic node-by-node filter --
+        // the same ~9s slowdown the rewrite is meant to avoid. Distributing
+        // first, then descending, lets visitLocationStep wrap each branch's
+        // step at the BRANCH-PathExpr parent, matching the runtime profile
+        // of the hand-written outer//A | outer//B | outer//C ...
+        boolean rewroteAny = true;
+        while (rewroteAny) {
+            rewroteAny = false;
+            for (int i = 0; i < pathExpr.getLength(); i++) {
+                final Expression step = pathExpr.getExpression(i);
+                if (step.getClass() != PathExpr.class || !(step instanceof final PathExpr inner)
+                        || inner.getLength() != 1) {
+                    continue;
+                }
+                final Expression innerStep = inner.getExpression(0);
+                if (innerStep instanceof final Union innerUnion
+                        && predicates == 0
+                        && hasOnlyLocationStepSuffix(pathExpr, i)
+                        && isDistributableUnion(innerUnion)) {
+                    final Union distributed = distributeOverUnion(pathExpr, i, innerUnion);
+                    distributed.setLocation(inner.getLine(), inner.getColumn());
+                    pathExpr.replaceAllSteps(distributed);
+                    hasOptimized = true;
+                    rewroteAny = true;
+                    break;
+                }
+            }
+        }
+
         super.visitPathExpr(pathExpr);
 
-        boolean rewroteAny = true;
+        // Case A is safe to apply post-descent: the single-LocationStep
+        // parens unwrap doesn't move pragma wrappers across parent boundaries.
+        rewroteAny = true;
         while (rewroteAny) {
             rewroteAny = false;
             for (int i = 0; i < pathExpr.getLength(); i++) {
@@ -221,30 +260,11 @@ public class Optimizer extends DefaultExpressionVisitor {
                     continue;
                 }
                 final Expression innerStep = inner.getExpression(0);
-
-                // Case A
                 if (innerStep instanceof final LocationStep innerLocationStep) {
                     pathExpr.replace(inner, innerLocationStep);
                     innerLocationStep.setParent(pathExpr);
                     hasOptimized = true;
                     visitLocationStep(innerLocationStep);
-                    rewroteAny = true;
-                    break;
-                }
-
-                // Case B
-                if (innerStep instanceof final Union innerUnion
-                        && predicates == 0
-                        && hasOnlyLocationStepSuffix(pathExpr, i)
-                        && isDistributableUnion(innerUnion)) {
-                    final Union distributed = distributeOverUnion(pathExpr, i, innerUnion);
-                    distributed.setLocation(inner.getLine(), inner.getColumn());
-                    pathExpr.replaceAllSteps(distributed);
-                    hasOptimized = true;
-                    // Re-visit so any further optimisations (Case A in a
-                    // distributed branch, predicate optimisation, ...) fire
-                    // on the rewritten tree.
-                    distributed.accept(this);
                     rewroteAny = true;
                     break;
                 }
@@ -343,12 +363,20 @@ public class Optimizer extends DefaultExpressionVisitor {
      * preserve the AST shape Union expects on its branches. Otherwise build
      * a fresh PathExpr containing the prefix + branch's steps + suffix.
      *
-     * <p>Prefix and suffix step instances are shared across the two new
-     * branches. This is safe: the optimizer triggers a full reset and
-     * re-analyze of the tree after rewriting, which will set each step's
-     * parent to the last branch to claim it. {@code parent} is metadata for
-     * error reporting; eval consults the path-local context, not the
-     * step's parent pointer.
+     * <p>Prefix/suffix LocationSteps are <em>cloned</em> per-branch via
+     * {@link #cloneLocationStepIfPossible(Expression)} rather than shared.
+     * Sharing causes a real runtime regression: {@link LocationStep#analyze}
+     * mutates per-instance state (notably rewriting {@code //}'s axis from
+     * descendant-or-self to descendant, and storing {@code parent},
+     * {@code unordered}, {@code staticReturnType}, etc.). With one shared
+     * step instance reachable from multiple branches, only the last branch
+     * to analyze "wins" and downstream eval (index dispatch in particular)
+     * loses the per-branch context, leaving the rewritten path no faster
+     * than the original parens form. Cloning gives each branch its own
+     * mutable state and matches the manual rewrite's runtime profile.
+     * Non-LocationStep prefix expressions (VariableReference, FunctionCall,
+     * etc.) are still shared -- their analyze paths don't carry destructive
+     * per-branch state.
      */
     private PathExpr distributeBranch(final PathExpr outer, final int unionStepIndex,
                                        final PathExpr branch) {
@@ -362,15 +390,40 @@ public class Optimizer extends DefaultExpressionVisitor {
         final PathExpr distributed = new PathExpr(context);
         distributed.setLocation(branch.getLine(), branch.getColumn());
         for (int j = 0; j < unionStepIndex; j++) {
-            distributed.add(outer.getExpression(j));
+            distributed.add(cloneLocationStepIfPossible(outer.getExpression(j)));
         }
         for (int j = 0; j < branch.getLength(); j++) {
             distributed.add(branch.getExpression(j));
         }
         for (int j = unionStepIndex + 1; j < outer.getLength(); j++) {
-            distributed.add(outer.getExpression(j));
+            distributed.add(cloneLocationStepIfPossible(outer.getExpression(j)));
         }
         return distributed;
+    }
+
+    /**
+     * Return a per-branch-private copy of {@code e} if it is a simple
+     * LocationStep (no predicates); otherwise return {@code e} unchanged.
+     * The simple-step case covers {@code //}, {@code /}, {@code ..}, named
+     * axis steps without filters -- the common shapes that appear as
+     * outer-path prefixes in the rewrites this optimizer performs. Steps
+     * carrying predicates are not cloned because re-creating Predicate
+     * subtrees would require deep AST cloning machinery the engine doesn't
+     * provide; in those cases we accept residual sharing rather than block
+     * the rewrite. ExtensionExpression-wrapped steps fall through (the
+     * wrapper is the optimizer's own {@code #exist:optimize#} pragma and
+     * its inner LocationStep typically carries the predicates we'd need to
+     * deep-clone anyway).
+     */
+    private Expression cloneLocationStepIfPossible(final Expression e) {
+        if (e instanceof final LocationStep ls
+                && (ls.getPredicates() == null || ls.getPredicates().length == 0)) {
+            final LocationStep clone = new LocationStep(context, ls.getAxis(), ls.getTest());
+            clone.setAbbreviated(ls.isAbbreviated());
+            clone.setLocation(ls.getLine(), ls.getColumn());
+            return clone;
+        }
+        return e;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -390,15 +390,34 @@ public class Optimizer extends DefaultExpressionVisitor {
         final PathExpr distributed = new PathExpr(context);
         distributed.setLocation(branch.getLine(), branch.getColumn());
         for (int j = 0; j < unionStepIndex; j++) {
-            distributed.add(cloneLocationStepIfPossible(outer.getExpression(j)));
+            addStepWithParent(distributed, cloneLocationStepIfPossible(outer.getExpression(j)));
         }
         for (int j = 0; j < branch.getLength(); j++) {
-            distributed.add(branch.getExpression(j));
+            addStepWithParent(distributed, branch.getExpression(j));
         }
         for (int j = unionStepIndex + 1; j < outer.getLength(); j++) {
-            distributed.add(cloneLocationStepIfPossible(outer.getExpression(j)));
+            addStepWithParent(distributed, cloneLocationStepIfPossible(outer.getExpression(j)));
         }
         return distributed;
+    }
+
+    /**
+     * Add {@code step} to {@code branch} and update its {@code parent}
+     * pointer. Setting the parent matters BEFORE the post-distribution
+     * super-descent: visitLocationStep reads {@code locationStep.getParentExpression()}
+     * to find the {@code RewritableExpression} it should call replace() on
+     * when wrapping a predicated step in {@code (#exist:optimize#)}. Without
+     * this, the LocationStep's parent still points at the original
+     * pre-distribution branch PathExpr (or is null for cloned prefix steps),
+     * so the wrap is inserted into a dead branch and the new branches end
+     * up unwrapped -- a 5x perf miss observed empirically against the
+     * manually-rewritten form.
+     */
+    private void addStepWithParent(final PathExpr branch, final Expression step) {
+        branch.add(step);
+        if (step instanceof final LocationStep ls) {
+            ls.setParent(branch);
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -160,25 +160,30 @@ public class Optimizer extends DefaultExpressionVisitor {
     public void visitPathExpr(final PathExpr pathExpr) {
         super.visitPathExpr(pathExpr);
 
-        // Unwrap parenthesised single-step expressions: `//(name)` -> `//name`,
-        // `$nodes/(child)` -> `$nodes/child`, etc. The parser produces a
-        // wrapping PathExpr for any parenthesised step expression without
-        // outer predicates. At runtime the engine treats such wrapped steps
-        // as generic expressions and materialises the descendant axis instead
-        // of using the structural index by qname. Lifting the inner
-        // LocationStep out of the wrapping PathExpr restores the optimised
-        // path and gets the same downstream optimiser treatment as the
-        // unparenthesised form.
+        // Two related rewrites for parenthesised step expressions. The parser
+        // produces a wrapping PathExpr for any parenthesised step expression
+        // without outer predicates. At runtime the engine treats such wrapped
+        // steps as generic expressions and materialises the descendant axis
+        // instead of dispatching by qname through the structural index. The
+        // performance gap is large (~50x at scale) because a generic
+        // descendant-axis materialisation walks every descendant node and
+        // applies the inner expression as a node-predicate, while an indexed
+        // step looks the qname up directly.
+        //
+        // Case A: `//(name)` -> `//name`. The wrapping PathExpr contains a
+        // single LocationStep; lift it out so it dispatches through the
+        // structural index like the unparenthesised form.
+        //
+        // Case B: `outer//(A | B [| C ...])` -> `outer//A | outer//B [| outer//C ...]`.
+        // The wrapping PathExpr contains a single Union (a tree of Unions for
+        // n-ary cases). Distribute the outer path over each branch so each
+        // branch dispatches through the structural index by qname. This is
+        // the AST-level equivalent of the manual user-land rewrite that
+        // applications have to do today.
         //
         // The wrapping PathExpr by definition has no predicates of its own
         // (predicates would have produced a FilteredExpression, handled by
-        // visitFilteredExpr below) so the unwrap is semantics-preserving.
-        //
-        // Note: the union-of-steps case `//(A | B)` is a related but distinct
-        // shape and is not handled here -- distributing the parent path over
-        // the union branches requires rewriting the outer PathExpr's steps in
-        // bulk, which the current PathExpr API doesn't support cleanly. That
-        // case is tracked separately; for now users can write `//A | //B`.
+        // visitFilteredExpr below) so both rewrites are semantics-preserving.
         boolean rewroteAny = true;
         while (rewroteAny) {
             rewroteAny = false;
@@ -189,22 +194,166 @@ public class Optimizer extends DefaultExpressionVisitor {
                 // EnclosedExpr, LogicalOp, RangeExpression, ...) that we must
                 // never unwrap. Only the parser's generic PathExpr-as-parens
                 // wrapper has class == PathExpr.class.
-                if (step.getClass() == PathExpr.class
-                        && step instanceof final PathExpr inner
-                        && inner.getLength() == 1
-                        && inner.getExpression(0) instanceof final LocationStep innerStep) {
-                    pathExpr.replace(inner, innerStep);
-                    innerStep.setParent(pathExpr);
+                if (step.getClass() != PathExpr.class || !(step instanceof final PathExpr inner)
+                        || inner.getLength() != 1) {
+                    continue;
+                }
+                final Expression innerStep = inner.getExpression(0);
+
+                // Case A: parenthesised single LocationStep
+                if (innerStep instanceof final LocationStep innerLocationStep) {
+                    pathExpr.replace(inner, innerLocationStep);
+                    innerLocationStep.setParent(pathExpr);
                     hasOptimized = true;
                     // Re-visit the unwrapped step so it gets the same optimiser
                     // treatment as if the user had written it without parens.
-                    visitLocationStep(innerStep);
+                    visitLocationStep(innerLocationStep);
                     rewroteAny = true;
                     // Restart the loop because the step at index i changed.
                     break;
                 }
+
+                // Case B: parenthesised Union of step expressions. Distribute
+                // outer path over each branch.
+                //
+                // Skip inside predicates: a predicate result tracks each
+                // matched node back to its candidate via per-step contextId
+                // bookkeeping (see Predicate.selectByNodeSet). A Union built
+                // here doesn't propagate the predicate's contextId through
+                // its branches, so the candidate-mapping is lost and the
+                // predicate engine throws "context is missing for node".
+                // The unparenthesised form `Author/ForeName | Author/LastName`
+                // would have the same issue, so we leave the parenthesised
+                // shape alone here as the safe choice.
+                //
+                // Skip when any suffix step (steps after the union) is not a
+                // LocationStep. Distribution moves the suffix INTO each
+                // branch, so the branch's last step becomes whatever was at
+                // the end of the original path. If that's a non-node-returning
+                // step like {@code /string()} or {@code /count(.)} the new
+                // Union fails its operand-must-be-a-node-sequence invariant
+                // (see CombiningExpression). LocationSteps preserve nodes;
+                // arbitrary expressions in step position generally don't.
+                if (innerStep instanceof final Union innerUnion
+                        && predicates == 0
+                        && hasOnlyLocationStepSuffix(pathExpr, i)
+                        && isDistributableUnion(innerUnion)) {
+                    final Union distributed = distributeOverUnion(pathExpr, i, innerUnion);
+                    distributed.setLocation(inner.getLine(), inner.getColumn());
+                    pathExpr.replaceAllSteps(distributed);
+                    hasOptimized = true;
+                    // Visit the new branches so any further optimisations
+                    // (Case A inside a distributed branch, predicate
+                    // optimisation, etc.) fire on the rewritten tree.
+                    distributed.accept(this);
+                    rewroteAny = true;
+                    // Restart the loop because the path's structure changed.
+                    break;
+                }
             }
         }
+    }
+
+    /**
+     * Check that every step after {@code unionStepIndex} in {@code outer} is
+     * a LocationStep. After distribution those suffix steps land at the end
+     * of each new branch, and the surrounding Union requires each branch to
+     * yield a node sequence. LocationSteps preserve nodes; function-call or
+     * filter steps generally don't.
+     */
+    private boolean hasOnlyLocationStepSuffix(final PathExpr outer, final int unionStepIndex) {
+        for (int j = unionStepIndex + 1; j < outer.getLength(); j++) {
+            if (!(outer.getExpression(j) instanceof LocationStep)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * A Union is distributable over an outer path if every leaf branch is a
+     * non-empty PathExpr consisting only of LocationSteps. Nested Unions on
+     * either side recurse: an n-ary union {@code A | B | C} parses as
+     * {@code Union(Union(A, B), C)} where one branch wraps a Union.
+     *
+     * <p>This conservative check rules out branches that depend on the outer
+     * context in a way distribution would break (e.g. branches containing
+     * {@code position()} or {@code last()} as a top-level step expression,
+     * which would parse as a FunctionCall step rather than a LocationStep).
+     * Predicates within a LocationStep are fine -- they refer to the step's
+     * own context, not the outer.
+     */
+    private boolean isDistributableUnion(final Union union) {
+        return isDistributableBranch(union.getLeft())
+                && isDistributableBranch(union.getRight());
+    }
+
+    private boolean isDistributableBranch(final PathExpr branch) {
+        if (branch == null || branch.getLength() == 0) {
+            return false;
+        }
+        // Single-step branch holding another Union: recurse for n-ary.
+        if (branch.getLength() == 1 && branch.getExpression(0) instanceof final Union nested) {
+            return isDistributableUnion(nested);
+        }
+        for (int i = 0; i < branch.getLength(); i++) {
+            if (!(branch.getExpression(i) instanceof LocationStep)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Build a new Union whose branches are full distributed paths:
+     * {@code outer.steps[0..i-1]} + branch.steps + {@code outer.steps[i+1..n]}
+     * for each branch of {@code innerUnion}. Recurses into nested Unions so
+     * n-ary cases get fully distributed.
+     */
+    private Union distributeOverUnion(final PathExpr outer, final int unionStepIndex,
+                                       final Union innerUnion) {
+        final PathExpr distributedLeft = distributeBranch(outer, unionStepIndex, innerUnion.getLeft());
+        final PathExpr distributedRight = distributeBranch(outer, unionStepIndex, innerUnion.getRight());
+        final Union result = new Union(context, distributedLeft, distributedRight);
+        result.setLocation(innerUnion.getLine(), innerUnion.getColumn());
+        return result;
+    }
+
+    /**
+     * Distribute the outer's surrounding steps over a single Union branch.
+     * If the branch itself wraps a nested Union (the n-ary case), recurse to
+     * produce a distributed Union and wrap it in a single-step PathExpr to
+     * preserve the AST shape Union expects on its branches. Otherwise build
+     * a fresh PathExpr containing the prefix + branch's steps + suffix.
+     *
+     * <p>Prefix and suffix step instances are shared across the two new
+     * branches. This is safe: the optimizer triggers a full reset and
+     * re-analyze of the tree after rewriting, which will set each step's
+     * parent to the last branch to claim it. {@code parent} is metadata for
+     * error reporting; eval consults the path-local context, not the
+     * step's parent pointer.
+     */
+    private PathExpr distributeBranch(final PathExpr outer, final int unionStepIndex,
+                                       final PathExpr branch) {
+        if (branch.getLength() == 1 && branch.getExpression(0) instanceof final Union nested) {
+            final Union distributedNested = distributeOverUnion(outer, unionStepIndex, nested);
+            final PathExpr wrap = new PathExpr(context);
+            wrap.setLocation(branch.getLine(), branch.getColumn());
+            wrap.add(distributedNested);
+            return wrap;
+        }
+        final PathExpr distributed = new PathExpr(context);
+        distributed.setLocation(branch.getLine(), branch.getColumn());
+        for (int j = 0; j < unionStepIndex; j++) {
+            distributed.add(outer.getExpression(j));
+        }
+        for (int j = 0; j < branch.getLength(); j++) {
+            distributed.add(branch.getExpression(j));
+        }
+        for (int j = unionStepIndex + 1; j < outer.getLength(); j++) {
+            distributed.add(outer.getExpression(j));
+        }
+        return distributed;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -156,84 +156,83 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
     }
 
+    /**
+     * Two related rewrites for parenthesised step expressions. The parser
+     * produces a wrapping PathExpr for any parenthesised step expression
+     * without outer predicates. At runtime the engine treats such wrapped
+     * steps as generic expressions and materialises the descendant axis
+     * instead of dispatching by qname through the structural index -- a
+     * ~50x slowdown at scale, since the generic path walks every descendant
+     * node while an indexed step looks the qname up directly.
+     *
+     * <p>Case A -- {@code //(name)} -> {@code //name}: the wrapping PathExpr
+     * contains a single LocationStep; lift it out.
+     *
+     * <p>Case B -- {@code outer//(A | B [| C ...])} ->
+     * {@code outer//A | outer//B [| outer//C ...]}: the wrapping PathExpr
+     * contains a single Union (a tree of Unions for n-ary cases). Distribute
+     * the outer path over each branch so each branch dispatches through the
+     * structural index by qname. Equivalent to the manual user-land rewrite
+     * applications have to do today.
+     *
+     * <p>The wrapping PathExpr by definition has no predicates of its own
+     * (predicates would have produced a FilteredExpression, handled by
+     * visitFilteredExpr) so both rewrites are semantics-preserving.
+     *
+     * <p>Case B safety guards (see method body):
+     * <ul>
+     *   <li><em>predicates == 0</em>: a Union built here doesn't propagate
+     *       the enclosing predicate's contextId through its branches, so the
+     *       per-step candidate-to-result mapping is lost and the predicate
+     *       engine throws "context is missing for node" (see
+     *       {@code Predicate.selectByNodeSet}).</li>
+     *   <li><em>{@link #hasOnlyLocationStepSuffix}</em>: distribution moves
+     *       suffix steps INTO each branch. A non-node-returning suffix like
+     *       {@code /string()} would fail the surrounding Union's
+     *       operand-must-be-a-node-sequence invariant.</li>
+     *   <li><em>{@link #isDistributableUnion}</em>: every leaf branch must
+     *       consist only of step-like node expressions (see
+     *       {@link #isStepLikeNodeExpr}).</li>
+     * </ul>
+     *
+     * <p>Note: super.visitPathExpr has already descended into the wrapping
+     * PathExpr's children before this loop runs. {@link #visitLocationStep}
+     * may have wrapped predicate-bearing LocationSteps inside union branches
+     * in {@code ExtensionExpression(#exist:optimize#)} pragmas. Branch
+     * recognition therefore accepts both raw LocationSteps and those
+     * pragma-wrapped steps; the wrapper preserves node-yielding semantics
+     * so distribution remains safe.
+     */
     @Override
     public void visitPathExpr(final PathExpr pathExpr) {
         super.visitPathExpr(pathExpr);
 
-        // Two related rewrites for parenthesised step expressions. The parser
-        // produces a wrapping PathExpr for any parenthesised step expression
-        // without outer predicates. At runtime the engine treats such wrapped
-        // steps as generic expressions and materialises the descendant axis
-        // instead of dispatching by qname through the structural index. The
-        // performance gap is large (~50x at scale) because a generic
-        // descendant-axis materialisation walks every descendant node and
-        // applies the inner expression as a node-predicate, while an indexed
-        // step looks the qname up directly.
-        //
-        // Case A: `//(name)` -> `//name`. The wrapping PathExpr contains a
-        // single LocationStep; lift it out so it dispatches through the
-        // structural index like the unparenthesised form.
-        //
-        // Case B: `outer//(A | B [| C ...])` -> `outer//A | outer//B [| outer//C ...]`.
-        // The wrapping PathExpr contains a single Union (a tree of Unions for
-        // n-ary cases). Distribute the outer path over each branch so each
-        // branch dispatches through the structural index by qname. This is
-        // the AST-level equivalent of the manual user-land rewrite that
-        // applications have to do today.
-        //
-        // The wrapping PathExpr by definition has no predicates of its own
-        // (predicates would have produced a FilteredExpression, handled by
-        // visitFilteredExpr below) so both rewrites are semantics-preserving.
         boolean rewroteAny = true;
         while (rewroteAny) {
             rewroteAny = false;
             for (int i = 0; i < pathExpr.getLength(); i++) {
                 final Expression step = pathExpr.getExpression(i);
-                // Exact class check: PathExpr has many semantically-loaded
-                // subclasses (UnaryExpr, BinaryOp, OpNumeric, ConcatExpr,
-                // EnclosedExpr, LogicalOp, RangeExpression, ...) that we must
-                // never unwrap. Only the parser's generic PathExpr-as-parens
-                // wrapper has class == PathExpr.class.
+                // Exact-class check: many PathExpr subclasses (UnaryExpr,
+                // BinaryOp, OpNumeric, EnclosedExpr, LogicalOp, RangeExpression, ...)
+                // are semantically loaded and must never be unwrapped. Only
+                // the parser's generic parens-wrapper has class == PathExpr.class.
                 if (step.getClass() != PathExpr.class || !(step instanceof final PathExpr inner)
                         || inner.getLength() != 1) {
                     continue;
                 }
                 final Expression innerStep = inner.getExpression(0);
 
-                // Case A: parenthesised single LocationStep
+                // Case A
                 if (innerStep instanceof final LocationStep innerLocationStep) {
                     pathExpr.replace(inner, innerLocationStep);
                     innerLocationStep.setParent(pathExpr);
                     hasOptimized = true;
-                    // Re-visit the unwrapped step so it gets the same optimiser
-                    // treatment as if the user had written it without parens.
                     visitLocationStep(innerLocationStep);
                     rewroteAny = true;
-                    // Restart the loop because the step at index i changed.
                     break;
                 }
 
-                // Case B: parenthesised Union of step expressions. Distribute
-                // outer path over each branch.
-                //
-                // Skip inside predicates: a predicate result tracks each
-                // matched node back to its candidate via per-step contextId
-                // bookkeeping (see Predicate.selectByNodeSet). A Union built
-                // here doesn't propagate the predicate's contextId through
-                // its branches, so the candidate-mapping is lost and the
-                // predicate engine throws "context is missing for node".
-                // The unparenthesised form `Author/ForeName | Author/LastName`
-                // would have the same issue, so we leave the parenthesised
-                // shape alone here as the safe choice.
-                //
-                // Skip when any suffix step (steps after the union) is not a
-                // LocationStep. Distribution moves the suffix INTO each
-                // branch, so the branch's last step becomes whatever was at
-                // the end of the original path. If that's a non-node-returning
-                // step like {@code /string()} or {@code /count(.)} the new
-                // Union fails its operand-must-be-a-node-sequence invariant
-                // (see CombiningExpression). LocationSteps preserve nodes;
-                // arbitrary expressions in step position generally don't.
+                // Case B
                 if (innerStep instanceof final Union innerUnion
                         && predicates == 0
                         && hasOnlyLocationStepSuffix(pathExpr, i)
@@ -242,12 +241,11 @@ public class Optimizer extends DefaultExpressionVisitor {
                     distributed.setLocation(inner.getLine(), inner.getColumn());
                     pathExpr.replaceAllSteps(distributed);
                     hasOptimized = true;
-                    // Visit the new branches so any further optimisations
-                    // (Case A inside a distributed branch, predicate
-                    // optimisation, etc.) fire on the rewritten tree.
+                    // Re-visit so any further optimisations (Case A in a
+                    // distributed branch, predicate optimisation, ...) fire
+                    // on the rewritten tree.
                     distributed.accept(this);
                     rewroteAny = true;
-                    // Restart the loop because the path's structure changed.
                     break;
                 }
             }
@@ -263,7 +261,7 @@ public class Optimizer extends DefaultExpressionVisitor {
      */
     private boolean hasOnlyLocationStepSuffix(final PathExpr outer, final int unionStepIndex) {
         for (int j = unionStepIndex + 1; j < outer.getLength(); j++) {
-            if (!(outer.getExpression(j) instanceof LocationStep)) {
+            if (!isStepLikeNodeExpr(outer.getExpression(j))) {
                 return false;
             }
         }
@@ -271,9 +269,28 @@ public class Optimizer extends DefaultExpressionVisitor {
     }
 
     /**
+     * True if {@code e} returns nodes from a step-like position: either a
+     * raw LocationStep, or an ExtensionExpression introduced by
+     * {@link #visitLocationStep(LocationStep)} to wrap an optimizable
+     * LocationStep in a {@code #exist:optimize#} pragma. The pragma wrapper
+     * preserves the wrapped step's node-yielding semantics, so distribution
+     * over a union remains valid.
+     */
+    private boolean isStepLikeNodeExpr(final Expression e) {
+        if (e instanceof LocationStep) {
+            return true;
+        }
+        return e instanceof final ExtensionExpression ext
+                && ext.getExpression() instanceof LocationStep;
+    }
+
+    /**
      * A Union is distributable over an outer path if every leaf branch is a
-     * non-empty PathExpr consisting only of LocationSteps. Nested Unions on
-     * either side recurse: an n-ary union {@code A | B | C} parses as
+     * non-empty PathExpr consisting only of step-like node expressions
+     * (raw LocationSteps, or LocationSteps wrapped in the optimizer's
+     * {@code #exist:optimize#} ExtensionExpression -- see
+     * {@link #isStepLikeNodeExpr(Expression)}). Nested Unions on either side
+     * recurse: an n-ary union {@code A | B | C} parses as
      * {@code Union(Union(A, B), C)} where one branch wraps a Union.
      *
      * <p>This conservative check rules out branches that depend on the outer
@@ -297,7 +314,7 @@ public class Optimizer extends DefaultExpressionVisitor {
             return isDistributableUnion(nested);
         }
         for (int i = 0; i < branch.getLength(); i++) {
-            if (!(branch.getExpression(i) instanceof LocationStep)) {
+            if (!isStepLikeNodeExpr(branch.getExpression(i))) {
                 return false;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -515,6 +515,20 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
         steps.set(steps.size() - 1, s);
     }
 
+    /**
+     * Replace this PathExpr's entire step list with a single expression.
+     * Used by the optimizer when collapsing a multi-step path into a single
+     * compound expression (e.g. distributing a union of steps into a Union
+     * of full paths). Unlike {@link #replace(Expression, Expression)}, which
+     * swaps one step at a time, this method replaces all steps atomically.
+     *
+     * @param newSingleStep the expression that becomes this path's only step
+     */
+    public void replaceAllSteps(final Expression newSingleStep) {
+        steps.clear();
+        steps.add(newSingleStep);
+    }
+
     public String getLiteralValue() {
         if (steps.isEmpty()) {
             return "";

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -128,110 +128,130 @@ public class UnionStepDistributionOptimizerTest {
         assertEquals("Optimized size: " + body, expected, optimized.getSize());
     }
 
+    /** {@code //(book | journal)} should match all books and journals. */
     @Test
     public void binaryUnionUnderDescendant() throws XMLDBException {
-        // //(book | journal) should match all books and journals
         assertCount(3, "$d//(book | journal)");
     }
 
+    /** {@code /library/(book | article)} reaches one of each at the top level. */
     @Test
     public void binaryUnionUnderChild() throws XMLDBException {
-        // /library/(book | article) reaches one of each at the top level
         assertCount(3, "$d/library/(book | article)");
     }
 
+    /**
+     * {@code //(book | journal | article)} — the n-ary case parses as
+     * {@code Union(Union(book, journal), article)}; distribution must produce
+     * three independent paths. Fixture: 2 books + 1 journal + 2 articles
+     * (one nested inside the journal, one top-level) = 5.
+     */
     @Test
     public void naryUnionThreeBranches() throws XMLDBException {
-        // //(book | journal | article) -- the n-ary case parses as
-        // Union(Union(book, journal), article); distribution must produce
-        // three independent paths. Fixture: 2 books + 1 journal +
-        // 2 articles (one nested inside the journal, one top-level) = 5.
         assertCount(5, "$d//(book | journal | article)");
     }
 
+    /**
+     * Four-branch union to exercise deeper recursion in the distribution
+     * helper. Fixture: 4 titles + 4 authors + 5 paras + 3 chapters = 16.
+     */
     @Test
     public void naryUnionFourBranches() throws XMLDBException {
-        // four-branch union to exercise deeper recursion in the
-        // distribution helper. Fixture: 4 titles + 4 authors + 5 paras +
-        // 3 chapters = 16.
         assertCount(16, "$d//(title | author | para | chapter)");
     }
 
+    /**
+     * {@code outer//(A | B)/c} shape — the optimizer must preserve the
+     * trailing step on every distributed branch. Fixture: 4 elements with
+     * a direct child {@code <title>} (b1, b2, j1, a1).
+     */
     @Test
     public void unionWithSuffixStep() throws XMLDBException {
-        // outer//(A | B)/c shape -- the optimizer must preserve the
-        // trailing step on every distributed branch. Fixture: 4 elements
-        // with a direct child <title> (b1, b2, j1, a1).
         assertCount(4, "$d//(book | journal | article)/title");
     }
 
+    /** {@code /library/(book | journal)/title} — prefix and trailing step. */
     @Test
     public void unionWithPrefixAndSuffix() throws XMLDBException {
-        // /library/(book | journal)/title -- prefix and trailing step
         assertCount(3, "$d/library/(book | journal)/title");
     }
 
+    /**
+     * A predicate that contains a union step expression should still
+     * produce the correct count — the rewrite needs to leave inner path
+     * expressions inside predicates evaluable.
+     */
     @Test
     public void unionInsidePredicate() throws XMLDBException {
-        // a predicate that contains a union step expression should still
-        // produce the correct count -- the rewrite needs to leave inner
-        // path expressions inside predicates evaluable
         assertOptimizerParity("$d//book[(title | author)]");
     }
 
+    /**
+     * Regression for {@code UnionTest.unionInPredicate_*}: the union step
+     * lives INSIDE a predicate's path expression. The predicate engine
+     * tracks candidate-to-result mapping via per-step contextId (see
+     * {@code Predicate.selectByNodeSet}). Rewriting the predicate's inner
+     * path into a Union loses the contextId thread, so distribution must
+     * be suppressed when {@code predicates > 0}.
+     *
+     * <p>Uses {@code exists()} to keep the predicate body a node-set
+     * expression (avoids an unrelated pre-existing GeneralComparison cast
+     * issue when the right-hand side is a sequence literal).
+     */
     @Test
     public void unionStepInsidePredicatePath() throws XMLDBException {
-        // Regression for UnionTest.unionInPredicate_*: the union step lives
-        // INSIDE a predicate's path expression. The predicate engine tracks
-        // candidate-to-result mapping via per-step contextId (see
-        // Predicate.selectByNodeSet). Rewriting the predicate's inner path
-        // into a Union loses the contextId thread, so distribution must be
-        // suppressed when predicates > 0.
-        // Use exists() to keep the predicate body a node-set expression
-        // (avoids an unrelated pre-existing GeneralComparison cast issue
-        // when the right-hand side is a sequence literal).
         assertCount(2, "$d//book[exists(chapter/(para | title))]");
     }
 
+    /**
+     * Each branch carries its own predicate — distribution must preserve
+     * per-branch filtering.
+     */
     @Test
     public void unionWithFilteredBranches() throws XMLDBException {
-        // each branch carries its own predicate -- distribution must
-        // preserve per-branch filtering
         assertCount(2, "$d//(book[@id='b1'] | journal[@id='j1'])");
     }
 
+    /** Attribute axis branches: {@code //(@id | @n)}. */
     @Test
     public void attributeUnionUnderDescendant() throws XMLDBException {
-        // attribute axis branches: //(@id | @n)
         assertCount(7, "$d//(@id | @n)");
     }
 
+    /**
+     * A variable-bound context followed by {@code //(A|B)} — the outer
+     * prefix includes a variable reference and a descendant-or-self step.
+     */
     @Test
     public void unionUnderVariableContextPath() throws XMLDBException {
-        // a variable-bound context followed by //(A|B) -- the outer prefix
-        // includes a variable reference and a descendant-or-self step
         assertOptimizerParity("$d/library//(book | journal)");
     }
 
+    /**
+     * A name that doesn't exist in the fixture — distribution must still
+     * return the existing branch's matches (just b1).
+     */
     @Test
     public void emptyUnionBranchProducesNoMatch() throws XMLDBException {
-        // a name that doesn't exist in the fixture -- distribution must
-        // still return the existing branch's matches (just b1)
         assertCount(1, "$d//(book[@id='b1'] | nonexistent)");
     }
 
+    /**
+     * {@code //(book/title | journal/title)} — each branch is a multi-step
+     * path; both steps in each branch are LocationSteps so the rewrite
+     * applies and each branch gets the outer descendant prefix.
+     */
     @Test
     public void nestedPathInsideUnionBranch() throws XMLDBException {
-        // //(book/title | journal/title) -- each branch is a multi-step
-        // path; both steps in each branch are LocationSteps so the rewrite
-        // applies and each branch gets the outer descendant prefix
         assertCount(3, "$d//(book/title | journal/title)");
     }
 
+    /**
+     * {@code |} is a set union with document-order sort and dedup. The
+     * distributed form must preserve this ordering.
+     */
     @Test
     public void unionPreservesDocumentOrder() throws XMLDBException {
-        // | is a set union with document-order sort and dedup. The
-        // distributed form must preserve this ordering.
         final XQueryService svc = server.getRoot().getService(XQueryService.class);
         final String body = "let $d := doc('/db/" + COLLECTION_NAME + "/" + DOC_NAME + "') "
                 + "return string-join($d//(book | journal | article)/@id, ',')";
@@ -240,35 +260,45 @@ public class UnionStepDistributionOptimizerTest {
         assertEquals(baseline, optimized);
     }
 
+    /**
+     * A FLWOR body containing a union-step path — the optimizer visits
+     * FLWOR-internal expressions; the rewrite must work when the outer
+     * path's parent is not a {@code RewritableExpression}.
+     */
     @Test
     public void unionInsideForLoopBody() throws XMLDBException {
-        // a FLWOR body containing a union-step path -- the optimizer
-        // visits FLWOR-internal expressions; the rewrite must work when
-        // the outer path's parent is not a RewritableExpression
         assertOptimizerParity(
                 "for $b in $d//book return $b//(title | chapter/para)");
     }
 
+    /**
+     * {@code count()} argument is the union path; the parent of the
+     * rewrite target is a {@code FunctionCall}, not a
+     * {@code RewritableExpression}.
+     */
     @Test
     public void unionInsideFunctionCallArgument() throws XMLDBException {
-        // count() argument is the union path; the parent of the rewrite
-        // target is a FunctionCall, not a RewritableExpression
         assertOptimizerParity("count($d//(book | journal | article))");
     }
 
+    /**
+     * {@code //(book | book)} — both branches match the same nodes; the
+     * distributed Union still dedups (per {@code CombiningExpression} eval).
+     */
     @Test
     public void redundantUnionDeduped() throws XMLDBException {
-        // //(book | book) -- both branches match the same nodes; the
-        // distributed Union still dedups (per CombiningExpression eval)
         assertCount(2, "$d//(book | book)");
     }
 
+    /**
+     * Replicates the search-everywhere shape from the function-documentation
+     * app: an outer {@code //(...)} over branches that mix single predicated
+     * LocationSteps with multi-step paths. line-o reported on PR #6310 that
+     * this query takes 9s and {@code PathExpr.replaceAllSteps} is never
+     * called.
+     */
     @Test
     public void fundocsShapeMixedBranches() throws XMLDBException {
-        // Replicates the search-everywhere shape from the function-documentation
-        // app: an outer //(...) over branches that mix single predicated
-        // LocationSteps with multi-step paths. line-o reported on PR #6310 that
-        // this query takes 9s and PathExpr.replaceAllSteps is never called.
         final String body = """
                 let $d := doc('/db/%s/%s')
                 return $d//(
@@ -441,14 +471,17 @@ public class UnionStepDistributionOptimizerTest {
         }
     }
 
+    /**
+     * {@code outer/(A|B)/string()} — the suffix returns strings, not nodes.
+     * Distribution would push {@code /string()} into each branch, making the
+     * resulting Union try to combine string sequences and fail
+     * {@code CombiningExpression}'s node-only invariant. The optimizer must
+     * detect this and skip distribution for this shape.
+     *
+     * <p>(Mirrors a regression caught by xmlts {@code UnionInPath} tests.)
+     */
     @Test
     public void unionWithNonNodeReturningSuffix() throws XMLDBException {
-        // outer/(A|B)/string() -- the suffix returns strings, not nodes.
-        // Distribution would push /string() into each branch, making the
-        // resulting Union try to combine string sequences and fail
-        // CombiningExpression's node-only invariant. The optimizer must
-        // detect this and skip distribution for this shape.
-        // (Mirrors a regression caught by xmlts UnionInPath tests.)
         assertOptimizerParity(
                 "let $a := <el><el1/><el2 att='val'/><el3/></el> "
                         + "return $a/el2/(@*[1]|@*[1])/string()");

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -1,0 +1,273 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the union-step distribution rewrite in
+ * {@link Optimizer#visitPathExpr(PathExpr)}.
+ *
+ * <p>The optimizer rewrites {@code outer//(A | B [| C ...])} into
+ * {@code outer//A | outer//B [| outer//C ...]} so each branch dispatches
+ * through the structural index by qname. This file verifies correctness:
+ * results with the optimizer enabled match results with it disabled, across
+ * a range of shapes (binary unions, n-ary unions, prefix and suffix steps,
+ * mixed axes, predicates inside branches).
+ *
+ * <p>Performance is verified separately in {@code exist-indexes-jmh}; here we
+ * only assert semantic equivalence.
+ */
+public class UnionStepDistributionOptimizerTest {
+
+    private static final String OPTIMIZE = "declare option exist:optimize 'enable=yes'; ";
+    private static final String NO_OPTIMIZE = "declare option exist:optimize 'enable=no'; ";
+
+    private static final String COLLECTION_NAME = "union-step-distribution-test";
+    private static final String DOC_NAME = "fixture.xml";
+
+    private static final String FIXTURE_XML = """
+            <library>
+              <book id="b1">
+                <title>One</title>
+                <author>Alice</author>
+                <chapter n="1"><para>p1</para></chapter>
+                <chapter n="2"><para>p2</para></chapter>
+              </book>
+              <book id="b2">
+                <title>Two</title>
+                <author>Bob</author>
+                <author>Carol</author>
+                <chapter n="1"><para>p3</para></chapter>
+              </book>
+              <journal id="j1">
+                <title>Three</title>
+                <article><author>Dave</author><para>p4</para></article>
+              </journal>
+              <article id="a1"><title>Four</title><para>p5</para></article>
+            </library>
+            """;
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    @BeforeClass
+    public static void loadFixture() throws XMLDBException {
+        final Collection root = server.getRoot();
+        final CollectionManagementService cms = root.getService(CollectionManagementService.class);
+        final Collection coll = cms.createCollection(COLLECTION_NAME);
+        final XMLResource res = coll.createResource(DOC_NAME, XMLResource.class);
+        res.setContent(FIXTURE_XML);
+        coll.storeResource(res);
+    }
+
+    @AfterClass
+    public static void cleanup() throws XMLDBException {
+        final Collection root = server.getRoot();
+        final CollectionManagementService cms = root.getService(CollectionManagementService.class);
+        cms.removeCollection(COLLECTION_NAME);
+    }
+
+    /**
+     * Run a query with and without the optimizer; assert the result sizes
+     * match. The query body is interpolated against the fixture document.
+     */
+    private void assertOptimizerParity(final String body) throws XMLDBException {
+        final XQueryService svc = server.getRoot().getService(XQueryService.class);
+        final String docPrefix = "let $d := doc('/db/" + COLLECTION_NAME + "/" + DOC_NAME + "') return ";
+        final ResourceSet baseline = svc.query(NO_OPTIMIZE + docPrefix + body);
+        final ResourceSet optimized = svc.query(OPTIMIZE + docPrefix + body);
+        assertEquals("Optimized result should match baseline for: " + body,
+                baseline.getSize(), optimized.getSize());
+    }
+
+    /** Shorthand: assert both forms return the given count. */
+    private void assertCount(final long expected, final String body) throws XMLDBException {
+        final XQueryService svc = server.getRoot().getService(XQueryService.class);
+        final String docPrefix = "let $d := doc('/db/" + COLLECTION_NAME + "/" + DOC_NAME + "') return ";
+        final ResourceSet baseline = svc.query(NO_OPTIMIZE + docPrefix + body);
+        final ResourceSet optimized = svc.query(OPTIMIZE + docPrefix + body);
+        assertEquals("Baseline (no opt) size: " + body, expected, baseline.getSize());
+        assertEquals("Optimized size: " + body, expected, optimized.getSize());
+    }
+
+    @Test
+    public void binaryUnionUnderDescendant() throws XMLDBException {
+        // //(book | journal) should match all books and journals
+        assertCount(3, "$d//(book | journal)");
+    }
+
+    @Test
+    public void binaryUnionUnderChild() throws XMLDBException {
+        // /library/(book | article) reaches one of each at the top level
+        assertCount(3, "$d/library/(book | article)");
+    }
+
+    @Test
+    public void naryUnionThreeBranches() throws XMLDBException {
+        // //(book | journal | article) -- the n-ary case parses as
+        // Union(Union(book, journal), article); distribution must produce
+        // three independent paths. Fixture: 2 books + 1 journal +
+        // 2 articles (one nested inside the journal, one top-level) = 5.
+        assertCount(5, "$d//(book | journal | article)");
+    }
+
+    @Test
+    public void naryUnionFourBranches() throws XMLDBException {
+        // four-branch union to exercise deeper recursion in the
+        // distribution helper. Fixture: 4 titles + 4 authors + 5 paras +
+        // 3 chapters = 16.
+        assertCount(16, "$d//(title | author | para | chapter)");
+    }
+
+    @Test
+    public void unionWithSuffixStep() throws XMLDBException {
+        // outer//(A | B)/c shape -- the optimizer must preserve the
+        // trailing step on every distributed branch. Fixture: 4 elements
+        // with a direct child <title> (b1, b2, j1, a1).
+        assertCount(4, "$d//(book | journal | article)/title");
+    }
+
+    @Test
+    public void unionWithPrefixAndSuffix() throws XMLDBException {
+        // /library/(book | journal)/title -- prefix and trailing step
+        assertCount(3, "$d/library/(book | journal)/title");
+    }
+
+    @Test
+    public void unionInsidePredicate() throws XMLDBException {
+        // a predicate that contains a union step expression should still
+        // produce the correct count -- the rewrite needs to leave inner
+        // path expressions inside predicates evaluable
+        assertOptimizerParity("$d//book[(title | author)]");
+    }
+
+    @Test
+    public void unionStepInsidePredicatePath() throws XMLDBException {
+        // Regression for UnionTest.unionInPredicate_*: the union step lives
+        // INSIDE a predicate's path expression. The predicate engine tracks
+        // candidate-to-result mapping via per-step contextId (see
+        // Predicate.selectByNodeSet). Rewriting the predicate's inner path
+        // into a Union loses the contextId thread, so distribution must be
+        // suppressed when predicates > 0.
+        // Use exists() to keep the predicate body a node-set expression
+        // (avoids an unrelated pre-existing GeneralComparison cast issue
+        // when the right-hand side is a sequence literal).
+        assertCount(2, "$d//book[exists(chapter/(para | title))]");
+    }
+
+    @Test
+    public void unionWithFilteredBranches() throws XMLDBException {
+        // each branch carries its own predicate -- distribution must
+        // preserve per-branch filtering
+        assertCount(2, "$d//(book[@id='b1'] | journal[@id='j1'])");
+    }
+
+    @Test
+    public void attributeUnionUnderDescendant() throws XMLDBException {
+        // attribute axis branches: //(@id | @n)
+        assertCount(7, "$d//(@id | @n)");
+    }
+
+    @Test
+    public void unionUnderVariableContextPath() throws XMLDBException {
+        // a variable-bound context followed by //(A|B) -- the outer prefix
+        // includes a variable reference and a descendant-or-self step
+        assertOptimizerParity("$d/library//(book | journal)");
+    }
+
+    @Test
+    public void emptyUnionBranchProducesNoMatch() throws XMLDBException {
+        // a name that doesn't exist in the fixture -- distribution must
+        // still return the existing branch's matches (just b1)
+        assertCount(1, "$d//(book[@id='b1'] | nonexistent)");
+    }
+
+    @Test
+    public void nestedPathInsideUnionBranch() throws XMLDBException {
+        // //(book/title | journal/title) -- each branch is a multi-step
+        // path; both steps in each branch are LocationSteps so the rewrite
+        // applies and each branch gets the outer descendant prefix
+        assertCount(3, "$d//(book/title | journal/title)");
+    }
+
+    @Test
+    public void unionPreservesDocumentOrder() throws XMLDBException {
+        // | is a set union with document-order sort and dedup. The
+        // distributed form must preserve this ordering.
+        final XQueryService svc = server.getRoot().getService(XQueryService.class);
+        final String body = "let $d := doc('/db/" + COLLECTION_NAME + "/" + DOC_NAME + "') "
+                + "return string-join($d//(book | journal | article)/@id, ',')";
+        final String baseline = svc.query(NO_OPTIMIZE + body).getResource(0).getContent().toString();
+        final String optimized = svc.query(OPTIMIZE + body).getResource(0).getContent().toString();
+        assertEquals(baseline, optimized);
+    }
+
+    @Test
+    public void unionInsideForLoopBody() throws XMLDBException {
+        // a FLWOR body containing a union-step path -- the optimizer
+        // visits FLWOR-internal expressions; the rewrite must work when
+        // the outer path's parent is not a RewritableExpression
+        assertOptimizerParity(
+                "for $b in $d//book return $b//(title | chapter/para)");
+    }
+
+    @Test
+    public void unionInsideFunctionCallArgument() throws XMLDBException {
+        // count() argument is the union path; the parent of the rewrite
+        // target is a FunctionCall, not a RewritableExpression
+        assertOptimizerParity("count($d//(book | journal | article))");
+    }
+
+    @Test
+    public void redundantUnionDeduped() throws XMLDBException {
+        // //(book | book) -- both branches match the same nodes; the
+        // distributed Union still dedups (per CombiningExpression eval)
+        assertCount(2, "$d//(book | book)");
+    }
+
+    @Test
+    public void unionWithNonNodeReturningSuffix() throws XMLDBException {
+        // outer/(A|B)/string() -- the suffix returns strings, not nodes.
+        // Distribution would push /string() into each branch, making the
+        // resulting Union try to combine string sequences and fail
+        // CombiningExpression's node-only invariant. The optimizer must
+        // detect this and skip distribution for this shape.
+        // (Mirrors a regression caught by xmlts UnionInPath tests.)
+        assertOptimizerParity(
+                "let $a := <el><el1/><el2 att='val'/><el3/></el> "
+                        + "return $a/el2/(@*[1]|@*[1])/string()");
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -23,6 +23,7 @@ package org.exist.xquery;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.EXistXQueryService;
+import org.exist.xquery.util.ExpressionDumper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -467,7 +468,7 @@ public class UnionStepDistributionOptimizerTest {
      */
     private static final class ExpressionDumperHelper {
         static String dump(final Expression e) {
-            return org.exist.xquery.util.ExpressionDumper.dump(e);
+            return ExpressionDumper.dump(e);
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -22,11 +22,13 @@
 package org.exist.xquery;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xmldb.EXistXQueryService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.CompiledExpression;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
@@ -34,6 +36,9 @@ import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XQueryService;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the union-step distribution rewrite in
@@ -277,6 +282,163 @@ public class UnionStepDistributionOptimizerTest {
         final ResourceSet baseline = svc.query(NO_OPTIMIZE + body);
         final ResourceSet optimized = svc.query(OPTIMIZE + body);
         assertEquals("Optimized must match baseline", baseline.getSize(), optimized.getSize());
+    }
+
+    /**
+     * AST-shape regression: assert that after the optimizer runs on a
+     * parenthesised-union path expression like {@code $d//(A[pred] | B[pred])},
+     * the resulting AST has been distributed -- the {@code Union} now sits
+     * in step position with one fully-formed PathExpr branch per original
+     * union arm, and the parser-produced parens-PathExpr wrapper that
+     * previously contained the union is gone from the tree.
+     *
+     * <p>This test guards three concrete regressions:
+     * <ol>
+     *   <li>The optimization stops firing entirely (parens-PathExpr wrapper
+     *       remains in the tree, no Union appears at the path level).</li>
+     *   <li>The optimization fires but produces a Union with the wrong
+     *       number of branches (e.g. nested-Union flattening breaks).</li>
+     *   <li>A distributed branch loses its leading prefix steps -- a
+     *       regression where {@link Optimizer#distributeBranch} stops
+     *       copying outer prefix into each branch and the rewritten
+     *       query no longer reaches the same nodes.</li>
+     * </ol>
+     *
+     * <p>This test exists because the prior test {@code fundocsShapeMixedBranches}
+     * passed on a broken intermediate fix (commit 1621fbafbf, which ran
+     * union distribution AFTER super.visitPathExpr descended) where the
+     * rewrite fired but the rewritten form ran no faster than the original
+     * 9s parens form. Result-set equivalence held either way. Stronger
+     * AST-shape assertions catch shape regressions at unit-test time
+     * even when result-set parity is preserved.
+     *
+     * <p>Caveat: this test does NOT catch the specific 1621fbafbf bug
+     * (post-descent ordering wrapped predicated steps against the
+     * parens-context before distribution moved them; the resulting
+     * structural tree is identical to the working form). Catching that
+     * regression structurally requires either a perf-bound assertion
+     * or wiring through visitor-call-order instrumentation -- both more
+     * brittle than this shape check. The shape check covers the broader
+     * class of "did distribution happen at all and produce a well-formed
+     * Union" regressions.
+     */
+    @Test
+    public void parensFormDistributesToUnionShape() throws XMLDBException {
+        final EXistXQueryService svc = server.getRoot().getService(EXistXQueryService.class);
+        final String prefix = "let $d := doc('/db/" + COLLECTION_NAME + "/" + DOC_NAME + "') return ";
+        final String parens = OPTIMIZE + prefix
+                + "$d//(book[contains(title, 'O')] | journal[contains(title, 'T')])";
+
+        final CompiledExpression compiled = svc.compile(parens);
+        // execute() triggers analyze + optimize on the compiled tree.
+        svc.execute(compiled);
+        final PathExpr root = (PathExpr) compiled;
+
+        final Union union = findUnion(root);
+        assertNotNull("After optimization, the parens form must contain a Union -- "
+                + "distribution did not fire. AST: " + ExpressionDumperHelper.dump(root), union);
+
+        // Distribution must produce one branch per original union arm
+        // (binary case here: 2 branches).
+        final java.util.List<PathExpr> branches = flattenUnionBranches(union);
+        assertEquals("Distributed Union should have 2 branches (one per original union arm). AST: "
+                + ExpressionDumperHelper.dump(union), 2, branches.size());
+
+        // Each branch must contain the original element name (book or journal).
+        // The branch's last LocationStep is whichever was the original union
+        // arm; assert the qnames cover the expected set so we catch regressions
+        // where distribution drops or duplicates branches.
+        final java.util.Set<String> branchNames = new java.util.HashSet<>();
+        for (final PathExpr branch : branches) {
+            for (int i = 0; i < branch.getLength(); i++) {
+                final Expression step = branch.getExpression(i);
+                final LocationStep ls;
+                if (step instanceof final LocationStep loc) {
+                    ls = loc;
+                } else if (step instanceof final ExtensionExpression ext
+                        && ext.getExpression() instanceof final LocationStep loc) {
+                    ls = loc;
+                } else {
+                    continue;
+                }
+                if (ls.getTest().getName() != null) {
+                    branchNames.add(ls.getTest().getName().getLocalPart());
+                }
+            }
+        }
+        assertTrue("Distributed branch must reference 'book': " + branchNames
+                        + " | AST: " + ExpressionDumperHelper.dump(union),
+                branchNames.contains("book"));
+        assertTrue("Distributed branch must reference 'journal': " + branchNames
+                        + " | AST: " + ExpressionDumperHelper.dump(union),
+                branchNames.contains("journal"));
+
+        // Each distributed branch must include the outer prefix steps (the
+        // VarRef $d and the descendant-or-self step from `//`). A regression
+        // in distributeBranch that drops the prefix would still produce a
+        // Union but the branches would only have the original union arm,
+        // and the result set would change.
+        for (final PathExpr branch : branches) {
+            assertTrue("Distributed branch is missing outer prefix steps "
+                            + "(expected at least 2 steps: VarRef + LocationStep + the branch arm). "
+                            + "Branch length=" + branch.getLength()
+                            + " | AST: " + ExpressionDumperHelper.dump(branch),
+                    branch.getLength() >= 2);
+            assertTrue("First step of distributed branch must be the outer VarRef $d "
+                            + "or a fused descendant LocationStep -- not the inner union arm directly. "
+                            + "Branch AST: " + ExpressionDumperHelper.dump(branch),
+                    branch.getExpression(0) instanceof VariableReference
+                            || branch.getExpression(0) instanceof LocationStep);
+        }
+    }
+
+    /**
+     * Walk an expression tree returning the first Union found, or null if
+     * none. Uses DefaultExpressionVisitor's visitor-driven descent so
+     * wrapper types (LetExpr, FilteredExpression, ...) are handled by their
+     * canonical visit methods rather than the inherited getSubExpression
+     * default, which returns 0 for many of them.
+     */
+    private static Union findUnion(final Expression e) {
+        if (e == null) {
+            return null;
+        }
+        final Union[] found = new Union[1];
+        e.accept(new DefaultExpressionVisitor() {
+            @Override
+            public void visitUnionExpr(final Union union) {
+                if (found[0] == null) {
+                    found[0] = union;
+                }
+            }
+        });
+        return found[0];
+    }
+
+    private static java.util.List<PathExpr> flattenUnionBranches(final Union u) {
+        final java.util.List<PathExpr> out = new java.util.ArrayList<>();
+        flattenBranchInto(u.getLeft(), out);
+        flattenBranchInto(u.getRight(), out);
+        return out;
+    }
+
+    private static void flattenBranchInto(final PathExpr branch, final java.util.List<PathExpr> out) {
+        if (branch.getLength() == 1 && branch.getExpression(0) instanceof final Union nested) {
+            flattenBranchInto(nested.getLeft(), out);
+            flattenBranchInto(nested.getRight(), out);
+            return;
+        }
+        out.add(branch);
+    }
+
+    /**
+     * Wrapper to keep the test file's static imports tidy. Calls the
+     * {@link org.exist.xquery.util.ExpressionDumper#dump(Expression)} helper.
+     */
+    private static final class ExpressionDumperHelper {
+        static String dump(final Expression e) {
+            return org.exist.xquery.util.ExpressionDumper.dump(e);
+        }
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -259,6 +259,27 @@ public class UnionStepDistributionOptimizerTest {
     }
 
     @Test
+    public void fundocsShapeMixedBranches() throws XMLDBException {
+        // Replicates the search-everywhere shape from the function-documentation
+        // app: an outer //(...) over branches that mix single predicated
+        // LocationSteps with multi-step paths. line-o reported on PR #6310 that
+        // this query takes 9s and PathExpr.replaceAllSteps is never called.
+        final String body = """
+                let $d := doc('/db/%s/%s')
+                return $d//(
+                    book[contains(title, 'One')]
+                    | book[contains(author, 'Bob')]
+                    | journal[contains(title, 'Three')]
+                    | article[@id='a1']
+                )
+                """.formatted(COLLECTION_NAME, DOC_NAME);
+        final XQueryService svc = server.getRoot().getService(XQueryService.class);
+        final ResourceSet baseline = svc.query(NO_OPTIMIZE + body);
+        final ResourceSet optimized = svc.query(OPTIMIZE + body);
+        assertEquals("Optimized must match baseline", baseline.getSize(), optimized.getSize());
+    }
+
+    @Test
     public void unionWithNonNodeReturningSuffix() throws XMLDBException {
         // outer/(A|B)/string() -- the suffix returns strings, not nodes.
         // Distribution would push /string() into each branch, making the


### PR DESCRIPTION
## Summary

Companion to #6303. That PR fixed the parenthesised single-step case `//(name)` -> `//name` so the structural index by qname could dispatch the step. The remaining slow shape is the union-of-steps form `outer//(A | B [| C ...])`. This PR rewrites it to `outer//A | outer//B [| outer//C ...]` so each branch dispatches through the structural index independently.

~~After this PR the user-land manual rewrite in [function-documentation#178](https://github.com/eXist-db/function-documentation/pull/178) becomes unnecessary -- the engine produces the same fast path automatically.~~

## Performance context

From the [#6295 investigation](https://github.com/eXist-db/exist/pull/6295#issuecomment-4387895437), on a 6,000-function xqdoc-style corpus on `develop`:

| Query | Time | Note |
|---|---|---|
| `//xqdoc:function \| //xqdoc:module` | 3 ms | baseline (split form) |
| `//(xqdoc:function \| xqdoc:module)` | 165 ms | ~55x slower |
| `//(xqdoc:function \| xqdoc:module \| xqdoc:name)` | 233 ms | scales with branches |
| `//*` (full descendant scan) | 22 ms | reference |

Same XPath result, dramatically different runtimes. The split form uses the structural index per branch; the parenthesised form materialises the descendant axis and applies the union as a generic step. After this PR the slow forms reach the same fast path.

## What changed

### `exist-core/src/main/java/org/exist/xquery/PathExpr.java`

* New `replaceAllSteps(Expression)` method. Collapses a multi-step path into a single-step path containing one expression. The existing `replace(old, new)` only swaps one step at a time and doesn't fit the bulk rewrite.

### `exist-core/src/main/java/org/exist/xquery/Optimizer.java`

* `visitPathExpr` extended with a Case B branch alongside the existing Case A unwrap.
* When a step is exactly `PathExpr.class` wrapping a `Union` (or a tree of Unions for n-ary cases), build a distributed `Union` whose branches are full paths combining `outer.prefix + branch.steps + outer.suffix`.
* Recurses over nested Unions so `A | B | C` (parses as `Union(Union(A, B), C)`) becomes `Union(Union(P_A, P_B), P_C)`.

## Safety constraints (each enforced and tested)

1. **Exact-class check (`step.getClass() == PathExpr.class`).** Many semantically loaded expression types extend `PathExpr` (`UnaryExpr`, `BinaryOp`, `OpNumeric`, `ConcatExpr`, `EnclosedExpr`, `LogicalOp`, `RangeExpression`, ...). A generic `instanceof PathExpr` would corrupt their semantics -- the same trap flagged in #6303.

2. **Skip when `predicates > 0`.** Inside a predicate, `Predicate.selectByNodeSet` walks each result node and looks up its `contextId` to map back to its candidate. Splitting the predicate's inner path into a Union breaks the contextId thread; the engine throws \`Internal evaluation error: context is missing for node ...\`. The existing `UnionTest.unionInPredicate_*` tests caught this regression.

3. **Skip when any suffix step is not a LocationStep.** Distribution moves the suffix into each branch, so the branch's last step becomes whatever was at the end of the original path. If that's `/string()` or another non-node-returning expression, the new Union fails its operand-must-be-node-sequence invariant in `CombiningExpression.combine`. Caught by xmlts \`UnionInPath\` tests.

4. **Require every leaf branch to be a non-empty PathExpr of LocationSteps** (recursing through nested Unions for n-ary cases). Conservative -- false negatives just mean missed optimisations, not broken code.

## Test plan

- [x] `OptimizerTest` (7), `UnionTest` (3), `XPathQueryTest` (150), `XQuery3Tests` (1,011), `xquery.CoreTests`, `xquery.xqsuite.XQSuiteTests` -- all green
- [x] Full `exist-core` suite: **6,687 tests, 0 failures, 105 pre-existing skipped**
- [x] `extensions/indexes/ngram` (39), `extensions/indexes/range` (428), `extensions/indexes/lucene` (659) -- all green
- [x] New `UnionStepDistributionOptimizerTest` (18 tests): binary and n-ary unions, prefix and suffix steps, attribute axes, mixed paths, predicate-internal unions (verifies the skip), non-node suffix (verifies the skip), document-order preservation, FLWOR/function-call parents
- [x] Codacy PMD: no new warnings introduced (the 6 reported warnings are all pre-existing on `develop`)

## References

* PR #6303 -- Case A (single-step parens unwrap)
* PR #6300 -- discipline for small surgical Optimizer fixes
* PR #6295 -- the originating investigation thread
* PR function-documentation#178 -- the user-land workaround this makes redundant

🤖 Generated with [Claude Code](https://claude.com/claude-code)