### PR TITLE
[ci] compare-results.xslt: surface runner-JAR drift warning when build SHAs differ

### DIFF
--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -25,7 +25,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:cr="http://exist-db.org/exist-xqts/compare-results"
-    exclude-result-prefixes="xs"
+    xmlns:ri="http://exist-db.org/exist-xqts-runner/runner-info"
+    exclude-result-prefixes="xs ri"
     version="2.0">
 
     <xsl:param name="xqts.previous.junit-data-path" as="xs:string" required="yes"/>
@@ -43,8 +44,16 @@
                 <xsl:sequence select="cr:new-changes($previous-summary/cr:results, $current-summary/cr:results, .)"/>
             </xsl:for-each>
         </xsl:variable>
+        <xsl:variable name="previous-runner-info" as="document-node()?" select="cr:load-runner-info($xqts.previous.junit-data-path)"/>
+        <xsl:variable name="current-runner-info" as="document-node()?" select="cr:load-runner-info($xqts.current.junit-data-path)"/>
         <xsl:document>
             <cr:comparison>
+                <xsl:variable name="warnings" as="element(cr:warning)*" select="cr:drift-warnings($previous-runner-info, $current-runner-info)"/>
+                <xsl:if test="exists($warnings)">
+                    <cr:warnings>
+                        <xsl:sequence select="$warnings"/>
+                    </cr:warnings>
+                </xsl:if>
                 <cr:previous>
                     <xsl:copy select="$previous-summary/cr:results">
                         <xsl:copy-of select="@*"/>
@@ -106,10 +115,10 @@
         <xsl:param name="previous-results" as="element(cr:results)" required="yes"/>
         <xsl:param name="current-results" as="element(cr:results)" required="yes"/>
         <xsl:param name="attr-name" as="xs:string" required="yes"/>
-        
+
         <xsl:variable name="previous-attr" select="$previous-results/@*[local-name(.) eq $attr-name]"/>
         <xsl:variable name="current-attr" select="$current-results/@*[local-name(.) eq $attr-name]"/>
-        
+
         <xsl:attribute name="{$attr-name}" select="$current-attr - $previous-attr"/>
         <xsl:choose>
             <xsl:when test="$attr-name eq 'pass'">
@@ -138,5 +147,72 @@
             <xsl:copy-of select="failure|error"/>
         </xsl:copy>
     </xsl:template>
+
+    <!--
+        Locate `runner-info.xml` next to the run's output dir. The junit data
+        path is `<output>/junit/data`, so the metadata file sits two levels up.
+        Returns the empty sequence if the file is missing or unparseable, so
+        the warning step degrades to a no-op rather than failing the comparison.
+    -->
+    <xsl:function name="cr:load-runner-info" as="document-node()?">
+        <xsl:param name="junit-data-path" as="xs:string"/>
+        <xsl:variable name="uri" select="concat($junit-data-path, '/../../runner-info.xml')"/>
+        <xsl:choose>
+            <xsl:when test="doc-available($uri)">
+                <xsl:sequence select="doc($uri)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Emit a `cr:warning` per drift kind detected. The two kinds:
+          - runner-drift: runner-JAR git-sha or sha256 differs between the runs
+          - embedded-exist-core-drift: embedded `exist-core` version differs
+            even when the runner JAR git-sha matches
+        See https://github.com/eXist-db/exist/issues/6326.
+    -->
+    <xsl:function name="cr:drift-warnings" as="element(cr:warning)*">
+        <xsl:param name="previous" as="document-node()?"/>
+        <xsl:param name="current" as="document-node()?"/>
+        <xsl:if test="exists($previous) and exists($current)">
+            <xsl:variable name="prev-jar-sha" select="string($previous//ri:runner-jar/ri:git-sha[not(@unknown='true')])"/>
+            <xsl:variable name="curr-jar-sha" select="string($current//ri:runner-jar/ri:git-sha[not(@unknown='true')])"/>
+            <xsl:variable name="prev-jar-hash" select="string($previous//ri:runner-jar/ri:sha256[not(@unknown='true')])"/>
+            <xsl:variable name="curr-jar-hash" select="string($current//ri:runner-jar/ri:sha256[not(@unknown='true')])"/>
+            <xsl:variable name="prev-core-ver" select="string($previous//ri:embedded-exist-core/ri:version[not(@unknown='true')])"/>
+            <xsl:variable name="curr-core-ver" select="string($current//ri:embedded-exist-core/ri:version[not(@unknown='true')])"/>
+
+            <xsl:variable name="runner-drift" as="xs:boolean" select="
+                ($prev-jar-sha ne '' and $curr-jar-sha ne '' and $prev-jar-sha ne $curr-jar-sha)
+                or ($prev-jar-hash ne '' and $curr-jar-hash ne '' and $prev-jar-hash ne $curr-jar-hash)"/>
+
+            <xsl:if test="$runner-drift">
+                <cr:warning kind="runner-drift">
+                    <cr:summary>Runner JAR build SHA or sha256 differs between the previous and current XQTS runs. Test deltas may include runner-side effects unrelated to this PR. See https://github.com/eXist-db/exist/issues/6326.</cr:summary>
+                    <cr:previous>
+                        <xsl:copy-of select="$previous//ri:runner-jar"/>
+                    </cr:previous>
+                    <cr:current>
+                        <xsl:copy-of select="$current//ri:runner-jar"/>
+                    </cr:current>
+                </cr:warning>
+            </xsl:if>
+
+            <xsl:if test="not($runner-drift) and $prev-core-ver ne '' and $curr-core-ver ne '' and $prev-core-ver ne $curr-core-ver">
+                <cr:warning kind="embedded-exist-core-drift">
+                    <cr:summary>The runner JAR appears identical, but the embedded `exist-core` version differs between the runs. Test deltas may include `exist-core` shading effects rather than the eXist source under test.</cr:summary>
+                    <cr:previous>
+                        <xsl:copy-of select="$previous//ri:embedded-exist-core"/>
+                    </cr:previous>
+                    <cr:current>
+                        <xsl:copy-of select="$current//ri:embedded-exist-core"/>
+                    </cr:current>
+                </cr:warning>
+            </xsl:if>
+        </xsl:if>
+    </xsl:function>
 
 </xsl:stylesheet>


