### PR TITLE
[bugfix] fn:abs and fn:min/fn:max XQTS 3.1 edge cases

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
@@ -230,6 +230,15 @@ the smallest value is made according to the collation that is used. """;
      */
     static AtomicValue validateAndWrapDuration(final DurationValue value, final AtomicValue accumulator,
             final Function expression) throws XPathException {
+        // Per XPath F&O fn:min/fn:max: duration values must all be xs:yearMonthDuration
+        // or all xs:dayTimeDuration. A plain xs:duration is neither and must raise
+        // FORG0006, even though wrap() can re-classify a P1Y or P1D value into a
+        // subtype -- the spec checks the item type, not the wrappable shape.
+        if (value.getType() == Type.DURATION) {
+            throw new XPathException(expression, ErrorCodes.FORG0006, "Cannot compare " +
+                    Type.getTypeName(Type.DURATION) +
+                    "; values must be xs:yearMonthDuration or xs:dayTimeDuration", value);
+        }
         final AtomicValue wrapped = value.wrap();
         if (wrapped.getType() == Type.YEAR_MONTH_DURATION) {
             if (accumulator != null && accumulator.getType() != Type.YEAR_MONTH_DURATION) {

--- a/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
@@ -455,7 +455,10 @@ public class IntegerValue extends NumericValue {
 
     @Override
     public NumericValue abs() throws XPathException {
-        return new IntegerValue(getExpression(), value.abs(), type);
+        // Per XPath F&O fn:abs: if $arg is derived from xs:integer, the result is
+        // xs:integer, not the derived subtype. Preserving the subtype caused
+        // FORG0001 for abs(xs:int(-2147483648)) and abs(xs:negativeInteger(...)).
+        return new IntegerValue(getExpression(), value.abs());
     }
 
     @Override


### PR DESCRIPTION
## Summary

Two small XPath F&O conformance fixes surfaced by an XQTS 3.1 gap analysis on develop:

- **`fn:abs`**: Always return base `xs:integer` for derived integer subtypes (12 fn-abs failures).
- **`fn:min` / `fn:max`**: Raise `FORG0006` for plain `xs:duration` values (6 cbcl-min/max failures).

Diff: 13 insertions, 1 deletion across two files.

## What changed

### `exist-core/.../value/IntegerValue.java`

`IntegerValue.abs()` was passing the derived type (e.g. `xs:int`, `xs:short`, `xs:negativeInteger`, `xs:nonPositiveInteger`) into the `IntegerValue` constructor, which validates the value against the type's range. For values at the negative edge of a subtype, `abs()` overflows the subtype's positive bound and the constructor raises `FORG0001`.

Per [XPath F&O §4.4.1 fn:abs](https://www.w3.org/TR/xpath-functions-31/#func-abs):

> If the type of `$arg` is one of the four numeric types `xs:float`, `xs:double`, `xs:decimal` or `xs:integer` the type of the result is the same as the type of `$arg`. If the type of `$arg` is a type derived from one of the numeric types, the result is an instance of the base numeric type.

Drop the `type` argument so the result is `xs:integer`. `FloatValue`, `DoubleValue`, and `DecimalValue` already do the right thing.

### `exist-core/.../functions/fn/FunMin.java`

`validateAndWrapDuration` (used by both `FunMin` and `FunMax`) called `DurationValue.wrap()` before checking the type. `wrap()` opportunistically re-classifies a `P1Y`-only `xs:duration` as `xs:yearMonthDuration` or a `P1D`-only `xs:duration` as `xs:dayTimeDuration`. That hid the original `xs:duration` item type and let mixed sequences silently produce a value rather than the spec-mandated error.

Per [XPath F&O §15.4.3 fn:min](https://www.w3.org/TR/xpath-functions-31/#func-min) and [§15.4.4 fn:max](https://www.w3.org/TR/xpath-functions-31/#func-max):

> Duration values must either all be `xs:yearMonthDuration` values or must all be `xs:dayTimeDuration` values.

Plain `xs:duration` is neither. Raise `FORG0006` on the item type before `wrap()`.

## Spec references

- fn:abs — https://www.w3.org/TR/xpath-functions-31/#func-abs
- fn:min — https://www.w3.org/TR/xpath-functions-31/#func-min
- fn:max — https://www.w3.org/TR/xpath-functions-31/#func-max

## XQTS 3.1 deltas (expected, based on test source)

| Test set | Before | Expected after |
|----------|--------|----------------|
| fn-abs | 12 unexpected `FORG0001` | 0 |
| fn-min | 4 unexpected (3 `FORG0006` missing + 1 dateTimeStamp) | 1 (the dateTimeStamp case is unrelated) |
| fn-max | 4 unexpected (3 `FORG0006` missing + 1 dateTimeStamp) | 1 (the dateTimeStamp case is unrelated) |

Specific test cases now satisfied:

- fn-abs: `fn-absint1args-1`, `fn-absnint1args-1/2/3`, `fn-absnpi1args-1/2`, `fn-abssht1args-1`, `K2-ABSFunc-2/3/15/16/42`
- fn-min: `cbcl-min-008`, `cbcl-min-016`, `cbcl-min-017`
- fn-max: `cbcl-max-008`, `cbcl-max-016`, `cbcl-max-017`

## Test plan

- [x] `mvn test -pl exist-core` (full): 6699 tests, 0 failures, 0 errors, 105 skipped (pre-existing)
- [x] Targeted: `XPathQueryTest`, `DurationTest`, `XQueryFunctionsTest`, `YearMonthDurationTest`, `DateTimeTest`, `DateTest`, `TimeTest`, `SubSequenceRangeTest` — all pass (497 tests)
- [ ] XQTS 3.1 fn-abs / fn-min / fn-max delta — not run locally; develop's xqts-runner build is stuck on Saxon-12-only modules. The fixed test cases match the asserted expected results exactly, so CI XQTS coverage will validate.
- [ ] QT4 regression on the same sets — same caveat.

## Risk

The fn:min/fn:max change is the more delicate of the two: PR #6207 (`abbcf754c3`) intentionally relaxed mixed-numeric comparisons. This change does not touch numeric handling — it strictly tightens the duration branch where the spec already mandates an error. No version gate needed; the rule is identical in XPath 3.1 and 4.0.

[This work was co-authored with Claude Code. -Joe]

🤖 Generated with [Claude Code](https://claude.com/claude-code)