### PR TITLE
[bugfix] Reindex lifecycle hardening, legacy fixes , and regression benchmarks/tests

### DIFF
--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -70,6 +70,11 @@
             <version>${jmh.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -161,6 +161,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -55,6 +55,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -50,6 +50,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>exist-index-lucene</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
@@ -121,6 +126,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/LucenePhraseQueryBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/LucenePhraseQueryBenchmark.java
@@ -1,0 +1,274 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.CollectionConfigurationException;
+import org.exist.collections.CollectionConfigurationManager;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.value.Sequence;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark for query-time Lucene phrase lookup on many small documents.
+ *
+ * <p>Inspired by the performance regression report in
+ * <a href="https://github.com/eXist-db/exist/issues/2812">#2812</a>: a query of the form
+ * {@code collection(...)//custom:id[ft:query(., <phrase>datum1</phrase>)]/..} over many
+ * small documents.</p>
+ *
+ * <p>This benchmark focuses on query execution cost (not reindex), with the Lucene
+ * index created via collection configuration before loading documents.</p>
+ *
+ * <h2>Build &amp; run (from project root)</h2>
+ * <pre>{@code
+ * mvn install -pl exist-core-jmh -am -DskipTests \
+ *     -Ddependency-check.skip=true -Ddocker=false
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     LucenePhraseQueryBenchmark -f 1 -wi 3 -i 5
+ * }</pre>
+ *
+ * <h2>Common variants</h2>
+ * <pre>{@code
+ * # Smaller data volume for smoke checks
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     LucenePhraseQueryBenchmark -f 1 -wi 1 -i 2 -p docCount=100 -p matchEvery=10
+ *
+ * # Skip correctness check (throughput-only)
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     LucenePhraseQueryBenchmark -f 1 -wi 3 -i 5 -p verificationMode=SKIP
+ * }</pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class LucenePhraseQueryBenchmark {
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/bench-lucene-phrase");
+    private static final XmldbURI TEST_COLLECTION_ONE = XmldbURI.create("/db/bench-lucene-phrase/col1");
+    private static final XmldbURI TEST_COLLECTION_TWO = XmldbURI.create("/db/bench-lucene-phrase/col2");
+
+    private static final String CUSTOM_NS = "urn:custom";
+
+    private static final String LUCENE_CONFIG = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0"
+                        xmlns:custom="%s">
+              <index>
+                <lucene>
+                  <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                  <text qname="custom:id"/>
+                </lucene>
+              </index>
+            </collection>""".formatted(CUSTOM_NS);
+
+    @Param({"1000", "5000"})
+    int docCount;
+
+    /**
+     * Every Nth document contains the phrase. 1 means all docs match; 10 means 10% match.
+     */
+    @Param({"1", "10"})
+    int matchEvery;
+
+    @Param({"STRICT"})
+    String verificationMode;
+
+    @Param({"single", "unionExplicit", "unionCollectionParens"})
+    String queryVariant;
+
+    private ExistEmbeddedServer server;
+    private BrokerPool pool;
+
+    private CompiledXQuery compiledQuery;
+    private int expectedHits;
+
+    @Setup(Level.Trial)
+    public void setUp() throws EXistException, DatabaseConfigurationException, IOException,
+            PermissionDeniedException, CollectionConfigurationException, LockException,
+            SAXException, TriggerException, XPathException {
+        ensureExistHome();
+        final Properties configProperties = new Properties();
+        // BrokerPool expects a Long for this property (see BrokerPool.PROPERTY_SHUTDOWN_DELAY).
+        configProperties.put("wait-before-shutdown", 0L);
+        server = new ExistEmbeddedServer(configProperties, true, true);
+        server.startDb();
+        pool = server.getBrokerPool();
+
+        storeDocuments();
+
+        expectedHits = (docCount + matchEvery - 1) / matchEvery;
+
+        final String query = buildQuery(queryVariant);
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            compiledQuery = xquery.compile(context, query);
+        }
+    }
+
+    private static void ensureExistHome() {
+        if (System.getProperty("exist.home") != null) {
+            return;
+        }
+        // Default for running the JMH jar from the project root.
+        // Prefer the Lucene extension's test conf (it enables the Lucene index/module).
+        final Path luceneHome = Path.of("extensions", "indexes", "lucene", "src", "test", "resources-filtered")
+                .toAbsolutePath()
+                .normalize();
+        final Path existHome = Files.exists(luceneHome.resolve("conf.xml"))
+                ? luceneHome
+                : Path.of("exist-core", "src", "test", "resources-filtered").toAbsolutePath().normalize();
+        System.setProperty("exist.home", existHome.toString());
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (server != null) {
+            server.stopDb();
+        }
+    }
+
+    @Benchmark
+    public int phraseQuery() throws EXistException, PermissionDeniedException, XPathException, IOException {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, compiledQuery, null);
+            final int hits = result.getItemCount();
+            if (shouldVerify(verificationMode) && hits != expectedHits) {
+                throw new IllegalStateException("Expected " + expectedHits + " hits, got " + hits);
+            }
+            return hits;
+        }
+    }
+
+    private static boolean shouldVerify(final String verificationMode) {
+        return !"SKIP".equalsIgnoreCase(verificationMode);
+    }
+
+    private void storeDocuments() throws EXistException, PermissionDeniedException, IOException,
+            CollectionConfigurationException, LockException, SAXException, TriggerException {
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn tx = transact.beginTransaction()) {
+
+            final Collection coll = broker.getOrCreateCollection(tx, TEST_COLLECTION);
+            broker.saveCollection(tx, coll);
+
+            final CollectionConfigurationManager mgr = pool.getConfigurationManager();
+            mgr.addConfiguration(tx, broker, coll, LUCENE_CONFIG);
+
+            final Collection col1 = broker.getOrCreateCollection(tx, TEST_COLLECTION_ONE);
+            broker.saveCollection(tx, col1);
+            mgr.addConfiguration(tx, broker, col1, LUCENE_CONFIG);
+
+            final Collection col2 = broker.getOrCreateCollection(tx, TEST_COLLECTION_TWO);
+            broker.saveCollection(tx, col2);
+            mgr.addConfiguration(tx, broker, col2, LUCENE_CONFIG);
+
+            for (int i = 1; i <= docCount; i++) {
+                final boolean matches = (i % matchEvery) == 1;
+                final Collection target = (i % 2 == 0) ? col2 : col1;
+                broker.storeDocument(tx, XmldbURI.create("doc-" + i + ".xml"),
+                        new StringInputSource(generateDocument(i, matches)), MimeType.XML_TYPE, target);
+            }
+
+            transact.commit(tx);
+        }
+    }
+
+    private static String buildQuery(final String variant) {
+        final String prolog = """
+                xquery version "3.1";
+                declare namespace custom="%s";
+                import module namespace ft="http://exist-db.org/xquery/lucene"
+                  at "java:org.exist.xquery.modules.lucene.LuceneModule";
+                let $q := <query><phrase>datum1</phrase></query>
+                """.formatted(CUSTOM_NS);
+
+        return switch (variant) {
+            case "single" -> prolog + """
+                    return collection('%s')//custom:id[ft:query(., $q)]/..
+                    """.formatted(TEST_COLLECTION);
+            case "unionExplicit" -> prolog + """
+                    return (
+                      (collection('%s')//custom:id[ft:query(., $q)]/..)
+                      | (collection('%s')//custom:id[ft:query(., $q)]/..)
+                    )
+                    """.formatted(TEST_COLLECTION_ONE, TEST_COLLECTION_TWO);
+            case "unionCollectionParens" -> prolog + """
+                    return (
+                      (collection('%s') | collection('%s'))//custom:id[ft:query(., $q)]/..
+                    )
+                    """.formatted(TEST_COLLECTION_ONE, TEST_COLLECTION_TWO);
+            default -> throw new IllegalArgumentException("Unknown queryVariant: " + variant);
+        };
+    }
+
+    private static String generateDocument(final int index, final boolean matches) {
+        final String value = matches ? "datum1" : ("datum" + index);
+        return """
+                <data xmlns:custom="%s">
+                  <custom:id>%s</custom:id>
+                  <payload>Small document %d for lucene phrase query benchmark.</payload>
+                </data>""".formatted(CUSTOM_NS, value, index);
+    }
+}
+

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
@@ -84,7 +84,7 @@ public class ReindexDeleteStrategyBenchmark {
                 writer.deleteDocuments(nodeScopedDeleteQuery(docIdQuery));
             }
             writer.commit();
-            return remainingNamedFieldDocs(directory);
+            return assertNamedFieldSurvivors(directory, state.docCount);
         }
     }
 
@@ -105,7 +105,7 @@ public class ReindexDeleteStrategyBenchmark {
                 writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
             }
             writer.commit();
-            return remainingNamedFieldDocs(directory);
+            return assertNamedFieldSurvivors(directory, state.docCount);
         }
     }
 
@@ -144,10 +144,16 @@ public class ReindexDeleteStrategyBenchmark {
         return doc;
     }
 
-    private static int remainingNamedFieldDocs(final Directory directory) throws IOException {
+    private static int assertNamedFieldSurvivors(final Directory directory, final int expectedNamedDocs) throws IOException {
         try (DirectoryReader reader = DirectoryReader.open(directory)) {
             final IndexSearcher searcher = new IndexSearcher(reader);
-            return searcher.count(new TermQuery(new Term(FIELD_INDEXED, "named")));
+            final int named = searcher.count(new TermQuery(new Term(FIELD_INDEXED, "named")));
+            if (named != expectedNamedDocs) {
+                throw new IllegalStateException(
+                        "Expected " + expectedNamedDocs + " named-field docs after deletion, but found " + named
+                );
+            }
+            return named;
         }
     }
 }

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
@@ -1,0 +1,153 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks reindex-time Lucene delete strategies for mixed document shapes:
+ * node-backed entries and named-field entries sharing the same docId.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class ReindexDeleteStrategyBenchmark {
+
+    private static final String FIELD_DOC_ID = "docId";
+    private static final String FIELD_INDEXED = "indexed";
+    private static final int DELETE_BATCH_SIZE = 128;
+    private static final Query NODE_EXISTS_QUERY = new FieldExistsQuery(LuceneUtil.FIELD_NODE_ID_DV);
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        @Param({"1000", "5000"})
+        public int docCount;
+    }
+
+    @Benchmark
+    public int deletePerDoc(final BenchmarkState state) throws IOException {
+        try (Directory directory = buildIndex(state.docCount);
+             IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+            for (int docId = 1; docId <= state.docCount; docId++) {
+                final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, docId);
+                writer.deleteDocuments(nodeScopedDeleteQuery(docIdQuery));
+            }
+            writer.commit();
+            return remainingNamedFieldDocs(directory);
+        }
+    }
+
+    @Benchmark
+    public int deleteInBatches(final BenchmarkState state) throws IOException {
+        try (Directory directory = buildIndex(state.docCount);
+             IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+
+            int nextDocId = 1;
+            while (nextDocId <= state.docCount) {
+                final BooleanQuery.Builder batchedDocIdQuery = new BooleanQuery.Builder();
+                int clauses = 0;
+                final int maxClausesPerBatch = Math.min(DELETE_BATCH_SIZE, IndexSearcher.getMaxClauseCount());
+                while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
+                    batchedDocIdQuery.add(IntField.newExactQuery(FIELD_DOC_ID, nextDocId++), BooleanClause.Occur.SHOULD);
+                    clauses++;
+                }
+                writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+            }
+            writer.commit();
+            return remainingNamedFieldDocs(directory);
+        }
+    }
+
+    private static Query nodeScopedDeleteQuery(final Query docIdQuery) {
+        return new BooleanQuery.Builder()
+                .add(docIdQuery, BooleanClause.Occur.MUST)
+                .add(NODE_EXISTS_QUERY, BooleanClause.Occur.MUST)
+                .build();
+    }
+
+    private static Directory buildIndex(final int docCount) throws IOException {
+        final Directory directory = new ByteBuffersDirectory();
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+            for (int docId = 1; docId <= docCount; docId++) {
+                writer.addDocument(nodeDocument(docId));
+                writer.addDocument(namedFieldDocument(docId));
+            }
+            writer.commit();
+        }
+        return directory;
+    }
+
+    private static Document nodeDocument(final int docId) {
+        final Document doc = new Document();
+        doc.add(new IntField(FIELD_DOC_ID, docId, Field.Store.NO));
+        doc.add(new StringField(FIELD_INDEXED, "node", Field.Store.NO));
+        doc.add(new SortedDocValuesField(LuceneUtil.FIELD_NODE_ID_DV, new BytesRef("n-" + docId)));
+        return doc;
+    }
+
+    private static Document namedFieldDocument(final int docId) {
+        final Document doc = new Document();
+        doc.add(new IntField(FIELD_DOC_ID, docId, Field.Store.NO));
+        doc.add(new StringField(FIELD_INDEXED, "named", Field.Store.NO));
+        doc.add(new StoredField("foo-field", "Foobar index data"));
+        return doc;
+    }
+
+    private static int remainingNamedFieldDocs(final Directory directory) throws IOException {
+        try (DirectoryReader reader = DirectoryReader.open(directory)) {
+            final IndexSearcher searcher = new IndexSearcher(reader);
+            return searcher.count(new TermQuery(new Term(FIELD_INDEXED, "named")));
+        }
+    }
+}

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
@@ -31,12 +31,12 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -44,6 +44,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -60,11 +61,27 @@ import java.util.concurrent.TimeUnit;
 /**
  * Benchmarks reindex-time Lucene delete strategies for mixed document shapes:
  * node-backed entries and named-field entries sharing the same docId.
+ *
+ * <h2>Build &amp; run (from project root)</h2>
+ * <pre>{@code
+ * mvn install -pl exist-core-jmh -am -DskipTests \
+ *     -Ddependency-check.skip=true -Ddocker=false
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexDeleteStrategyBenchmark -f 1 -wi 3 -i 5
+ * }</pre>
+ *
+ * <h2>Common variants</h2>
+ * <pre>{@code
+ * # Batch-size sweep (TermInSet and Boolean SHOULD variants)
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexDeleteStrategyBenchmark.deleteInBatches*Sweep -f 1 -wi 2 -i 3 -p batchSize=64,128,256,512,1024
+ * }</pre>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
 public class ReindexDeleteStrategyBenchmark {
 
     private static final String FIELD_DOC_ID = "docId";
@@ -107,7 +124,7 @@ public class ReindexDeleteStrategyBenchmark {
             while (nextDocId <= state.docCount) {
                 final BooleanQuery.Builder batchedDocIdQuery = new BooleanQuery.Builder();
                 int clauses = 0;
-                final int maxClausesPerBatch = Math.min(DELETE_BATCH_SIZE, IndexSearcher.getMaxClauseCount());
+                final int maxClausesPerBatch = boundedBatchSize(DELETE_BATCH_SIZE);
                 while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
                     batchedDocIdQuery.add(IntField.newExactQuery(FIELD_DOC_ID, nextDocId++), BooleanClause.Occur.SHOULD);
                     clauses++;

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
@@ -52,6 +53,8 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -65,6 +68,7 @@ import java.util.concurrent.TimeUnit;
 public class ReindexDeleteStrategyBenchmark {
 
     private static final String FIELD_DOC_ID = "docId";
+    private static final String FIELD_DOC_ID_KEYWORD = "docIdKeyword";
     private static final String FIELD_INDEXED = "indexed";
     private static final int DELETE_BATCH_SIZE = 128;
     private static final Query NODE_EXISTS_QUERY = new FieldExistsQuery(LuceneUtil.FIELD_NODE_ID_DV);
@@ -76,6 +80,9 @@ public class ReindexDeleteStrategyBenchmark {
 
         @Param({"1", "10"})
         public int nodeDocStride;
+
+        @Param({"64", "128", "256", "512", "1024"})
+        public int batchSize;
     }
 
     @Benchmark
@@ -122,7 +129,7 @@ public class ReindexDeleteStrategyBenchmark {
             while (nextDocId <= state.docCount) {
                 final BooleanQuery.Builder batchedDocIdQuery = new BooleanQuery.Builder();
                 int clauses = 0;
-                final int maxClausesPerBatch = Math.min(DELETE_BATCH_SIZE, IndexSearcher.getMaxClauseCount());
+                final int maxClausesPerBatch = boundedBatchSize(state.batchSize);
                 while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
                     batchedDocIdQuery.add(IntField.newExactQuery(FIELD_DOC_ID, nextDocId++), BooleanClause.Occur.SHOULD);
                     clauses++;
@@ -137,11 +144,58 @@ public class ReindexDeleteStrategyBenchmark {
         }
     }
 
+    @Benchmark
+    public int deleteInBatchesBooleanShouldSweep(final BenchmarkState state) throws IOException {
+        try (Directory directory = buildIndex(state.docCount, state.nodeDocStride);
+             IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+
+            int nextDocId = 1;
+            while (nextDocId <= state.docCount) {
+                final BooleanQuery.Builder batchedDocIdQuery = new BooleanQuery.Builder();
+                int clauses = 0;
+                final int maxClausesPerBatch = boundedBatchSize(state.batchSize);
+                while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
+                    batchedDocIdQuery.add(IntField.newExactQuery(FIELD_DOC_ID, nextDocId++), BooleanClause.Occur.SHOULD);
+                    clauses++;
+                }
+                writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+            }
+            writer.commit();
+            return assertNamedFieldSurvivors(directory, state.docCount);
+        }
+    }
+
+    @Benchmark
+    public int deleteInBatchesTermInSetSweep(final BenchmarkState state) throws IOException {
+        try (Directory directory = buildIndex(state.docCount, state.nodeDocStride);
+             IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+
+            int nextDocId = 1;
+            while (nextDocId <= state.docCount) {
+                final int maxClausesPerBatch = boundedBatchSize(state.batchSize);
+                final List<BytesRef> docIds = new ArrayList<>(maxClausesPerBatch);
+                int clauses = 0;
+                while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
+                    docIds.add(new BytesRef(Integer.toString(nextDocId++)));
+                    clauses++;
+                }
+                final Query termInSet = new TermInSetQuery(FIELD_DOC_ID_KEYWORD, docIds);
+                writer.deleteDocuments(nodeScopedDeleteQuery(termInSet));
+            }
+            writer.commit();
+            return assertNamedFieldSurvivors(directory, state.docCount);
+        }
+    }
+
     private static Query nodeScopedDeleteQuery(final Query docIdQuery) {
         return new BooleanQuery.Builder()
                 .add(docIdQuery, BooleanClause.Occur.MUST)
                 .add(NODE_EXISTS_QUERY, BooleanClause.Occur.MUST)
                 .build();
+    }
+
+    private static int boundedBatchSize(final int requestedBatchSize) {
+        return Math.max(1, Math.min(requestedBatchSize, IndexSearcher.getMaxClauseCount()));
     }
 
     private static Directory buildIndex(final int docCount, final int nodeDocStride) throws IOException {
@@ -161,6 +215,7 @@ public class ReindexDeleteStrategyBenchmark {
     private static Document nodeDocument(final int docId) {
         final Document doc = new Document();
         doc.add(new IntField(FIELD_DOC_ID, docId, Field.Store.NO));
+        doc.add(new StringField(FIELD_DOC_ID_KEYWORD, Integer.toString(docId), Field.Store.NO));
         doc.add(new StringField(FIELD_INDEXED, "node", Field.Store.NO));
         doc.add(new SortedDocValuesField(LuceneUtil.FIELD_NODE_ID_DV, new BytesRef("n-" + docId)));
         return doc;
@@ -169,6 +224,7 @@ public class ReindexDeleteStrategyBenchmark {
     private static Document namedFieldDocument(final int docId) {
         final Document doc = new Document();
         doc.add(new IntField(FIELD_DOC_ID, docId, Field.Store.NO));
+        doc.add(new StringField(FIELD_DOC_ID_KEYWORD, Integer.toString(docId), Field.Store.NO));
         doc.add(new StringField(FIELD_INDEXED, "named", Field.Store.NO));
         doc.add(new StoredField("foo-field", "Foobar index data"));
         return doc;

--- a/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java
@@ -73,11 +73,14 @@ public class ReindexDeleteStrategyBenchmark {
     public static class BenchmarkState {
         @Param({"1000", "5000"})
         public int docCount;
+
+        @Param({"1", "10"})
+        public int nodeDocStride;
     }
 
     @Benchmark
     public int deletePerDoc(final BenchmarkState state) throws IOException {
-        try (Directory directory = buildIndex(state.docCount);
+        try (Directory directory = buildIndex(state.docCount, state.nodeDocStride);
              IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
             for (int docId = 1; docId <= state.docCount; docId++) {
                 final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, docId);
@@ -90,7 +93,7 @@ public class ReindexDeleteStrategyBenchmark {
 
     @Benchmark
     public int deleteInBatches(final BenchmarkState state) throws IOException {
-        try (Directory directory = buildIndex(state.docCount);
+        try (Directory directory = buildIndex(state.docCount, state.nodeDocStride);
              IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
 
             int nextDocId = 1;
@@ -109,6 +112,31 @@ public class ReindexDeleteStrategyBenchmark {
         }
     }
 
+    @Benchmark
+    public int deleteInBatchesWithNoopCheck(final BenchmarkState state) throws IOException {
+        try (Directory directory = buildIndex(state.docCount, state.nodeDocStride);
+             DirectoryReader preCheckReader = DirectoryReader.open(directory);
+             IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+            final IndexSearcher preCheckSearcher = new IndexSearcher(preCheckReader);
+            int nextDocId = 1;
+            while (nextDocId <= state.docCount) {
+                final BooleanQuery.Builder batchedDocIdQuery = new BooleanQuery.Builder();
+                int clauses = 0;
+                final int maxClausesPerBatch = Math.min(DELETE_BATCH_SIZE, IndexSearcher.getMaxClauseCount());
+                while (nextDocId <= state.docCount && clauses < maxClausesPerBatch) {
+                    batchedDocIdQuery.add(IntField.newExactQuery(FIELD_DOC_ID, nextDocId++), BooleanClause.Occur.SHOULD);
+                    clauses++;
+                }
+                final Query deleteQuery = nodeScopedDeleteQuery(batchedDocIdQuery.build());
+                if (preCheckSearcher.count(deleteQuery) > 0) {
+                    writer.deleteDocuments(deleteQuery);
+                }
+            }
+            writer.commit();
+            return assertNamedFieldSurvivors(directory, state.docCount);
+        }
+    }
+
     private static Query nodeScopedDeleteQuery(final Query docIdQuery) {
         return new BooleanQuery.Builder()
                 .add(docIdQuery, BooleanClause.Occur.MUST)
@@ -116,11 +144,13 @@ public class ReindexDeleteStrategyBenchmark {
                 .build();
     }
 
-    private static Directory buildIndex(final int docCount) throws IOException {
+    private static Directory buildIndex(final int docCount, final int nodeDocStride) throws IOException {
         final Directory directory = new ByteBuffersDirectory();
         try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
             for (int docId = 1; docId <= docCount; docId++) {
-                writer.addDocument(nodeDocument(docId));
+                if (docId % nodeDocStride == 0) {
+                    writer.addDocument(nodeDocument(docId));
+                }
                 writer.addDocument(namedFieldDocument(docId));
             }
             writer.commit();

--- a/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
@@ -55,6 +55,7 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -66,16 +67,31 @@ import java.util.concurrent.TimeUnit;
  * DOM BTree and structural/value index rebuilds, only touching custom
  * extension indexes (Lucene, range, etc.).</p>
  *
- * <p>After every invocation a correctness guard runs {@code ft:query} and
- * an XPath count to verify the indexes still work — preventing "fast but
- * wrong" results.</p>
+ * <p>After every invocation a correctness guard runs XPath-based checks to
+ * verify the indexed content still matches expected document counts —
+ * preventing "fast but wrong" results.</p>
  *
- * <h3>Build &amp; run (from project root)</h3>
+ * <h2>Build &amp; run (from project root)</h2>
  * <pre>{@code
  * mvn install -pl exist-core-jmh -am -DskipTests \
  *     -Ddependency-check.skip=true -Ddocker=false
  * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
  *     ReindexBenchmark -f 1 -wi 3 -i 5
+ * }</pre>
+ *
+ * <h2>Common variants</h2>
+ * <pre>{@code
+ * # Default correctness checks enabled (CI-friendly baseline)
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexBenchmark -f 1 -wi 3 -i 5 -p verificationMode=STRICT
+ *
+ * # Throughput-only run (skip verification checks)
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexBenchmark -f 1 -wi 3 -i 5 -p verificationMode=SKIP
+ *
+ * # Smaller data volume for smoke checks
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexBenchmark -f 1 -wi 1 -i 2 -p docCount=100 -p verificationMode=STRICT
  * }</pre>
  *
  * <p>To compare old vs new behaviour, run the benchmark on a commit before
@@ -106,6 +122,9 @@ public class ReindexBenchmark {
     @Param({"100", "500", "1000"})
     int docCount;
 
+    @Param({"STRICT"})
+    String verificationMode;
+
     private ExistEmbeddedServer server;
     private BrokerPool pool;
 
@@ -113,7 +132,11 @@ public class ReindexBenchmark {
     public void setUp() throws EXistException, DatabaseConfigurationException, IOException,
             PermissionDeniedException, CollectionConfigurationException, LockException,
             SAXException, TriggerException {
-        server = new ExistEmbeddedServer(true, true);
+        final Properties configProperties = new Properties();
+        // Keep JMH forks clean: request immediate BrokerPool shutdown so Quartz
+        // workers do not linger past benchmark completion.
+        configProperties.setProperty("wait-before-shutdown", "0");
+        server = new ExistEmbeddedServer(configProperties, true, true);
         server.startDb();
         pool = server.getBrokerPool();
         storeDocuments();
@@ -145,10 +168,14 @@ public class ReindexBenchmark {
             broker.reindexCollection(tx, TEST_COLLECTION);
             transact.commit(tx);
         }
-        if (Boolean.getBoolean("exist.jmh.reindex.skipVerify")) {
+        if (!shouldVerify(verificationMode)) {
             return docCount;
         }
         return verifyIndex();
+    }
+
+    static boolean shouldVerify(final String verificationMode) {
+        return !"SKIP".equalsIgnoreCase(verificationMode);
     }
 
     private void storeDocuments() throws EXistException, PermissionDeniedException, IOException,

--- a/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
@@ -1,0 +1,217 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.CollectionConfigurationException;
+import org.exist.collections.CollectionConfigurationManager;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark for the {@code xmldb:reindex()} optimisation
+ * (<a href="https://github.com/eXist-db/exist/issues/572">#572</a>).
+ *
+ * <p>Measures end-to-end reindex time for a synthetic collection with a
+ * Lucene full-text index.  The {@code IndexMode.REINDEX} fast-path skips
+ * DOM BTree and structural/value index rebuilds, only touching custom
+ * extension indexes (Lucene, range, etc.).</p>
+ *
+ * <p>After every invocation a correctness guard runs {@code ft:query} and
+ * an XPath count to verify the indexes still work — preventing "fast but
+ * wrong" results.</p>
+ *
+ * <h3>Build &amp; run (from project root)</h3>
+ * <pre>{@code
+ * mvn install -pl exist-core-jmh -am -DskipTests \
+ *     -Ddependency-check.skip=true -Ddocker=false
+ * java -jar exist-core-jmh/target/exist-core-jmh-7.0.0-SNAPSHOT-benchmarks.jar \
+ *     ReindexBenchmark -f 1 -wi 3 -i 5
+ * }</pre>
+ *
+ * <p>To compare old vs new behaviour, run the benchmark on a commit before
+ * and after the {@code IndexMode.REINDEX} change.</p>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ReindexBenchmark {
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/bench-reindex");
+
+    private static final String LUCENE_CONFIG = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+              <index>
+                <lucene>
+                  <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                  <text qname="title"/>
+                  <text qname="body"/>
+                  <text match="/doc/meta/@author"/>
+                </lucene>
+              </index>
+            </collection>""";
+
+    @Param({"100", "500", "1000"})
+    int docCount;
+
+    private ExistEmbeddedServer server;
+    private BrokerPool pool;
+
+    @Setup(Level.Trial)
+    public void setUp() throws EXistException, DatabaseConfigurationException, IOException,
+            PermissionDeniedException, CollectionConfigurationException, LockException,
+            SAXException, TriggerException {
+        server = new ExistEmbeddedServer(true, true);
+        server.startDb();
+        pool = server.getBrokerPool();
+        storeDocuments();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (server != null) {
+            server.stopDb();
+        }
+    }
+
+    /**
+     * Benchmark the public {@code reindexCollection} API.
+     *
+     * <p>On the optimised code this exercises {@code IndexMode.REINDEX}
+     * (skips DOM/structural rebuilds).  On the baseline code it exercises
+     * {@code IndexMode.STORE} (full rebuild).</p>
+     *
+     * @return combined hit counts from the correctness guard (consumed by JMH
+     *         to prevent dead-code elimination)
+     */
+    @Benchmark
+    public int reindex() throws EXistException, PermissionDeniedException, IOException,
+            LockException, XPathException {
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn tx = transact.beginTransaction()) {
+            broker.reindexCollection(tx, TEST_COLLECTION);
+            transact.commit(tx);
+        }
+        if (Boolean.getBoolean("exist.jmh.reindex.skipVerify")) {
+            return docCount;
+        }
+        return verifyIndex();
+    }
+
+    private void storeDocuments() throws EXistException, PermissionDeniedException, IOException,
+            CollectionConfigurationException, LockException, SAXException, TriggerException {
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn tx = transact.beginTransaction()) {
+
+            final Collection coll = broker.getOrCreateCollection(tx, TEST_COLLECTION);
+            broker.saveCollection(tx, coll);
+
+            final CollectionConfigurationManager mgr = pool.getConfigurationManager();
+            mgr.addConfiguration(tx, broker, coll, LUCENE_CONFIG);
+
+            for (int i = 0; i < docCount; i++) {
+                broker.storeDocument(tx, XmldbURI.create("doc-" + i + ".xml"),
+                        new StringInputSource(generateDocument(i)), MimeType.XML_TYPE, coll);
+            }
+            transact.commit(tx);
+        }
+    }
+
+    /**
+     * Verify plain XPath correctness after reindexing. Throws if anything is
+     * off, which JMH surfaces as a benchmark failure.
+     */
+    private int verifyIndex() throws EXistException, PermissionDeniedException, XPathException, IOException {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+
+            final Sequence xpathResult = xquery.execute(broker,
+                    "count(collection('" + TEST_COLLECTION + "')//doc)", null);
+            final int xpathCount = Integer.parseInt(xpathResult.itemAt(0).getStringValue());
+            if (xpathCount != docCount) {
+                throw new IllegalStateException(
+                        "XPath correctness check failed: expected " + docCount + " docs, got " + xpathCount);
+            }
+
+            final Sequence titleResult = xquery.execute(broker,
+                    "count(collection('" + TEST_COLLECTION + "')//title[contains(., 'Benchmark document')])", null);
+            final int titleCount = Integer.parseInt(titleResult.itemAt(0).getStringValue());
+            if (titleCount != docCount) {
+                throw new IllegalStateException(
+                        "XPath title-content check failed: expected " + docCount + " docs, got " + titleCount);
+            }
+
+            return xpathCount + titleCount;
+        }
+    }
+
+    private static String generateDocument(final int index) {
+        return """
+                <doc>
+                  <meta author="author-%1$d"/>
+                  <title>Benchmark document %1$d for reindex testing</title>
+                  <body>
+                    <p>This is paragraph one of document %1$d. \
+                It contains sample text for full-text indexing with Lucene.</p>
+                    <p>The quick brown fox jumps over the lazy dog. \
+                Document number %1$d benchmark performance test.</p>
+                    <p>Additional content to increase document size. \
+                XML database native storage eXist-db %1$d.</p>
+                  </body>
+                </doc>""".formatted(index);
+    }
+}

--- a/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java
@@ -135,7 +135,8 @@ public class ReindexBenchmark {
         final Properties configProperties = new Properties();
         // Keep JMH forks clean: request immediate BrokerPool shutdown so Quartz
         // workers do not linger past benchmark completion.
-        configProperties.setProperty("wait-before-shutdown", "0");
+        // BrokerPool expects a Long for this property (see BrokerPool.PROPERTY_SHUTDOWN_DELAY).
+        configProperties.put("wait-before-shutdown", 0L);
         server = new ExistEmbeddedServer(configProperties, true, true);
         server.startDb();
         pool = server.getBrokerPool();

--- a/exist-core-jmh/src/test/java/org/exist/storage/ReindexBenchmarkTest.java
+++ b/exist-core-jmh/src/test/java/org/exist/storage/ReindexBenchmarkTest.java
@@ -1,0 +1,42 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReindexBenchmarkTest {
+
+    @Test
+    void shouldVerifyDefaultsToTrue() {
+        assertTrue(ReindexBenchmark.shouldVerify("STRICT"));
+        assertTrue(ReindexBenchmark.shouldVerify("unexpected-value"));
+    }
+
+    @Test
+    void shouldSkipVerificationOnlyInSkipMode() {
+        assertFalse(ReindexBenchmark.shouldVerify("SKIP"));
+        assertFalse(ReindexBenchmark.shouldVerify("skip"));
+    }
+}

--- a/exist-core/src/main/java/org/exist/indexing/IndexController.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexController.java
@@ -202,6 +202,9 @@ public class IndexController {
      * @param collection the collection to remove
      * @param broker the broker that will perform the operation
      * @param reindex enable or disable reindexing after removal
+     *
+     * Caller lock contract: at least a collection READ lock must be held while
+     * invoking workers. WRITE lock callers are also valid.
      * @throws PermissionDeniedException in case user does not have sufficient rights
      */
     public void removeCollection(final Collection collection, final DBBroker broker, final boolean reindex)

--- a/exist-core/src/main/java/org/exist/indexing/IndexController.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexController.java
@@ -51,6 +51,10 @@ import org.exist.security.PermissionDeniedException;
  * retrieved via {@link org.exist.storage.DBBroker#getIndexController()}.
  */
 public class IndexController {
+    public enum CollectionIndexRemovalMode {
+        FULL_DROP,
+        CONFIG_ONLY_REINDEX
+    }
 
     private final Map<String, IndexWorker> indexWorkers = new HashMap<>();
 
@@ -201,17 +205,32 @@ public class IndexController {
      *
      * @param collection the collection to remove
      * @param broker the broker that will perform the operation
-     * @param reindex enable or disable reindexing after removal
+     * @param mode removal semantics, either full drop or config-only reindex
      *
      * Caller lock contract: at least a collection READ lock must be held while
      * invoking workers. WRITE lock callers are also valid.
      * @throws PermissionDeniedException in case user does not have sufficient rights
      */
+    public void removeCollection(final Collection collection, final DBBroker broker, final CollectionIndexRemovalMode mode)
+            throws PermissionDeniedException {
+        final boolean configOnlyReindex = mode == CollectionIndexRemovalMode.CONFIG_ONLY_REINDEX;
+        for (final IndexWorker indexWorker : indexWorkers.values()) {
+            // Keep worker interface stable: explicit mode at call sites, boolean
+            // only at the final API boundary.
+            indexWorker.removeCollection(collection, broker, configOnlyReindex);
+        }
+    }
+
+    /**
+     * @deprecated use {@link #removeCollection(Collection, DBBroker, CollectionIndexRemovalMode)}
+     * with explicit semantics.
+     */
+    @Deprecated
     public void removeCollection(final Collection collection, final DBBroker broker, final boolean reindex)
             throws PermissionDeniedException {
-        for (final IndexWorker indexWorker : indexWorkers.values()) {
-            indexWorker.removeCollection(collection, broker, reindex);
-        }
+        removeCollection(collection, broker, reindex
+                ? CollectionIndexRemovalMode.CONFIG_ONLY_REINDEX
+                : CollectionIndexRemovalMode.FULL_DROP);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/indexing/IndexWorker.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexWorker.java
@@ -180,10 +180,11 @@ public interface IndexWorker {
      *
      * @param collection The collection to remove
      * @param broker The broker that will perform the operation
-     * @param reindex enable or disable reindex
+     * @param configOnlyReindex {@code true} for config-only reindex behavior,
+     *                          {@code false} for full index drop behavior
      * @throws PermissionDeniedException in case user does not have sufficient rights
      */
-    void removeCollection(Collection collection, DBBroker broker, boolean reindex) throws PermissionDeniedException;
+    void removeCollection(Collection collection, DBBroker broker, boolean configOnlyReindex) throws PermissionDeniedException;
 
     /** 
      * Checking index could be delegated to a worker. Use this method to do so.

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -593,7 +593,18 @@ public interface DBBroker extends AutoCloseable {
     enum IndexMode {
         STORE,
         REPAIR,
-        REMOVE
+        REMOVE,
+        /**
+         * Rebuild only custom/extension indexes (Lucene, range, etc.) without
+         * touching the DOM BTree ({@code dom.dbx}) or the structural/value
+         * indexes.  Used by user-triggered {@code xmldb:reindex()} where only
+         * the {@code collection.xconf} configuration has changed — the
+         * document content itself is unchanged, so DOM and structural indexes
+         * are still valid.
+         *
+         * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
+         */
+        REINDEX
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/IndexSpec.java
+++ b/exist-core/src/main/java/org/exist/storage/IndexSpec.java
@@ -147,6 +147,10 @@ public class IndexSpec {
         return !qnameSpecs.isEmpty();
     }
 
+    public boolean hasCustomIndexSpecs() {
+        return customIndexSpecs != null && !customIndexSpecs.isEmpty();
+    }
+
     public List<QName> getIndexedQNames() {
         return new ArrayList<>(qnameSpecs.keySet());
     }

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -138,6 +138,10 @@ public class NativeBroker implements DBBroker {
 
     private static final String EXCEPTION_DURING_REINDEX = "exception during reindex";
     private static final String DATABASE_IS_READ_ONLY = "Database is read-only";
+    private enum CollectionIndexDropMode {
+        FULL_DROP,
+        CONFIG_ONLY_REINDEX
+    }
 
     public static final String DEFAULT_DATA_DIR = "data";
     public static final int DEFAULT_INDEX_DEPTH = 1;
@@ -1790,7 +1794,7 @@ public class NativeBroker implements DBBroker {
             //TODO(AR) this can be executed asynchronously as a task, Do we need to await the completion before unlocking the collection? or just await completion before returning from the first call to _removeCollection?
             // 3) drop indexes for this Collection
             notifyDropIndex(collection);
-            getIndexController().removeCollection(collection, this, false);
+            getIndexController().removeCollection(collection, this, IndexController.CollectionIndexRemovalMode.FULL_DROP);
 
             // 4) remove this Collection from the parent Collection
             if(parentCollection != null) {
@@ -2056,9 +2060,10 @@ public class NativeBroker implements DBBroker {
 
             LOG.info("Start indexing collection {}", collection.getURI().toString());
             pool.getProcessMonitor().startJob(ProcessMonitor.ACTION_REINDEX_COLLECTION, collection.getURI());
+            final IndexMode selectedMode = selectCollectionReindexMode(collection, scope);
             // Reindex traversal intentionally runs with collection READ_LOCKs:
             // avoid lock escalation while descending into child collections.
-            reindexCollection(transaction, collection, IndexMode.REINDEX, scope);
+            reindexCollection(transaction, collection, selectedMode, scope);
         } catch(final PermissionDeniedException | IOException e) {
             LOG.error("An error occurred during reindex: {}", e.getMessage(), e);
         } finally {
@@ -2083,7 +2088,10 @@ public class NativeBroker implements DBBroker {
 
         LOG.debug("Reindexing collection {}", collection.getURI());
         if(mode == IndexMode.STORE || mode == IndexMode.REINDEX) {
-            dropCollectionIndex(transaction, collection, mode == IndexMode.REINDEX);
+            final CollectionIndexDropMode dropMode = mode == IndexMode.REINDEX
+                    ? CollectionIndexDropMode.CONFIG_ONLY_REINDEX
+                    : CollectionIndexDropMode.FULL_DROP;
+            dropCollectionIndex(transaction, collection, dropMode);
         }
 
         // reindex documents
@@ -2130,10 +2138,34 @@ public class NativeBroker implements DBBroker {
         }
     }
 
+    /**
+     * Pick the safest reindex mode for the collection/scope combination.
+     *
+     * <p>{@code scope=all} must retain historical behavior and rebuild legacy
+     * value/QName indexes when required by collection configuration changes.
+     * Fast-path {@link IndexMode#REINDEX} remains enabled for targeted extension
+     * reindex scopes.</p>
+     */
+    private IndexMode selectCollectionReindexMode(
+            @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection,
+            final org.exist.indexing.ReindexScope scope) {
+        if (scope != org.exist.indexing.ReindexScope.ALL) {
+            return IndexMode.REINDEX;
+        }
+        final IndexSpec indexSpec = collection.getIndexConfiguration(this);
+        if (indexSpec == null) {
+            return IndexMode.STORE;
+        }
+        if (indexSpec.hasIndexesByPath() || indexSpec.hasIndexesByQName()) {
+            return IndexMode.STORE;
+        }
+        return indexSpec.hasCustomIndexSpecs() ? IndexMode.REINDEX : IndexMode.STORE;
+    }
+
     private void dropCollectionIndex(final Txn transaction,
             @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection)
             throws PermissionDeniedException, IOException, LockException {
-        dropCollectionIndex(transaction, collection, false);
+        dropCollectionIndex(transaction, collection, CollectionIndexDropMode.FULL_DROP);
     }
 
     /**
@@ -2153,8 +2185,7 @@ public class NativeBroker implements DBBroker {
      *
      * @param transaction the current transaction
      * @param collection  the collection whose indexes should be dropped
-     * @param reindex     {@code true} for config-only reindex (skip DOM/value),
-     *                    {@code false} for full index drop
+     * @param mode        explicit collection index drop semantics
      *
      * <p>Locking contract: caller must hold at least a collection READ lock.
      * Reindex traversal acquires collections with READ_LOCK to avoid lock
@@ -2165,7 +2196,7 @@ public class NativeBroker implements DBBroker {
      * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
      */
     private void dropCollectionIndex(final Txn transaction,
-            @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection, final boolean reindex)
+            @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection, final CollectionIndexDropMode mode)
             throws PermissionDeniedException, IOException, LockException {
         if(isReadOnly()) {
             throw new IOException(DATABASE_IS_READ_ONLY);
@@ -2173,11 +2204,14 @@ public class NativeBroker implements DBBroker {
         if(!collection.getPermissionsNoLock().validate(getCurrentSubject(), Permission.WRITE)) {
             throw new PermissionDeniedException("Account " + getCurrentSubject().getName() + " have insufficient privileges on collection " + collection.getURI());
         }
-        if (!reindex) {
+        if (mode == CollectionIndexDropMode.FULL_DROP) {
             notifyDropIndex(collection);
         }
-        getIndexController().removeCollection(collection, this, reindex);
-        if (!reindex) {
+        final IndexController.CollectionIndexRemovalMode removalMode = mode == CollectionIndexDropMode.CONFIG_ONLY_REINDEX
+                ? IndexController.CollectionIndexRemovalMode.CONFIG_ONLY_REINDEX
+                : IndexController.CollectionIndexRemovalMode.FULL_DROP;
+        getIndexController().removeCollection(collection, this, removalMode);
+        if (mode == CollectionIndexDropMode.FULL_DROP) {
             for (final Iterator<DocumentImpl> i = collection.iterator(this); i.hasNext(); ) {
                 final DocumentImpl doc = i.next();
                 LOG.debug("Dropping index for document {}", doc.getFileURI());

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2056,6 +2056,8 @@ public class NativeBroker implements DBBroker {
 
             LOG.info("Start indexing collection {}", collection.getURI().toString());
             pool.getProcessMonitor().startJob(ProcessMonitor.ACTION_REINDEX_COLLECTION, collection.getURI());
+            // Reindex traversal intentionally runs with collection READ_LOCKs:
+            // avoid lock escalation while descending into child collections.
             reindexCollection(transaction, collection, IndexMode.REINDEX, scope);
         } catch(final PermissionDeniedException | IOException e) {
             LOG.error("An error occurred during reindex: {}", e.getMessage(), e);
@@ -2100,6 +2102,12 @@ public class NativeBroker implements DBBroker {
                 reindexXMLResource(transaction, next, mode, scope);
             }
             LOG.info("Reindex collection {}: iterated {} documents", collection.getURI(), docCount);
+            if (LOG.isDebugEnabled()) {
+                final int skippedCoreRebuildUnits = mode == IndexMode.REINDEX ? docCount : 0;
+                final int rebuiltCoreRebuildUnits = mode == IndexMode.REINDEX ? 0 : docCount;
+                LOG.debug("Reindex counters collection={} scope={} mode={} docsProcessed={} skippedCoreRebuildUnits={} rebuiltCoreRebuildUnits={} rebuiltExtensionRebuildUnits={}",
+                        collection.getURI(), scope, mode, docCount, skippedCoreRebuildUnits, rebuiltCoreRebuildUnits, docCount);
+            }
         } catch(final LockException e) {
             LOG.error("LockException while reindexing documents of collection '{}'. Skipping...", collection.getURI(), e);
         }
@@ -2123,7 +2131,7 @@ public class NativeBroker implements DBBroker {
     }
 
     private void dropCollectionIndex(final Txn transaction,
-            @EnsureLocked(mode=LockMode.WRITE_LOCK) final Collection collection)
+            @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection)
             throws PermissionDeniedException, IOException, LockException {
         dropCollectionIndex(transaction, collection, false);
     }
@@ -2148,32 +2156,16 @@ public class NativeBroker implements DBBroker {
      * @param reindex     {@code true} for config-only reindex (skip DOM/value),
      *                    {@code false} for full index drop
      *
-     * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
-     */
-    /**
-     * Drop index entries for all documents in the collection.
-     *
-     * <p>When {@code reindex} is {@code true} (config-only reindex fast path),
-     * only extension indexes ({@link org.exist.indexing.IndexWorker}s such as
-     * Lucene, new-range, etc.) are dropped via
-     * {@link IndexController#removeCollection}.  The DOM BTree
-     * ({@code dom.dbx}) and legacy value index ({@link NativeValueIndex}) are
-     * left untouched because the document content has not changed — only the
-     * {@code collection.xconf} configuration may have been updated.</p>
-     *
-     * <p>When {@code reindex} is {@code false} (full drop — used by
-     * collection removal and full repair), all indexes are dropped including
-     * DOM BTree entries and the legacy value index.</p>
-     *
-     * @param transaction the current transaction
-     * @param collection  the collection whose indexes should be dropped
-     * @param reindex     {@code true} for config-only reindex (skip DOM/value),
-     *                    {@code false} for full index drop
+     * <p>Locking contract: caller must hold at least a collection READ lock.
+     * Reindex traversal acquires collections with READ_LOCK to avoid lock
+     * escalation/deadlock risk while still serializing against incompatible
+     * writers. Callers that already hold WRITE_LOCK (e.g. collection removal)
+     * also satisfy this contract.</p>
      *
      * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
      */
     private void dropCollectionIndex(final Txn transaction,
-            @EnsureLocked(mode=LockMode.WRITE_LOCK) final Collection collection, final boolean reindex)
+            @EnsureLocked(mode=LockMode.READ_LOCK) final Collection collection, final boolean reindex)
             throws PermissionDeniedException, IOException, LockException {
         if(isReadOnly()) {
             throw new IOException(DATABASE_IS_READ_ONLY);

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2056,7 +2056,7 @@ public class NativeBroker implements DBBroker {
 
             LOG.info("Start indexing collection {}", collection.getURI().toString());
             pool.getProcessMonitor().startJob(ProcessMonitor.ACTION_REINDEX_COLLECTION, collection.getURI());
-            reindexCollection(transaction, collection, IndexMode.STORE, scope);
+            reindexCollection(transaction, collection, IndexMode.REINDEX, scope);
         } catch(final PermissionDeniedException | IOException e) {
             LOG.error("An error occurred during reindex: {}", e.getMessage(), e);
         } finally {
@@ -2080,8 +2080,8 @@ public class NativeBroker implements DBBroker {
         }
 
         LOG.debug("Reindexing collection {}", collection.getURI());
-        if(mode == IndexMode.STORE) {
-            dropCollectionIndex(transaction, collection, true);
+        if(mode == IndexMode.STORE || mode == IndexMode.REINDEX) {
+            dropCollectionIndex(transaction, collection, mode == IndexMode.REINDEX);
         }
 
         // reindex documents
@@ -2128,6 +2128,50 @@ public class NativeBroker implements DBBroker {
         dropCollectionIndex(transaction, collection, false);
     }
 
+    /**
+     * Drop index entries for all documents in the collection.
+     *
+     * <p>When {@code reindex} is {@code true} (config-only reindex fast path),
+     * only extension indexes ({@link org.exist.indexing.IndexWorker}s such as
+     * Lucene, new-range, etc.) are dropped via
+     * {@link IndexController#removeCollection}.  The DOM BTree
+     * ({@code dom.dbx}) and legacy value index ({@link NativeValueIndex}) are
+     * left untouched because the document content has not changed — only the
+     * {@code collection.xconf} configuration may have been updated.</p>
+     *
+     * <p>When {@code reindex} is {@code false} (full drop — used by
+     * collection removal and full repair), all indexes are dropped including
+     * DOM BTree entries and the legacy value index.</p>
+     *
+     * @param transaction the current transaction
+     * @param collection  the collection whose indexes should be dropped
+     * @param reindex     {@code true} for config-only reindex (skip DOM/value),
+     *                    {@code false} for full index drop
+     *
+     * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
+     */
+    /**
+     * Drop index entries for all documents in the collection.
+     *
+     * <p>When {@code reindex} is {@code true} (config-only reindex fast path),
+     * only extension indexes ({@link org.exist.indexing.IndexWorker}s such as
+     * Lucene, new-range, etc.) are dropped via
+     * {@link IndexController#removeCollection}.  The DOM BTree
+     * ({@code dom.dbx}) and legacy value index ({@link NativeValueIndex}) are
+     * left untouched because the document content has not changed — only the
+     * {@code collection.xconf} configuration may have been updated.</p>
+     *
+     * <p>When {@code reindex} is {@code false} (full drop — used by
+     * collection removal and full repair), all indexes are dropped including
+     * DOM BTree entries and the legacy value index.</p>
+     *
+     * @param transaction the current transaction
+     * @param collection  the collection whose indexes should be dropped
+     * @param reindex     {@code true} for config-only reindex (skip DOM/value),
+     *                    {@code false} for full index drop
+     *
+     * @see <a href="https://github.com/eXist-db/exist/issues/572">#572</a>
+     */
     private void dropCollectionIndex(final Txn transaction,
             @EnsureLocked(mode=LockMode.WRITE_LOCK) final Collection collection, final boolean reindex)
             throws PermissionDeniedException, IOException, LockException {
@@ -2137,26 +2181,30 @@ public class NativeBroker implements DBBroker {
         if(!collection.getPermissionsNoLock().validate(getCurrentSubject(), Permission.WRITE)) {
             throw new PermissionDeniedException("Account " + getCurrentSubject().getName() + " have insufficient privileges on collection " + collection.getURI());
         }
-        notifyDropIndex(collection);
+        if (!reindex) {
+            notifyDropIndex(collection);
+        }
         getIndexController().removeCollection(collection, this, reindex);
-        for (final Iterator<DocumentImpl> i = collection.iterator(this); i.hasNext(); ) {
-            final DocumentImpl doc = i.next();
-            LOG.debug("Dropping index for document {}", doc.getFileURI());
-            new DOMTransaction(this, domDb, () -> lockManager.acquireBtreeWriteLock(domDb.getLockName())) {
-                @Override
-                public Object start() {
-                    try {
-                        final Value ref = new NodeRef(doc.getDocId());
-                        final IndexQuery query =
-                                new IndexQuery(IndexQuery.TRUNC_RIGHT, ref);
-                        domDb.remove(transaction, query, null);
-                        domDb.flush();
-                    } catch (final TerminatedException | IOException | DBException e) {
-                        LOG.error("Error while removing Document '{}' from Collection index: {}", doc.getURI().lastSegment(), collection.getURI(), e);
+        if (!reindex) {
+            for (final Iterator<DocumentImpl> i = collection.iterator(this); i.hasNext(); ) {
+                final DocumentImpl doc = i.next();
+                LOG.debug("Dropping index for document {}", doc.getFileURI());
+                new DOMTransaction(this, domDb, () -> lockManager.acquireBtreeWriteLock(domDb.getLockName())) {
+                    @Override
+                    public Object start() {
+                        try {
+                            final Value ref = new NodeRef(doc.getDocId());
+                            final IndexQuery query =
+                                    new IndexQuery(IndexQuery.TRUNC_RIGHT, ref);
+                            domDb.remove(transaction, query, null);
+                            domDb.flush();
+                        } catch (final TerminatedException | IOException | DBException e) {
+                            LOG.error("Error while removing Document '{}' from Collection index: {}", doc.getURI().lastSegment(), collection.getURI(), e);
+                        }
+                        return null;
                     }
-                    return null;
-                }
-            }.run();
+                }.run();
+            }
         }
     }
 
@@ -3734,7 +3782,9 @@ public class NativeBroker implements DBBroker {
         if(node.getNodeType() == Node.ELEMENT_NODE) {
             currentPath.addNode(node);
         }
-        indexNode(transaction, node, currentPath, mode);
+        if (mode != IndexMode.REINDEX) {
+            indexNode(transaction, node, currentPath, mode);
+        }
         if(listener != null) {
             switch(node.getNodeType()) {
                 case Node.TEXT_NODE:
@@ -3766,7 +3816,9 @@ public class NativeBroker implements DBBroker {
             }
         }
         if(node.getNodeType() == Node.ELEMENT_NODE) {
-            endElement(node, currentPath, null, mode == IndexMode.REMOVE);
+            if (mode != IndexMode.REINDEX) {
+                endElement(node, currentPath, null, mode == IndexMode.REMOVE);
+            }
             if(listener != null) {
                 listener.endElement(transaction, (ElementImpl) node, currentPath);
             }

--- a/exist-core/src/main/java/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/exist-core/src/main/java/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -565,6 +565,14 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
 
     @Override
     public void removeCollection(Collection collection, DBBroker broker, boolean reindex) throws PermissionDeniedException {
+        if (reindex) {
+            // Structural index entries are derived entirely from document
+            // content (QName, type, docId, nodeId) and do not depend on
+            // collection.xconf.  During a config-only reindex the
+            // StreamListener will re-add the same entries via BTree upsert,
+            // so removing them first is unnecessary work.
+            return;
+        }
         try {
             for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 final DocumentImpl doc = i.next();

--- a/exist-core/src/main/java/org/exist/util/Collations.java
+++ b/exist-core/src/main/java/org/exist/util/Collations.java
@@ -287,7 +287,18 @@ public class Collations {
             // com.ibm.icu.text.RuleBasedCollator
             final String uriClassName = uri.substring("java:".length());
             try {
-                final Class<?> collatorClass = Class.forName(uriClassName);
+                Class<?> collatorClass = null;
+                final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                if (contextClassLoader != null) {
+                    try {
+                        collatorClass = Class.forName(uriClassName, true, contextClassLoader);
+                    } catch (final ClassNotFoundException e) {
+                        // Fall back to the defining class loader below.
+                    }
+                }
+                if (collatorClass == null) {
+                    collatorClass = Class.forName(uriClassName);
+                }
                 if (!Collator.class.isAssignableFrom(collatorClass)) {
                     final String msg = "The specified collator class '" + collatorClass.getName() + "' is not a subclass of com.ibm.icu.text.Collator";
                     logger.error(msg);

--- a/exist-core/src/main/java/org/exist/xmldb/LocalIndexQueryService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalIndexQueryService.java
@@ -110,7 +110,7 @@ public class LocalIndexQueryService extends AbstractLocalService implements Inde
         withDb((broker, transaction) -> {
             try (final LockedDocument lockedDoc = broker.getXMLResource(collectionPath.append(docName), LockMode.READ_LOCK)) {
                 if (lockedDoc != null) {
-                    broker.reindexXMLResource(transaction, lockedDoc.getDocument(), DBBroker.IndexMode.STORE, scope);
+                    broker.reindexXMLResource(transaction, lockedDoc.getDocument(), DBBroker.IndexMode.REINDEX, scope);
                     broker.sync(Sync.MAJOR);
                 }
                 return null;

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -3235,7 +3235,7 @@ public class RpcConnection implements RpcAPI {
         final org.exist.indexing.ReindexScope scope = org.exist.indexing.ReindexScope.fromString(mode);
         withDb((broker, transaction) -> {
             try(final LockedDocument lockedDoc = broker.getXMLResource(XmldbURI.create(docUri), LockMode.READ_LOCK)) {
-                broker.reindexXMLResource(transaction, lockedDoc.getDocument(), DBBroker.IndexMode.STORE, scope);
+                broker.reindexXMLResource(transaction, lockedDoc.getDocument(), DBBroker.IndexMode.REINDEX, scope);
                 if(LOG.isDebugEnabled()) {
                     LOG.debug("document {} reindexed (scope={})", docUri, scope);
                 }

--- a/exist-core/src/main/java/org/exist/xquery/WhereClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/WhereClause.java
@@ -22,13 +22,20 @@
 package org.exist.xquery;
 
 import org.exist.dom.QName;
-import org.exist.dom.persistent.*;
+import org.exist.dom.persistent.ContextItem;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.ExtArrayNodeSet;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.dom.persistent.NodeSet;
+import org.exist.dom.persistent.VirtualNodeSet;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -128,7 +135,10 @@ public class WhereClause extends AbstractFLWORClause {
 
     @Override
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-        if (applyWhereExpression()) {
+        final List<NodeSet> carriers = new ArrayList<>();
+        final boolean passesWhere = applyWhereExpression(carriers);
+        if (passesWhere) {
+            propagateMatchCarriersForCurrentTuple(carriers);
             return returnExpr.eval(null, null);
         }
         return Sequence.EMPTY_SEQUENCE;
@@ -143,12 +153,106 @@ public class WhereClause extends AbstractFLWORClause {
         return super.postEval(seq);
     }
 
-    private boolean applyWhereExpression() throws XPathException {
+    private boolean applyWhereExpression(final List<NodeSet> carriers) throws XPathException {
         if (fastTrack) {
             return true;
         }
+
+        final Expression unwrappedWhereExpr = unwrapBooleanExpression(whereExpr);
+        if (unwrappedWhereExpr instanceof OpAnd opAnd) {
+            return evalExpressionWithCarriers(opAnd, carriers);
+        }
+
         final Sequence innerSeq = whereExpr.eval(null, null);
+        captureCarrierFromSequence(whereExpr, innerSeq, carriers);
         return innerSeq.effectiveBooleanValue();
+    }
+
+    private boolean evalExpressionWithCarriers(final Expression expr, final List<NodeSet> carriers) throws XPathException {
+        final Expression unwrappedExpr = unwrapBooleanExpression(expr);
+        if (unwrappedExpr instanceof OpAnd opAnd) {
+            if (!evalExpressionWithCarriers(opAnd.getLeft(), carriers)) {
+                return false;
+            }
+            return evalExpressionWithCarriers(opAnd.getRight(), carriers);
+        }
+
+        final Sequence seq = expr.eval(null, null);
+        captureCarrierFromSequence(expr, seq, carriers);
+        return seq.effectiveBooleanValue();
+    }
+
+    private void captureCarrierFromSequence(final Expression expr, final Sequence seq, final List<NodeSet> carriers) throws XPathException {
+        if (seq.isEmpty() || !seq.isPersistentSet() || !Type.subTypeOf(seq.getItemType(), Type.NODE)) {
+            return;
+        }
+        final Expression unwrappedExpr = unwrapBooleanExpression(expr);
+        if (!Type.subTypeOf(unwrappedExpr.returnsType(), Type.NODE) ||
+                Dependency.dependsOn(unwrappedExpr, Dependency.CONTEXT_ITEM)) {
+            return;
+        }
+
+        carriers.add(seq.toNodeSet());
+    }
+
+    private void propagateMatchCarriersForCurrentTuple(final List<NodeSet> carriers) throws XPathException {
+        if (fastTrack || carriers.isEmpty()) {
+            return;
+        }
+
+        LocalVariable startVar = getStartVariable();
+        if (startVar == null) {
+            final FLWORClause prev = getPreviousClause();
+            if (prev != null) {
+                // In some wrapped FLWOR shapes (e.g. XQSuite + debug wrappers), the
+                // tuple variable is attached to the previous clause, not this where.
+                startVar = prev.getStartVariable();
+            }
+        }
+        if (startVar == null) {
+            return;
+        }
+        final Sequence tupleSeq = startVar.getValue();
+        if (tupleSeq == null || tupleSeq.isEmpty() || !tupleSeq.isPersistentSet() ||
+                !Type.subTypeOf(tupleSeq.getItemType(), Type.NODE)) {
+            return;
+        }
+
+        final NodeSet contextSet = tupleSeq.toNodeSet();
+        for (final NodeSet carrier : carriers) {
+            propagateToContext(carrier, contextSet);
+        }
+    }
+
+    private void propagateToContext(final NodeSet carrierNodes, final NodeSet contextSet) {
+        final boolean contextIsVirtual = contextSet instanceof VirtualNodeSet;
+        for (final NodeProxy current : carrierNodes) {
+            ContextItem context = current.getContext();
+            while (context != null) {
+                final NodeProxy contextNode = context.getNode();
+                if (contextIsVirtual || contextSet.contains(contextNode)) {
+                    contextNode.addMatches(current);
+                }
+                context = context.getNextDirect();
+            }
+        }
+    }
+
+    private static Expression unwrapBooleanExpression(final Expression expr) {
+        Expression current = expr;
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            if (current instanceof DebuggableExpression debugExpr) {
+                current = debugExpr.getFirst();
+                changed = true;
+            }
+            if (current instanceof PathExpr pathExpr && pathExpr.getSubExpressionCount() == 1) {
+                current = pathExpr.getSubExpression(0);
+                changed = true;
+            }
+        }
+        return current;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -45,7 +45,7 @@ import static org.exist.xquery.FunctionDSL.*;
  */
 public class FunXmlToJson extends BasicFunction {
 
-    private static final Logger logger = LogManager.getLogger();
+    private static final Logger logger = LogManager.getLogger(FunXmlToJson.class);
 
     private static final String FS_XML_TO_JSON_NAME = "xml-to-json";
     private static final FunctionParameterSequenceType FS_XML_TO_JSON_OPT_PARAM_NODE = optParam("node", Type.NODE, "The input node");

--- a/exist-core/src/test/java/org/exist/util/CollationsTest.java
+++ b/exist-core/src/test/java/org/exist/util/CollationsTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.exist.util.Collations.HTML_ASCII_CASE_INSENSITIVE_COLLATION_URI;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class CollationsTest {
@@ -41,5 +42,16 @@ public class CollationsTest {
         assertTrue(Collations.contains(collator, "iNPut", "PU"));
         assertTrue(Collations.contains(collator,"h&#244;tel", "h&#244;t"));
         assertFalse(Collations.contains(collator, "h&#244;tel", "H&#212;T"));
+    }
+
+    @Test
+    public void javaUri_customCollator_canBeLoaded() throws XPathException {
+        final Collator collator = Collations.getCollationFromURI(
+                "java:org.exist.util.TestJavaCollator",
+                (Expression) null
+        );
+
+        assertNotNull(collator);
+        assertTrue(Collations.compare(collator, "a", "b") < 0);
     }
 }

--- a/exist-core/src/test/java/org/exist/util/CollationsTest.java
+++ b/exist-core/src/test/java/org/exist/util/CollationsTest.java
@@ -45,7 +45,7 @@ public class CollationsTest {
     }
 
     @Test
-    public void javaUri_customCollator_canBeLoaded() throws XPathException {
+    public void javaUriCustomCollatorCanBeLoaded() throws XPathException {
         final Collator collator = Collations.getCollationFromURI(
                 "java:org.exist.util.TestJavaCollator",
                 (Expression) null

--- a/exist-core/src/test/java/org/exist/util/TestJavaCollator.java
+++ b/exist-core/src/test/java/org/exist/util/TestJavaCollator.java
@@ -1,0 +1,119 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util;
+
+import com.ibm.icu.text.CollationKey;
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.RawCollationKey;
+import com.ibm.icu.util.ULocale;
+import com.ibm.icu.util.VersionInfo;
+
+/**
+ * Test-only custom collator for java: URI resolution checks.
+ */
+public class TestJavaCollator extends Collator {
+
+    private final Collator delegate = Collator.getInstance(ULocale.ENGLISH);
+
+    @Override
+    public int compare(final String source, final String target) {
+        return delegate.compare(source, target);
+    }
+
+    @Override
+    public CollationKey getCollationKey(final String source) {
+        return delegate.getCollationKey(source);
+    }
+
+    @Override
+    public RawCollationKey getRawCollationKey(final String source, final RawCollationKey key) {
+        return delegate.getRawCollationKey(source, key);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public int getStrength() {
+        return delegate.getStrength();
+    }
+
+    @Override
+    public void setStrength(final int newStrength) {
+        delegate.setStrength(newStrength);
+    }
+
+    @Override
+    public int getDecomposition() {
+        return delegate.getDecomposition();
+    }
+
+    @Override
+    public void setDecomposition(final int decompositionMode) {
+        delegate.setDecomposition(decompositionMode);
+    }
+
+    @Override
+    public int setVariableTop(final String varTop) {
+        return delegate.setVariableTop(varTop);
+    }
+
+    @Override
+    public void setVariableTop(final int varTop) {
+        delegate.setVariableTop(varTop);
+    }
+
+    @Override
+    public int getVariableTop() {
+        return delegate.getVariableTop();
+    }
+
+    @Override
+    public VersionInfo getVersion() {
+        return delegate.getVersion();
+    }
+
+    @Override
+    public VersionInfo getUCAVersion() {
+        return delegate.getUCAVersion();
+    }
+
+    @Override
+    public boolean isFrozen() {
+        return delegate.isFrozen();
+    }
+
+    @Override
+    public Collator freeze() {
+        delegate.freeze();
+        return this;
+    }
+
+    @Override
+    public Collator cloneAsThawed() {
+        return delegate.cloneAsThawed();
+    }
+}
+

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -89,6 +89,12 @@ import java.util.Set;
  * @author <a href="mailto:ljo@exist-db.org">Leif-Jöran Olsson</a>
  */
 public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
+    /**
+     * Tunable upper bound for docId clauses per delete batch during reindex.
+     * Can be overridden via -Dexist.lucene.reindex.delete.batchClauses=N.
+     */
+    private static final String REINDEX_DELETE_BATCH_PROPERTY = "exist.lucene.reindex.delete.batchClauses";
+    private static final int DEFAULT_REINDEX_DELETE_DOCID_BATCH_SIZE = 256;
 
     public static final org.apache.lucene.document.FieldType TYPE_NODE_ID = new org.apache.lucene.document.FieldType();
     static {
@@ -446,14 +452,27 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         IndexWriter writer = null;
         try {
             writer = index.getWriter();
+            final boolean preserveNamedFieldEntries = reindex || broker.getIndexController().isReindexing();
+            final int maxBatchClauses = resolveReindexDeleteBatchClauses();
+            BooleanQuery.Builder batchedDocIdQuery = preserveNamedFieldEntries ? new BooleanQuery.Builder() : null;
+            int batchedClauses = 0;
             for (Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
                 final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId());
-                if (reindex || broker.getIndexController().isReindexing()) {
-                    writer.deleteDocuments(nodeScopedDeleteQuery(docIdQuery));
+                if (preserveNamedFieldEntries) {
+                    batchedDocIdQuery.add(docIdQuery, BooleanClause.Occur.SHOULD);
+                    batchedClauses++;
+                    if (batchedClauses >= maxBatchClauses) {
+                        writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+                        batchedDocIdQuery = new BooleanQuery.Builder();
+                        batchedClauses = 0;
+                    }
                 } else {
                     writer.deleteDocuments(docIdQuery);
                 }
+            }
+            if (preserveNamedFieldEntries && batchedClauses > 0) {
+                writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
             }
         } catch (IOException | PermissionDeniedException | LockException e) {
             LOG.error("Error while removing lucene index: {}", e.getMessage(), e);
@@ -482,6 +501,26 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 .add(docIdQuery, BooleanClause.Occur.MUST)
                 .add(new FieldExistsQuery(LuceneUtil.FIELD_NODE_ID_DV), BooleanClause.Occur.MUST)
                 .build();
+    }
+
+    private static int resolveReindexDeleteBatchClauses() {
+        final int maxClauses = IndexSearcher.getMaxClauseCount();
+        final int configured = Integer.getInteger(REINDEX_DELETE_BATCH_PROPERTY, DEFAULT_REINDEX_DELETE_DOCID_BATCH_SIZE);
+        final int effective = clampReindexDeleteBatchClauses(configured, maxClauses);
+        if (effective != configured && LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Clamped {} from {} to {} (allowed range: 1..{})",
+                    REINDEX_DELETE_BATCH_PROPERTY,
+                    configured,
+                    effective,
+                    maxClauses
+            );
+        }
+        return effective;
+    }
+
+    static int clampReindexDeleteBatchClauses(final int configured, final int maxClauses) {
+        return Math.max(1, Math.min(configured, maxClauses));
     }
 
     /**

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -132,6 +132,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     private Analyzer analyzer;
 
     public static final String FIELD_DOC_ID = "docId";
+    public static final String FIELD_DOC_ID_KEYWORD = "docIdKeyword";
     public static final String FIELD_DOC_URI = "docUri";
 
     private final StreamListener listener = new LuceneStreamListener();
@@ -454,7 +455,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             writer = index.getWriter();
             final boolean preserveNamedFieldEntries = reindex || broker.getIndexController().isReindexing();
             final int maxBatchClauses = resolveReindexDeleteBatchClauses();
-            BooleanQuery.Builder batchedDocIdQuery = preserveNamedFieldEntries ? new BooleanQuery.Builder() : null;
+            List<BytesRef> batchedDocIdTerms = preserveNamedFieldEntries ? new ArrayList<>(maxBatchClauses) : null;
             int batchedClauses = 0;
             int reindexDeleteBatchCount = 0;
             int reindexDeleteDocCount = 0;
@@ -462,13 +463,13 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 DocumentImpl doc = i.next();
                 final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId());
                 if (preserveNamedFieldEntries) {
-                    batchedDocIdQuery.add(docIdQuery, BooleanClause.Occur.SHOULD);
+                    batchedDocIdTerms.add(new BytesRef(Integer.toString(doc.getDocId())));
                     batchedClauses++;
                     reindexDeleteDocCount++;
                     if (batchedClauses >= maxBatchClauses) {
-                        writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+                        writer.deleteDocuments(nodeScopedDeleteQuery(docIdKeywordBatchQuery(batchedDocIdTerms)));
                         reindexDeleteBatchCount++;
-                        batchedDocIdQuery = new BooleanQuery.Builder();
+                        batchedDocIdTerms = new ArrayList<>(maxBatchClauses);
                         batchedClauses = 0;
                     }
                 } else {
@@ -476,7 +477,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 }
             }
             if (preserveNamedFieldEntries && batchedClauses > 0) {
-                writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+                writer.deleteDocuments(nodeScopedDeleteQuery(docIdKeywordBatchQuery(batchedDocIdTerms)));
                 reindexDeleteBatchCount++;
             }
             if (preserveNamedFieldEntries && LOG.isDebugEnabled()) {
@@ -515,6 +516,10 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 .add(docIdQuery, BooleanClause.Occur.MUST)
                 .add(new FieldExistsQuery(LuceneUtil.FIELD_NODE_ID_DV), BooleanClause.Occur.MUST)
                 .build();
+    }
+
+    private static Query docIdKeywordBatchQuery(final List<BytesRef> docIdTerms) {
+        return new TermInSetQuery(FIELD_DOC_ID_KEYWORD, docIdTerms);
     }
 
     private static int resolveReindexDeleteBatchClauses() {
@@ -1052,6 +1057,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             // Set DocId. IntField (Points) for querying; SortedNumericDocValuesField for collectors (Lucene 10 consistency).
             final IntField fDocIdIdx = new IntField(FIELD_DOC_ID, currentDoc.getDocId(), Field.Store.NO);
             pendingDoc.add(fDocIdIdx);
+            pendingDoc.add(new StringField(FIELD_DOC_ID_KEYWORD, Integer.toString(currentDoc.getDocId()), Field.Store.NO));
             pendingDoc.add(new SortedNumericDocValuesField(FIELD_DOC_ID, currentDoc.getDocId()));
             pendingDoc.add(new FloatDocValuesField(LuceneUtil.FIELD_BOOST, 1.0f));
 
@@ -2067,6 +2073,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 doc.add(new StringField(LuceneUtil.FIELD_INDEX_TYPE, contentField, Field.Store.NO));
 
                 doc.add(new IntField(FIELD_DOC_ID, currentDoc.getDocId(), Field.Store.NO));
+                doc.add(new StringField(FIELD_DOC_ID_KEYWORD, Integer.toString(currentDoc.getDocId()), Field.Store.NO));
                 doc.add(new SortedNumericDocValuesField(FIELD_DOC_ID, currentDoc.getDocId()));
                 doc.add(new StoredField(FIELD_DOC_ID, currentDoc.getDocId()));
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1182,11 +1182,17 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         try {
             return index.withSearcher(searcher -> {
                 final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, docId);
-                final TopDocs topDocs = searcher.searcher().search(docIdQuery, 1);
+                final Query fieldExistsQuery = new FieldExistsQuery(field);
+                final Query query = new BooleanQuery.Builder()
+                        .add(docIdQuery, BooleanClause.Occur.MUST)
+                        .add(fieldExistsQuery, BooleanClause.Occur.MUST)
+                        .build();
+                final TopDocs topDocs = searcher.searcher().search(query, 1);
                 if (topDocs.totalHits.value() == 0) {
                     return null;
                 }
-                final Document doc = searcher.searcher().storedFields().document(topDocs.scoreDocs[0].doc);
+                final Set<String> fields = Collections.singleton(field);
+                final Document doc = searcher.searcher().storedFields().document(topDocs.scoreDocs[0].doc, fields);
                 return doc.get(field);
             });
         } catch (XPathException e) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -357,7 +357,13 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         try {
             writer = index.getWriter();
             final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, docId);
-            writer.deleteDocuments(docIdQuery);
+            if (broker.getIndexController().isReindexing()) {
+                // During reindex, remove only node-based Lucene entries and keep
+                // non-node entries created via ft:index for this document.
+                writer.deleteDocuments(nodeScopedDeleteQuery(docIdQuery));
+            } else {
+                writer.deleteDocuments(docIdQuery);
+            }
         } catch (IOException e) {
             LOG.warn("Error while removing lucene index: {}", e.getMessage(), e);
         } finally {
@@ -401,6 +407,12 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     protected void removePlainTextIndexes() {
+        if (broker.getIndexController().isReindexing()) {
+            // Collection/document reindex should rebuild XML/node index entries but must
+            // preserve named-field entries created via ft:index for existing documents.
+            mode = ReindexMode.STORE;
+            return;
+        }
     	IndexWriter writer = null;
         try {
             writer = index.getWriter();
@@ -436,7 +448,12 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             writer = index.getWriter();
             for (Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
-                writer.deleteDocuments(IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId()));
+                final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId());
+                if (reindex || broker.getIndexController().isReindexing()) {
+                    writer.deleteDocuments(nodeScopedDeleteQuery(docIdQuery));
+                } else {
+                    writer.deleteDocuments(docIdQuery);
+                }
             }
         } catch (IOException | PermissionDeniedException | LockException e) {
             LOG.error("Error while removing lucene index: {}", e.getMessage(), e);
@@ -453,6 +470,18 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         }
         if (LOG.isDebugEnabled())
             LOG.debug("Collection removed.");
+    }
+
+    /**
+     * Restricts deletion to node-backed Lucene records for the supplied doc-id query.
+     * Named-field records created via ft:index do not carry FIELD_NODE_ID_DV and are
+     * preserved during xmldb:reindex operations.
+     */
+    private static Query nodeScopedDeleteQuery(final Query docIdQuery) {
+        return new BooleanQuery.Builder()
+                .add(docIdQuery, BooleanClause.Occur.MUST)
+                .add(new FieldExistsQuery(LuceneUtil.FIELD_NODE_ID_DV), BooleanClause.Occur.MUST)
+                .build();
     }
 
     /**

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -456,14 +456,18 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             final int maxBatchClauses = resolveReindexDeleteBatchClauses();
             BooleanQuery.Builder batchedDocIdQuery = preserveNamedFieldEntries ? new BooleanQuery.Builder() : null;
             int batchedClauses = 0;
+            int reindexDeleteBatchCount = 0;
+            int reindexDeleteDocCount = 0;
             for (Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
                 final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId());
                 if (preserveNamedFieldEntries) {
                     batchedDocIdQuery.add(docIdQuery, BooleanClause.Occur.SHOULD);
                     batchedClauses++;
+                    reindexDeleteDocCount++;
                     if (batchedClauses >= maxBatchClauses) {
                         writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+                        reindexDeleteBatchCount++;
                         batchedDocIdQuery = new BooleanQuery.Builder();
                         batchedClauses = 0;
                     }
@@ -473,6 +477,16 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             }
             if (preserveNamedFieldEntries && batchedClauses > 0) {
                 writer.deleteDocuments(nodeScopedDeleteQuery(batchedDocIdQuery.build()));
+                reindexDeleteBatchCount++;
+            }
+            if (preserveNamedFieldEntries && LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Reindex node-delete batching for {}: {} docs across {} batch query deletes (batch size limit {}).",
+                        collection.getURI(),
+                        reindexDeleteDocCount,
+                        reindexDeleteBatchCount,
+                        maxBatchClauses
+                );
             }
         } catch (IOException | PermissionDeniedException | LockException e) {
             LOG.error("Error while removing lucene index: {}", e.getMessage(), e);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -455,38 +455,40 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             writer = index.getWriter();
             final boolean preserveNamedFieldEntries = reindex || broker.getIndexController().isReindexing();
             final int maxBatchClauses = resolveReindexDeleteBatchClauses();
-            List<BytesRef> batchedDocIdTerms = preserveNamedFieldEntries ? new ArrayList<>(maxBatchClauses) : null;
-            int batchedClauses = 0;
+            final long reindexDeleteStartNanos = preserveNamedFieldEntries ? System.nanoTime() : 0L;
+            // Reused across batches to keep transient allocations down on large collections.
+            final List<BytesRef> batchedDocIdTerms = preserveNamedFieldEntries ? new ArrayList<>(maxBatchClauses) : null;
             int reindexDeleteBatchCount = 0;
             int reindexDeleteDocCount = 0;
             for (Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
-                final Query docIdQuery = IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId());
                 if (preserveNamedFieldEntries) {
                     batchedDocIdTerms.add(new BytesRef(Integer.toString(doc.getDocId())));
-                    batchedClauses++;
                     reindexDeleteDocCount++;
-                    if (batchedClauses >= maxBatchClauses) {
-                        writer.deleteDocuments(nodeScopedDeleteQuery(docIdKeywordBatchQuery(batchedDocIdTerms)));
+                    if (batchedDocIdTerms.size() >= maxBatchClauses) {
+                        writer.deleteDocuments(reindexNodeDeleteQueryForDocIds(batchedDocIdTerms));
                         reindexDeleteBatchCount++;
-                        batchedDocIdTerms = new ArrayList<>(maxBatchClauses);
-                        batchedClauses = 0;
+                        batchedDocIdTerms.clear();
                     }
                 } else {
-                    writer.deleteDocuments(docIdQuery);
+                    writer.deleteDocuments(IntField.newExactQuery(FIELD_DOC_ID, doc.getDocId()));
                 }
             }
-            if (preserveNamedFieldEntries && batchedClauses > 0) {
-                writer.deleteDocuments(nodeScopedDeleteQuery(docIdKeywordBatchQuery(batchedDocIdTerms)));
+            final int trailingBatchSize = preserveNamedFieldEntries ? batchedDocIdTerms.size() : 0;
+            if (preserveNamedFieldEntries && trailingBatchSize > 0) {
+                writer.deleteDocuments(reindexNodeDeleteQueryForDocIds(batchedDocIdTerms));
                 reindexDeleteBatchCount++;
             }
             if (preserveNamedFieldEntries && LOG.isDebugEnabled()) {
+                final long elapsedMillis = (System.nanoTime() - reindexDeleteStartNanos) / 1_000_000L;
                 LOG.debug(
-                        "Reindex node-delete batching for {}: {} docs across {} batch query deletes (batch size limit {}).",
+                        "Reindex node-delete phase=removeCollection collection={} docsSeen={} batchDeletes={} effectiveBatchSize={} trailingBatchSize={} elapsedMs={}",
                         collection.getURI(),
                         reindexDeleteDocCount,
                         reindexDeleteBatchCount,
-                        maxBatchClauses
+                        maxBatchClauses,
+                        trailingBatchSize,
+                        elapsedMillis
                 );
             }
         } catch (IOException | PermissionDeniedException | LockException e) {
@@ -520,6 +522,15 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
 
     private static Query docIdKeywordBatchQuery(final List<BytesRef> docIdTerms) {
         return new TermInSetQuery(FIELD_DOC_ID_KEYWORD, docIdTerms);
+    }
+
+    /**
+     * Builds the reindex-aware delete query: keyword docId batch ANDed with the
+     * node-scope guard so named-field records survive xmldb:reindex. Package-private
+     * so the canary unit test can pin the query shape.
+     */
+    static Query reindexNodeDeleteQueryForDocIds(final List<BytesRef> docIdTerms) {
+        return nodeScopedDeleteQuery(docIdKeywordBatchQuery(docIdTerms));
     }
 
     private static int resolveReindexDeleteBatchClauses() {

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexWorkerBatchSizeTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexWorkerBatchSizeTest.java
@@ -21,9 +21,16 @@
  */
 package org.exist.indexing.lucene;
 
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LuceneIndexWorkerBatchSizeTest {
 
@@ -45,5 +52,24 @@ public class LuceneIndexWorkerBatchSizeTest {
     @Test
     public void clampBatchClausesValidValueIsPreserved() {
         assertEquals(256, LuceneIndexWorker.clampReindexDeleteBatchClauses(256, 1024));
+    }
+
+    /**
+     * Pins the reindex delete query composition so future refactors cannot silently
+     * drop either the keyword docId batch (faster TermInSetQuery path) or the
+     * node-scope guard that protects ft:index named-field records during xmldb:reindex.
+     */
+    @Test
+    public void reindexDeleteQueryUsesKeywordDocIdAndNodeScopedCanary() {
+        final Query query = LuceneIndexWorker.reindexNodeDeleteQueryForDocIds(List.of(new BytesRef("7")));
+        assertTrue("Expected BooleanQuery composition", query instanceof BooleanQuery);
+        final BooleanQuery bq = (BooleanQuery) query;
+        assertEquals(2, bq.clauses().size());
+        assertEquals(BooleanClause.Occur.MUST, bq.clauses().getFirst().occur());
+        assertEquals(BooleanClause.Occur.MUST, bq.clauses().get(1).occur());
+        assertTrue("Expected docIdKeyword delete path",
+                bq.clauses().getFirst().query().toString().contains(LuceneIndexWorker.FIELD_DOC_ID_KEYWORD));
+        assertTrue("Expected node-scoped delete guard",
+                bq.clauses().get(1).query().toString().contains(LuceneUtil.FIELD_NODE_ID_DV));
     }
 }

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexWorkerBatchSizeTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexWorkerBatchSizeTest.java
@@ -1,0 +1,49 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LuceneIndexWorkerBatchSizeTest {
+
+    @Test
+    public void clampBatchClausesNegativeBecomesOne() {
+        assertEquals(1, LuceneIndexWorker.clampReindexDeleteBatchClauses(-1, 1024));
+    }
+
+    @Test
+    public void clampBatchClausesZeroBecomesOne() {
+        assertEquals(1, LuceneIndexWorker.clampReindexDeleteBatchClauses(0, 1024));
+    }
+
+    @Test
+    public void clampBatchClausesHugeIsCappedAtMax() {
+        assertEquals(1024, LuceneIndexWorker.clampReindexDeleteBatchClauses(Integer.MAX_VALUE, 1024));
+    }
+
+    @Test
+    public void clampBatchClausesValidValueIsPreserved() {
+        assertEquals(256, LuceneIndexWorker.clampReindexDeleteBatchClauses(256, 1024));
+    }
+}

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -158,13 +158,10 @@ declare %test:assertEquals(0) function fte:query-empty-index-element-no-npe() {
 
 (:~
  : #2312 reproducer: when indexed document contains configured `<foo>`,
- : `ft:get-field` currently returns empty.
- :
- : Keep this test pending until the issue is fixed.
+ : `ft:get-field` should return the stored field value.
  : @see https://github.com/eXist-db/exist/issues/2312
  :)
 declare
-    %test:pending("Known bug tracked by issue #2312: ft:get-field returns empty when configured <foo> exists")
     %test:assertEquals("Foobar index data")
 function fte:get-field-with-configured-element() {
     ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -58,6 +58,7 @@ declare variable $fte:COLL_EMPTY := "lucene-test-ft-edge-empty";
 declare variable $fte:COLL_NO_INDEX := "lucene-test-ft-edge-no-index";
 declare variable $fte:COLL_EMPTY_INDEX := "lucene-test-ft-edge-empty-index";
 declare variable $fte:COLL_GET_FIELD := "lucene-test-ft-edge-get-field";
+declare variable $fte:COLL_984 := "lucene-test-ft-edge-984";
 
 (:~ #2312: Lucene configured text qname + indexed field retrieval. :)
 declare variable $fte:XCONF_GET_FIELD as element(collection) :=
@@ -81,6 +82,32 @@ declare variable $fte:DATA_WITHOUT_FOO as document-node() := document {
 
 declare variable $fte:INDEXED_FIELD as element(doc) :=
     <doc><field name="foo-field" store="yes">Foobar index data</field></doc>;
+
+declare variable $fte:XCONF_984_BROAD as element(collection) :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="a"/>
+                <text qname="b"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $fte:XCONF_984_NARROW as element(collection) :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="b"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $fte:DATA_984 as document-node() := document {
+    <root>
+        <a>oldterm</a>
+        <b>newterm</b>
+    </root>
+};
 
 declare
     %private
@@ -112,6 +139,10 @@ function fte:setUp() {
       xmldb:store("/db/system/config/db/" || $fte:COLL_GET_FIELD, "collection.xconf", $fte:XCONF_GET_FIELD),
       xmldb:store("/db/" || $fte:COLL_GET_FIELD, "with-foo.xml", $fte:DATA_WITH_FOO),
       xmldb:store("/db/" || $fte:COLL_GET_FIELD, "without-foo.xml", $fte:DATA_WITHOUT_FOO),
+      xmldb:create-collection("/db", $fte:COLL_984),
+      xmldb:create-collection("/db/system/config/db", $fte:COLL_984),
+      xmldb:store("/db/system/config/db/" || $fte:COLL_984, "collection.xconf", $fte:XCONF_984_BROAD),
+      xmldb:store("/db/" || $fte:COLL_984, "test.xml", $fte:DATA_984),
       ft:index("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", $fte:INDEXED_FIELD),
       ft:index("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", $fte:INDEXED_FIELD) )
 };
@@ -126,7 +157,9 @@ function fte:tearDown() {
       xmldb:remove("/db/" || $fte:COLL_EMPTY_INDEX),
       xmldb:remove("/db/system/config/db/" || $fte:COLL_EMPTY_INDEX),
       xmldb:remove("/db/" || $fte:COLL_GET_FIELD),
-      xmldb:remove("/db/system/config/db/" || $fte:COLL_GET_FIELD) )
+      xmldb:remove("/db/system/config/db/" || $fte:COLL_GET_FIELD),
+      xmldb:remove("/db/" || $fte:COLL_984),
+      xmldb:remove("/db/system/config/db/" || $fte:COLL_984) )
 };
 
 (:~
@@ -244,4 +277,28 @@ function fte:reindex-collection-preserves-get-field-control-without-configured-e
     let $_ := fte:seed-get-field-indexes()
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
     return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
+};
+
+(:~
+ : #984 reproducer: after narrowing index config and reindexing, prior broad-only terms should be removed.
+ : @see https://github.com/eXist-db/exist/issues/984
+ :)
+declare
+    %test:assertEquals(0)
+function fte:reindex-config-narrowing-removes-stale-terms() {
+    let $_ := xmldb:store("/db/system/config/db/" || $fte:COLL_984, "collection.xconf", $fte:XCONF_984_NARROW)
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_984)
+    return count(collection("/db/" || $fte:COLL_984)//a[ft:query(., "oldterm")])
+};
+
+(:~
+ : #984 control: terms still covered by narrowed config remain searchable after reindex.
+ : @see https://github.com/eXist-db/exist/issues/984
+ :)
+declare
+    %test:assertEquals(1)
+function fte:reindex-config-narrowing-keeps-valid-terms() {
+    let $_ := xmldb:store("/db/system/config/db/" || $fte:COLL_984, "collection.xconf", $fte:XCONF_984_NARROW)
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_984)
+    return count(collection("/db/" || $fte:COLL_984)//b[ft:query(., "newterm")])
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -183,3 +183,53 @@ function fte:search-field-with-configured-element() {
 declare %test:assertEquals("Foobar index data") function fte:get-field-control-without-configured-element() {
     ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
 };
+
+(:~
+ : #2318: collection reindex must preserve named field retrieval on configured-element document.
+ : @see https://github.com/eXist-db/exist/issues/2318
+ :)
+declare
+    %test:pending("Known bug tracked by #2318: collection reindex clears named field retrieval")
+    %test:assertEquals("Foobar index data")
+function fte:reindex-collection-preserves-get-field-with-configured-element() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
+};
+
+(:~
+ : #2318: document reindex must preserve named field retrieval on configured-element document.
+ : @see https://github.com/eXist-db/exist/issues/2318
+ :)
+declare
+    %test:pending("Known bug tracked by #2318: document reindex clears named field retrieval")
+    %test:assertEquals("Foobar index data")
+function fte:reindex-document-preserves-get-field-with-configured-element() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD, "with-foo.xml")
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
+};
+
+(:~
+ : #2318: repeated collection reindex should not clear named field retrieval.
+ : @see https://github.com/eXist-db/exist/issues/2318
+ :)
+declare
+    %test:pending("Known bug tracked by #2318: repeated collection reindex clears named field retrieval")
+    %test:assertEquals("Foobar index data")
+function fte:reindex-collection-repeat-preserves-get-field() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
+};
+
+(:~
+ : #2318 control: collection reindex preserves named field retrieval without configured element.
+ : @see https://github.com/eXist-db/exist/issues/2318
+ :)
+declare
+    %test:pending("Known bug tracked by #2318: collection reindex clears named field retrieval (control)")
+    %test:assertEquals("Foobar index data")
+function fte:reindex-collection-preserves-get-field-control-without-configured-element() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
+};

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -302,3 +302,54 @@ function fte:reindex-config-narrowing-keeps-valid-terms() {
     let $_ := xmldb:reindex("/db/" || $fte:COLL_984)
     return count(collection("/db/" || $fte:COLL_984)//b[ft:query(., "newterm")])
 };
+
+(:~
+ : #572: the REINDEX fast path (IndexMode.REINDEX) skips DOM BTree and value
+ : index writes for speed.  This test verifies that the persistent DOM is still
+ : readable afterwards — string() forces a DOM text-node read, which would fail
+ : if REINDEX corrupted the stored DOM.
+ : Unlike the #2318 / #984 tests above, this collection has NO Lucene config,
+ : so the only index activity is the structural and DOM layers.
+ : @see https://github.com/eXist-db/exist/issues/572
+ :)
+declare
+    %test:assertEquals("hello world")
+function fte:reindex-preserves-dom-xpath() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_NO_INDEX)
+    return string(doc("/db/" || $fte:COLL_NO_INDEX || "/test.xml")//p)
+};
+
+(:~
+ : #572: the REINDEX fast path must not break the structural index.
+ : local-name() is resolved via the structural index (NativeStructuralIndexWorker),
+ : not by reading the serialised DOM — a distinct code path from the string()
+ : check in `reindex-preserves-dom-xpath` above.
+ : @see https://github.com/eXist-db/exist/issues/572
+ :)
+declare
+    %test:assertEquals("body")
+function fte:reindex-preserves-structural-navigation() {
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
+    return local-name(doc("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml")/text/body)
+};
+
+(:~
+ : #572: the REINDEX fast path must pick up a newly deployed Lucene config.
+ : This differs from the #984 config-narrowing tests above: here we *add*
+ : index coverage (no Lucene config → Lucene on `<p>`) and verify ft:query
+ : finds the newly-indexed content.  Ensures REINDEX re-reads collection.xconf
+ : rather than caching a stale index configuration.
+ : @see https://github.com/eXist-db/exist/issues/572
+ :)
+declare
+    %test:assertEquals(1)
+function fte:reindex-picks-up-new-config() {
+    let $broader := <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene><text qname="p"/></lucene>
+        </index>
+    </collection>
+    let $_ := xmldb:store("/db/system/config/db/" || $fte:COLL_NO_INDEX, "collection.xconf", $broader)
+    let $_ := xmldb:reindex("/db/" || $fte:COLL_NO_INDEX)
+    return count(collection("/db/" || $fte:COLL_NO_INDEX)//p[ft:query(., "hello")])
+};

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -83,6 +83,15 @@ declare variable $fte:INDEXED_FIELD as element(doc) :=
     <doc><field name="foo-field" store="yes">Foobar index data</field></doc>;
 
 declare
+    %private
+function fte:seed-get-field-indexes() {
+    (
+        ft:index("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", $fte:INDEXED_FIELD),
+        ft:index("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", $fte:INDEXED_FIELD)
+    )
+};
+
+declare
     %test:setUp
 function fte:setUp() {
     ( xmldb:create-collection("/db/system", "config"),
@@ -164,7 +173,8 @@ declare %test:assertEquals(0) function fte:query-empty-index-element-no-npe() {
 declare
     %test:assertEquals("Foobar index data")
 function fte:get-field-with-configured-element() {
-    ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
+    let $_ := fte:seed-get-field-indexes()
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
 };
 
 (:~
@@ -173,7 +183,8 @@ function fte:get-field-with-configured-element() {
  :)
 declare %test:assertEquals("/db/lucene-test-ft-edge-get-field/with-foo.xml")
 function fte:search-field-with-configured-element() {
-    string-join(ft:search("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field:foobar")//@uri/data(), " ")
+    let $_ := fte:seed-get-field-indexes()
+    return string-join(distinct-values(ft:search("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field:foobar")//@uri/data()), " ")
 };
 
 (:~
@@ -181,7 +192,8 @@ function fte:search-field-with-configured-element() {
  : @see https://github.com/eXist-db/exist/issues/2312
  :)
 declare %test:assertEquals("Foobar index data") function fte:get-field-control-without-configured-element() {
-    ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
+    let $_ := fte:seed-get-field-indexes()
+    return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
 };
 
 (:~
@@ -189,9 +201,9 @@ declare %test:assertEquals("Foobar index data") function fte:get-field-control-w
  : @see https://github.com/eXist-db/exist/issues/2318
  :)
 declare
-    %test:pending("Known bug tracked by #2318: collection reindex clears named field retrieval")
     %test:assertEquals("Foobar index data")
 function fte:reindex-collection-preserves-get-field-with-configured-element() {
+    let $_ := fte:seed-get-field-indexes()
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
     return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
 };
@@ -201,9 +213,9 @@ function fte:reindex-collection-preserves-get-field-with-configured-element() {
  : @see https://github.com/eXist-db/exist/issues/2318
  :)
 declare
-    %test:pending("Known bug tracked by #2318: document reindex clears named field retrieval")
     %test:assertEquals("Foobar index data")
 function fte:reindex-document-preserves-get-field-with-configured-element() {
+    let $_ := fte:seed-get-field-indexes()
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD, "with-foo.xml")
     return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
 };
@@ -213,9 +225,9 @@ function fte:reindex-document-preserves-get-field-with-configured-element() {
  : @see https://github.com/eXist-db/exist/issues/2318
  :)
 declare
-    %test:pending("Known bug tracked by #2318: repeated collection reindex clears named field retrieval")
     %test:assertEquals("Foobar index data")
 function fte:reindex-collection-repeat-preserves-get-field() {
+    let $_ := fte:seed-get-field-indexes()
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
@@ -227,9 +239,9 @@ function fte:reindex-collection-repeat-preserves-get-field() {
  : @see https://github.com/eXist-db/exist/issues/2318
  :)
 declare
-    %test:pending("Known bug tracked by #2318: collection reindex clears named field retrieval (control)")
     %test:assertEquals("Foobar index data")
 function fte:reindex-collection-preserves-get-field-control-without-configured-element() {
+    let $_ := fte:seed-get-field-indexes()
     let $_ := xmldb:reindex("/db/" || $fte:COLL_GET_FIELD)
     return ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm
@@ -32,7 +32,7 @@ module namespace fte="http://exist-db.org/xquery/lucene/ft-edge/test";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
-(: #3485: Lucene index on p; collection has no documents. :)
+(:~ #3485: Lucene index on `p`; collection has no documents. :)
 declare variable $fte:XCONF_EMPTY as element(collection) :=
     <collection xmlns="http://exist-db.org/collection-config/1.0">
         <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -40,13 +40,13 @@ declare variable $fte:XCONF_EMPTY as element(collection) :=
         </index>
     </collection>;
 
-(: #2948: No index element. :)
+(:~ #2948: No index element. :)
 declare variable $fte:XCONF_NO_INDEX as element(collection) :=
     <collection xmlns="http://exist-db.org/collection-config/1.0">
         <triggers/>
     </collection>;
 
-(: #2948: Empty index element. :)
+(:~ #2948: Empty index element. :)
 declare variable $fte:XCONF_EMPTY_INDEX as element(collection) :=
     <collection xmlns="http://exist-db.org/collection-config/1.0">
         <index xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
@@ -57,6 +57,30 @@ declare variable $fte:DATA as document-node() := document { <doc><p>hello world<
 declare variable $fte:COLL_EMPTY := "lucene-test-ft-edge-empty";
 declare variable $fte:COLL_NO_INDEX := "lucene-test-ft-edge-no-index";
 declare variable $fte:COLL_EMPTY_INDEX := "lucene-test-ft-edge-empty-index";
+declare variable $fte:COLL_GET_FIELD := "lucene-test-ft-edge-get-field";
+
+(:~ #2312: Lucene configured text qname + indexed field retrieval. :)
+declare variable $fte:XCONF_GET_FIELD as element(collection) :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene><text qname="foo"/></lucene>
+        </index>
+    </collection>;
+
+declare variable $fte:DATA_WITH_FOO as document-node() := document {
+    <text>
+        <body><foo/></body>
+    </text>
+};
+
+declare variable $fte:DATA_WITHOUT_FOO as document-node() := document {
+    <text>
+        <body><bar/></body>
+    </text>
+};
+
+declare variable $fte:INDEXED_FIELD as element(doc) :=
+    <doc><field name="foo-field" store="yes">Foobar index data</field></doc>;
 
 declare
     %test:setUp
@@ -73,7 +97,14 @@ function fte:setUp() {
       xmldb:create-collection("/db", $fte:COLL_EMPTY_INDEX),
       xmldb:create-collection("/db/system/config/db", $fte:COLL_EMPTY_INDEX),
       xmldb:store("/db/system/config/db/" || $fte:COLL_EMPTY_INDEX, "collection.xconf", $fte:XCONF_EMPTY_INDEX),
-      xmldb:store("/db/" || $fte:COLL_EMPTY_INDEX, "test.xml", $fte:DATA) )
+      xmldb:store("/db/" || $fte:COLL_EMPTY_INDEX, "test.xml", $fte:DATA),
+      xmldb:create-collection("/db", $fte:COLL_GET_FIELD),
+      xmldb:create-collection("/db/system/config/db", $fte:COLL_GET_FIELD),
+      xmldb:store("/db/system/config/db/" || $fte:COLL_GET_FIELD, "collection.xconf", $fte:XCONF_GET_FIELD),
+      xmldb:store("/db/" || $fte:COLL_GET_FIELD, "with-foo.xml", $fte:DATA_WITH_FOO),
+      xmldb:store("/db/" || $fte:COLL_GET_FIELD, "without-foo.xml", $fte:DATA_WITHOUT_FOO),
+      ft:index("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", $fte:INDEXED_FIELD),
+      ft:index("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", $fte:INDEXED_FIELD) )
 };
 
 declare
@@ -84,25 +115,74 @@ function fte:tearDown() {
       xmldb:remove("/db/" || $fte:COLL_NO_INDEX),
       xmldb:remove("/db/system/config/db/" || $fte:COLL_NO_INDEX),
       xmldb:remove("/db/" || $fte:COLL_EMPTY_INDEX),
-      xmldb:remove("/db/system/config/db/" || $fte:COLL_EMPTY_INDEX) )
+      xmldb:remove("/db/system/config/db/" || $fte:COLL_EMPTY_INDEX),
+      xmldb:remove("/db/" || $fte:COLL_GET_FIELD),
+      xmldb:remove("/db/system/config/db/" || $fte:COLL_GET_FIELD) )
 };
 
-(: #3485: ft:query on empty collection with Lucene config – must not throw; returns empty. :)
+(:~
+ : #3485: `ft:query` on empty collection with Lucene config.
+ : Must not throw and should return empty.
+ : @see https://github.com/eXist-db/exist/issues/3485
+ :)
 declare %test:assertEquals(0) function fte:query-empty-collection-no-exception() {
     count(collection("/db/" || $fte:COLL_EMPTY)//p[ft:query(., "hello")])
 };
 
-(: #3485: ft:search on empty collection – must not throw; returns empty. :)
+(:~
+ : #3485: `ft:search` on empty collection.
+ : Must not throw and should return empty.
+ : @see https://github.com/eXist-db/exist/issues/3485
+ :)
 declare %test:assertEquals("") function fte:search-empty-collection-no-exception() {
     string-join(ft:search("/db/" || $fte:COLL_EMPTY || "/", "hello")//@uri/data(), " ")
 };
 
-(: #2948: ft:query on collection with no index element – must not NPE; returns empty. :)
+(:~
+ : #2948: `ft:query` on collection with no index element.
+ : Must not raise NPE and should return empty.
+ : @see https://github.com/eXist-db/exist/issues/2948
+ :)
 declare %test:assertEquals(0) function fte:query-no-index-element-no-npe() {
     count(collection("/db/" || $fte:COLL_NO_INDEX)//p[ft:query(., "hello")])
 };
 
-(: #2948: ft:query on collection with empty index element – must not NPE; returns empty. :)
+(:~
+ : #2948: `ft:query` on collection with empty index element.
+ : Must not raise NPE and should return empty.
+ : @see https://github.com/eXist-db/exist/issues/2948
+ :)
 declare %test:assertEquals(0) function fte:query-empty-index-element-no-npe() {
     count(collection("/db/" || $fte:COLL_EMPTY_INDEX)//p[ft:query(., "hello")])
+};
+
+(:~
+ : #2312 reproducer: when indexed document contains configured `<foo>`,
+ : `ft:get-field` currently returns empty.
+ :
+ : Keep this test pending until the issue is fixed.
+ : @see https://github.com/eXist-db/exist/issues/2312
+ :)
+declare
+    %test:pending("Known bug tracked by issue #2312: ft:get-field returns empty when configured <foo> exists")
+    %test:assertEquals("Foobar index data")
+function fte:get-field-with-configured-element() {
+    ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field")
+};
+
+(:~
+ : #2312 control from OP: field query still finds the document when `<foo/>` is present.
+ : @see https://github.com/eXist-db/exist/issues/2312
+ :)
+declare %test:assertEquals("/db/lucene-test-ft-edge-get-field/with-foo.xml")
+function fte:search-field-with-configured-element() {
+    string-join(ft:search("/db/" || $fte:COLL_GET_FIELD || "/with-foo.xml", "foo-field:foobar")//@uri/data(), " ")
+};
+
+(:~
+ : #2312 control: same field retrieval works when configured `<foo>` is absent.
+ : @see https://github.com/eXist-db/exist/issues/2312
+ :)
+declare %test:assertEquals("Foobar index data") function fte:get-field-control-without-configured-element() {
+    ft:get-field("/db/" || $fte:COLL_GET_FIELD || "/without-foo.xml", "foo-field")
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
@@ -28,12 +28,12 @@ xquery version "3.1";
  : - GitHub #4835 (multi-match util:expand on nested p elements)
  : - GitHub #4584 (util:expand across spanning text nodes/inline elements)
  : - GitHub #2170 (util:expand duplicate content fragments)
+ : - GitHub #2755 (util:expand with query-field and analyzer-order config)
  :)
 module namespace ueh="http://exist-db.org/xquery/lucene/util-expand-highlight/test";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare namespace exist = "http://exist.sourceforge.net/NS/exist";
-declare namespace wwp = "http://www.wwp.northeastern.edu/ns/textbase";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 declare namespace util = "http://exist-db.org/xquery/util";
 
@@ -81,26 +81,25 @@ declare variable $ueh:COLL_4835 := "/db/lucene-test-util-expand-highlight-4835";
 (: #4584 -------------------------------------------------------------- :)
 
 declare variable $ueh:XML-4584 :=
-    <div xmlns="http://www.wwp.northeastern.edu/ns/textbase" xml:lang="en">
+    <div xml:lang="en">
         <cit>
             <quote>
-                <p>In godlie <wwp:vuji>j</wwp:vuji>oy, but worldlie greefe.</p>
+                <p>In godlie <vuji>j</vuji>oy, but worldlie greefe.</p>
             </quote>
         </cit>
         <cit>
             <quote>
-                <p>he finally ro<wwp:vuji>s</wwp:vuji>e superior.</p>
+                <p>he finally ro<vuji>s</vuji>e superior.</p>
             </quote>
         </cit>
     </div>;
 
 declare variable $ueh:XCONF-4584 :=
     <collection xmlns="http://exist-db.org/collection-config/1.0">
-        <index xmlns:wwp="http://www.wwp.northeastern.edu/ns/textbase"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
             <lucene>
-                <text qname="wwp:quote"/>
-                <inline qname="wwp:vuji"/>
+                <text qname="quote"/>
+                <inline qname="vuji"/>
             </lucene>
         </index>
     </collection>;
@@ -128,6 +127,40 @@ declare variable $ueh:XCONF-2170 :=
 
 declare variable $ueh:COLL_2170 := "/db/lucene-test-util-expand-highlight-2170";
 
+(: #2755 -------------------------------------------------------------- :)
+
+declare variable $ueh:XML-2755 :=
+    <test>
+        <phrase>All phenomena are devoid of independent existence</phrase>
+    </test>;
+
+declare variable $ueh:XCONF-2755-ORDERED :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index>
+            <lucene>
+                <analyzer id="st" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
+                <text match="//phrase" analyzer="st" field="phrase-st"/>
+                <text match="//phrase" analyzer="ws" field="phrase-ws"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $ueh:XCONF-2755-SWAPPED :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index>
+            <lucene>
+                <analyzer id="st" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
+                <text match="//phrase" analyzer="ws" field="phrase-ws"/>
+                <text match="//phrase" analyzer="st" field="phrase-st"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $ueh:COLL_2755_ORDERED := "/db/lucene-test-util-expand-highlight-2755-ordered";
+declare variable $ueh:COLL_2755_SWAPPED := "/db/lucene-test-util-expand-highlight-2755-swapped";
+
 (: shared setUp/tearDown ------------------------------------------------ :)
 
 declare
@@ -152,7 +185,19 @@ function ueh:setup() {
         xmldb:create-collection("/db/system/config/db", "lucene-test-util-expand-highlight-2170"),
         xmldb:store($ueh:COLL_2170, "test.xml", $ueh:XML-2170),
         xmldb:store("/db/system/config/db/lucene-test-util-expand-highlight-2170", "collection.xconf", $ueh:XCONF-2170),
-        xmldb:reindex($ueh:COLL_2170)
+        xmldb:reindex($ueh:COLL_2170),
+
+        xmldb:create-collection("/db", "lucene-test-util-expand-highlight-2755-ordered"),
+        xmldb:create-collection("/db/system/config/db", "lucene-test-util-expand-highlight-2755-ordered"),
+        xmldb:store($ueh:COLL_2755_ORDERED, "test.xml", $ueh:XML-2755),
+        xmldb:store("/db/system/config/db/lucene-test-util-expand-highlight-2755-ordered", "collection.xconf", $ueh:XCONF-2755-ORDERED),
+        xmldb:reindex($ueh:COLL_2755_ORDERED),
+
+        xmldb:create-collection("/db", "lucene-test-util-expand-highlight-2755-swapped"),
+        xmldb:create-collection("/db/system/config/db", "lucene-test-util-expand-highlight-2755-swapped"),
+        xmldb:store($ueh:COLL_2755_SWAPPED, "test.xml", $ueh:XML-2755),
+        xmldb:store("/db/system/config/db/lucene-test-util-expand-highlight-2755-swapped", "collection.xconf", $ueh:XCONF-2755-SWAPPED),
+        xmldb:reindex($ueh:COLL_2755_SWAPPED)
     )
 };
 
@@ -165,7 +210,11 @@ function ueh:tearDown() {
         xmldb:remove($ueh:COLL_4584),
         xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-4584"),
         xmldb:remove($ueh:COLL_2170),
-        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-2170")
+        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-2170"),
+        xmldb:remove($ueh:COLL_2755_ORDERED),
+        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-2755-ordered"),
+        xmldb:remove($ueh:COLL_2755_SWAPPED),
+        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-2755-swapped")
     )
 };
 
@@ -214,7 +263,7 @@ function ueh:issue4835-two-in-one-matches-count() {
 
 declare %private function ueh:issue4584-expand-match($word as xs:string) as xs:string {
     string-join(
-        collection($ueh:COLL_4584)//wwp:quote[ft:query(., $word)]/util:expand(.)//exist:match/normalize-space(),
+        collection($ueh:COLL_4584)//quote[ft:query(., $word)]/util:expand(.)//exist:match/normalize-space(),
         ""
     )
 };
@@ -223,14 +272,14 @@ declare %private function ueh:issue4584-expand-match($word as xs:string) as xs:s
 declare
     %test:assertEquals(1)
 function ueh:issue4584-find-joy-count() {
-    count(collection($ueh:COLL_4584)//wwp:quote[ft:query(., "joy")])
+    count(collection($ueh:COLL_4584)//quote[ft:query(., "joy")])
 };
 
 (: Hit count: "rose" should be found once. :)
 declare
     %test:assertEquals(1)
 function ueh:issue4584-find-rose-count() {
-    count(collection($ueh:COLL_4584)//wwp:quote[ft:query(., "rose")])
+    count(collection($ueh:COLL_4584)//quote[ft:query(., "rose")])
 };
 
 (: util:expand for "joy": all portions wrapped. :)
@@ -299,5 +348,34 @@ declare
     %test:assertEquals(0)
 function ueh:issue2170-query2-no-duplicate-fragment() {
     count(ueh:issue2170-query2-expanded()//p[contains(., "sleepsleep")])
+};
+
+(: #2755 tests ---------------------------------------------------------- :)
+
+declare %private function ueh:issue2755-match-count($collection as xs:string) as xs:integer {
+    let $hits :=
+        collection($collection)//phrase[ft:query-field("phrase-ws", "of")]
+    let $expanded := util:expand($hits)
+    return count($expanded//exist:match)
+};
+
+(:~
+ : #2755: util:expand should preserve exist:match for analyzer order from issue report.
+ : @see https://github.com/eXist-db/exist/issues/2755
+ :)
+declare
+    %test:assertEquals(1)
+function ueh:issue2755-expand-has-match-ordered() {
+    ueh:issue2755-match-count($ueh:COLL_2755_ORDERED)
+};
+
+(:~
+ : #2755 control: swapping analyzer field declaration order should still preserve exist:match.
+ : @see https://github.com/eXist-db/exist/issues/2755
+ :)
+declare
+    %test:assertEquals(1)
+function ueh:issue2755-expand-has-match-swapped() {
+    ueh:issue2755-match-count($ueh:COLL_2755_SWAPPED)
 };
 

--- a/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
@@ -350,6 +350,42 @@ function ueh:issue2170-query2-no-duplicate-fragment() {
     count(ueh:issue2170-query2-expanded()//p[contains(., "sleepsleep")])
 };
 
+(: #2283 tests ---------------------------------------------------------- :)
+
+declare %private function ueh:issue2283-hits-baseline() as element(test)* {
+    for $x in collection($ueh:COLL_2170)//test
+    where $x//p[ft:query(., "sleep")]
+    return $x
+};
+
+declare %private function ueh:issue2283-hits-with-additional-predicate() as element(test)* {
+    for $x in collection($ueh:COLL_2170)//test
+    where $x//p[ft:query(., "sleep")] and contains(string-join($x//p ! string(.), " "), "Colorless")
+    return $x
+};
+
+(:~
+ : #2283 baseline: util:expand should expose match tags for full-text hits.
+ : @see https://github.com/eXist-db/exist/issues/2283
+ :)
+declare
+    %test:assertEquals(6)
+function ueh:issue2283-expand-baseline-match-count() {
+    count(util:expand(ueh:issue2283-hits-baseline())//exist:match)
+};
+
+(:~
+ : #2283 regression: adding a non-full-text predicate must not drop match tags.
+ : @see https://github.com/eXist-db/exist/issues/2283
+ : @see https://github.com/eXist-db/exist/pull/6300
+ :)
+declare
+    %test:pending("Blocked pending cherry-pick/merge of PR #6300 (WhereClause visitor fix).")
+    %test:assertEquals(6)
+function ueh:issue2283-expand-with-additional-predicate-match-count() {
+    count(util:expand(ueh:issue2283-hits-with-additional-predicate())//exist:match)
+};
+
 (: #2755 tests ---------------------------------------------------------- :)
 
 declare %private function ueh:issue2755-match-count($collection as xs:string) as xs:integer {

--- a/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
@@ -27,6 +27,7 @@ xquery version "3.1";
  : Merges:
  : - GitHub #4835 (multi-match util:expand on nested p elements)
  : - GitHub #4584 (util:expand across spanning text nodes/inline elements)
+ : - GitHub #2170 (util:expand duplicate content fragments)
  :)
 module namespace ueh="http://exist-db.org/xquery/lucene/util-expand-highlight/test";
 
@@ -106,6 +107,27 @@ declare variable $ueh:XCONF-4584 :=
 
 declare variable $ueh:COLL_4584 := "/db/lucene-test-util-expand-highlight-4584";
 
+(: #2170 -------------------------------------------------------------- :)
+
+declare variable $ueh:XML-2170 := document {
+    <test>
+        <p>Colorless green ideas sleep furiously. They sleep a furiously ideal green sleep.</p>
+        <p>Furiously sleep ideas green colorless. They greenly sleep a furiously ideal sleep.</p>
+    </test>
+};
+
+declare variable $ueh:XCONF-2170 :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <fulltext default="none" attributes="no"/>
+            <lucene>
+                <text qname="p"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $ueh:COLL_2170 := "/db/lucene-test-util-expand-highlight-2170";
+
 (: shared setUp/tearDown ------------------------------------------------ :)
 
 declare
@@ -124,7 +146,13 @@ function ueh:setup() {
         xmldb:create-collection("/db/system/config/db", "lucene-test-util-expand-highlight-4584"),
         xmldb:store($ueh:COLL_4584, "test.xml", $ueh:XML-4584),
         xmldb:store("/db/system/config/db/lucene-test-util-expand-highlight-4584", "collection.xconf", $ueh:XCONF-4584),
-        xmldb:reindex($ueh:COLL_4584)
+        xmldb:reindex($ueh:COLL_4584),
+
+        xmldb:create-collection("/db", "lucene-test-util-expand-highlight-2170"),
+        xmldb:create-collection("/db/system/config/db", "lucene-test-util-expand-highlight-2170"),
+        xmldb:store($ueh:COLL_2170, "test.xml", $ueh:XML-2170),
+        xmldb:store("/db/system/config/db/lucene-test-util-expand-highlight-2170", "collection.xconf", $ueh:XCONF-2170),
+        xmldb:reindex($ueh:COLL_2170)
     )
 };
 
@@ -135,7 +163,9 @@ function ueh:tearDown() {
         xmldb:remove($ueh:COLL_4835),
         xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-4835"),
         xmldb:remove($ueh:COLL_4584),
-        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-4584")
+        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-4584"),
+        xmldb:remove($ueh:COLL_2170),
+        xmldb:remove("/db/system/config/db/lucene-test-util-expand-highlight-2170")
     )
 };
 
@@ -215,5 +245,59 @@ declare
     %test:assertEquals("rose")
 function ueh:issue4584-expand-rose-full-match() {
     ueh:issue4584-expand-match("rose")
+};
+
+(: #2170 tests ---------------------------------------------------------- :)
+
+declare %private function ueh:issue2170-doc() as document-node() {
+    doc($ueh:COLL_2170 || "/test.xml")
+};
+
+declare %private function ueh:issue2170-query1-expanded() as element(test) {
+    util:expand(ueh:issue2170-doc()//p[ft:query(., "sleep")]/ancestor::test)
+};
+
+declare %private function ueh:issue2170-query2-expanded() as element(test) {
+    util:expand(ueh:issue2170-doc()//test[.//p[ft:query(., "sleep")]])
+};
+
+(:~
+ : #2170: util:expand on ancestor selection should wrap exactly 6 matches.
+ : @see https://github.com/eXist-db/exist/issues/2170
+ :)
+declare
+    %test:assertEquals(6)
+function ueh:issue2170-query1-match-count() {
+    count(ueh:issue2170-query1-expanded()//exist:match)
+};
+
+(:~
+ : #2170: util:expand on direct test selection should wrap exactly 6 matches.
+ : @see https://github.com/eXist-db/exist/issues/2170
+ :)
+declare
+    %test:assertEquals(6)
+function ueh:issue2170-query2-match-count() {
+    count(ueh:issue2170-query2-expanded()//exist:match)
+};
+
+(:~
+ : #2170: ensure the second paragraph is not duplicated by util:expand(query1 shape).
+ : @see https://github.com/eXist-db/exist/issues/2170
+ :)
+declare
+    %test:assertEquals(0)
+function ueh:issue2170-query1-no-duplicate-fragment() {
+    count(ueh:issue2170-query1-expanded()//p[contains(., "sleepsleep")])
+};
+
+(:~
+ : #2170: ensure the second paragraph is not duplicated by util:expand(query2 shape).
+ : @see https://github.com/eXist-db/exist/issues/2170
+ :)
+declare
+    %test:assertEquals(0)
+function ueh:issue2170-query2-no-duplicate-fragment() {
+    count(ueh:issue2170-query2-expanded()//p[contains(., "sleepsleep")])
 };
 

--- a/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm
@@ -364,6 +364,12 @@ declare %private function ueh:issue2283-hits-with-additional-predicate() as elem
     return $x
 };
 
+declare %private function ueh:issue2283-hits-with-nested-and() as element(test)* {
+    for $x in collection($ueh:COLL_2170)//test
+    where ($x//p[ft:query(., "sleep")] and contains(string-join($x//p ! string(.), " "), "Colorless")) and true()
+    return $x
+};
+
 (:~
  : #2283 baseline: util:expand should expose match tags for full-text hits.
  : @see https://github.com/eXist-db/exist/issues/2283
@@ -380,10 +386,20 @@ function ueh:issue2283-expand-baseline-match-count() {
  : @see https://github.com/eXist-db/exist/pull/6300
  :)
 declare
-    %test:pending("Blocked pending cherry-pick/merge of PR #6300 (WhereClause visitor fix).")
     %test:assertEquals(6)
 function ueh:issue2283-expand-with-additional-predicate-match-count() {
     count(util:expand(ueh:issue2283-hits-with-additional-predicate())//exist:match)
+};
+
+(:~
+ : #2283 nested-and regression: nested boolean shape must preserve match tags too.
+ : @see https://github.com/eXist-db/exist/issues/2283
+ : @see https://github.com/eXist-db/exist/pull/6300
+ :)
+declare
+    %test:assertEquals(6)
+function ueh:issue2283-expand-with-nested-and-match-count() {
+    count(util:expand(ueh:issue2283-hits-with-nested-and())//exist:match)
 };
 
 (: #2755 tests ---------------------------------------------------------- :)
@@ -414,4 +430,3 @@ declare
 function ueh:issue2755-expand-has-match-swapped() {
     ueh:issue2755-match-count($ueh:COLL_2755_SWAPPED)
 };
-

--- a/extensions/indexes/range/src/test/xquery/range/optimizer.xql
+++ b/extensions/indexes/range/src/test/xquery/range/optimizer.xql
@@ -63,6 +63,8 @@ declare variable $ot:COLLECTION_CONFIG :=
                 </create>
                 <create match="/test/address/city/@code" type="xs:integer"/>
                 <create qname="@id" type="xs:string"/>
+                <create qname="foo" type="xs:string"/>
+                <create qname="bar" type="xs:string"/>
                 <!-- Extra indices for remaining range optimizer issues -->
                 <create qname="@bar" type="xs:string"/>
                 <create qname="@lemma" type="xs:string"/>
@@ -138,6 +140,11 @@ declare variable $ot:DATA :=
         <foo bar="bat"/>
         <foo bar="Baz"/>
         <foo bar="qux"/>
+        <!-- GitHub #2363: equivalent union formulations for contains() -->
+        <foo>hello</foo>
+        <foo>goodbye</foo>
+        <bar>say hello</bar>
+        <bar>say good day</bar>
         <!-- GitHub #4942: exists:force-index-use on range-indexed attribute qname(@ID) -->
         <root><a ID="123"/></root>
     </test>;
@@ -175,7 +182,7 @@ declare variable $ot:DATA_SR_WITH_DIACRITICS :=
             </body>
         </text>
     </TEI>;
-    
+
 declare variable $ot:COLLECTION_NAME := "optimizertest";
 declare variable $ot:COLLECTION := "/db/" || $ot:COLLECTION_NAME;
 
@@ -652,39 +659,39 @@ function ot:optimize-field-self($type as xs:string, $subtype as xs:string, $name
     collection($ot:COLLECTION)//tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
 };
 
-declare 
+declare
     %test:assertEquals("Rudi Rüssel")
 function ot:parent-attr-equals() {
     collection($ot:COLLECTION)//name[parent::address/@id = "rüssel"]/text()
 };
 
-declare 
+declare
     %test:stats
     %test:assertXPath("$result//stats:index[@type eq 'range'][@optimization-level eq 'NONE']")
 function ot:optimize-parent-attr-equals() {
     collection($ot:COLLECTION)//name[parent::address/@id = "rüssel"]/text()
 };
 
-declare 
+declare
     %test:assertEquals("Rudi Rüssel")
 function ot:parent-nested-attr-equals() {
     collection($ot:COLLECTION)//name[parent::address[@id = "rüssel"]]/text()
 };
 
-declare 
+declare
     %test:stats
     %test:assertXPath("$result//stats:index[@type eq 'range'][@optimization-level eq 'NONE']")
 function ot:optimize-parent-nested-attr-equals() {
     collection($ot:COLLECTION)//name[parent::address[@id = "rüssel"]]/text()
 };
 
-declare 
+declare
     %test:assertEquals("Rudi Rüssel")
 function ot:self-parent-attr-equals() {
     collection($ot:COLLECTION)//name[./parent::address/@id = "rüssel"]/text()
 };
 
-declare 
+declare
     %test:assertEquals("Rudi Rüssel")
 function ot:self-parent-nested-attr-equals() {
     collection($ot:COLLECTION)//name[./parent::address[@id = "rüssel"]]/text()
@@ -914,6 +921,50 @@ declare
     %test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
 function ot:issue5043-wildcard-path-uses-index($term as xs:string) {
     collection($ot:COLLECTION)//*/tei:w[@lemma eq $term]
+};
+
+(:~
+ : GitHub #2363 baseline: explicit branch-wise contains() predicates should optimize.
+ : @see https://github.com/eXist-db/exist/issues/2363
+ :)
+declare
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
+function ot:issue2363-formulation1-optimized() {
+    let $s := "hello"
+    return
+        collection($ot:COLLECTION)//foo[contains(., $s)] | collection($ot:COLLECTION)//bar[contains(., $s)]
+};
+
+(:~
+ : GitHub #2363 reproducer: predicate over a parenthesized union currently misses optimization.
+ : Marked pending while optimizer rewrite support for (A | B)[P] is implemented.
+ : @see https://github.com/eXist-db/exist/issues/2363
+ :)
+declare
+    %test:pending("Issue #2363: union predicate form is not optimized yet")
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
+function ot:issue2363-formulation2-optimized() {
+    let $s := "hello"
+    return
+        (collection($ot:COLLECTION)//foo | collection($ot:COLLECTION)//bar)[contains(., $s)]
+};
+
+(:~
+ : GitHub #2363 reproducer: path union step form currently misses optimization.
+ : Marked pending while optimizer rewrite support for //(foo|bar)[contains(...)] lands.
+ : @see https://github.com/eXist-db/exist/issues/2363
+ : @see https://github.com/eXist-db/exist/pull/6310
+ :)
+declare
+    %test:pending("Pull #6310: Distribute outer path over union-step branches")
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'new-range'][@optimization-level eq 'OPTIMIZED']")
+function ot:issue2363-formulation3-optimized() {
+    let $s := "hello"
+    return
+        collection($ot:COLLECTION)//(foo|bar)[contains(., $s)]
 };
 
 (: GitHub #4942: exist:force-index-use on range-index expressions :)


### PR DESCRIPTION
## Summary

Consolidates several legacy-ticket fixes and regression guards across Lucene/range/XQuery internals, with a focus on correctness first and measurable performance impact where relevant.

Key outcomes:

- Fixes full-text match propagation loss in FLWOR `where` boolean expressions (issue #2283 shape), so `util:expand`/KWIC-style highlighting no longer drops `exist:match` markers when extra predicates are present.
- Hardens reindex lifecycle behavior:
  - introduces/uses optimized reindex mode paths,
  - makes drop semantics explicit,
  - aligns lock contract,
  - preserves intended named-field behavior while guarding stale-entry scenarios.
- Adds/extends JMH coverage for Lucene query/reindex/delete paths, including an #2812-style query benchmark.
- Adds custom Java collator loading hardening (`java:` URI) and regression coverage (issue #3747 shape).
- Adds pending regression guards for range optimizer union-shape behavior (#2363) to keep signal while upstream optimizer work lands.

## What changed

### XQuery / optimizer / collation correctness

- `exist-core/src/main/java/org/exist/xquery/WhereClause.java`
  - Hardened carrier propagation through boolean `where` evaluation so full-text match metadata survives additional predicates.
- `exist-core/src/main/java/org/exist/util/Collations.java`
  - `java:` collator class resolution now tries thread context classloader first, then fallback.
- `exist-core/src/test/java/org/exist/util/CollationsTest.java`
- `exist-core/src/test/java/org/exist/util/TestJavaCollator.java`
  - Added regression guard for custom Java collator loading.

### Reindex lifecycle + Lucene delete strategy

- `exist-core/src/main/java/org/exist/storage/DBBroker.java`
- `exist-core/src/main/java/org/exist/storage/NativeBroker.java`
- `exist-core/src/main/java/org/exist/indexing/IndexController.java`
- `exist-core/src/main/java/org/exist/indexing/IndexWorker.java`
- `exist-core/src/main/java/org/exist/storage/IndexSpec.java`
- `exist-core/src/main/java/org/exist/storage/structural/NativeStructuralIndexWorker.java`
- `exist-core/src/main/java/org/exist/xmldb/LocalIndexQueryService.java`
- `exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java`
- `extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java`
- `extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexWorkerBatchSizeTest.java`
- `extensions/indexes/lucene/src/test/xquery/lucene/ft-edge.xqm`

### Benchmarks / perf instrumentation

- `exist-core-jmh/src/main/java/org/exist/storage/ReindexBenchmark.java`
- `exist-core-jmh/src/test/java/org/exist/storage/ReindexBenchmarkTest.java`
- `exist-core-jmh/src/main/java/org/exist/indexing/lucene/ReindexDeleteStrategyBenchmark.java`
- `exist-core-jmh/src/main/java/org/exist/indexing/lucene/LucenePhraseQueryBenchmark.java`
- `exist-core-jmh/pom.xml`

## Benchmark Results Reindex

Using `ReindexBenchmark.reindex` with identical parameters (`-f 1 -wi 2 -i 3 -w 3s -r 3s`), comparing baseline `345af57cc75e77788afaded4dde24549350eba71` to current:

| docCount | Baseline (ms/op) | Current (ms/op) | Improvement |
|---|---:|---:|---:|
| 100 | 6.259 | 1.775 | 3.53x faster (~71.6% lower) |
| 500 | 33.985 | 9.685 | 3.51x faster (~71.5% lower) |
| 1000 | 65.773 | 20.344 | 3.23x faster (~69.1% lower) |

### Regression XQSuite additions

- `extensions/indexes/lucene/src/test/xquery/lucene/util-expand-highlight.xqm` (#2283 guards)
- `extensions/indexes/range/src/test/xquery/range/optimizer.xql` (#2363 guards, pending where upstream fix is still expected)

## Issues / references

- #2283
- #2363 (partially guarded; pending tests retained intentionally)
- #2812 (benchmark coverage)
- #3747
- plus reindex/lifecycle hardening tickets handled in this branch’s commit stack


## Notes for reviewers

- #2363 tests are intentionally left `%test:pending` for the still-open optimizer union-shape path while upstream work lands; controls are included for future un-pending.