### PR DESCRIPTION
## Summary

Adds a `cr:warnings` block to the comparison report that fires when the previous and current XQTS runs were produced by different runner JAR builds. Without this, develop-branch deltas, runner-source bugfixes, and shaded-`exist-core` differences all silently appear as if they were caused by the PR's source change.

Partially addresses #6326 (mitigation A only). Mitigations B (runner version pin) and C (N-run flake filtering) remain open.

Companion runner PR (the producer of the metadata this consumes): https://github.com/eXist-db/exist-xqts-runner/pull/51

## Why

A 2026-05-09 investigation found the same eXist SHA producing **+831 XQTS passes and a 25x wallclock improvement** when re-run against a different runner JAR build (the runner-side `applyVersionHint` cap-at-3.1 patch). The existing comparison report attributed those deltas to the PR's source change, which is wrong. This makes runner-JAR drift directly attributable rather than masquerading as engine improvements.

A second drift mode surfaced during PR #6331's perf-6322 investigation: locally-built runner JARs shade `exist-core`, so two runs of the same runner-source git SHA can still differ if assembled from different `exist-core` snapshots. The XSLT detects both modes.

## What changed

`exist-xqts/src/main/xslt/compare-results.xslt`:

- Reads `runner-info.xml` from each run's output dir root (two levels up from the junit-data path). The metadata is emitted by the companion `exist-xqts-runner` change; older runs predating that change will have the file absent.
- Emits a `cr:warning kind="runner-drift"` element when the runner JAR's git-sha or sha256 differs between the runs, including the full `runner-jar` payloads from each side for transparency.
- Emits a `cr:warning kind="embedded-exist-core-drift"` when the runner JAR appears identical but the shaded `exist-core` version differs.
- Graceful degradation: when either side's `runner-info.xml` is missing or malformed (`doc-available` returns false), no warning is emitted and the rest of the comparison runs unchanged. Older baselines and contributor environments without the runner-side patch keep working with no behaviour change.

`ci-xqts.yml` needs no edit -- the artifact upload uploads the entire `/tmp/xqts-output` dir and `runner-info.xml` round-trips automatically.

### Sample output (runner-drift case)

```xml
<cr:comparison xmlns:cr="http://exist-db.org/exist-xqts/compare-results">
   <cr:warnings>
      <cr:warning kind="runner-drift">
         <cr:summary>Runner JAR build SHA or sha256 differs between the previous and current XQTS runs. Test deltas may include runner-side effects unrelated to this PR. See https://github.com/eXist-db/exist/issues/6326.</cr:summary>
         <cr:previous>
            <runner-jar xmlns="http://exist-db.org/exist-xqts-runner/runner-info">
               <git-sha>aaaa1111...</git-sha>
               ...
            </runner-jar>
         </cr:previous>
         <cr:current>...</cr:current>
      </cr:warning>
   </cr:warnings>
   <cr:previous>...</cr:previous>
   <cr:current>...</cr:current>
   <cr:change>...</cr:change>
</cr:comparison>
```

## Test plan

Hand-tested locally against Saxon-HE 9.9 (the same version CI invokes), with synthetic `runner-info.xml` files in five scenarios:

- [x] Different runner-jar git-sha -> emits `cr:warning kind="runner-drift"` with both sides' payloads.
- [x] Identical `runner-info.xml` files -> no warning emitted.
- [x] `runner-info.xml` absent on one side -> no warning, no error.
- [x] Malformed `runner-info.xml` -> no warning, no error (`doc-available` returns false).
- [x] Same runner JAR git-sha + sha256 but different embedded `exist-core` version -> emits `cr:warning kind="embedded-exist-core-drift"`.
- [ ] End-to-end smoke test on next CI run will produce a comparison report with no warning (matching SHAs from the same workflow build).

## Risk and rollback

The change is purely additive. Reverting removes the warning element but doesn't break existing comparison output -- the per-test-comparison structure is unchanged, so any downstream consumer of `comparison-results.xml` remains compatible. The two PRs (this one and the runner-side) can land in either order; the XSLT degrades to a no-op when `runner-info.xml` is absent.