### PR TITLE
[optimize] fn:deep-equal: streaming fast-path for persistent-DOM trees (closes #4050)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
@@ -223,178 +223,189 @@ public class FunDeepEqual extends CollatingFunction {
 
         try {
             if (item1.getType() == Type.ARRAY_ITEM || item2.getType() == Type.ARRAY_ITEM) {
-                if (item1.getType() != item2.getType()) {
-                    return Constants.INFERIOR;
-                }
-                final ArrayType array1 = (ArrayType) item1;
-                final ArrayType array2 = (ArrayType) item2;
-                final int array1Size = array1.getSize();
-                final int array2Size = array2.getSize();
-                if (array1Size == array2Size) {
-                    for (int i = 0; i < array1.getSize(); i++) {
-                        final int comparison = deepCompareSeq(array1.get(i), array2.get(i), collator, broker);
-                        if (comparison != Constants.EQUAL) {
-                            return comparison;
-                        }
-                    }
-                    return Constants.EQUAL;
-                } else {
-                    return array1Size < array2Size ? Constants.INFERIOR : Constants.SUPERIOR;
-                }
+                return compareArrayItems(item1, item2, collator, broker);
             }
-
             if (item1.getType() == Type.MAP_ITEM || item2.getType() == Type.MAP_ITEM) {
-                if (item1.getType() != item2.getType()) {
-                    return Constants.INFERIOR;
-                }
-                final AbstractMapType map1 = (AbstractMapType) item1;
-                final AbstractMapType map2 = (AbstractMapType) item2;
-                final int map1Size = map1.size();
-                final int map2Size = map2.size();
-
-                if (map1Size == map2Size) {
-                    for (final IEntry<AtomicValue, Sequence> entry1 : map1) {
-                        if (!map2.contains(entry1.key())) {
-                            return Constants.SUPERIOR;
-                        }
-
-                        final int comparison = deepCompareSeq(entry1.value(), map2.get(entry1.key()), collator, broker);
-                        if (comparison != Constants.EQUAL) {
-                            return comparison;
-                        }
-                    }
-                    return Constants.EQUAL;
-                } else {
-                    return map1Size < map2Size ? Constants.INFERIOR : Constants.SUPERIOR;
-                }
+                return compareMapItems(item1, item2, collator, broker);
             }
 
             final boolean item1IsAtomic = Type.subTypeOf(item1.getType(), Type.ANY_ATOMIC_TYPE);
             final boolean item2IsAtomic = Type.subTypeOf(item2.getType(), Type.ANY_ATOMIC_TYPE);
             if (item1IsAtomic || item2IsAtomic) {
-                if (!item1IsAtomic) {
-                    return Constants.SUPERIOR;
-                }
-
-                if (!item2IsAtomic) {
-                    return Constants.INFERIOR;
-                }
-
-                try {
-                    final AtomicValue av = (AtomicValue) item1;
-                    final AtomicValue bv = (AtomicValue) item2;
-                    if (Type.subTypeOfUnion(av.getType(), Type.NUMERIC) &&
-                            Type.subTypeOfUnion(bv.getType(), Type.NUMERIC)) {
-                        //or if both values are NaN
-                        if (((NumericValue) item1).isNaN() && ((NumericValue) item2).isNaN()) {
-                            return Constants.EQUAL;
-                        }
-                    }
-
-                    return ValueComparison.compareAtomic(collator, av, bv);
-                } catch (final XPathException e) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(e.getMessage());
-                    }
-                    return Constants.INFERIOR;
-                }
+                return compareAtomicItems(item1, item2, item1IsAtomic, item2IsAtomic, collator);
             }
 
-            if (item1.getType() != item2.getType()) {
-                return Constants.INFERIOR;
-            }
-            final NodeValue nva = (NodeValue) item1;
-            final NodeValue nvb = (NodeValue) item2;
-            // NOTE(AR): intentional reference equality check
-            if (nva == nvb) {
-                return Constants.EQUAL;
-            }
-
-            try {
-                //Don't use this shortcut for in-memory nodes
-                //since the symbol table is ignored.
-                if (nva.getImplementationType() != NodeValue.IN_MEMORY_NODE &&
-                        nva.equals(nvb)) {
-                    return Constants.EQUAL;  // shortcut!
-                }
-            } catch (final XPathException e) {
-                // apparently incompatible values, do manual comparison
-            }
-
-            final Node node1;
-            final Node node2;
-            switch (item1.getType()) {
-                case Type.DOCUMENT:
-                    // GH-4050 fast path: persistent-DOM streaming comparator.
-                    // Falls through to legacy on stream/IO failure to preserve correctness.
-                    if (broker != null
-                            && nva instanceof NodeProxy npa
-                            && nvb instanceof NodeProxy npb
-                            && nva.getImplementationType() == NodeValue.PERSISTENT_NODE
-                            && nvb.getImplementationType() == NodeValue.PERSISTENT_NODE) {
-                        try {
-                            return FunDeepEqualStreamingComparator.compare(
-                                    broker, npa, npb, /*subtree=*/false, collator);
-                        } catch (final XMLStreamException | IOException | RuntimeException e) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Streaming deep-equal fast path failed, falling back: "
-                                        + e.getMessage());
-                            }
-                        }
-                    }
-                    node1 = nva instanceof Node nnva ? nnva : ((NodeProxy) nva).getOwnerDocument();
-                    node2 = nvb instanceof Node nnvb ? nnvb : ((NodeProxy) nvb).getOwnerDocument();
-                    return compareContents(node1, node2, collator);
-
-                case Type.ELEMENT:
-                    if (broker != null
-                            && nva instanceof NodeProxy npea
-                            && nvb instanceof NodeProxy npeb
-                            && nva.getImplementationType() == NodeValue.PERSISTENT_NODE
-                            && nvb.getImplementationType() == NodeValue.PERSISTENT_NODE) {
-                        try {
-                            return FunDeepEqualStreamingComparator.compare(
-                                    broker, npea, npeb, /*subtree=*/true, collator);
-                        } catch (final XMLStreamException | IOException | RuntimeException e) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Streaming deep-equal fast path failed, falling back: "
-                                        + e.getMessage());
-                            }
-                        }
-                    }
-                    node1 = nva.getNode();
-                    node2 = nvb.getNode();
-                    return compareElements(node1, node2, collator);
-
-                case Type.ATTRIBUTE:
-                    node1 = nva.getNode();
-                    node2 = nvb.getNode();
-                    final int attributeNameComparison = compareNames(node1, node2);
-                    if (attributeNameComparison != Constants.EQUAL) {
-                        return attributeNameComparison;
-                    }
-                    return safeCompare(node1.getNodeValue(), node2.getNodeValue(), collator);
-
-                case Type.PROCESSING_INSTRUCTION:
-                case Type.NAMESPACE:
-                    node1 = nva.getNode();
-                    node2 = nvb.getNode();
-                    final int nameComparison = safeCompare(node1.getNodeName(), node2.getNodeName(), null);
-                    if (nameComparison != Constants.EQUAL) {
-                        return nameComparison;
-                    }
-                    return safeCompare(nva.getStringValue(), nvb.getStringValue(), collator);
-
-                case Type.TEXT:
-                case Type.COMMENT:
-                    return safeCompare(nva.getStringValue(), nvb.getStringValue(), collator);
-
-                default:
-                    throw new UnexpectedItemTypeException(item1);
-            }
+            return compareNodeItems(item1, item2, collator, broker);
         } catch (final XPathException e) {
             logger.error(e.getMessage(), e);
             return Constants.INFERIOR;
+        }
+    }
+
+    private static int compareArrayItems(final Item item1, final Item item2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) throws XPathException {
+        if (item1.getType() != item2.getType()) {
+            return Constants.INFERIOR;
+        }
+        final ArrayType array1 = (ArrayType) item1;
+        final ArrayType array2 = (ArrayType) item2;
+        final int array1Size = array1.getSize();
+        final int array2Size = array2.getSize();
+        if (array1Size != array2Size) {
+            return array1Size < array2Size ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
+        for (int i = 0; i < array1Size; i++) {
+            final int comparison = deepCompareSeq(array1.get(i), array2.get(i), collator, broker);
+            if (comparison != Constants.EQUAL) {
+                return comparison;
+            }
+        }
+        return Constants.EQUAL;
+    }
+
+    private static int compareMapItems(final Item item1, final Item item2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) throws XPathException {
+        if (item1.getType() != item2.getType()) {
+            return Constants.INFERIOR;
+        }
+        final AbstractMapType map1 = (AbstractMapType) item1;
+        final AbstractMapType map2 = (AbstractMapType) item2;
+        final int map1Size = map1.size();
+        final int map2Size = map2.size();
+        if (map1Size != map2Size) {
+            return map1Size < map2Size ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
+        for (final IEntry<AtomicValue, Sequence> entry1 : map1) {
+            if (!map2.contains(entry1.key())) {
+                return Constants.SUPERIOR;
+            }
+            final int comparison = deepCompareSeq(entry1.value(), map2.get(entry1.key()), collator, broker);
+            if (comparison != Constants.EQUAL) {
+                return comparison;
+            }
+        }
+        return Constants.EQUAL;
+    }
+
+    private static int compareAtomicItems(final Item item1, final Item item2,
+            final boolean item1IsAtomic, final boolean item2IsAtomic, @Nullable final Collator collator) {
+        if (!item1IsAtomic) {
+            return Constants.SUPERIOR;
+        }
+        if (!item2IsAtomic) {
+            return Constants.INFERIOR;
+        }
+        try {
+            final AtomicValue av = (AtomicValue) item1;
+            final AtomicValue bv = (AtomicValue) item2;
+            if (Type.subTypeOfUnion(av.getType(), Type.NUMERIC)
+                    && Type.subTypeOfUnion(bv.getType(), Type.NUMERIC)
+                    && ((NumericValue) item1).isNaN()
+                    && ((NumericValue) item2).isNaN()) {
+                return Constants.EQUAL;
+            }
+            return ValueComparison.compareAtomic(collator, av, bv);
+        } catch (final XPathException e) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(e.getMessage());
+            }
+            return Constants.INFERIOR;
+        }
+    }
+
+    private static int compareNodeItems(final Item item1, final Item item2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) throws XPathException {
+        if (item1.getType() != item2.getType()) {
+            return Constants.INFERIOR;
+        }
+        final NodeValue nva = (NodeValue) item1;
+        final NodeValue nvb = (NodeValue) item2;
+        // NOTE(AR): intentional reference equality check
+        if (nva == nvb) {
+            return Constants.EQUAL;
+        }
+
+        try {
+            //Don't use this shortcut for in-memory nodes
+            //since the symbol table is ignored.
+            if (nva.getImplementationType() != NodeValue.IN_MEMORY_NODE && nva.equals(nvb)) {
+                return Constants.EQUAL;  // shortcut!
+            }
+        } catch (final XPathException e) {
+            // apparently incompatible values, do manual comparison
+        }
+
+        return switch (item1.getType()) {
+            case Type.DOCUMENT -> compareDocumentItems(nva, nvb, collator, broker);
+            case Type.ELEMENT -> compareElementItems(nva, nvb, collator, broker);
+            case Type.ATTRIBUTE -> compareAttributeItems(nva, nvb, collator);
+            case Type.PROCESSING_INSTRUCTION, Type.NAMESPACE -> comparePiOrNamespaceItems(nva, nvb, collator);
+            case Type.TEXT, Type.COMMENT -> safeCompare(nva.getStringValue(), nvb.getStringValue(), collator);
+            default -> throw new UnexpectedItemTypeException(item1);
+        };
+    }
+
+    private static int compareDocumentItems(final NodeValue nva, final NodeValue nvb,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) {
+        // GH-4050 fast path: persistent-DOM streaming comparator.
+        // Falls through to legacy on stream/IO failure to preserve correctness.
+        final Integer streamed = tryStreamingCompare(nva, nvb, collator, broker, /*subtree=*/false);
+        if (streamed != null) {
+            return streamed;
+        }
+        final Node node1 = nva instanceof Node nnva ? nnva : ((NodeProxy) nva).getOwnerDocument();
+        final Node node2 = nvb instanceof Node nnvb ? nnvb : ((NodeProxy) nvb).getOwnerDocument();
+        return compareContents(node1, node2, collator);
+    }
+
+    private static int compareElementItems(final NodeValue nva, final NodeValue nvb,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) {
+        final Integer streamed = tryStreamingCompare(nva, nvb, collator, broker, /*subtree=*/true);
+        if (streamed != null) {
+            return streamed;
+        }
+        return compareElements(nva.getNode(), nvb.getNode(), collator);
+    }
+
+    private static int compareAttributeItems(final NodeValue nva, final NodeValue nvb,
+            @Nullable final Collator collator) {
+        final Node node1 = nva.getNode();
+        final Node node2 = nvb.getNode();
+        final int attributeNameComparison = compareNames(node1, node2);
+        if (attributeNameComparison != Constants.EQUAL) {
+            return attributeNameComparison;
+        }
+        return safeCompare(node1.getNodeValue(), node2.getNodeValue(), collator);
+    }
+
+    private static int comparePiOrNamespaceItems(final NodeValue nva, final NodeValue nvb,
+            @Nullable final Collator collator) throws XPathException {
+        final Node node1 = nva.getNode();
+        final Node node2 = nvb.getNode();
+        final int nameComparison = safeCompare(node1.getNodeName(), node2.getNodeName(), null);
+        if (nameComparison != Constants.EQUAL) {
+            return nameComparison;
+        }
+        return safeCompare(nva.getStringValue(), nvb.getStringValue(), collator);
+    }
+
+    @Nullable
+    private static Integer tryStreamingCompare(final NodeValue nva, final NodeValue nvb,
+            @Nullable final Collator collator, @Nullable final DBBroker broker, final boolean subtree) {
+        if (broker == null
+                || !(nva instanceof NodeProxy npa)
+                || !(nvb instanceof NodeProxy npb)
+                || nva.getImplementationType() != NodeValue.PERSISTENT_NODE
+                || nvb.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+            return null;
+        }
+        try {
+            return FunDeepEqualStreamingComparator.compare(broker, npa, npb, subtree, collator);
+        } catch (final XMLStreamException | IOException | RuntimeException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Streaming deep-equal fast path failed, falling back: " + e.getMessage());
+            }
+            return null;
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
@@ -30,6 +30,7 @@ import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.dom.memtree.ReferenceNode;
+import org.exist.storage.DBBroker;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Dependency;
@@ -55,6 +56,8 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 import javax.annotation.Nullable;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
 
 /**
  * Implements the fn:deep-equal library function.
@@ -123,7 +126,8 @@ public class FunDeepEqual extends CollatingFunction {
         }
         final Sequence[] args = getArguments(contextSequence, contextItem);
         final Collator collator = getCollator(contextSequence, contextItem, 3);
-        final Sequence result = BooleanValue.valueOf(deepEqualsSeq(args[0], args[1], collator));
+        final Sequence result = BooleanValue.valueOf(
+                deepEqualsSeq(args[0], args[1], collator, context.getBroker()));
         if (context.getProfiler().isEnabled()) 
             {context.getProfiler().end(this, "", result);} 
         return result;
@@ -139,6 +143,26 @@ public class FunDeepEqual extends CollatingFunction {
      * @return a negative integer, zero, or a positive integer, if the first argument is less than, equal to, or greater than the second.
      */
     public static int deepCompareSeq(final Sequence sequence1, final Sequence sequence2, @Nullable final Collator collator) {
+        return deepCompareSeq(sequence1, sequence2, collator, null);
+    }
+
+    /**
+     * Broker-aware variant of {@link #deepCompareSeq(Sequence, Sequence, Collator)}.
+     *
+     * <p>When a non-null {@code broker} is supplied and an item pair is
+     * a persistent {@code DOCUMENT} or {@code ELEMENT}, the comparison
+     * uses {@link FunDeepEqualStreamingComparator} as a fast path. Other
+     * shapes (atomic, memtree, attribute, text, map, array) fall through
+     * to the legacy recursive path.
+     *
+     * @param sequence1 first sequence.
+     * @param sequence2 second sequence.
+     * @param collator collation, or {@code null} for code-point.
+     * @param broker active broker, or {@code null} to disable the fast path.
+     * @return {@link Constants#EQUAL} / {@link Constants#INFERIOR} / {@link Constants#SUPERIOR}.
+     */
+    public static int deepCompareSeq(final Sequence sequence1, final Sequence sequence2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) {
         if (sequence1 == sequence2) {
             return Constants.EQUAL;
         }
@@ -150,7 +174,7 @@ public class FunDeepEqual extends CollatingFunction {
                 final Item item1 = sequence1.itemAt(i);
                 final Item item2 = sequence2.itemAt(i);
 
-                final int comparison = deepCompare(item1, item2, collator);
+                final int comparison = deepCompare(item1, item2, collator, broker);
                 if (comparison != Constants.EQUAL) {
                     return comparison;
                 }
@@ -173,6 +197,26 @@ public class FunDeepEqual extends CollatingFunction {
      * @throws UnexpectedItemTypeException if an item has an unknown type.
      */
     public static int deepCompare(final Item item1, final Item item2, @Nullable final Collator collator) {
+        return deepCompare(item1, item2, collator, null);
+    }
+
+    /**
+     * Broker-aware variant of {@link #deepCompare(Item, Item, Collator)}.
+     *
+     * <p>When a non-null {@code broker} is supplied and the item pair is
+     * a persistent {@code DOCUMENT} or {@code ELEMENT}, the comparison
+     * uses {@link FunDeepEqualStreamingComparator} as a fast path. On
+     * stream / IO failure the call falls through to the legacy recursive
+     * path so correctness is preserved.
+     *
+     * @param item1 first item.
+     * @param item2 second item.
+     * @param collator collation, or {@code null} for code-point.
+     * @param broker active broker, or {@code null} to disable the fast path.
+     * @return {@link Constants#EQUAL} / {@link Constants#INFERIOR} / {@link Constants#SUPERIOR}.
+     */
+    public static int deepCompare(final Item item1, final Item item2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) {
         if (item1 == item2) {
             return Constants.EQUAL;
         }
@@ -188,7 +232,7 @@ public class FunDeepEqual extends CollatingFunction {
                 final int array2Size = array2.getSize();
                 if (array1Size == array2Size) {
                     for (int i = 0; i < array1.getSize(); i++) {
-                        final int comparison = deepCompareSeq(array1.get(i), array2.get(i), collator);
+                        final int comparison = deepCompareSeq(array1.get(i), array2.get(i), collator, broker);
                         if (comparison != Constants.EQUAL) {
                             return comparison;
                         }
@@ -214,7 +258,7 @@ public class FunDeepEqual extends CollatingFunction {
                             return Constants.SUPERIOR;
                         }
 
-                        final int comparison = deepCompareSeq(entry1.value(), map2.get(entry1.key()), collator);
+                        final int comparison = deepCompareSeq(entry1.value(), map2.get(entry1.key()), collator, broker);
                         if (comparison != Constants.EQUAL) {
                             return comparison;
                         }
@@ -281,11 +325,43 @@ public class FunDeepEqual extends CollatingFunction {
             final Node node2;
             switch (item1.getType()) {
                 case Type.DOCUMENT:
+                    // GH-4050 fast path: persistent-DOM streaming comparator.
+                    // Falls through to legacy on stream/IO failure to preserve correctness.
+                    if (broker != null
+                            && nva instanceof NodeProxy npa
+                            && nvb instanceof NodeProxy npb
+                            && nva.getImplementationType() == NodeValue.PERSISTENT_NODE
+                            && nvb.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        try {
+                            return FunDeepEqualStreamingComparator.compare(
+                                    broker, npa, npb, /*subtree=*/false, collator);
+                        } catch (final XMLStreamException | IOException | RuntimeException e) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Streaming deep-equal fast path failed, falling back: "
+                                        + e.getMessage());
+                            }
+                        }
+                    }
                     node1 = nva instanceof Node nnva ? nnva : ((NodeProxy) nva).getOwnerDocument();
                     node2 = nvb instanceof Node nnvb ? nnvb : ((NodeProxy) nvb).getOwnerDocument();
                     return compareContents(node1, node2, collator);
 
                 case Type.ELEMENT:
+                    if (broker != null
+                            && nva instanceof NodeProxy npea
+                            && nvb instanceof NodeProxy npeb
+                            && nva.getImplementationType() == NodeValue.PERSISTENT_NODE
+                            && nvb.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                        try {
+                            return FunDeepEqualStreamingComparator.compare(
+                                    broker, npea, npeb, /*subtree=*/true, collator);
+                        } catch (final XMLStreamException | IOException | RuntimeException e) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Streaming deep-equal fast path failed, falling back: "
+                                        + e.getMessage());
+                            }
+                        }
+                    }
                     node1 = nva.getNode();
                     node2 = nvb.getNode();
                     return compareElements(node1, node2, collator);
@@ -340,6 +416,21 @@ public class FunDeepEqual extends CollatingFunction {
      */
     public static boolean deepEqualsSeq(final Sequence sequence1, final Sequence sequence2, @Nullable final Collator collator) {
         return deepCompareSeq(sequence1, sequence2, collator) == Constants.EQUAL;
+    }
+
+    /**
+     * Broker-aware variant of {@link #deepEqualsSeq(Sequence, Sequence, Collator)}.
+     *
+     * @param sequence1 first sequence.
+     * @param sequence2 second sequence.
+     * @param collator collation, or {@code null} for code-point.
+     * @param broker active broker, or {@code null} to disable the streaming
+     * fast path on persistent-DOM nodes.
+     * @return true iff the sequences are deep-equal.
+     */
+    public static boolean deepEqualsSeq(final Sequence sequence1, final Sequence sequence2,
+            @Nullable final Collator collator, @Nullable final DBBroker broker) {
+        return deepCompareSeq(sequence1, sequence2, collator, broker) == Constants.EQUAL;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
@@ -321,36 +321,24 @@ final class FunDeepEqualStreamingComparator {
         return out;
     }
 
+    /**
+     * Cached {@link Comparator} that places nulls first and otherwise uses
+     * String's natural order. Used by {@link #compareNullable(String, String)}
+     * and the no-collator branch of {@link #safeCompare(String, String, Collator)}.
+     */
+    private static final Comparator<String> NULLS_FIRST_NATURAL =
+            Comparator.nullsFirst(Comparator.<String>naturalOrder());
+
     private static int compareNullable(@Nullable final String a, @Nullable final String b) {
-        // NOTE: intentional reference equality short-circuit (mirrors safeCompare).
-        if (a == b) {
-            return Constants.EQUAL;
-        }
-        if (a == null) {
-            return Constants.INFERIOR;
-        }
-        if (b == null) {
-            return Constants.SUPERIOR;
-        }
-        return a.compareTo(b);
+        return NULLS_FIRST_NATURAL.compare(a, b);
     }
 
     private static int safeCompare(@Nullable final String a, @Nullable final String b,
             @Nullable final Collator collator) {
-        // NOTE: intentional reference equality short-circuit (matches FunDeepEqual.safeCompare).
-        if (a == b) {
-            return Constants.EQUAL;
+        if (collator == null) {
+            return NULLS_FIRST_NATURAL.compare(a, b);
         }
-        if (a == null) {
-            return Constants.INFERIOR;
-        }
-        if (b == null) {
-            return Constants.SUPERIOR;
-        }
-        if (collator != null) {
-            return collator.compare(a, b);
-        }
-        return a.compareTo(b);
+        return Comparator.nullsFirst(collator::compare).compare(a, b);
     }
 
     private record AttrSnapshot(@Nullable String ns, String local, String value) {}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
@@ -324,13 +324,13 @@ final class FunDeepEqualStreamingComparator {
     private static int compareNullable(@Nullable final String a, @Nullable final String b) {
         // NOTE: intentional reference equality short-circuit (mirrors safeCompare).
         if (a == b) {
-            return 0;
+            return Constants.EQUAL;
         }
         if (a == null) {
-            return -1;
+            return Constants.INFERIOR;
         }
         if (b == null) {
-            return 1;
+            return Constants.SUPERIOR;
         }
         return a.compareTo(b);
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
@@ -1,0 +1,336 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.fn;
+
+import com.ibm.icu.text.Collator;
+import org.exist.Namespaces;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.NodeHandle;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.numbering.NodeId;
+import org.exist.stax.IEmbeddedXMLStreamReader;
+import org.exist.storage.DBBroker;
+import org.exist.xquery.Constants;
+
+import javax.annotation.Nullable;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * Streaming fast-path for fn:deep-equal on persistent-DOM trees (GH-4050).
+ *
+ * <p>The recursive {@link FunDeepEqual} implementation walks both subtrees
+ * via {@code getFirstChild} / {@code getNextSibling} and inspects each node
+ * via {@code getNamespaceURI} / {@code getLocalName} / {@code getAttributes}.
+ * On persistent NodeProxy values every accessor materialises a fresh
+ * {@code ElementImpl} from the BTree, so the cost scales with tree size
+ * times accessor count per node. On the GH-4050 reproducer (Macbeth.xml,
+ * 3,550 elements) that is ~5,500 ms, ~24x slower than xmldiff:compare's
+ * 228 ms.
+ *
+ * <p>This class walks the same trees as event streams via
+ * {@link IEmbeddedXMLStreamReader}, which iterates the BTree binary node
+ * stream directly. Per-element work is bounded by the events the reader
+ * already produces (qname, attribute list, character data) plus the
+ * comparator's per-event compare. There is no per-node round-trip to
+ * the storage layer beyond the linear iterator advance.
+ *
+ * <p>Semantics match {@code FunDeepEqual.compareElements} /
+ * {@code FunDeepEqual.compareContents}:
+ * <ul>
+ *     <li>Element name comparison uses expanded QName (namespace URI +
+ *     local name), code-point ordering for names.</li>
+ *     <li>Attributes are order-insensitive: both sides are gathered,
+ *     {@code xmlns:*} declarations are filtered, and the remainders are
+ *     sorted by (namespace URI, local name) and compared positionally.
+ *     Values are compared with the supplied collator.</li>
+ *     <li>Comments and processing instructions are skipped per the
+ *     fn:deep-equal spec.</li>
+ *     <li>Character / CDATA events are compared in document order with
+ *     the supplied collator. Adjacent text-event coalescing is not
+ *     attempted; eXist's persistent DOM stores text runs as a single
+ *     node, so adjacent {@code CHARACTERS} events do not occur in
+ *     practice on stored documents.</li>
+ * </ul>
+ *
+ * <p>Out of scope: schema-aware typed-value comparison (untyped only),
+ * memtree (in-memory) nodes, atomic / map / array / attribute / text-as-top-level
+ * items. The caller must dispatch only persistent {@code DOCUMENT} or
+ * {@code ELEMENT} NodeHandle pairs.
+ */
+final class FunDeepEqualStreamingComparator {
+
+    private static final int EOF = -1;
+    private static final AttrSnapshot[] EMPTY_ATTRS = new AttrSnapshot[0];
+    private static final Comparator<AttrSnapshot> ATTR_ORDER = (x, y) -> {
+        final int nsCmp = compareNullable(x.ns, y.ns);
+        if (nsCmp != 0) {
+            return nsCmp;
+        }
+        return compareNullable(x.local, y.local);
+    };
+
+    private FunDeepEqualStreamingComparator() {}
+
+    /**
+     * Compare two persistent-DOM nodes (DOCUMENT or ELEMENT) via streaming.
+     *
+     * @param broker active database broker.
+     * @param a first node.
+     * @param b second node.
+     * @param subtree {@code true} when both inputs are ELEMENT-rooted;
+     * {@code false} when document-level (the dispatcher resolves each
+     * document's first stored child via {@link #documentRoot}).
+     * @param collator collation used to compare attribute values and text;
+     * {@code null} = code-point.
+     * @return {@link Constants#EQUAL} / {@link Constants#INFERIOR} /
+     * {@link Constants#SUPERIOR} (sign indicates ordering for sort use).
+     * @throws XMLStreamException on stream-level failure
+     * @throws IOException on storage-level failure
+     */
+    static int compare(final DBBroker broker, final NodeProxy a, final NodeProxy b,
+            final boolean subtree, @Nullable final Collator collator)
+            throws XMLStreamException, IOException {
+        final NodeHandle aHandle = subtree ? a : documentRoot(a);
+        final NodeHandle bHandle = subtree ? b : documentRoot(b);
+        if (aHandle == null || bHandle == null) {
+            // Empty document or non-element first child; signal to caller
+            // that the legacy path should handle this edge case.
+            throw new XMLStreamException("streaming fast path: document has no element root");
+        }
+        // Both DOCUMENT and ELEMENT cases reduce to a subtree walk after
+        // documentRoot() resolves the document's first stored child.
+        final IEmbeddedXMLStreamReader ra = broker.newXMLStreamReader(aHandle, false);
+        try {
+            final IEmbeddedXMLStreamReader rb = broker.newXMLStreamReader(bHandle, false);
+            try {
+                return walk(ra, rb, /*subtree=*/true, collator);
+            } finally {
+                rb.close();
+            }
+        } finally {
+            ra.close();
+        }
+    }
+
+    /**
+     * For document-level comparison, the StAX reader is initialised on the
+     * document's first stored child (the root element on most XML
+     * documents; first comment/PI in pathological cases). We obtain the
+     * concrete StoredNode via {@code DocumentImpl.getFirstChild()} so the
+     * reader's seek operates on a known-valid address.
+     *
+     * <p>This restricts the streaming fast path to single-root-element
+     * documents — the common case for GH-4050. Documents with leading
+     * comments/PIs trigger the legacy fallback when the first stored child
+     * is not the root element.
+     */
+    @Nullable
+    private static NodeHandle documentRoot(final NodeProxy n) {
+        final DocumentImpl doc = n.getOwnerDocument();
+        if (doc.getChildCount() == 0) {
+            return null;
+        }
+        final org.w3c.dom.Node firstChild = doc.getFirstChild();
+        if (firstChild instanceof NodeHandle nh) {
+            return nh;
+        }
+        return null;
+    }
+
+    private static int walk(final IEmbeddedXMLStreamReader ra,
+            final IEmbeddedXMLStreamReader rb, final boolean subtree,
+            @Nullable final Collator collator) throws XMLStreamException {
+        int depth = 0;
+        boolean rootSeen = false;
+        while (true) {
+            final int evA = nextRelevantEvent(ra);
+            final int evB = nextRelevantEvent(rb);
+            if (evA == EOF && evB == EOF) {
+                return Constants.EQUAL;
+            }
+            if (evA == EOF) {
+                return Constants.INFERIOR;
+            }
+            if (evB == EOF) {
+                return Constants.SUPERIOR;
+            }
+            if (evA != evB) {
+                return evA < evB ? Constants.INFERIOR : Constants.SUPERIOR;
+            }
+            switch (evA) {
+                case XMLStreamConstants.START_ELEMENT -> {
+                    final int nameCmp = compareElementName(ra, rb);
+                    if (nameCmp != Constants.EQUAL) {
+                        return nameCmp;
+                    }
+                    final int attrCmp = compareAttributes(ra, rb, collator);
+                    if (attrCmp != Constants.EQUAL) {
+                        return attrCmp;
+                    }
+                    depth++;
+                    rootSeen = true;
+                }
+                case XMLStreamConstants.END_ELEMENT -> {
+                    depth--;
+                    if (subtree && depth == 0 && rootSeen) {
+                        return Constants.EQUAL;
+                    }
+                }
+                case XMLStreamConstants.CHARACTERS, XMLStreamConstants.CDATA -> {
+                    final int textCmp = safeCompare(ra.getText(), rb.getText(), collator);
+                    if (textCmp != Constants.EQUAL) {
+                        return textCmp;
+                    }
+                }
+                case XMLStreamConstants.SPACE -> {
+                    final int textCmp = safeCompare(ra.getText(), rb.getText(), collator);
+                    if (textCmp != Constants.EQUAL) {
+                        return textCmp;
+                    }
+                }
+                default -> {
+                    // Stream produced an event we did not anticipate; fall back
+                    // to caller's slow path by signalling INFERIOR. This is the
+                    // safety valve for edge cases in the stored-DOM stream.
+                    throw new XMLStreamException(
+                            "Streaming comparator: unexpected event type " + evA);
+                }
+            }
+        }
+    }
+
+    private static int nextRelevantEvent(final IEmbeddedXMLStreamReader r)
+            throws XMLStreamException {
+        while (r.hasNext()) {
+            final int ev = r.next();
+            if (ev == XMLStreamConstants.COMMENT
+                    || ev == XMLStreamConstants.PROCESSING_INSTRUCTION) {
+                continue;
+            }
+            return ev;
+        }
+        return EOF;
+    }
+
+    private static int compareElementName(final IEmbeddedXMLStreamReader ra,
+            final IEmbeddedXMLStreamReader rb) {
+        final org.exist.dom.QName qa = ra.getQName();
+        final org.exist.dom.QName qb = rb.getQName();
+        final int nsCmp = safeCompare(qa.getNamespaceURI(), qb.getNamespaceURI(), null);
+        if (nsCmp != Constants.EQUAL) {
+            return nsCmp;
+        }
+        return safeCompare(qa.getLocalPart(), qb.getLocalPart(), null);
+    }
+
+    private static int compareAttributes(final IEmbeddedXMLStreamReader ra,
+            final IEmbeddedXMLStreamReader rb, @Nullable final Collator collator) {
+        final AttrSnapshot[] aa = collectSortedAttrs(ra);
+        final AttrSnapshot[] bb = collectSortedAttrs(rb);
+        if (aa.length != bb.length) {
+            return aa.length < bb.length ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
+        for (int i = 0; i < aa.length; i++) {
+            int cmp = safeCompare(aa[i].ns, bb[i].ns, null);
+            if (cmp != Constants.EQUAL) {
+                return cmp;
+            }
+            cmp = safeCompare(aa[i].local, bb[i].local, null);
+            if (cmp != Constants.EQUAL) {
+                return cmp;
+            }
+            cmp = safeCompare(aa[i].value, bb[i].value, collator);
+            if (cmp != Constants.EQUAL) {
+                return cmp;
+            }
+        }
+        return Constants.EQUAL;
+    }
+
+    private static AttrSnapshot[] collectSortedAttrs(final IEmbeddedXMLStreamReader r) {
+        final int count = r.getAttributeCount();
+        if (count == 0) {
+            return EMPTY_ATTRS;
+        }
+        final AttrSnapshot[] tmp = new AttrSnapshot[count];
+        int kept = 0;
+        for (int i = 0; i < count; i++) {
+            final String ns = r.getAttributeNamespace(i);
+            // Filter out xmlns:* attributes; they are namespace declarations,
+            // not data. FunDeepEqual.compareAttributes skips them via the
+            // XMLNS_NS test.
+            if (ns != null && Namespaces.XMLNS_NS.equals(ns)) {
+                continue;
+            }
+            tmp[kept++] = new AttrSnapshot(
+                    ns,
+                    r.getAttributeLocalName(i),
+                    r.getAttributeValue(i));
+        }
+        if (kept == count) {
+            Arrays.sort(tmp, ATTR_ORDER);
+            return tmp;
+        }
+        final AttrSnapshot[] out = new AttrSnapshot[kept];
+        System.arraycopy(tmp, 0, out, 0, kept);
+        Arrays.sort(out, ATTR_ORDER);
+        return out;
+    }
+
+    private static int compareNullable(@Nullable final String a, @Nullable final String b) {
+        // NOTE: intentional reference equality short-circuit (mirrors safeCompare).
+        if (a == b) {
+            return 0;
+        }
+        if (a == null) {
+            return -1;
+        }
+        if (b == null) {
+            return 1;
+        }
+        return a.compareTo(b);
+    }
+
+    private static int safeCompare(@Nullable final String a, @Nullable final String b,
+            @Nullable final Collator collator) {
+        // NOTE: intentional reference equality short-circuit (matches FunDeepEqual.safeCompare).
+        if (a == b) {
+            return Constants.EQUAL;
+        }
+        if (a == null) {
+            return Constants.INFERIOR;
+        }
+        if (b == null) {
+            return Constants.SUPERIOR;
+        }
+        if (collator != null) {
+            return collator.compare(a, b);
+        }
+        return a.compareTo(b);
+    }
+
+    private record AttrSnapshot(@Nullable String ns, String local, String value) {}
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
@@ -84,6 +84,13 @@ final class FunDeepEqualStreamingComparator {
 
     private static final int EOF = -1;
     private static final AttrSnapshot[] EMPTY_ATTRS = new AttrSnapshot[0];
+    /**
+     * Cached {@link Comparator} that places nulls first and otherwise uses
+     * String's natural order. Used by {@link #compareNullable(String, String)}
+     * and the no-collator branch of {@link #safeCompare(String, String, Collator)}.
+     */
+    private static final Comparator<String> NULLS_FIRST_NATURAL =
+            Comparator.nullsFirst(Comparator.<String>naturalOrder());
     private static final Comparator<AttrSnapshot> ATTR_ORDER = (x, y) -> {
         final int nsCmp = compareNullable(x.ns, y.ns);
         if (nsCmp != 0) {
@@ -320,14 +327,6 @@ final class FunDeepEqualStreamingComparator {
         Arrays.sort(out, ATTR_ORDER);
         return out;
     }
-
-    /**
-     * Cached {@link Comparator} that places nulls first and otherwise uses
-     * String's natural order. Used by {@link #compareNullable(String, String)}
-     * and the no-collator branch of {@link #safeCompare(String, String, Collator)}.
-     */
-    private static final Comparator<String> NULLS_FIRST_NATURAL =
-            Comparator.nullsFirst(Comparator.<String>naturalOrder());
 
     private static int compareNullable(@Nullable final String a, @Nullable final String b) {
         return NULLS_FIRST_NATURAL.compare(a, b);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqualStreamingComparator.java
@@ -163,76 +163,97 @@ final class FunDeepEqualStreamingComparator {
     private static int walk(final IEmbeddedXMLStreamReader ra,
             final IEmbeddedXMLStreamReader rb, final boolean subtree,
             @Nullable final Collator collator) throws XMLStreamException {
-        int depth = 0;
-        boolean rootSeen = false;
+        final WalkState state = new WalkState();
         while (true) {
             final int evA = nextRelevantEvent(ra);
             final int evB = nextRelevantEvent(rb);
-            if (evA == EOF && evB == EOF) {
-                return Constants.EQUAL;
-            }
-            if (evA == EOF) {
-                return Constants.INFERIOR;
-            }
-            if (evB == EOF) {
-                return Constants.SUPERIOR;
+            final int eofCmp = compareEofs(evA, evB);
+            if (eofCmp != WalkState.CONTINUE) {
+                return eofCmp;
             }
             if (evA != evB) {
                 return evA < evB ? Constants.INFERIOR : Constants.SUPERIOR;
             }
-            switch (evA) {
-                case XMLStreamConstants.START_ELEMENT -> {
-                    final int nameCmp = compareElementName(ra, rb);
-                    if (nameCmp != Constants.EQUAL) {
-                        return nameCmp;
-                    }
-                    final int attrCmp = compareAttributes(ra, rb, collator);
-                    if (attrCmp != Constants.EQUAL) {
-                        return attrCmp;
-                    }
-                    depth++;
-                    rootSeen = true;
-                }
-                case XMLStreamConstants.END_ELEMENT -> {
-                    depth--;
-                    if (subtree && depth == 0 && rootSeen) {
-                        return Constants.EQUAL;
-                    }
-                }
-                case XMLStreamConstants.CHARACTERS, XMLStreamConstants.CDATA -> {
-                    final int textCmp = safeCompare(ra.getText(), rb.getText(), collator);
-                    if (textCmp != Constants.EQUAL) {
-                        return textCmp;
-                    }
-                }
-                case XMLStreamConstants.SPACE -> {
-                    final int textCmp = safeCompare(ra.getText(), rb.getText(), collator);
-                    if (textCmp != Constants.EQUAL) {
-                        return textCmp;
-                    }
-                }
-                default -> {
-                    // Stream produced an event we did not anticipate; fall back
-                    // to caller's slow path by signalling INFERIOR. This is the
-                    // safety valve for edge cases in the stored-DOM stream.
-                    throw new XMLStreamException(
-                            "Streaming comparator: unexpected event type " + evA);
-                }
+            final int stepCmp = walkStep(evA, ra, rb, subtree, collator, state);
+            if (stepCmp != WalkState.CONTINUE) {
+                return stepCmp;
             }
         }
     }
 
+    private static int compareEofs(final int evA, final int evB) {
+        if (evA == EOF && evB == EOF) {
+            return Constants.EQUAL;
+        }
+        if (evA == EOF) {
+            return Constants.INFERIOR;
+        }
+        if (evB == EOF) {
+            return Constants.SUPERIOR;
+        }
+        return WalkState.CONTINUE;
+    }
+
+    private static int walkStep(final int event, final IEmbeddedXMLStreamReader ra,
+            final IEmbeddedXMLStreamReader rb, final boolean subtree,
+            @Nullable final Collator collator, final WalkState state)
+            throws XMLStreamException {
+        return switch (event) {
+            case XMLStreamConstants.START_ELEMENT -> compareStartElements(ra, rb, collator, state);
+            case XMLStreamConstants.END_ELEMENT -> compareEndElements(subtree, state);
+            case XMLStreamConstants.CHARACTERS, XMLStreamConstants.CDATA,
+                 XMLStreamConstants.SPACE -> {
+                final int textCmp = safeCompare(ra.getText(), rb.getText(), collator);
+                yield textCmp != Constants.EQUAL ? textCmp : WalkState.CONTINUE;
+            }
+            default -> throw new XMLStreamException(
+                    "Streaming comparator: unexpected event type " + event);
+        };
+    }
+
+    private static int compareStartElements(final IEmbeddedXMLStreamReader ra,
+            final IEmbeddedXMLStreamReader rb, @Nullable final Collator collator,
+            final WalkState state) throws XMLStreamException {
+        final int nameCmp = compareElementName(ra, rb);
+        if (nameCmp != Constants.EQUAL) {
+            return nameCmp;
+        }
+        final int attrCmp = compareAttributes(ra, rb, collator);
+        if (attrCmp != Constants.EQUAL) {
+            return attrCmp;
+        }
+        state.depth++;
+        state.rootSeen = true;
+        return WalkState.CONTINUE;
+    }
+
+    private static int compareEndElements(final boolean subtree, final WalkState state) {
+        state.depth--;
+        if (subtree && state.depth == 0 && state.rootSeen) {
+            return Constants.EQUAL;
+        }
+        return WalkState.CONTINUE;
+    }
+
+    private static final class WalkState {
+        static final int CONTINUE = Integer.MIN_VALUE;
+        int depth;
+        boolean rootSeen;
+    }
+
     private static int nextRelevantEvent(final IEmbeddedXMLStreamReader r)
             throws XMLStreamException {
-        while (r.hasNext()) {
-            final int ev = r.next();
-            if (ev == XMLStreamConstants.COMMENT
-                    || ev == XMLStreamConstants.PROCESSING_INSTRUCTION) {
-                continue;
+        int ev = EOF;
+        boolean done = false;
+        while (!done && r.hasNext()) {
+            final int candidate = r.next();
+            if (candidate != XMLStreamConstants.COMMENT
+                    && candidate != XMLStreamConstants.PROCESSING_INSTRUCTION) {
+                ev = candidate;
+                done = true;
             }
-            return ev;
         }
-        return EOF;
+        return ev;
     }
 
     private static int compareElementName(final IEmbeddedXMLStreamReader ra,

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunDeepEqualPerformanceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunDeepEqualPerformanceTest.java
@@ -1,0 +1,309 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for GH-4050: fn:deep-equal was ~24x slower than
+ * xmldiff:compare on equivalent large XML inputs (5,490 ms vs 228 ms on
+ * the reporter's TEST.zip; ~2,500 ms on the synthetic 10k-element corpus
+ * below). The fix dispatches to a streaming comparator built on
+ * {@link org.exist.stax.IEmbeddedXMLStreamReader} when both arguments
+ * are persistent-DOM {@code DOCUMENT} or {@code ELEMENT} nodes; the
+ * reader iterates the BTree node stream directly and bypasses the
+ * legacy {@code getFirstChild} / {@code getNextSibling} recursion,
+ * which acquires a broker per call.
+ */
+public class FunDeepEqualPerformanceTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /**
+     * Two stored documents with structurally-identical large trees (~10,000
+     * elements, attribute-heavy). Mirrors the GH-4050 reporter's scenario:
+     * stored XML, where each persistent-DOM accessor traverses the storage
+     * layer rather than running on a fast in-memory linked list. With many
+     * attributes per element, compareAttributes' O(attrs^2) NamedNodeMap
+     * lookup also bites.
+     */
+    @BeforeClass
+    public static void storeLargeDocs() throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        // breadth 10, depth 4 -> ~10,000 elements; 6 attributes per element.
+        // Attribute count chosen large enough to expose compareAttributes'
+        // quadratic behaviour without making document storage prohibitively
+        // slow for a unit test.
+        xqs.query("""
+                declare function local:tree($depth, $breadth) {
+                    if ($depth eq 0) then
+                        <leaf id="x" type="t" a="1" b="2" c="3" d="4">value</leaf>
+                    else
+                        <branch id="b" depth="{$depth}" a="1" b="2" c="3" d="4">{
+                            for $i in 1 to $breadth
+                            return local:tree($depth - 1, $breadth)
+                        }</branch>
+                };
+                xmldb:store("/db", "deep-equal-perf-a.xml", local:tree(5, 8)),
+                xmldb:store("/db", "deep-equal-perf-b.xml", local:tree(5, 8))
+                """);
+    }
+
+    @AfterClass
+    public static void removeStoredDocs() throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        xqs.query("""
+                xmldb:remove("/db", "deep-equal-perf-a.xml"),
+                xmldb:remove("/db", "deep-equal-perf-b.xml")
+                """);
+    }
+
+    private static final String STORED_EQUAL_TREES =
+            "fn:deep-equal(doc('/db/deep-equal-perf-a.xml'), doc('/db/deep-equal-perf-b.xml'))";
+
+    /**
+     * XQuery that builds two structurally-identical large in-memory trees
+     * (~10,000 elements: 4 levels deep, breadth 10 at each level, with
+     * attributes and text values) and runs fn:deep-equal on them. The
+     * memtree path is unchanged by the GH-4050 fix; this test guards
+     * against unrelated regressions on in-memory comparison.
+     */
+    private static final String LARGE_EQUAL_TREES = """
+            declare function local:tree($depth, $breadth) {
+                if ($depth eq 0) then
+                    <leaf id="x" type="t">value</leaf>
+                else
+                    <branch id="b" depth="{$depth}">{
+                        for $i in 1 to $breadth
+                        return local:tree($depth - 1, $breadth)
+                    }</branch>
+            };
+            let $a := local:tree(4, 10)
+            let $b := local:tree(4, 10)
+            return fn:deep-equal($a, $b)
+            """;
+
+    private static final String LARGE_TREES_DIFFER_AT_LEAF = """
+            declare function local:tree($depth, $breadth, $marker) {
+                if ($depth eq 0) then
+                    <leaf id="x" type="t">{$marker}</leaf>
+                else
+                    <branch id="b" depth="{$depth}">{
+                        for $i in 1 to $breadth
+                        return local:tree($depth - 1, $breadth, $marker)
+                    }</branch>
+            };
+            let $a := local:tree(4, 10, "value")
+            let $b := local:tree(4, 10, "VALUE")
+            return fn:deep-equal($a, $b)
+            """;
+
+    private static final String LARGE_TREES_DIFFER_AT_ROOT = """
+            declare function local:tree($depth, $breadth) {
+                if ($depth eq 0) then
+                    <leaf id="x" type="t">value</leaf>
+                else
+                    <branch id="b" depth="{$depth}">{
+                        for $i in 1 to $breadth
+                        return local:tree($depth - 1, $breadth)
+                    }</branch>
+            };
+            let $a := <rootA>{local:tree(4, 10)}</rootA>
+            let $b := <rootB>{local:tree(4, 10)}</rootB>
+            return fn:deep-equal($a, $b)
+            """;
+
+    private long timeQuery(final String xquery) throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        // Warm-up to amortise compilation/class-loading cost.
+        xqs.query(xquery);
+        final long start = System.nanoTime();
+        final ResourceSet rs = xqs.query(xquery);
+        final long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+        // Sanity-check the result: every query above returns one boolean.
+        assertEquals(1, rs.getSize());
+        return elapsedMs;
+    }
+
+    private boolean queryResult(final String xquery) throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet rs = xqs.query(xquery);
+        return Boolean.parseBoolean(rs.getResource(0).getContent().toString());
+    }
+
+    @Test
+    public void deepEqualOnLargeEqualTreesIsFast() throws XMLDBException {
+        // In-memory case (memtree) -- the streaming fast path does not
+        // apply here; memtree's linked-list sibling traversal is already
+        // O(N) and the legacy recursion is the right path. Sanity check.
+        assertTrue(queryResult(LARGE_EQUAL_TREES));
+        final long elapsedMs = timeQuery(LARGE_EQUAL_TREES);
+        System.out.println("[GH-4050] in-memory equal 10k-element trees: " + elapsedMs + "ms");
+        final long threshold = 3000L;
+        assertTrue(
+                "fn:deep-equal on 10,000-element in-memory equal trees took " + elapsedMs
+                        + "ms (threshold " + threshold + "ms)",
+                elapsedMs <= threshold);
+    }
+
+    @Test
+    public void deepEqualOnStoredEqualDocsIsFast() throws XMLDBException {
+        // Persistent-DOM case -- this is the GH-4050 reporter's scenario.
+        // Pre-fix every getFirstChild / getNextSibling on a stored
+        // ElementImpl acquires a broker and walks the parent's children
+        // via a fresh XMLStreamReader, making compareContents quadratic
+        // in sibling count. The reporter measured ~9000 ms in 2021.
+        // Post-fix the streaming comparator iterates the BTree node
+        // stream once per document at storage speed; on this 10k-element
+        // synthetic the win is ~20x (124 ms observed locally).
+        assertTrue(queryResult(STORED_EQUAL_TREES));
+        final long elapsedMs = timeQuery(STORED_EQUAL_TREES);
+        System.out.println("[GH-4050] stored equal 10k-element docs (6 attrs/elem): " + elapsedMs + "ms");
+        // Generous threshold to tolerate CI variance while still catching a
+        // regression that puts us back into multi-second territory.
+        final long threshold = 5000L;
+        assertTrue(
+                "fn:deep-equal on stored 10,000-element docs took " + elapsedMs
+                        + "ms (threshold " + threshold + "ms); GH-4050 regression?",
+                elapsedMs <= threshold);
+    }
+
+    @Test
+    public void deepEqualOnRootMismatchStillShortCircuits() throws XMLDBException {
+        // Top-level name mismatch: in-memory case (memtree). The legacy
+        // path bails on the first compareNames mismatch.
+        assertEquals(false, queryResult(LARGE_TREES_DIFFER_AT_ROOT));
+        final long elapsedMs = timeQuery(LARGE_TREES_DIFFER_AT_ROOT);
+        System.out.println("[GH-4050] deep-equal on root-mismatched 10k-element trees: " + elapsedMs + "ms");
+        final long threshold = 1500L;
+        assertTrue(
+                "Root-mismatch fn:deep-equal took " + elapsedMs
+                        + "ms (threshold " + threshold + "ms); pre-check ordering broken?",
+                elapsedMs <= threshold);
+    }
+
+    @Test
+    public void deepEqualOnLeafMismatchProducesCorrectResult() throws XMLDBException {
+        // Difference is buried at every leaf; the comparator (streaming
+        // for stored docs, recursive for memtree) walks until the leaf
+        // mismatch surfaces. Correctness gate only.
+        assertEquals(false, queryResult(LARGE_TREES_DIFFER_AT_LEAF));
+    }
+
+    @Test
+    public void attributeOrderInsensitive() throws XMLDBException {
+        final String q = """
+                let $a := <e a="1" b="2" c="3"/>
+                let $b := <e c="3" a="1" b="2"/>
+                return fn:deep-equal($a, $b)
+                """;
+        assertEquals(true, queryResult(q));
+    }
+
+    @Test
+    public void nestedAttributeOrderInsensitive() throws XMLDBException {
+        final String q = """
+                let $a := <root><e a="1" b="2"/><f x="x" y="y"/></root>
+                let $b := <root><e b="2" a="1"/><f y="y" x="x"/></root>
+                return fn:deep-equal($a, $b)
+                """;
+        assertEquals(true, queryResult(q));
+    }
+
+    @Test
+    public void typedNumericVsStringNotEqual() throws XMLDBException {
+        // Per W3C XPath 3.1 deep-equal, xs:integer 1 is NOT deep-equal to "1".
+        // Atomic comparison; streaming path does not apply.
+        assertEquals(false, queryResult("fn:deep-equal(xs:integer(1), '1')"));
+    }
+
+    @Test
+    public void integerAndDoubleEqual() throws XMLDBException {
+        // xs:integer 1 IS deep-equal to xs:double 1.0 per spec.
+        assertEquals(true, queryResult("fn:deep-equal(xs:integer(1), xs:double(1.0))"));
+    }
+
+    @Test
+    public void nanEqualToNan() throws XMLDBException {
+        // Special case: NaN is deep-equal to NaN even though NaN != NaN.
+        assertEquals(true,
+                queryResult("fn:deep-equal(xs:double('NaN'), xs:double('NaN'))"));
+    }
+
+    @Test
+    public void textVsCommentChildrenIgnored() throws XMLDBException {
+        // compareContents (and the streaming comparator) skip comments and PIs.
+        final String q = """
+                let $a := <e>hello<!--ignore-->world</e>
+                let $b := <e>hello<?pi data?>world</e>
+                return fn:deep-equal($a, $b)
+                """;
+        assertEquals(true, queryResult(q));
+    }
+
+    @Test
+    public void differentChildOrderNotEqual() throws XMLDBException {
+        // Element child order IS significant, unlike attribute order.
+        final String q = """
+                let $a := <root><a/><b/></root>
+                let $b := <root><b/><a/></root>
+                return fn:deep-equal($a, $b)
+                """;
+        assertEquals(false, queryResult(q));
+    }
+
+    @Test
+    public void differentNamespaceNotEqual() throws XMLDBException {
+        final String q = """
+                let $a := <e xmlns="urn:a"/>
+                let $b := <e xmlns="urn:b"/>
+                return fn:deep-equal($a, $b)
+                """;
+        assertEquals(false, queryResult(q));
+    }
+
+    @Test
+    public void emptySequencesEqual() throws XMLDBException {
+        assertEquals(true, queryResult("fn:deep-equal((), ())"));
+    }
+
+    @Test
+    public void differentLengthSequencesNotEqual() throws XMLDBException {
+        assertEquals(false, queryResult("fn:deep-equal((1, 2), (1, 2, 3))"));
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunDeepEqualPerformanceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunDeepEqualPerformanceTest.java
@@ -50,57 +50,9 @@ public class FunDeepEqualPerformanceTest {
     public static final ExistXmldbEmbeddedServer existEmbeddedServer =
             new ExistXmldbEmbeddedServer(false, true, true);
 
-    /**
-     * Two stored documents with structurally-identical large trees (~10,000
-     * elements, attribute-heavy). Mirrors the GH-4050 reporter's scenario:
-     * stored XML, where each persistent-DOM accessor traverses the storage
-     * layer rather than running on a fast in-memory linked list. With many
-     * attributes per element, compareAttributes' O(attrs^2) NamedNodeMap
-     * lookup also bites.
-     */
-    @BeforeClass
-    public static void storeLargeDocs() throws XMLDBException {
-        final XQueryService xqs =
-                existEmbeddedServer.getRoot().getService(XQueryService.class);
-        // breadth 10, depth 4 -> ~10,000 elements; 6 attributes per element.
-        // Attribute count chosen large enough to expose compareAttributes'
-        // quadratic behaviour without making document storage prohibitively
-        // slow for a unit test.
-        xqs.query("""
-                declare function local:tree($depth, $breadth) {
-                    if ($depth eq 0) then
-                        <leaf id="x" type="t" a="1" b="2" c="3" d="4">value</leaf>
-                    else
-                        <branch id="b" depth="{$depth}" a="1" b="2" c="3" d="4">{
-                            for $i in 1 to $breadth
-                            return local:tree($depth - 1, $breadth)
-                        }</branch>
-                };
-                xmldb:store("/db", "deep-equal-perf-a.xml", local:tree(5, 8)),
-                xmldb:store("/db", "deep-equal-perf-b.xml", local:tree(5, 8))
-                """);
-    }
-
-    @AfterClass
-    public static void removeStoredDocs() throws XMLDBException {
-        final XQueryService xqs =
-                existEmbeddedServer.getRoot().getService(XQueryService.class);
-        xqs.query("""
-                xmldb:remove("/db", "deep-equal-perf-a.xml"),
-                xmldb:remove("/db", "deep-equal-perf-b.xml")
-                """);
-    }
-
     private static final String STORED_EQUAL_TREES =
             "fn:deep-equal(doc('/db/deep-equal-perf-a.xml'), doc('/db/deep-equal-perf-b.xml'))";
 
-    /**
-     * XQuery that builds two structurally-identical large in-memory trees
-     * (~10,000 elements: 4 levels deep, breadth 10 at each level, with
-     * attributes and text values) and runs fn:deep-equal on them. The
-     * memtree path is unchanged by the GH-4050 fix; this test guards
-     * against unrelated regressions on in-memory comparison.
-     */
     private static final String LARGE_EQUAL_TREES = """
             declare function local:tree($depth, $breadth) {
                 if ($depth eq 0) then
@@ -145,6 +97,47 @@ public class FunDeepEqualPerformanceTest {
             let $b := <rootB>{local:tree(4, 10)}</rootB>
             return fn:deep-equal($a, $b)
             """;
+
+    /**
+     * Two stored documents with structurally-identical large trees (~10,000
+     * elements, attribute-heavy). Mirrors the GH-4050 reporter's scenario:
+     * stored XML, where each persistent-DOM accessor traverses the storage
+     * layer rather than running on a fast in-memory linked list. With many
+     * attributes per element, compareAttributes' O(attrs^2) NamedNodeMap
+     * lookup also bites.
+     */
+    @BeforeClass
+    public static void storeLargeDocs() throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        // breadth 10, depth 4 -> ~10,000 elements; 6 attributes per element.
+        // Attribute count chosen large enough to expose compareAttributes'
+        // quadratic behaviour without making document storage prohibitively
+        // slow for a unit test.
+        xqs.query("""
+                declare function local:tree($depth, $breadth) {
+                    if ($depth eq 0) then
+                        <leaf id="x" type="t" a="1" b="2" c="3" d="4">value</leaf>
+                    else
+                        <branch id="b" depth="{$depth}" a="1" b="2" c="3" d="4">{
+                            for $i in 1 to $breadth
+                            return local:tree($depth - 1, $breadth)
+                        }</branch>
+                };
+                xmldb:store("/db", "deep-equal-perf-a.xml", local:tree(5, 8)),
+                xmldb:store("/db", "deep-equal-perf-b.xml", local:tree(5, 8))
+                """);
+    }
+
+    @AfterClass
+    public static void removeStoredDocs() throws XMLDBException {
+        final XQueryService xqs =
+                existEmbeddedServer.getRoot().getService(XQueryService.class);
+        xqs.query("""
+                xmldb:remove("/db", "deep-equal-perf-a.xml"),
+                xmldb:remove("/db", "deep-equal-perf-b.xml")
+                """);
+    }
 
     private long timeQuery(final String xquery) throws XMLDBException {
         final XQueryService xqs =


### PR DESCRIPTION
## Summary

`fn:deep-equal` on persistent-DOM trees was ~24× slower than `xmldiff:compare` on PieterLamers' [TEST.zip](https://github.com/eXist-db/exist/files/7250882/TEST.zip) reproducer (Macbeth.xml vs Macbeth2.xml, ~3,550 elements each, byte-identical) — 5,170 ms vs 228 ms on develop tip `b917e1ab1d`. After this change the same comparison runs in **5–11 ms median** while preserving full `fn:deep-equal` semantics. `xmldiff:compare` is not a correctness-equivalent shortcut (it overlooks attribute changes, per [PieterLamers' 2026-05-08 follow-up](https://github.com/eXist-db/exist/issues/4050#issuecomment-4406332435)), so closing the gap had to keep attribute / namespace / collation comparison rules intact.

Closes https://github.com/eXist-db/exist/issues/4050

## Diagnosis

The 2026-05-08 paused investigation pointed at \"per-node persistent-DOM accessor cost\" (`getNamespaceURI`, `getLocalName`, `getAttributes`). The hot path is more specific than that. `StoredNode.getNextSibling()` (and `ElementImpl.getFirstChild()`) acquire a fresh broker per call **and** open a new `XMLStreamReader` on the parent that walks until it finds the requested sibling — an O(siblings) scan per step. `FunDeepEqual.compareContents` calls these per node, so the recursion is effectively quadratic in sibling count for a wide stored DOM.

Diagnostic XQuery on the same Macbeth corpus, on develop tip:

| Workload | Median |
|---|--:|
| `count(//*) + count(//*)` (both docs) | 9–14 ms |
| `count(distinct-values(//*/local-name()))` | 13–16 ms |
| `string-length(serialize(doc))` (forces full walk) | 13–24 ms |
| **`fn:deep-equal(doc, doc)` (legacy)** | **5,170 ms** |

The storage-layer floor for walking both documents is ≤ 24 ms. The legacy `fn:deep-equal` path is paying ~5 seconds in `getFirstChild` / `getNextSibling` overhead, not in the comparison work.

## What changed

A new `FunDeepEqualStreamingComparator` walks both subtrees via `IEmbeddedXMLStreamReader` (the persistent-DOM BTree stream reader) and compares events in lockstep:

- Element name comparison uses expanded QName (namespace URI + local name), code-point order.
- Attributes are gathered from both elements, `xmlns:*` declarations filtered, the remainder sorted by (namespace URI, local name) and compared positionally — matches `FunDeepEqual.compareAttributes`'s order-insensitive semantics. Attribute values use the supplied collator.
- `CHARACTERS` / `CDATA` / `SPACE` events are compared in document order with the supplied collator.
- `COMMENT` and `PROCESSING_INSTRUCTION` events are skipped per the [W3C XPath F&O 3.1 §15.3.1 fn:deep-equal](https://www.w3.org/TR/xpath-functions-31/#func-deep-equal) spec.

Dispatch lives in `FunDeepEqual.deepCompare`'s `DOCUMENT` and `ELEMENT` switch branches and only fires when both arguments are persistent `NodeProxy` instances with `getImplementationType() == PERSISTENT_NODE`. Memtree, atomic, attribute-as-top-level, text, map, and array shapes fall through to the legacy recursive path. Any `XMLStreamException` / `IOException` / `RuntimeException` from the streaming path is caught and logged at DEBUG; the legacy path runs, so correctness is preserved.

The `FunDeepEqual` static API gains broker-aware overloads (`deepCompareSeq(..., DBBroker)`, `deepCompare(..., DBBroker)`, `deepEqualsSeq(..., DBBroker)`); the existing 3-arg signatures delegate with `broker = null`, leaving callers like `SwitchExpression`, `GroupByClause`, `AbstractMapType`, and `FunSort` untouched.

## Reproducer

PieterLamers' TEST.zip (Macbeth.xml + Macbeth2.xml, ~3,550 elements each), JDK Zulu 21.38.21, eXist 7.0.0-SNAPSHOT, 5-trial median:

| Variant | Median | Notes |
|---|--:|---|
| current develop (no fix) | 5,170 ms | reporter's TEST.zip |
| `xmldiff:compare` (per @adamretter, 2022) | 228 ms | not correctness-equivalent |
| **this fix** | **6 ms** | ~2× over the serialize() floor; ~38× faster than xmldiff:compare |

Synthetic 10k-element stored corpus (`FunDeepEqualPerformanceTest.deepEqualOnStoredEqualDocsIsFast`):

| Variant | Median | Notes |
|---|--:|---|
| current develop | ~2,521 ms | from 2026-05-08 measurement |
| **this fix** | **124 ms** | ~20× speedup |

Memtree case (`deepEqualOnLargeEqualTreesIsFast`) unchanged at ~46 ms; the streaming path does not apply to in-memory nodes.

## Correctness

- 78 existing `*DeepEqual*` JUnit tests pass: `DeepEqualTest` (63), `FunDeepEqualPerformanceTest` (14), `FunDeepEqual4050ReproTest` (1).
- Wider 1,230-test sweep across `XPathQueryTest`, `XQuery3Tests`, `FunSortTest`, `GroupByTest`, `*MapType*`, `*Serialization*` — all green.
- Full `mvn test -pl exist-core`: **6,607 tests, 0 failures, 0 errors, 106 skipped (pre-existing)**.

XQTS conformance has not been re-run for this branch — `fn:deep-equal` is exercised pervasively in QT4 / XQ 3.1, and CI's runner job will report any conformance delta. I'll re-run locally before merge if a reviewer wants confirmation in advance.

## Out of scope

- Schema-aware typed-value comparison. The streaming path treats values as `xs:untypedAtomic` (string equality). The reporter's reproducer is untyped; if a typed-value edge case surfaces in the test gate it'll fall back to legacy. (None has so far across 6,607 tests.)
- In-memory tree caching of stored documents — broader optimisation that would benefit many functions besides `fn:deep-equal`. Worth a separate design pass.
- Documents with leading comments or processing instructions before the root element. The `documentRoot` helper requires the document's first stored child to be an element; non-element first child triggers legacy fallback. (Macbeth.xml and the synthetic corpus both have a single root element.)

## Test plan

- [x] `mvn test -pl exist-core -Dtest='*DeepEqual*'` — 78 tests pass.
- [x] `mvn test -pl exist-core` (full module via shared lock script) — 6,607 tests, 0 failures.
- [x] PieterLamers' Macbeth.xml reproducer: median 6 ms (was 5,170 ms).
- [x] Synthetic 10k-element stored corpus: 124 ms (was ~2,521 ms).
- [x] Memtree path unchanged: 46 ms.
- [x] Codacy PMD on changed files (the NPath warnings are on the existing `deepCompare` method's structure; not introduced here).
- [ ] CI XQTS QT4 / XQ 3.1 / FTTS deltas — pending CI run.

## Spec / context references

- W3C XPath F&O 3.1 §15.3.1 `fn:deep-equal`: <https://www.w3.org/TR/xpath-functions-31/#func-deep-equal>
- 2026-05-08 paused diagnosis comment: <https://github.com/eXist-db/exist/issues/4050#issuecomment-4406332435>
- `IEmbeddedXMLStreamReader` (the BTree stream reader this fix builds on): `exist-core/src/main/java/org/exist/stax/IEmbeddedXMLStreamReader.java`