### PR TITLE
[bugfix] DurationValue: deterministic hashCode for cross-type op:same-key (closes #6327)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/DurationValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DurationValue.java
@@ -33,6 +33,7 @@ import javax.xml.datatype.Duration;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.util.Objects;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
@@ -417,9 +418,21 @@ public class DurationValue extends ComputableValue {
         if (this == obj) {
             return true;
         }
-        if (DurationValue.class.isAssignableFrom(obj.getClass())) {
-            return duration.equals(((DurationValue) obj).duration);
+        if (obj == null || !DurationValue.class.isAssignableFrom(obj.getClass())) {
+            return false;
         }
-        return false;
+        final DurationValue other = (DurationValue) obj;
+        return monthsValueSigned().equals(other.monthsValueSigned())
+                && secondsValueSigned().compareTo(other.secondsValueSigned()) == 0;
+    }
+
+    // Hash on canonical (signed total months, signed total seconds) so equal-value instances
+    // across xs:duration / xs:yearMonthDuration / xs:dayTimeDuration share an op:same-key bucket.
+    @Override
+    public int hashCode() {
+        final BigInteger months = monthsValueSigned();
+        BigDecimal seconds = secondsValueSigned();
+        seconds = seconds.signum() == 0 ? BigDecimal.ZERO : seconds.stripTrailingZeros();
+        return Objects.hash(months, seconds);
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/value/DurationTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/DurationTest.java
@@ -178,4 +178,69 @@ public class DurationTest extends AbstractTimeRelatedTestCase {
         checkMinMaxFails(dv2, dv3);
         checkMinMaxFails(dv3, dv2);
     }
+
+    // --- Cross-type canonicalisation (issue #6327) ---
+    // op:same-key requires equal hashCodes for equal-value durations across xs:duration
+    // family subtypes; the bifurcan map in MapType keys on AtomicValue::hashCode and the
+    // map-contains-017 XQTS test exercises this path.
+
+    @Test
+    public void hashCodeEqualForDurationAndYearMonthDuration() throws XPathException {
+        final DurationValue d = new DurationValue("P1Y");
+        final YearMonthDurationValue ymd = new YearMonthDurationValue("P12M");
+        assertEquals(d.hashCode(), ymd.hashCode());
+        assertEquals(ymd.hashCode(), d.hashCode());
+    }
+
+    @Test
+    public void hashCodeEqualForDurationAndDayTimeDuration() throws XPathException {
+        final DurationValue d = new DurationValue("P1D");
+        final DayTimeDurationValue dtd = new DayTimeDurationValue("PT24H");
+        assertEquals(d.hashCode(), dtd.hashCode());
+    }
+
+    @Test
+    public void hashCodeEqualForZeroDurations() throws XPathException {
+        final DurationValue d = new DurationValue("P0D");
+        final YearMonthDurationValue ymd = new YearMonthDurationValue("P0M");
+        final DayTimeDurationValue dtd = new DayTimeDurationValue("PT0S");
+        assertEquals(d.hashCode(), ymd.hashCode());
+        assertEquals(d.hashCode(), dtd.hashCode());
+        assertEquals(ymd.hashCode(), dtd.hashCode());
+    }
+
+    @Test
+    public void hashCodeEqualForNegativeDurations() throws XPathException {
+        final DurationValue d = new DurationValue("-P1Y");
+        final YearMonthDurationValue ymd = new YearMonthDurationValue("-P12M");
+        assertEquals(d.hashCode(), ymd.hashCode());
+    }
+
+    @Test
+    public void hashCodeDifferentForUnequalDurations() throws XPathException {
+        // sanity: unequal durations should generally hash differently
+        final DurationValue p1y = new YearMonthDurationValue("P1Y");
+        final DurationValue p2y = new YearMonthDurationValue("P2Y");
+        org.junit.Assert.assertNotEquals(p1y.hashCode(), p2y.hashCode());
+    }
+
+    @Test
+    public void equalsCommutativeAcrossDurationSubtypes() throws XPathException {
+        final DurationValue d = new DurationValue("P1Y");
+        final YearMonthDurationValue ymd = new YearMonthDurationValue("P12M");
+        org.junit.Assert.assertEquals(d, ymd);
+        org.junit.Assert.assertEquals(ymd, d);
+    }
+
+    @Test
+    public void hashCodeDeterministicAcrossInstances() throws XPathException {
+        // 100-iter loop exposes any non-determinism (e.g., identity-hash leaks)
+        final int expected = new DurationValue("P1Y").hashCode();
+        for (int i = 0; i < 100; i++) {
+            final DurationValue d = new DurationValue("P1Y");
+            final YearMonthDurationValue ymd = new YearMonthDurationValue("P12M");
+            assertEquals("iter " + i + ": DurationValue", expected, d.hashCode());
+            assertEquals("iter " + i + ": YearMonthDurationValue", expected, ymd.hashCode());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/value/DurationTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/DurationTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
@@ -221,15 +222,15 @@ public class DurationTest extends AbstractTimeRelatedTestCase {
         // sanity: unequal durations should generally hash differently
         final DurationValue p1y = new YearMonthDurationValue("P1Y");
         final DurationValue p2y = new YearMonthDurationValue("P2Y");
-        org.junit.Assert.assertNotEquals(p1y.hashCode(), p2y.hashCode());
+        assertNotEquals(p1y.hashCode(), p2y.hashCode());
     }
 
     @Test
     public void equalsCommutativeAcrossDurationSubtypes() throws XPathException {
         final DurationValue d = new DurationValue("P1Y");
         final YearMonthDurationValue ymd = new YearMonthDurationValue("P12M");
-        org.junit.Assert.assertEquals(d, ymd);
-        org.junit.Assert.assertEquals(ymd, d);
+        assertEquals(d, ymd);
+        assertEquals(ymd, d);
     }
 
     @Test

--- a/exist-core/src/test/xquery/maps/maps.xqm
+++ b/exist-core/src/test/xquery/maps/maps.xqm
@@ -994,6 +994,38 @@ function mt:map-merge-2-empty-options-map() {
     return $expected?Su eq $actual?Su
 };
 
+(: test for issue https://github.com/eXist-db/exist/issues/6327 -
+   xs:duration vs xs:yearMonthDuration must compare equal under op:same-key
+   regardless of which subtype is used as the search key. :)
+declare
+    %test:assertTrue
+function mt:duration-vs-yearMonthDuration-contains() {
+    map:contains(map{xs:duration('P1Y'):"x"}, xs:yearMonthDuration('P12M'))
+};
+
+declare
+    %test:assertTrue
+function mt:yearMonthDuration-vs-duration-contains() {
+    map:contains(map{xs:yearMonthDuration('P12M'):"x"}, xs:duration('P1Y'))
+};
+
+declare
+    %test:assertTrue
+function mt:duration-vs-dayTimeDuration-contains() {
+    map:contains(map{xs:duration('P1D'):"x"}, xs:dayTimeDuration('PT24H'))
+};
+
+declare
+    %test:assertEquals("Wednesday")
+function mt:duration-key-lookup-mirrors-XQTS-map-contains-017() {
+    let $m := map{
+        1:"Sunday",2:"Monday",3:"Tuesday",
+        xs:duration('P1Y'):"Wednesday",
+        5:"Thursday",6:"Friday",7:"Saturday"
+    }
+    return $m(xs:yearMonthDuration('P12M'))
+};
+
 (: test for issue https://github.com/eXist-db/exist/issues/5685 :)
 declare
     %test:assertEquals("<ul><li>Scotland<ul><li>Highlands<ul><li>Fort William</li><li>Inverness</li></ul></li><li>Lowlands<ul><li>Glasgow</li></ul></li></ul></li></ul>")


### PR DESCRIPTION
## Summary

`DurationValue` had no `hashCode()` override, so the Bifurcan map in `MapType` (keyed on `AtomicValue::hashCode`) gave `xs:duration('P1Y')` and `xs:yearMonthDuration('P12M')` different hash buckets despite `op:same-key` returning `true`. `map:contains` therefore missed the cross-type lookup whenever the two identity-based hashes happened not to collide modulo the bucket count - the ~1-in-8 pass rate observed on XQTS `map-contains-017`.

## Root cause

`AbstractMapType.MapType` builds a Bifurcan map with:

```java
new Map<>(AtomicValue::hashCode, (k1, k2) -> sameKey(collator, k1, k2));
```

`sameKey` for the `xs:duration` family routes through `FunDeepEqual.deepEquals`, which would correctly equate `P1Y` with `P12M` - **if the lookup ever made it that far**. Bifurcan first probes by hash, so a hash mismatch short-circuits before `sameKey` is ever called. With `DurationValue` inheriting `Object.hashCode` (identity-based), every instance had a different hash and the lookup almost always landed in the wrong bucket.

## What changed

`DurationValue.hashCode()` (new) - hashes on the canonical `(signed total months, signed total seconds)` tuple computed from `monthsValueSigned()` / `secondsValueSigned()`. This tuple is invariant across `xs:duration` / `xs:yearMonthDuration` / `xs:dayTimeDuration` for equal-value durations:

| Value | months | seconds |
|---|---:|---:|
| `xs:duration('P1Y')` | 12 | 0 |
| `xs:yearMonthDuration('P12M')` | 12 | 0 |
| `xs:duration('P1D')` | 0 | 86400 |
| `xs:dayTimeDuration('PT24H')` | 0 | 86400 |
| `xs:duration('-P1Y')` | -12 | 0 |
| `xs:duration('P0D')` / `P0M` / `PT0S` | 0 | 0 |

`BigDecimal` scale is normalized (`stripTrailingZeros`, with explicit zero handling) so that `BigDecimal("0")` and `BigDecimal("0.000")` hash identically.

`DurationValue.equals(Object)` is also rewritten to read the same canonical tuple instead of delegating to JDK `Duration.equals`. This removes a potential `equals`/`hashCode` contract divergence and matches the canonical-comparison behaviour `op:duration-equal` already implements.

## Spec references

- W3C XPath F&O 3.1 14.2.2 [`op:same-key`](https://www.w3.org/TR/xpath-functions-31/#func-same-key) - `xs:duration` family is compared via `fn:deep-equal`, which uses canonical value comparison.
- W3C XPath F&O 3.1 9.4.2 `op:duration-equal` - the canonical-month / canonical-second comparison this fix mirrors.

## Test plan

- New JUnit tests in `DurationTest`:
  - `hashCodeEqualForDurationAndYearMonthDuration` - issue case
  - `hashCodeEqualForDurationAndDayTimeDuration` - dayTime analogue
  - `hashCodeEqualForZeroDurations` - all three zero forms hash equal
  - `hashCodeEqualForNegativeDurations` - signed parity
  - `hashCodeDifferentForUnequalDurations` - sanity: distinct values still hash apart
  - `equalsCommutativeAcrossDurationSubtypes` - cross-type `equals()` is reflexive
  - `hashCodeDeterministicAcrossInstances` - 100-iter loop, all produce the same hash
- New XQuery tests in `xquery/maps/maps.xqm` - replicate the `map-contains-017` pattern at the XQuery surface, in both argument orders, plus the `xs:duration` <-> `xs:dayTimeDuration` analogue.
- Without the fix, the 5 hashCode-equality JUnit tests and all 4 new XQuery `map:contains` tests fail (verified by stashing the fix and re-running). With the fix, all pass.
- Full `mvn test -pl exist-core` gate: **6603 tests, 0 failures, 0 errors**.
- Targeted reruns: `*Duration*`, `*DateTime*`, `*DeepEqual*`, `*MapTest*`, `xquery.maps.MapTests`, `BifurcanMapTest` - 335 tests, all green.
- Full XQTS QT4 / XQ 3.1 / FTTS not re-run locally (worktree XQTS-runner build had an unrelated SNAPSHOT-resolution issue); CI will exercise these. The change is surgical (hashCode addition + equals canonicalization, no comparison/arithmetic logic touched), so XQTS regressions outside the duration-key path should not be expected.

## Risk

The `hashCode` addition strictly tightens the existing contract - durations that previously had distinct identity hashes now hash by canonical value, which is what `sameKey` already requires. The `equals` rewrite returns the same answer as JDK `Duration.equals` for definite cases (P1Y == P12M, P30D != P1M) and the same `false` answer for indeterminate cases (P30D vs P1M, P365D vs P1Y).

Closes https://github.com/eXist-db/exist/issues/6327
Refs https://github.com/eXist-db/exist/issues/6122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
