### PR TITLE
[bugfix] NumericValue + BooleanValue: hashCode contract for op:same-key (PR #6333 family)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/BooleanValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BooleanValue.java
@@ -226,4 +226,9 @@ public class BooleanValue extends AtomicValue {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(value);
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
@@ -496,11 +496,6 @@ public class DecimalValue extends NumericValue {
         }
     }
 
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
-
     //Copied from Saxon 8.8
 
     /* (non-Javadoc)

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -490,11 +490,6 @@ public class DoubleValue extends NumericValue {
         return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;
     }
 
-    @Override
-    public int hashCode() {
-        return Double.valueOf(value).hashCode();
-    }
-
     /**
      * Serializes to a ByteBuffer.
      * 8 bytes.

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -529,11 +529,6 @@ public class FloatValue extends NumericValue {
         }
     }
 
-    @Override
-    public int hashCode() {
-        return Float.valueOf(value).hashCode();
-    }
-
     /**
      * Serializes to a ByteBuffer.
      *

--- a/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
@@ -562,11 +562,6 @@ public class IntegerValue extends NumericValue {
         }
     }
 
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
-
     //TODO(AR) this is not a very good serialization method, the size of the IntegerValue is unbounded and may not fit in 8 bytes.
     /**
      * Serializes to a byte array.

--- a/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
@@ -34,6 +34,11 @@ import java.util.function.IntSupplier;
 
 public abstract class NumericValue extends ComputableValue {
 
+    /** Sentinel hashes for NaN and the infinities in the numeric same-key cluster. */
+    private static final int NAN_HASH = 0x7FC00000;
+    private static final int POSITIVE_INFINITY_HASH = 0x7F800000;
+    private static final int NEGATIVE_INFINITY_HASH = 0xFF800000;
+
     protected NumericValue() {
         this(null);
     }
@@ -182,6 +187,37 @@ public abstract class NumericValue extends ComputableValue {
                 // should not be possible due to type check
             }
         return false;
+    }
+
+    /**
+     * Canonical hash for the numeric same-key cluster ({@code xs:decimal}, {@code xs:double},
+     * {@code xs:float} and their derived types).
+     *
+     * Returns the same value for any two NumericValues whose op:numeric-equal comparison
+     * over their canonical {@code xs:decimal} form is true, plus dedicated sentinels for
+     * NaN and the infinities. This preserves the equals/hashCode contract under
+     * {@link NumericValue#equals(Object)} (which compares via op:numeric-equal) and ensures
+     * that cross-type spec-equal pairs (e.g. {@code xs:integer(1)} / {@code xs:double(1.0)})
+     * land in the same Bifurcan bucket under {@code op:same-key}.
+     */
+    @Override
+    public int hashCode() {
+        if (isNaN()) {
+            return NAN_HASH;
+        }
+        if (isPositiveInfinity()) {
+            return POSITIVE_INFINITY_HASH;
+        }
+        if (isNegativeInfinity()) {
+            return NEGATIVE_INFINITY_HASH;
+        }
+        try {
+            // canonical decimal form: trailing zeros stripped at DecimalValue construction
+            return ((DecimalValue) convertTo(Type.DECIMAL)).getValue().hashCode();
+        } catch (final XPathException e) {
+            // unreachable for valid numeric values
+            return 0;
+        }
     }
 
     public abstract NumericValue negate() throws XPathException;

--- a/exist-core/src/test/java/org/exist/xquery/value/HashCodeContractTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/HashCodeContractTest.java
@@ -1,0 +1,160 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.value;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Guards the Object.equals/hashCode contract across {@link AtomicValue} subclasses
+ * whose equals method admits cross-type spec equality. Without these guards,
+ * Bifurcan-backed map operations ({@code map:contains}, {@code map:get}) bucket
+ * spec-equal keys differently and silently mis-report containment.
+ *
+ * Scope: numeric same-key cluster (xs:integer / xs:decimal / xs:double / xs:float)
+ * and xs:boolean. The xs:duration family is closed by PR #6333. The string and
+ * date/time clusters already satisfy the contract (covered here as guards).
+ */
+public class HashCodeContractTest {
+
+    // --- Numeric same-key cluster: cross-type spec equality must imply hash equality ---
+
+    @Test
+    public void integerEqualsDecimalSharesHashCode() {
+        final AtomicValue i = new IntegerValue(BigInteger.ONE);
+        final AtomicValue d = new DecimalValue(new BigDecimal("1"));
+        assertTrue(i.equals(d));
+        assertEquals(i.hashCode(), d.hashCode());
+    }
+
+    @Test
+    public void integerEqualsDecimalWithTrailingZerosSharesHashCode() {
+        final AtomicValue i = new IntegerValue(BigInteger.ONE);
+        final AtomicValue d = new DecimalValue(new BigDecimal("1.0"));
+        assertTrue(i.equals(d));
+        assertEquals(i.hashCode(), d.hashCode());
+    }
+
+    @Test
+    public void integerEqualsDoubleSharesHashCode() {
+        final AtomicValue i = new IntegerValue(BigInteger.ONE);
+        final AtomicValue dbl = new DoubleValue(1.0);
+        assertTrue(i.equals(dbl));
+        assertEquals(i.hashCode(), dbl.hashCode());
+    }
+
+    @Test
+    public void decimalEqualsDoubleSharesHashCode() {
+        final AtomicValue d = new DecimalValue(new BigDecimal("1.0"));
+        final AtomicValue dbl = new DoubleValue(1.0);
+        assertTrue(d.equals(dbl));
+        assertEquals(d.hashCode(), dbl.hashCode());
+    }
+
+    @Test
+    public void doubleEqualsFloatSharesHashCode() {
+        final AtomicValue dbl = new DoubleValue(1.0);
+        final AtomicValue f = new FloatValue(1.0f);
+        assertTrue(dbl.equals(f));
+        assertEquals(dbl.hashCode(), f.hashCode());
+    }
+
+    @Test
+    public void positiveInfinitySharesHashCodeAcrossDoubleAndFloat() {
+        final AtomicValue dbl = new DoubleValue(Double.POSITIVE_INFINITY);
+        final AtomicValue f = new FloatValue(Float.POSITIVE_INFINITY);
+        assertTrue(dbl.equals(f));
+        assertEquals(dbl.hashCode(), f.hashCode());
+    }
+
+    @Test
+    public void negativeInfinitySharesHashCodeAcrossDoubleAndFloat() {
+        final AtomicValue dbl = new DoubleValue(Double.NEGATIVE_INFINITY);
+        final AtomicValue f = new FloatValue(Float.NEGATIVE_INFINITY);
+        assertTrue(dbl.equals(f));
+        assertEquals(dbl.hashCode(), f.hashCode());
+    }
+
+    @Test
+    public void distinctIntegersHaveDistinctHashCodes() {
+        // Probabilistic: distinct small integers should not collide.
+        assertNotEquals(new IntegerValue(BigInteger.valueOf(1)).hashCode(),
+                new IntegerValue(BigInteger.valueOf(2)).hashCode());
+        assertNotEquals(new IntegerValue(BigInteger.valueOf(0)).hashCode(),
+                new IntegerValue(BigInteger.valueOf(42)).hashCode());
+    }
+
+    @Test
+    public void integerHashCodeIsDeterministicAcross100Iterations() {
+        final int reference = new IntegerValue(BigInteger.valueOf(12345)).hashCode();
+        for (int i = 0; i < 100; i++) {
+            assertEquals(reference, new IntegerValue(BigInteger.valueOf(12345)).hashCode());
+        }
+    }
+
+    @Test
+    public void doubleHashCodeIsDeterministicAcross100Iterations() {
+        final int reference = new DoubleValue(3.14159).hashCode();
+        for (int i = 0; i < 100; i++) {
+            assertEquals(reference, new DoubleValue(3.14159).hashCode());
+        }
+    }
+
+    // --- Boolean: non-singleton instances must hash by value, not identity ---
+
+    @Test
+    public void newBooleanInstancesShareHashCode() {
+        final AtomicValue a = new BooleanValue(true);
+        final AtomicValue b = new BooleanValue(true);
+        assertTrue(a.equals(b));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void booleanSingletonAndNewInstanceShareHashCode() {
+        final AtomicValue a = BooleanValue.TRUE;
+        final AtomicValue b = new BooleanValue(true);
+        assertTrue(a.equals(b));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void booleanTrueAndFalseHaveDistinctHashCodes() {
+        assertNotEquals(BooleanValue.TRUE.hashCode(), BooleanValue.FALSE.hashCode());
+    }
+
+    // --- Codepoint same-key cluster (regression guard) ---
+
+    @Test
+    public void stringEqualsStringSharesHashCode() {
+        final AtomicValue a = new StringValue("foo");
+        final AtomicValue b = new StringValue("foo");
+        assertTrue(a.equals(b));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/exist-core/src/test/xquery/maps/maps.xqm
+++ b/exist-core/src/test/xquery/maps/maps.xqm
@@ -177,11 +177,13 @@ function mt:size() {
 };
 
 declare
-    %test:assertEquals("Sunday", "Tuesday", "Thursday", "Saturday")
+    %test:assertEquals("Saturday", "Sunday", "Thursday", "Tuesday")
 function mt:for-each() {
-    map:for-each($mt:integerKeys, function($key, $value) {
+    (: map:for-each iteration order is implementation-defined; sort the
+       result so this test guards the selection, not Bifurcan bucket layout :)
+    sort(map:for-each($mt:integerKeys, function($key, $value) {
         if ($key mod 2) then ($value) else ()
-    })
+    }))
 };
 
 declare
@@ -1018,4 +1020,70 @@ function mt:nested-map-for-each() {
         })
     }</ul>
     => serialize(map{'indent':false()})
+};
+
+(:
+ : Regression guards for the equals/hashCode contract on AtomicValue subclasses
+ : that participate in op:same-key.
+ :
+ : Pre-fix symptom: when two spec-equal but different-XDM-type keys hashed to
+ : different Bifurcan buckets, map:contains and map:get returned false/() even
+ : though sameKey reported equality. Matches the PR #6333 / map-contains-017
+ : diagnostic signature for the numeric and xs:boolean clusters.
+ :)
+declare
+    %test:assertTrue
+function mt:map-contains-integer-decimal-cross-type() {
+    map:contains(map { 1: "one" }, xs:decimal(1.0))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-integer-double-cross-type() {
+    map:contains(map { 1: "one" }, xs:double(1.0))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-integer-float-cross-type() {
+    map:contains(map { 1: "one" }, xs:float(1.0))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-decimal-double-cross-type() {
+    map:contains(map { xs:decimal(1.5): "x" }, xs:double(1.5))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-decimal-trailing-zeros() {
+    map:contains(map { xs:decimal("1.0"): "x" }, xs:decimal("1.00"))
+};
+
+declare
+    %test:assertEquals("one")
+function mt:map-get-integer-via-double-key() {
+    map:get(map { 1: "one" }, xs:double(1.0))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-nan-key() {
+    map:contains(map { xs:double('NaN'): "x" }, xs:double('NaN'))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-positive-infinity-cross-type() {
+    map:contains(map { xs:double('INF'): "x" }, xs:float('INF'))
+};
+
+declare
+    %test:assertTrue
+function mt:map-contains-boolean-non-singleton() {
+    (: BooleanValue inherits identity hashCode without the fix; new instances would mis-bucket :)
+    let $key1 := xs:boolean("true")
+    let $key2 := xs:boolean("true")
+    return map:contains(map { $key1: "yes" }, $key2)
 };

--- a/exist-core/src/test/xquery/xqsuite/custom-assertion.xqm
+++ b/exist-core/src/test/xquery/xqsuite/custom-assertion.xqm
@@ -101,7 +101,7 @@ function ca:map-assertion-wrong-value() as item()* {
 };
 
 declare
-    %test:assertEquals("Additional keys found: (o, 23)", "{""a"":1,""o"":""o"",""23"":3}", "map-assertion-failure")
+    %test:assertEquals("Additional keys found: (23, o)", "{""23"":3,""a"":1,""o"":""o""}", "map-assertion-failure")
 function ca:map-assertion-additional-key() as item()* {
     try {
         ca:map-assertion($ca:var, map {"a": 1, 23: 3, "o": "o"})
@@ -143,8 +143,12 @@ function ca:map-assertion ($expected as map(*), $actual as item()*) as item()* {
     else if (not(empty(
         map:keys(map:remove($actual, map:keys($expected))))))
     then test:fail(
+             (: sort additional keys so the diagnostic is deterministic;
+                map:keys order is implementation-defined :)
              "Additional keys found: (" || string-join(
-                map:keys(map:remove($actual, map:keys($expected))), ', ') || ")",
+                for $k in map:keys(map:remove($actual, map:keys($expected)))
+                order by xs:string($k)
+                return xs:string($k), ', ') || ")",
              $expected,
              $actual,
              $ca:MAP_ASSERTION_TYPE


### PR DESCRIPTION
## Summary

Closes the family of AtomicValue subclasses that violate the `equals`/`hashCode` contract under `op:same-key` semantics. PR #6333 fixed `xs:duration`; this sweep covers `xs:integer` / `xs:decimal` / `xs:double` / `xs:float` and `xs:boolean`.

Without these guards, Bifurcan-backed map operations (`map:contains`, `map:get`, ...) bucket spec-equal cross-type keys differently and silently mis-report containment. The diagnostic signature is the same "1-in-N pass rate" symptom that produced `map-contains-017` on `xs:duration`.

## Why

In `MapType.KEY_HASH_FN = AtomicValue::hashCode`, Bifurcan uses each value's `hashCode` for bucketing and only consults `sameKey` for equality within a bucket. If two spec-equal cross-type values hash to different buckets, the equality check is never reached.

### Confirmed contract violations on develop (b917e1ab1d)

| Pair | `equals` | `hashCode` |
|---|---|---|
| `IntegerValue(1)` vs `DecimalValue(1)` | true | 1 / 31 ❌ |
| `IntegerValue(1)` vs `DoubleValue(1.0)` | true | 1 / 1072693248 ❌ |
| `DecimalValue(1.0)` vs `DoubleValue(1.0)` | true | 31 / 1072693248 ❌ |
| `DoubleValue(1.0)` vs `FloatValue(1.0f)` | true | 1072693248 / 1065353216 ❌ |
| `DoubleValue(+INF)` vs `FloatValue(+INF)` | true | 2146435072 / 2139095040 ❌ |
| `new BooleanValue(true)` vs `new BooleanValue(true)` | true | identity / identity ❌ |

## What changed

| File | Change |
|---|---|
| `NumericValue.java` | Add canonical `hashCode()`: NaN / ±INF sentinels, else `((DecimalValue) convertTo(DECIMAL)).getValue().hashCode()` (trailing-zero-stripped at construction). Equals already uses op:numeric-equal, so the contract now holds. |
| `IntegerValue.java`, `DecimalValue.java`, `DoubleValue.java`, `FloatValue.java` | Drop per-class `hashCode()` overrides; inherit the canonical form from `NumericValue`. |
| `BooleanValue.java` | Add `hashCode()` = `Boolean.hashCode(value)`. Non-singleton instances previously hashed by identity. |
| `HashCodeContractTest.java` (new) | 14 contract assertions across the numeric and boolean clusters; 100-iter determinism guard. |
| `maps.xqm` | 9 XQuery regression cases mirroring `map-contains-017` (numeric cross-type, NaN, infinities, non-singleton booleans). `mt:for-each` updated to sort its result — the previous assertion relied on Bifurcan bucket iteration order, which has no spec guarantee. |
| `custom-assertion.xqm` | Sort additional-keys diagnostic for determinism; one test expectation updated for new bucket distribution. |

## Inventory of AtomicValue subclasses surveyed

| Class | equals override | hashCode override | Verdict |
|---|---|---|---|
| `IntegerValue` | inherited from NumericValue (cross-type numeric-eq) | replaced by canonical NumericValue | **fixed** |
| `DecimalValue` | inherited | replaced | **fixed** |
| `DoubleValue` | inherited | replaced | **fixed** |
| `FloatValue` | inherited | replaced | **fixed** |
| `BooleanValue` | by-value | **added** | **fixed** |
| `DurationValue` (+ `OrderedDurationValue` / `YearMonthDurationValue` / `DayTimeDurationValue`) | by canonical tuple | (added in PR #6333) | scope of PR #6333 |
| `StringValue`, `AnyURIValue`, `UntypedAtomicValue` | by value | by value | already correct (codepoint-equal cluster delegates to `String.hashCode`) |
| `AbstractDateTimeValue` (+ all date/time/gXxx subclasses) | by `calendar` | by `calendar.hashCode` | already correct within-class; cross-type sameKey requires lexical match so no cross-type collision needed |
| `BinaryValue` (+ `BinaryValueFromBinaryString`, `BinaryValueFromFile`, `BinaryValueFromInputStream`, `Base64BinaryDocument`) | by `getClass()` + content | by stream-read hash | within-class consistent; cross-type (hexBinary vs base64Binary) returns false in `equals` and `fn:deep-equal` returns false too |
| `QNameValue` | by `qname` | by `qname.hashCode` | already correct |
| `FunctionReference`, `JavaObjectValue` | not used as map keys per spec | n/a | out of scope |

## Spec references

- [XPath/XQuery 3.1 op:same-key](https://www.w3.org/TR/xpath-functions-31/#func-same-key)
- [Bifurcan `Map` hashing contract](https://github.com/lacuna/bifurcan/blob/master/doc/comparison.md)
- PR #6333 - reference implementation against `DurationValue`
- `map-contains-017` - canonical reproduction shape

## Test plan

- [x] `HashCodeContractTest` (14/14 pass)
- [x] `MapTests` XQuery suite (134 pass, was failing `mt:for-each` due to bucket order)
- [x] `XQSuiteTests` (90 pass after `custom-assertion.xqm` determinism fix)
- [x] Full `mvn test -pl exist-core` under shared lock (6615 tests, no hashCode-related failures)
- [ ] XQTS QT4 / XQ 3.1 / FTTS - to be validated in CI; runner-JAR-shaded-exist-core hazard means local runs are unreliable for this change shape (cf. `project_xqts_runner_info_drift_warnings.md`)

## Risk and rollback

Hash bucket layout for numeric and boolean keys changes. Map iteration order is implementation-defined per spec; tests that asserted specific orderings have been updated to sort. Each value-class change is independently revertable.
