### PR TITLE
[bugfix] repair JMX client

### DIFF
--- a/exist-core/src/main/java/org/exist/management/Agent.java
+++ b/exist-core/src/main/java/org/exist/management/Agent.java
@@ -31,13 +31,41 @@ import org.exist.util.DatabaseConfigurationException;
  */
 public interface Agent {
 
+    /**
+     * Initialise JMX MBeans for a new database instance.
+     *
+     * @param instance the broker pool representing the database instance
+     */
     void initDBInstance(BrokerPool instance);
 
+    /**
+     * Deregister all JMX MBeans associated with a database instance that is being closed.
+     *
+     * @param instance the broker pool representing the database instance
+     */
     void closeDBInstance(BrokerPool instance);
 
+    /**
+     * Register an additional MBean with the MBean server.
+     *
+     * @param mbean the MBean to register
+     * @throws DatabaseConfigurationException if the MBean cannot be registered
+     */
     void addMBean(PerInstanceMBean mbean) throws DatabaseConfigurationException;
 
+    /**
+     * Notify the agent that the status of a background task has changed.
+     *
+     * @param instance     the broker pool representing the database instance
+     * @param actualStatus the new task status
+     */
     void changeStatus(BrokerPool instance, TaskStatus actualStatus);
 
+    /**
+     * Update the percentage-complete of a running background task.
+     *
+     * @param instance   the broker pool representing the database instance
+     * @param percentage the percentage of work completed (0–100)
+     */
     void updateStatus(BrokerPool instance, int percentage);
 }

--- a/exist-core/src/main/java/org/exist/management/AgentFactory.java
+++ b/exist-core/src/main/java/org/exist/management/AgentFactory.java
@@ -30,6 +30,13 @@ import java.lang.invoke.MethodHandles;
 
 import static java.lang.invoke.MethodType.methodType;
 
+/**
+ * Factory for obtaining the singleton {@link Agent} instance.
+ * <p>
+ * The concrete agent class can be overridden via the system property
+ * {@code exist.jmxagent}. If no suitable class is found a {@link DummyAgent}
+ * is used as a fallback.
+ */
 @ThreadSafe
 public class AgentFactory {
 
@@ -37,6 +44,11 @@ public class AgentFactory {
 
     private static Agent instance = null;
 
+    /**
+     * Return the singleton {@link Agent} instance, creating it on first call.
+     *
+     * @return the agent instance (never {@code null})
+     */
     public static synchronized Agent getInstance() {
         if (instance == null) {
             final String className = System.getProperty("exist.jmxagent", "org.exist.management.impl.JMXAgent");

--- a/exist-core/src/main/java/org/exist/management/Cache.java
+++ b/exist-core/src/main/java/org/exist/management/Cache.java
@@ -24,15 +24,30 @@ package org.exist.management;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+/**
+ * JMX MBean exposing statistics for a single internal page cache
+ * ({@link org.exist.storage.cache.Cache}).
+ */
 public class Cache implements CacheMXBean {
     private final String instanceId;
     private final org.exist.storage.cache.Cache cache;
 
+    /**
+     * Create a new Cache MBean wrapper.
+     *
+     * @param instanceId the identifier of the database instance
+     * @param cache      the underlying cache to expose
+     */
     public Cache(final String instanceId, final org.exist.storage.cache.Cache cache) {
         this.instanceId = instanceId;
         this.cache = cache;
     }
 
+    /**
+     * Return a JMX object-name query that matches all Cache MBeans across all instances.
+     *
+     * @return the wildcard query string
+     */
     public static String getAllInstancesQuery() {
         return "org.exist.management." + '*' + ":type=CacheManager.Cache," + '*';
     }

--- a/exist-core/src/main/java/org/exist/management/Cache.java
+++ b/exist-core/src/main/java/org/exist/management/Cache.java
@@ -47,7 +47,7 @@ public class Cache implements CacheMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/CacheMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/CacheMXBean.java
@@ -30,15 +30,45 @@ import org.exist.storage.cache.Cache;
  */
 public interface CacheMXBean extends PerInstanceMBean {
 
+    /**
+     * Get the type of this cache.
+     *
+     * @return the cache type
+     */
     Cache.CacheType getType();
 
+    /**
+     * Get the total number of buffers allocated to this cache.
+     *
+     * @return total buffer count
+     */
     int getSize();
 
+    /**
+     * Get the number of buffers currently in use.
+     *
+     * @return used buffer count
+     */
     int getUsed();
 
+    /**
+     * Get the number of cache hits since the last reset.
+     *
+     * @return cache hit count
+     */
     int getHits();
 
+    /**
+     * Get the number of cache misses since the last reset.
+     *
+     * @return cache miss count
+     */
     int getFails();
 
+    /**
+     * Get the name of this cache.
+     *
+     * @return the cache name
+     */
     String getCacheName();
 }

--- a/exist-core/src/main/java/org/exist/management/CacheManager.java
+++ b/exist-core/src/main/java/org/exist/management/CacheManager.java
@@ -47,7 +47,7 @@ public class CacheManager implements CacheManagerMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/CacheManager.java
+++ b/exist-core/src/main/java/org/exist/management/CacheManager.java
@@ -24,15 +24,29 @@ package org.exist.management;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+/**
+ * JMX MBean exposing aggregate statistics for the eXist-db cache manager.
+ */
 public class CacheManager implements CacheManagerMXBean {
     private final String instanceId;
     private final org.exist.storage.CacheManager manager;
 
+    /**
+     * Create a new CacheManager MBean wrapper.
+     *
+     * @param instanceId the identifier of the database instance
+     * @param manager    the underlying cache manager to expose
+     */
     public CacheManager(final String instanceId, final org.exist.storage.CacheManager manager) {
         this.instanceId = instanceId;
         this.manager = manager;
     }
 
+    /**
+     * Return a JMX object-name query that matches all CacheManager MBeans across all instances.
+     *
+     * @return the wildcard query string
+     */
     public static String getAllInstancesQuery() {
         return "org.exist.management." + '*' + ":type=CacheManager";
     }

--- a/exist-core/src/main/java/org/exist/management/CacheManagerMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/CacheManagerMXBean.java
@@ -23,11 +23,29 @@ package org.exist.management;
 
 import org.exist.management.impl.PerInstanceMBean;
 
+/**
+ * JMX MXBean interface exposing aggregate statistics for the eXist-db cache manager.
+ */
 public interface CacheManagerMXBean extends PerInstanceMBean {
 
+    /**
+     * Get the maximum total memory (in bytes) that may be used across all caches.
+     *
+     * @return maximum total cache memory in bytes
+     */
     long getMaxTotal();
 
+    /**
+     * Get the maximum memory (in bytes) that a single cache may use.
+     *
+     * @return maximum per-cache memory in bytes
+     */
     long getMaxSingle();
 
+    /**
+     * Get the total memory (in bytes) currently used by all caches.
+     *
+     * @return current total cache memory in bytes
+     */
     long getCurrentSize();
 }

--- a/exist-core/src/main/java/org/exist/management/TaskStatus.java
+++ b/exist-core/src/main/java/org/exist/management/TaskStatus.java
@@ -30,16 +30,32 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Represents the current status of a background task, including its state,
+ * the time the state last changed, an optional reason object, and a
+ * percentage-complete indicator.
+ */
 public class TaskStatus {
 
     private Status status = Status.NA;
     private Date _statusChangeTime = Calendar.getInstance().getTime();
     private Object _reason = null;
     private int _percentageDone = 0;
+    /**
+     * Create a new TaskStatus with the given initial status.
+     *
+     * @param newStatus the initial status
+     */
     public TaskStatus(final Status newStatus) {
         setStatus(newStatus);
     }
 
+    /**
+     * Reconstruct a TaskStatus from JMX composite data.
+     *
+     * @param compositeData the composite data previously produced by {@link #getCompositeData()}
+     * @return the reconstructed TaskStatus
+     */
     public static TaskStatus getTaskStatus(final CompositeDataSupport compositeData) {
 
         final TaskStatus status = new TaskStatus((Status) compositeData.get("status"));
@@ -49,24 +65,50 @@ public class TaskStatus {
         return status;
     }
 
+    /**
+     * Get the reason object associated with the current status.
+     *
+     * @return the reason, or {@code null} if none has been set
+     */
     public Object getReason() {
         return _reason;
     }
 
+    /**
+     * Set the reason object associated with the current status.
+     *
+     * @param reason the reason object (ignored if {@code null})
+     */
     public void setReason(final Object reason) {
         if (reason != null) {
             _reason = reason;
         }
     }
 
+    /**
+     * Get the current status.
+     *
+     * @return the current status
+     */
     public Status getStatus() {
         return status;
     }
 
+    /**
+     * Set the current status.
+     *
+     * @param newStatus the new status
+     */
     public void setStatus(final Status newStatus) {
         status = newStatus;
     }
 
+    /**
+     * Get a human-readable representation of the current status, including
+     * the percentage done when applicable.
+     *
+     * @return the status string
+     */
     public String getStatusString() {
         String percentageInfo = "";
         switch (status) {
@@ -85,24 +127,48 @@ public class TaskStatus {
         return this + percentageInfo;
     }
 
+    /**
+     * Get the time at which the status last changed.
+     *
+     * @return the status-change timestamp
+     */
     public Date getStatusChangeTime() {
         return _statusChangeTime;
     }
 
+    /**
+     * Record the current time as the status-change timestamp.
+     */
     public void setStatusChangeTime() {
         _statusChangeTime = Calendar.getInstance().getTime();
     }
 
+    /**
+     * Get the percentage of work completed.
+     *
+     * @return percentage done (0–100)
+     */
     public int getPercentage() {
         return _percentageDone;
     }
 
+    /**
+     * Set the percentage of work completed.
+     * Values outside the range 1–100 are silently ignored.
+     *
+     * @param percentage the percentage done (1–100)
+     */
     public void setPercentage(final int percentage) {
         if (percentage > 0 && percentage < 101) {
             _percentageDone = percentage;
         }
     }
 
+    /**
+     * Serialise this TaskStatus as JMX {@link CompositeDataSupport}.
+     *
+     * @return the composite data representation, or {@code null} if serialisation fails
+     */
     public CompositeDataSupport getCompositeData() {
         final Map<String, Object> data = new HashMap<>();
         CompositeDataSupport compositeData = null;

--- a/exist-core/src/main/java/org/exist/management/TaskStatus.java
+++ b/exist-core/src/main/java/org/exist/management/TaskStatus.java
@@ -21,38 +21,39 @@
  */
 package org.exist.management;
 
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.SimpleType;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.management.openmbean.CompositeDataSupport;
-import javax.management.openmbean.CompositeType;
-import javax.management.openmbean.OpenDataException;
-import javax.management.openmbean.SimpleType;
-
 public class TaskStatus {
 
-    public enum Status {
-        NA, NEVER_RUN, INIT, PAUSED, STOPPED_OK, STOPPED_ERROR, RUNNING_CHECK, RUNNING_BACKUP,
-        PING_OK, PING_ERROR, PING_WAIT
-    }
-
     private Status status = Status.NA;
-
     private Date _statusChangeTime = Calendar.getInstance().getTime();
     private Object _reason = null;
     private int _percentageDone = 0;
-
-    public TaskStatus(Status newStatus) {
+    public TaskStatus(final Status newStatus) {
         setStatus(newStatus);
+    }
+
+    public static TaskStatus getTaskStatus(final CompositeDataSupport compositeData) {
+
+        final TaskStatus status = new TaskStatus((Status) compositeData.get("status"));
+        status._reason = compositeData.get("reason");
+        status._statusChangeTime = (Date) compositeData.get("statusChangeTime");
+        status._percentageDone = ((Integer) compositeData.get("percentage"));
+        return status;
     }
 
     public Object getReason() {
         return _reason;
     }
 
-    public void setReason(Object reason) {
+    public void setReason(final Object reason) {
         if (reason != null) {
             _reason = reason;
         }
@@ -62,24 +63,24 @@ public class TaskStatus {
         return status;
     }
 
-    public void setStatus(Status newStatus) {
-        status=newStatus;
+    public void setStatus(final Status newStatus) {
+        status = newStatus;
     }
 
     public String getStatusString() {
         String percentageInfo = "";
         switch (status) {
-        case INIT:
-        case NA:
-        case NEVER_RUN:
-        case STOPPED_OK:
-        case PING_ERROR:
-        case PING_OK:
-        case PING_WAIT:
-            break;
-        default:
-            percentageInfo = " - " + _percentageDone + "% done";
-            break;
+            case INIT:
+            case NA:
+            case NEVER_RUN:
+            case STOPPED_OK:
+            case PING_ERROR:
+            case PING_OK:
+            case PING_WAIT:
+                break;
+            default:
+                percentageInfo = " - " + _percentageDone + "% done";
+                break;
         }
         return this + percentageInfo;
     }
@@ -92,14 +93,14 @@ public class TaskStatus {
         _statusChangeTime = Calendar.getInstance().getTime();
     }
 
-    public void setPercentage(int percentage) {
+    public int getPercentage() {
+        return _percentageDone;
+    }
+
+    public void setPercentage(final int percentage) {
         if (percentage > 0 && percentage < 101) {
             _percentageDone = percentage;
         }
-    }
-
-    public int getPercentage() {
-        return _percentageDone;
     }
 
     public CompositeDataSupport getCompositeData() {
@@ -111,27 +112,23 @@ public class TaskStatus {
         data.put("percentage", _percentageDone);
         try {
             compositeData = new CompositeDataSupport(new CompositeType("TaskStatus", "Status of the task", //
-                    new String[] { "status", "statusChangeTime", "reason", "percentage" }, //
-                    new String[] { "status of the task", "reason for this status", "time when the status has changed",
-                            "percentage of work" },//
-                    new SimpleType[] { SimpleType.INTEGER, SimpleType.DATE, SimpleType.OBJECTNAME, SimpleType.INTEGER }), data);
+                    new String[]{"status", "statusChangeTime", "reason", "percentage"}, //
+                    new String[]{"status of the task", "reason for this status", "time when the status has changed",
+                            "percentage of work"},//
+                    new SimpleType[]{SimpleType.INTEGER, SimpleType.DATE, SimpleType.OBJECTNAME, SimpleType.INTEGER}), data);
         } catch (final OpenDataException e) {
             // TODO TI: Make correct error handling
         }
         return compositeData;
     }
 
-    public static TaskStatus getTaskStatus(CompositeDataSupport compositeData) {
-
-        final TaskStatus status = new TaskStatus((Status)compositeData.get("status"));
-        status._reason = compositeData.get("reason");
-        status._statusChangeTime = (Date) compositeData.get("statusChangeTime");
-        status._percentageDone = ((Integer) compositeData.get("percentage"));
-        return status;
-    }
-
     @Override
     public String toString() {
         return status.toString();
+    }
+
+    public enum Status {
+        NA, NEVER_RUN, INIT, PAUSED, STOPPED_OK, STOPPED_ERROR, RUNNING_CHECK, RUNNING_BACKUP,
+        PING_OK, PING_ERROR, PING_WAIT
     }
 }

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -485,21 +485,6 @@ public class JMXClient {
     }
 
     /**
-     * Extracts attribute values from an {@link AttributeList} in positional order.
-     *
-     * @param attribs the attribute list returned by
-     *                {@link MBeanServerConnection#getAttributes}
-     * @return an array of attribute values in the same order as {@code attribs}
-     */
-    private Object[] getValues(final AttributeList attribs) {
-        final Object[] v = new Object[attribs.size()];
-        for (int i = 0; i < attribs.size(); i++) {
-            v[i] = ((Attribute) attribs.get(i)).getValue();
-        }
-        return v;
-    }
-
-    /**
      * Extracts attribute values from an {@link AttributeList} by name, returning
      * a result array aligned to {@code cols}.
      * <p>

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -212,18 +212,25 @@ public class JMXClient {
         echo("-----------------------------------------------");
         try {
             final ObjectName name = new ObjectName("org.exist.management." + instance + ":type=LockTable");
-            @SuppressWarnings("unchecked")
-            final Map<String, Map<String, List<Map<String, ?>>>> attempting =
-                    (Map<String, Map<String, List<Map<String, ?>>>>) connection.getAttribute(name, "Attempting");
+            // Over JMX remote, Map<String, Map<LockType, List<LockModeOwner>>> is serialized as nested TabularData:
+            //   outer TabularData: key=lockId (String), value=TabularData
+            //     inner TabularData: key=LockType name (String), value=CompositeData[]
+            //       each CompositeData: fields lockMode, ownerThread, trace
+            final TabularData attempting = (TabularData) connection.getAttribute(name, "Attempting");
             if (attempting == null || attempting.isEmpty()) {
                 echo("(none)");
                 return;
             }
-            for (final Map.Entry<String, Map<String, List<Map<String, ?>>>> lockEntry : attempting.entrySet()) {
-                final String lockId = lockEntry.getKey();
-                for (final Map.Entry<String, List<Map<String, ?>>> typeEntry : lockEntry.getValue().entrySet()) {
-                    final String lockType = typeEntry.getKey();
-                    for (final Map<String, ?> modeOwner : typeEntry.getValue()) {
+            for (final Object outerObj : attempting.values()) {
+                final CompositeData outerRow = (CompositeData) outerObj;
+                final String lockId = (String) outerRow.get("key");
+                final TabularData innerTable = (TabularData) outerRow.get("value");
+                for (final Object innerObj : innerTable.values()) {
+                    final CompositeData innerRow = (CompositeData) innerObj;
+                    final String lockType = (String) innerRow.get("key");
+                    final Object[] modeOwners = (Object[]) innerRow.get("value");
+                    for (final Object modeOwnerObj : modeOwners) {
+                        final CompositeData modeOwner = (CompositeData) modeOwnerObj;
                         echo("%20s: %s".formatted("Lock id", lockId));
                         echo("%20s: %s".formatted("Lock type", lockType));
                         echo("%20s: %s".formatted("Lock mode", modeOwner.get("lockMode")));

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -51,16 +51,35 @@ import static org.exist.util.ArgumentUtil.getBool;
 import static se.softhouse.jargo.Arguments.*;
 
 /**
+ * Command-line JMX client for monitoring a running eXist-db instance.
+ * <p>
+ * Connects to an eXist-db JMX endpoint via RMI and prints statistics about
+ * memory usage, cache state, lock contention, sanity reports, and running jobs.
+ * Intended to be invoked via {@code bin/jmxclient.sh}.
+ * </p>
  */
 public class JMXClient {
 
     private MBeanServerConnection connection;
     private String instance;
 
+    /**
+     * Creates a new JMXClient targeting the named eXist-db database instance.
+     *
+     * @param instanceName the JMX instance name used in MBean object names
+     *                     (e.g. {@code "exist"} for {@code org.exist.management.exist:…})
+     */
     public JMXClient(String instanceName) {
         this.instance = instanceName;
     }
 
+    /**
+     * Opens a JMX/RMI connection to the specified server.
+     *
+     * @param address hostname or IP address of the eXist-db server
+     * @param port    RMI registry port (typically {@code 1099})
+     * @throws IOException if the connection cannot be established
+     */
     public void connect(String address,int port) throws IOException {
         final JMXServiceURL url =
                 new JMXServiceURL("service:jmx:rmi:///jndi/rmi://"+address+":" + port + "/jmxrmi");
@@ -73,6 +92,10 @@ public class JMXClient {
         echo("Connected to MBean server.");
     }
 
+    /**
+     * Prints JVM heap memory statistics (used, committed, and max heap) to stdout.
+     * Reads the {@code java.lang:type=Memory} MBean.
+     */
     public void memoryStats() {
         try {
             final ObjectName name = new ObjectName("java.lang:type=Memory");
@@ -88,30 +111,42 @@ public class JMXClient {
         }
     }
 
+    /**
+     * Prints eXist-db instance statistics to stdout, including reserved/cache memory,
+     * broker pool counts, and any currently active broker threads.
+     * Reads the {@code org.exist.management.&lt;instance&gt;:type=Database} MBean.
+     */
     public void instanceStats() {
         try {
             echo("\nINSTANCE:");
             final ObjectName name = new ObjectName("org.exist.management." + instance + ":type=Database");
             final Long memReserved = (Long) connection.getAttribute(name, "ReservedMem");
-            echo("%25s: %10d k".formatted("Reserved memory", memReserved / 1024));
+            echo("%25s: %10d k".formatted("Reserved memory", memReserved != null ? memReserved / 1024 : 0L));
             final Long memCache = (Long) connection.getAttribute(name, "CacheMem");
-            echo("%25s: %10d k".formatted("Cache memory", memCache / 1024));
+            echo("%25s: %10d k".formatted("Cache memory", memCache != null ? memCache / 1024 : 0L));
             final Long memCollCache = (Long) connection.getAttribute(name, "CollectionCacheMem");
-            echo("%25s: %10d k".formatted("Collection cache memory", memCollCache / 1024));
+            echo("%25s: %10d k".formatted("Collection cache memory", memCollCache != null ? memCollCache / 1024 : 0L));
 
             final String cols[] = { "MaxBrokers", "AvailableBrokers", "ActiveBrokers" };
             echo("\n%17s %17s %17s".formatted(cols[0], cols[1], cols[2]));
             final AttributeList attrs = connection.getAttributes(name, cols);
-            final Object values[] = getValues(attrs);
-            echo("%17d %17d %17d".formatted(values[0], values[1], values[2]));
+            final Object values[] = getValues(attrs, cols);
+            echo("%17d %17d %17d".formatted(
+                    values[0] != null ? values[0] : 0,
+                    values[1] != null ? values[1] : 0,
+                    values[2] != null ? values[2] : 0));
 
-            final TabularData table = (TabularData) connection.getAttribute(name, "ActiveBrokersMap");
-            if (!table.isEmpty()) {
+            final Object activeBrokersRaw = connection.getAttribute(name, "ActiveBrokersMap");
+            final CompositeData[] activeBrokers = activeBrokersRaw instanceof CompositeData[]
+                    ? (CompositeData[]) activeBrokersRaw
+                    : activeBrokersRaw instanceof TabularData
+                        ? ((TabularData) activeBrokersRaw).values().toArray(new CompositeData[0])
+                        : new CompositeData[0];
+            if (activeBrokers.length > 0) {
                 echo("\nCurrently active threads:");
             }
 
-            for (Object o : table.values()) {
-                final CompositeData data = (CompositeData) o;
+            for (final CompositeData data : activeBrokers) {
                 echo("\t%20s: %3d".formatted(data.get("owner"), data.get("referenceCount")));
             }
         } catch (final Exception e) {
@@ -119,55 +154,81 @@ public class JMXClient {
         }
     }
 
+    /**
+     * Prints cache statistics to stdout, including per-cache type, file name, size,
+     * usage, hits, and failures, as well as collection-cache totals.
+     * Reads the {@code CacheManager} and {@code CollectionCacheManager} MBeans.
+     */
     public void cacheStats() {
         try {
             ObjectName name = new ObjectName("org.exist.management." + instance + ":type=CacheManager");
             String cols[] = { "MaxTotal", "CurrentSize" };
             AttributeList attrs = connection.getAttributes(name, cols);
-            Object values[] = getValues(attrs);
-            echo("\nCACHE [%8d pages max. / %8d pages allocated]".formatted(values[0], values[1]));
+            Object values[] = getValues(attrs, cols);
+            echo("\nCACHE [%8d pages max. / %8d pages allocated]".formatted(
+                    values[0] != null ? values[0] : 0,
+                    values[1] != null ? values[1] : 0));
 
             final Set<ObjectName> beans = connection.queryNames(new ObjectName("org.exist.management." + instance + ":type=CacheManager.Cache,*"), null);
-            cols = new String[] {"Type", "FileName", "Size", "Used", "Hits", "Fails"};
-            echo("%10s %20s %10s %10s %10s %10s".formatted(cols[0], cols[1], cols[2], cols[3], cols[4], cols[5]));
+            cols = new String[] {"Type", "CacheName", "Size", "Used", "Hits", "Fails"};
+            echo("%10s %20s %10s %10s %10s %10s".formatted(cols[0], "FileName", cols[2], cols[3], cols[4], cols[5]));
+            final List<Object[]> cacheRows = new ArrayList<>();
             for (ObjectName bean : beans) {
-                name = bean;
-                attrs = connection.getAttributes(name, cols);
-                values = getValues(attrs);
-                echo("%10s %20s %,10d %,10d %,10d %,10d".formatted(values[0], values[1], values[2], values[3], values[4], values[5]));
+                attrs = connection.getAttributes(bean, cols);
+                cacheRows.add(getValues(attrs, cols));
+            }
+            cacheRows.sort(Comparator
+                    .comparing((Object[] r) -> r[1] != null ? r[1].toString() : "")
+                    .thenComparing(r -> r[0] != null ? r[0].toString() : ""));
+            for (final Object[] row : cacheRows) {
+                echo("%10s %20s %,10d %,10d %,10d %,10d".formatted(
+                        row[0] != null ? row[0] : "N/A",
+                        row[1] != null ? row[1] : "N/A",
+                        row[2] != null ? row[2] : 0L,
+                        row[3] != null ? row[3] : 0L,
+                        row[4] != null ? row[4] : 0L,
+                        row[5] != null ? row[5] : 0L));
             }
             
             echo("");
-           name = new ObjectName("org.exist.management." + instance + ":type=CollectionCacheManager");
-            cols = new String[] { "MaxTotal", "CurrentSize" };
+            name = new ObjectName("org.exist.management." + instance + ":type=CollectionCache");
+            cols = new String[] { "MaxCacheSize" };
             attrs = connection.getAttributes(name, cols);
-            values = getValues(attrs);
-           echo("Collection Cache: %10d k max / %10d k allocated".formatted(
-                   ((Long)values[0] / 1024), ((Long)values[1] / 1024)));
+            values = getValues(attrs, cols);
+            echo("Collection Cache: %10d k max".formatted(
+                    values[0] != null ? (Long)values[0] / 1024 : 0L));
         } catch (final Exception e) {
             error(e);
         }
     }
 
+    /**
+     * Prints the list of threads currently waiting for a lock to stdout.
+     * Useful for diagnosing deadlocks. During normal operation the list is empty.
+     * Reads the {@code org.exist.management.&lt;instance&gt;:type=LockTable} MBean.
+     */
     public void lockTable() {
         echo("\nList of threads currently waiting for a lock:");
         echo("-----------------------------------------------");
         try {
-            final TabularData table = (TabularData) connection.getAttribute(new ObjectName("org.exist.management:type=LockManager"), "WaitingThreads");
-            for (Object o : table.values()) {
-                final CompositeData data = (CompositeData) o;
-                echo("Thread " + data.get("waitingThread"));
-                echo("%20s: %s".formatted("Lock type", data.get("lockType")));
-                echo("%20s: %s".formatted("Lock mode", data.get("lockMode")));
-                echo("%20s: %s".formatted("Lock id", data.get("id")));
-                echo("%20s: %s".formatted("Held by", Arrays.toString((String[])data.get("owner"))));
-                final String[] readers = (String[]) data.get("waitingForRead");
-                if (readers.length > 0) {
-                    echo("%20s: %s".formatted("Wait for read", Arrays.toString(readers)));
-                }
-                final String[] writers = (String[]) data.get("waitingForWrite");
-                if (writers.length > 0) {
-                    echo("%20s: %s".formatted("Wait for write", Arrays.toString(writers)));
+            final ObjectName name = new ObjectName("org.exist.management." + instance + ":type=LockTable");
+            @SuppressWarnings("unchecked")
+            final Map<String, Map<String, List<Map<String, ?>>>> attempting =
+                    (Map<String, Map<String, List<Map<String, ?>>>>) connection.getAttribute(name, "Attempting");
+            if (attempting == null || attempting.isEmpty()) {
+                echo("(none)");
+                return;
+            }
+            for (final Map.Entry<String, Map<String, List<Map<String, ?>>>> lockEntry : attempting.entrySet()) {
+                final String lockId = lockEntry.getKey();
+                for (final Map.Entry<String, List<Map<String, ?>>> typeEntry : lockEntry.getValue().entrySet()) {
+                    final String lockType = typeEntry.getKey();
+                    for (final Map<String, ?> modeOwner : typeEntry.getValue()) {
+                        echo("%20s: %s".formatted("Lock id", lockId));
+                        echo("%20s: %s".formatted("Lock type", lockType));
+                        echo("%20s: %s".formatted("Lock mode", modeOwner.get("lockMode")));
+                        echo("%20s: %s".formatted("Waiting thread", modeOwner.get("ownerThread")));
+                    }
                 }
             }
         } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
@@ -175,6 +236,11 @@ public class JMXClient {
         }
     }
 
+    /**
+     * Prints the latest sanity-check report to stdout, including status,
+     * start/end timestamps, duration, and any reported errors.
+     * Reads the {@code org.exist.management.&lt;instance&gt;.tasks:type=SanityReport} MBean.
+     */
     public void sanityReport() {
         echo("\nSanity report");
         echo("-----------------------------------------------");
@@ -184,23 +250,28 @@ public class JMXClient {
             final Date lastCheckStart = (Date) connection.getAttribute(name, "LastCheckStart");
             final Date lastCheckEnd = (Date) connection.getAttribute(name, "LastCheckEnd");
             echo("%22s: %s".formatted("Status", status));
-            echo("%22s: %s".formatted("Last check start", lastCheckStart));
-            echo("%22s: %s".formatted("Last check end", lastCheckEnd));
+            echo("%22s: %s".formatted("Last check start", lastCheckStart != null ? lastCheckStart : "N/A"));
+            echo("%22s: %s".formatted("Last check end", lastCheckEnd != null ? lastCheckEnd : "N/A"));
             if (lastCheckStart != null && lastCheckEnd != null)
                 {echo("%22s: %dms".formatted("Check took", (lastCheckEnd.getTime() - lastCheckStart.getTime())));}
 
-            final TabularData table = (TabularData)
+            final CompositeData[] errors = (CompositeData[])
                     connection.getAttribute(name, "Errors");
-            for (Object o : table.values()) {
-                final CompositeData data = (CompositeData) o;
-                echo("%22s: %s".formatted("Error code", data.get("errcode")));
-                echo("%22s: %s".formatted("Description", data.get("description")));
+            if (errors != null) {
+                for (final CompositeData data : errors) {
+                    echo("%22s: %s".formatted("Error code", data.get("errcode")));
+                    echo("%22s: %s".formatted("Description", data.get("description")));
+                }
             }
         } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
             error(e);
         }
     }
 
+    /**
+     * Prints the currently running jobs and XQuery processes to stdout.
+     * Reads the {@code org.exist.management.&lt;instance&gt;:type=ProcessReport} MBean.
+     */
     public void jobReport() {
         echo("\nRunning jobs report");
         echo("-----------------------------------------------");
@@ -231,6 +302,13 @@ public class JMXClient {
         }
     }
 
+    /**
+     * Extracts attribute values from an {@link AttributeList} in positional order.
+     *
+     * @param attribs the attribute list returned by
+     *                {@link MBeanServerConnection#getAttributes}
+     * @return an array of attribute values in the same order as {@code attribs}
+     */
     private Object[] getValues(AttributeList attribs) {
         final Object[] v = new Object[attribs.size()];
         for (int i = 0; i < attribs.size(); i++) {
@@ -239,10 +317,49 @@ public class JMXClient {
         return v;
     }
 
+    /**
+     * Extracts attribute values from an {@link AttributeList} by name, returning
+     * a result array aligned to {@code cols}.
+     * <p>
+     * If the server did not return a value for a requested attribute name the
+     * corresponding element in the result array will be {@code null} rather than
+     * causing an {@link ArrayIndexOutOfBoundsException}.
+     * </p>
+     *
+     * @param attribs the attribute list returned by
+     *                {@link MBeanServerConnection#getAttributes}
+     * @param cols    the attribute names whose values should be extracted,
+     *                in the desired output order
+     * @return an array of the same length as {@code cols} with each element
+     *         holding the corresponding attribute value, or {@code null} if absent
+     */
+    private Object[] getValues(AttributeList attribs, String[] cols) {
+        final Map<String, Object> byName = new LinkedHashMap<>();
+        for (int i = 0; i < attribs.size(); i++) {
+            final Attribute a = (Attribute) attribs.get(i);
+            byName.put(a.getName(), a.getValue());
+        }
+        final Object[] v = new Object[cols.length];
+        for (int i = 0; i < cols.length; i++) {
+            v[i] = byName.get(cols[i]);
+        }
+        return v;
+    }
+
+    /**
+     * Writes a line of output to {@link System#out}.
+     *
+     * @param msg the message to print
+     */
     private void echo(String msg) {
         System.out.println(msg);
     }
     
+    /**
+     * Writes an error message and stack trace to {@link System#err}.
+     *
+     * @param e the exception to report
+     */
     private void error(Exception e) {
         System.err.println("ERROR: " + e.getMessage());
         e.printStackTrace();
@@ -305,6 +422,12 @@ public class JMXClient {
         LOCKS
     }
 
+    /**
+     * Entry point for the {@code jmxclient.sh} command.
+     * Parses command-line arguments and delegates to {@link #process(ParsedArguments)}.
+     *
+     * @param args command-line arguments
+     */
     @SuppressWarnings("unchecked")
 	public static void main(final String[] args) {
         try {
@@ -331,6 +454,13 @@ public class JMXClient {
 
     }
 
+    /**
+     * Processes parsed command-line arguments: connects to the JMX server and
+     * repeatedly prints the requested statistics until the optional wait interval
+     * expires or a single pass completes.
+     *
+     * @param arguments the parsed command-line arguments
+     */
     private static void process(final ParsedArguments arguments) {
         final String address = arguments.get(addressArg);
         final int port = Optional.ofNullable(arguments.get(portArg)).orElse(DEFAULT_PORT);

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -349,11 +349,15 @@ public class JMXClient {
 
             echo("");
             name = new ObjectName("org.exist.management." + instance + ":type=CollectionCache");
-            cols = new String[]{"MaxCacheSize"};
-            attrs = connection.getAttributes(name, cols);
-            values = getValues(attrs, cols);
-            echo("Collection Cache: %10d k max".formatted(
-                    values[0] != null ? (Long) values[0] / 1024 : 0L));
+            try {
+                cols = new String[]{"MaxCacheSize"};
+                attrs = connection.getAttributes(name, cols);
+                values = getValues(attrs, cols);
+                echo("Collection Cache: %10d k max".formatted(
+                        values[0] != null ? (Long) values[0] / 1024 : 0L));
+            } catch (final InstanceNotFoundException e) {
+                echo("Collection Cache: (not available)");
+            }
         } catch (final Exception e) {
             error(e);
         }

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -45,10 +45,21 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.exist.util.ArgumentUtil.getBool;
-import static se.softhouse.jargo.Arguments.*;
+import static se.softhouse.jargo.Arguments.helpArgument;
+import static se.softhouse.jargo.Arguments.integerArgument;
+import static se.softhouse.jargo.Arguments.optionArgument;
+import static se.softhouse.jargo.Arguments.stringArgument;
 
 /**
  * Command-line JMX client for monitoring a running eXist-db instance.
@@ -60,17 +71,163 @@ import static se.softhouse.jargo.Arguments.*;
  */
 public class JMXClient {
 
+    private static final int DEFAULT_PORT = 1099;
+    private static final int DEFAULT_WAIT_TIME = 0;
+    /* general arguments */
+    private static final Argument<?> helpArg = helpArgument("-h", "--help");
+    /* connection arguments */
+    private static final Argument<String> addressArg = stringArgument("-a", "--address")
+            .description("RMI address of the server")
+            .defaultValue("localhost")
+            .build();
+    private static final Argument<Integer> portArg = integerArgument("-p", "--port")
+            .description("RMI port of the server")
+            .defaultValue(DEFAULT_PORT)
+            .build();
+    private static final Argument<String> instanceArg = stringArgument("-i", "--instance")
+            .description("The ID of the database instance to connect to")
+            .defaultValue("exist")
+            .build();
+    private static final Argument<Integer> waitArg = integerArgument("-w", "--wait")
+            .description("while displaying server statistics: keep retrieving statistics, but wait the specified number of seconds between calls.")
+            .defaultValue(DEFAULT_WAIT_TIME)
+            .build();
+    /* display mode options */
+    private static final Argument<Boolean> cacheDisplayArg = optionArgument("-c", "--cache")
+            .description("displays server statistics on cache and memory usage.")
+            .defaultValue(false)
+            .build();
+    private static final Argument<Boolean> locksDisplayArg = optionArgument("-l", "--locks")
+            .description("lock manager: display locking information on all threads currently waiting for a lock on a resource or collection. Useful to debug deadlocks. During normal operation, the list will usually be empty (means: no blocked threads).")
+            .defaultValue(false)
+            .build();
+    /* display info options */
+    private static final Argument<Boolean> dbInfoArg = optionArgument("-d", "--db")
+            .description("display general info about the db instance.")
+            .defaultValue(false)
+            .build();
+    private static final Argument<Boolean> memoryInfoArg = optionArgument("-m", "--memory")
+            .description("display info on free and total memory. Can be combined with other parameters.")
+            .defaultValue(false)
+            .build();
+    private static final Argument<Boolean> sanityCheckInfoArg = optionArgument("-s", "--report")
+            .description("retrieve sanity check report from the db")
+            .defaultValue(false)
+            .build();
+    private static final Argument<Boolean> jobsInfoArg = optionArgument("-j", "--jobs")
+            .description("retrieve sanity check report from the db")
+            .defaultValue(false)
+            .build();
     private MBeanServerConnection connection;
-    private String instance;
-
+    private final String instance;
     /**
      * Creates a new JMXClient targeting the named eXist-db database instance.
      *
      * @param instanceName the JMX instance name used in MBean object names
      *                     (e.g. {@code "exist"} for {@code org.exist.management.exist:…})
      */
-    public JMXClient(String instanceName) {
+    public JMXClient(final String instanceName) {
         this.instance = instanceName;
+    }
+
+    /**
+     * Entry point for the {@code jmxclient.sh} command.
+     * Parses command-line arguments and delegates to {@link #process(ParsedArguments)}.
+     *
+     * @param args command-line arguments
+     */
+    @SuppressWarnings("unchecked")
+    public static void main(final String[] args) {
+        try {
+            CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+            final ParsedArguments arguments = CommandLineParser
+                    .withArguments(addressArg, portArg, instanceArg, waitArg)
+                    .andArguments(cacheDisplayArg, locksDisplayArg)
+                    .andArguments(dbInfoArg, memoryInfoArg, sanityCheckInfoArg, jobsInfoArg)
+                    .andArguments(helpArg)
+                    .programName("jmxclient" + (OSUtil.isWindows() ? ".bat" : ".sh"))
+                    .parse(args);
+
+            process(arguments);
+        } catch (final StartException e) {
+            if (e.getMessage() != null && !e.getMessage().isEmpty()) {
+                System.err.println(e.getMessage());
+            }
+            System.exit(e.getErrorCode());
+        } catch (final ArgumentException e) {
+            System.out.println(e.getMessageAndUsage());
+            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
+        }
+
+    }
+
+    /**
+     * Processes parsed command-line arguments: connects to the JMX server and
+     * repeatedly prints the requested statistics until the optional wait interval
+     * expires or a single pass completes.
+     *
+     * @param arguments the parsed command-line arguments
+     */
+    private static void process(final ParsedArguments arguments) {
+        final String address = arguments.get(addressArg);
+        final int port = Optional.ofNullable(arguments.get(portArg)).orElse(DEFAULT_PORT);
+        final String dbInstance = arguments.get(instanceArg);
+        final long waitTime = Optional.ofNullable(arguments.get(waitArg)).orElse(DEFAULT_WAIT_TIME);
+
+        Mode mode = Mode.STATS;
+        if (getBool(arguments, cacheDisplayArg)) {
+            mode = Mode.STATS;
+        }
+        if (getBool(arguments, locksDisplayArg)) {
+            mode = Mode.LOCKS;
+        }
+
+        final boolean displayInstance = getBool(arguments, dbInfoArg);
+        final boolean displayMem = getBool(arguments, memoryInfoArg);
+        final boolean displayReport = getBool(arguments, sanityCheckInfoArg);
+        final boolean jobReport = getBool(arguments, jobsInfoArg);
+
+        try {
+            final JMXClient stats = new JMXClient(dbInstance);
+            stats.connect(address, port);
+            stats.memoryStats();
+            while (true) {
+                switch (mode) {
+                    case STATS:
+                        stats.cacheStats();
+                        break;
+                    case LOCKS:
+                        stats.lockTable();
+                        break;
+                }
+                if (displayInstance) {
+                    stats.instanceStats();
+                }
+                if (displayMem) {
+                    stats.memoryStats();
+                }
+                if (displayReport) {
+                    stats.sanityReport();
+                }
+                if (jobReport) {
+                    stats.jobReport();
+                }
+                if (waitTime > 0) {
+                    synchronized (stats) {
+                        try {
+                            stats.wait(waitTime);
+                        } catch (final InterruptedException e) {
+                            System.err.println("INTERRUPTED: " + e.getMessage());
+                        }
+                    }
+                } else {
+                    return;
+                }
+            }
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -80,9 +237,9 @@ public class JMXClient {
      * @param port    RMI registry port (typically {@code 1099})
      * @throws IOException if the connection cannot be established
      */
-    public void connect(String address,int port) throws IOException {
+    public void connect(final String address, final int port) throws IOException {
         final JMXServiceURL url =
-                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://"+address+":" + port + "/jmxrmi");
+                new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + address + ":" + port + "/jmxrmi");
         final Map<String, String[]> env = new HashMap<>();
         final String[] creds = {"guest", "guest"};
         env.put(JMXConnector.CREDENTIALS, creds);
@@ -103,8 +260,8 @@ public class JMXClient {
             if (composite != null) {
                 echo("\nMEMORY:");
                 echo("Current heap: %,12d k        Committed memory:  %,12d k".formatted(
-                        ((Long)composite.get("used")) / 1024, ((Long)composite.get("committed")) / 1024));
-                echo("Max memory:   %,12d k".formatted(((Long)composite.get("max")) / 1024));
+                        ((Long) composite.get("used")) / 1024, ((Long) composite.get("committed")) / 1024));
+                echo("Max memory:   %,12d k".formatted(((Long) composite.get("max")) / 1024));
             }
         } catch (final Exception e) {
             error(e);
@@ -127,10 +284,10 @@ public class JMXClient {
             final Long memCollCache = (Long) connection.getAttribute(name, "CollectionCacheMem");
             echo("%25s: %10d k".formatted("Collection cache memory", memCollCache != null ? memCollCache / 1024 : 0L));
 
-            final String cols[] = { "MaxBrokers", "AvailableBrokers", "ActiveBrokers" };
+            final String[] cols = {"MaxBrokers", "AvailableBrokers", "ActiveBrokers"};
             echo("\n%17s %17s %17s".formatted(cols[0], cols[1], cols[2]));
             final AttributeList attrs = connection.getAttributes(name, cols);
-            final Object values[] = getValues(attrs, cols);
+            final Object[] values = getValues(attrs, cols);
             echo("%17d %17d %17d".formatted(
                     values[0] != null ? values[0] : 0,
                     values[1] != null ? values[1] : 0,
@@ -140,8 +297,8 @@ public class JMXClient {
             final CompositeData[] activeBrokers = activeBrokersRaw instanceof CompositeData[]
                     ? (CompositeData[]) activeBrokersRaw
                     : activeBrokersRaw instanceof TabularData
-                        ? ((TabularData) activeBrokersRaw).values().toArray(new CompositeData[0])
-                        : new CompositeData[0];
+                      ? ((TabularData) activeBrokersRaw).values().toArray(new CompositeData[0])
+                      : new CompositeData[0];
             if (activeBrokers.length > 0) {
                 echo("\nCurrently active threads:");
             }
@@ -162,18 +319,18 @@ public class JMXClient {
     public void cacheStats() {
         try {
             ObjectName name = new ObjectName("org.exist.management." + instance + ":type=CacheManager");
-            String cols[] = { "MaxTotal", "CurrentSize" };
+            String[] cols = {"MaxTotal", "CurrentSize"};
             AttributeList attrs = connection.getAttributes(name, cols);
-            Object values[] = getValues(attrs, cols);
+            Object[] values = getValues(attrs, cols);
             echo("\nCACHE [%8d pages max. / %8d pages allocated]".formatted(
                     values[0] != null ? values[0] : 0,
                     values[1] != null ? values[1] : 0));
 
             final Set<ObjectName> beans = connection.queryNames(new ObjectName("org.exist.management." + instance + ":type=CacheManager.Cache,*"), null);
-            cols = new String[] {"Type", "CacheName", "Size", "Used", "Hits", "Fails"};
+            cols = new String[]{"Type", "CacheName", "Size", "Used", "Hits", "Fails"};
             echo("%10s %20s %10s %10s %10s %10s".formatted(cols[0], "FileName", cols[2], cols[3], cols[4], cols[5]));
             final List<Object[]> cacheRows = new ArrayList<>();
-            for (ObjectName bean : beans) {
+            for (final ObjectName bean : beans) {
                 attrs = connection.getAttributes(bean, cols);
                 cacheRows.add(getValues(attrs, cols));
             }
@@ -189,14 +346,14 @@ public class JMXClient {
                         row[4] != null ? row[4] : 0L,
                         row[5] != null ? row[5] : 0L));
             }
-            
+
             echo("");
             name = new ObjectName("org.exist.management." + instance + ":type=CollectionCache");
-            cols = new String[] { "MaxCacheSize" };
+            cols = new String[]{"MaxCacheSize"};
             attrs = connection.getAttributes(name, cols);
             values = getValues(attrs, cols);
             echo("Collection Cache: %10d k max".formatted(
-                    values[0] != null ? (Long)values[0] / 1024 : 0L));
+                    values[0] != null ? (Long) values[0] / 1024 : 0L));
         } catch (final Exception e) {
             error(e);
         }
@@ -238,7 +395,8 @@ public class JMXClient {
                     }
                 }
             }
-        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
+        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException |
+                       IOException | MalformedObjectNameException e) {
             error(e);
         }
     }
@@ -259,8 +417,9 @@ public class JMXClient {
             echo("%22s: %s".formatted("Status", status));
             echo("%22s: %s".formatted("Last check start", lastCheckStart != null ? lastCheckStart : "N/A"));
             echo("%22s: %s".formatted("Last check end", lastCheckEnd != null ? lastCheckEnd : "N/A"));
-            if (lastCheckStart != null && lastCheckEnd != null)
-                {echo("%22s: %dms".formatted("Check took", (lastCheckEnd.getTime() - lastCheckStart.getTime())));}
+            if (lastCheckStart != null && lastCheckEnd != null) {
+                echo("%22s: %dms".formatted("Check took", (lastCheckEnd.getTime() - lastCheckStart.getTime())));
+            }
 
             final CompositeData[] errors = (CompositeData[])
                     connection.getAttribute(name, "Errors");
@@ -270,7 +429,8 @@ public class JMXClient {
                     echo("%22s: %s".formatted("Description", data.get("description")));
                 }
             }
-        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
+        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException |
+                       IOException | MalformedObjectNameException e) {
             error(e);
         }
     }
@@ -287,12 +447,12 @@ public class JMXClient {
 
             TabularData table = (TabularData)
                     connection.getAttribute(name, "RunningJobs");
-            String[] cols = new String[] { "ID", "Action", "Info" };
+            String[] cols = new String[]{"ID", "Action", "Info"};
             echo("%15s %30s %30s".formatted(cols[0], cols[1], cols[2]));
             if (table.isEmpty()) {
                 echo("(none)");
             } else {
-                for (Object value : table.values()) {
+                for (final Object value : table.values()) {
                     final CompositeData row = (CompositeData) value;
                     final CompositeData data = (CompositeData) row.get("value");
                     echo("%15s %30s %30s".formatted(data.get("id"), data.get("action"), data.get("info")));
@@ -303,18 +463,19 @@ public class JMXClient {
             echo("-----------------------------------------------");
             table = (TabularData)
                     connection.getAttribute(name, "RunningQueries");
-            cols = new String[] { "ID", "Type", "Key", "Terminating" };
+            cols = new String[]{"ID", "Type", "Key", "Terminating"};
             echo("%10s %10s %30s %s".formatted(cols[0], cols[1], cols[2], cols[3]));
             if (table.isEmpty()) {
                 echo("(none)");
             } else {
-                for (Object o : table.values()) {
+                for (final Object o : table.values()) {
                     final CompositeData row = (CompositeData) o;
                     final CompositeData data = (CompositeData) row.get("value");
                     echo("%15s %15s %30s %6s".formatted(data.get("id"), data.get("sourceType"), data.get("sourceKey"), data.get("terminating")));
                 }
             }
-        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
+        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException |
+                       IOException | MalformedObjectNameException e) {
             error(e);
         }
     }
@@ -326,10 +487,10 @@ public class JMXClient {
      *                {@link MBeanServerConnection#getAttributes}
      * @return an array of attribute values in the same order as {@code attribs}
      */
-    private Object[] getValues(AttributeList attribs) {
+    private Object[] getValues(final AttributeList attribs) {
         final Object[] v = new Object[attribs.size()];
         for (int i = 0; i < attribs.size(); i++) {
-            v[i] = ((Attribute)attribs.get(i)).getValue();
+            v[i] = ((Attribute) attribs.get(i)).getValue();
         }
         return v;
     }
@@ -348,9 +509,9 @@ public class JMXClient {
      * @param cols    the attribute names whose values should be extracted,
      *                in the desired output order
      * @return an array of the same length as {@code cols} with each element
-     *         holding the corresponding attribute value, or {@code null} if absent
+     * holding the corresponding attribute value, or {@code null} if absent
      */
-    private Object[] getValues(AttributeList attribs, String[] cols) {
+    private Object[] getValues(final AttributeList attribs, final String[] cols) {
         final Map<String, Object> byName = new LinkedHashMap<>();
         for (int i = 0; i < attribs.size(); i++) {
             final Attribute a = (Attribute) attribs.get(i);
@@ -368,165 +529,22 @@ public class JMXClient {
      *
      * @param msg the message to print
      */
-    private void echo(String msg) {
+    private void echo(final String msg) {
         System.out.println(msg);
     }
-    
+
     /**
      * Writes an error message and stack trace to {@link System#err}.
      *
      * @param e the exception to report
      */
-    private void error(Exception e) {
+    private void error(final Exception e) {
         System.err.println("ERROR: " + e.getMessage());
         e.printStackTrace();
     }
 
-    private static final int DEFAULT_PORT = 1099;
-    private static final int DEFAULT_WAIT_TIME = 0;
-
-    /* general arguments */
-    private static final Argument<?> helpArg = helpArgument("-h", "--help");
-
-    /* connection arguments */
-    private static final Argument<String> addressArg = stringArgument("-a", "--address")
-            .description("RMI address of the server")
-            .defaultValue("localhost")
-            .build();
-    private static final Argument<Integer> portArg = integerArgument("-p", "--port")
-            .description("RMI port of the server")
-            .defaultValue(DEFAULT_PORT)
-            .build();
-    private static final Argument<String> instanceArg = stringArgument("-i", "--instance")
-            .description("The ID of the database instance to connect to")
-            .defaultValue("exist")
-            .build();
-    private static final Argument<Integer> waitArg = integerArgument("-w", "--wait")
-            .description("while displaying server statistics: keep retrieving statistics, but wait the specified number of seconds between calls.")
-            .defaultValue(DEFAULT_WAIT_TIME)
-            .build();
-
-    /* display mode options */
-    private static final Argument<Boolean> cacheDisplayArg = optionArgument("-c", "--cache")
-            .description("displays server statistics on cache and memory usage.")
-            .defaultValue(false)
-            .build();
-    private static final Argument<Boolean> locksDisplayArg = optionArgument("-l", "--locks")
-            .description("lock manager: display locking information on all threads currently waiting for a lock on a resource or collection. Useful to debug deadlocks. During normal operation, the list will usually be empty (means: no blocked threads).")
-            .defaultValue(false)
-            .build();
-
-    /* display info options */
-    private static final Argument<Boolean> dbInfoArg = optionArgument("-d", "--db")
-            .description("display general info about the db instance.")
-            .defaultValue(false)
-            .build();
-    private static final Argument<Boolean> memoryInfoArg = optionArgument("-m", "--memory")
-            .description("display info on free and total memory. Can be combined with other parameters.")
-            .defaultValue(false)
-            .build();
-    private static final Argument<Boolean> sanityCheckInfoArg = optionArgument("-s", "--report")
-            .description("retrieve sanity check report from the db")
-            .defaultValue(false)
-            .build();
-    private static final Argument<Boolean> jobsInfoArg = optionArgument("-j", "--jobs")
-            .description("retrieve sanity check report from the db")
-            .defaultValue(false)
-            .build();
-
     private enum Mode {
         STATS,
         LOCKS
-    }
-
-    /**
-     * Entry point for the {@code jmxclient.sh} command.
-     * Parses command-line arguments and delegates to {@link #process(ParsedArguments)}.
-     *
-     * @param args command-line arguments
-     */
-    @SuppressWarnings("unchecked")
-	public static void main(final String[] args) {
-        try {
-            CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
-
-            final ParsedArguments arguments = CommandLineParser
-                    .withArguments(addressArg, portArg, instanceArg, waitArg)
-                    .andArguments(cacheDisplayArg, locksDisplayArg)
-                    .andArguments(dbInfoArg, memoryInfoArg, sanityCheckInfoArg, jobsInfoArg)
-                    .andArguments(helpArg)
-                    .programName("jmxclient" + (OSUtil.isWindows() ? ".bat" : ".sh"))
-                    .parse(args);
-
-            process(arguments);
-        } catch (final StartException e) {
-            if (e.getMessage() != null && !e.getMessage().isEmpty()) {
-                System.err.println(e.getMessage());
-            }
-            System.exit(e.getErrorCode());
-        } catch (final ArgumentException e) {
-            System.out.println(e.getMessageAndUsage());
-            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
-        }
-
-    }
-
-    /**
-     * Processes parsed command-line arguments: connects to the JMX server and
-     * repeatedly prints the requested statistics until the optional wait interval
-     * expires or a single pass completes.
-     *
-     * @param arguments the parsed command-line arguments
-     */
-    private static void process(final ParsedArguments arguments) {
-        final String address = arguments.get(addressArg);
-        final int port = Optional.ofNullable(arguments.get(portArg)).orElse(DEFAULT_PORT);
-        final String dbInstance = arguments.get(instanceArg);
-        final long waitTime = Optional.ofNullable(arguments.get(waitArg)).orElse(DEFAULT_WAIT_TIME);
-
-        Mode mode = Mode.STATS;
-        if(getBool(arguments, cacheDisplayArg)) {
-            mode = Mode.STATS;
-        }
-        if(getBool(arguments, locksDisplayArg)) {
-            mode = Mode.LOCKS;
-        }
-
-        final boolean displayInstance = getBool(arguments, dbInfoArg);
-        final boolean displayMem = getBool(arguments, memoryInfoArg);
-        final boolean displayReport = getBool(arguments, sanityCheckInfoArg);
-        final boolean jobReport = getBool(arguments, jobsInfoArg);
-
-        try {
-            final JMXClient stats = new JMXClient(dbInstance);
-            stats.connect(address,port);
-            stats.memoryStats();
-            while (true) {
-                switch (mode) {
-                    case STATS :
-                        stats.cacheStats();
-                        break;
-                    case LOCKS :
-                        stats.lockTable();
-                        break;
-                }
-                if (displayInstance) {stats.instanceStats();}
-                if (displayMem) {stats.memoryStats();}
-                if (displayReport) {stats.sanityReport();}
-                if (jobReport) {stats.jobReport();}
-                if (waitTime > 0) {
-                    synchronized (stats) {
-                        try {
-                            stats.wait(waitTime);
-                        } catch (final InterruptedException e) {
-                            System.err.println("INTERRUPTED: " + e.getMessage());
-                        }
-                    }
-                } else
-                    {return;}
-            }
-        } catch (final IOException e) {
-            e.printStackTrace(); 
-        } 
     }
 }

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -282,9 +282,14 @@ public class JMXClient {
                     connection.getAttribute(name, "RunningJobs");
             String[] cols = new String[] { "ID", "Action", "Info" };
             echo("%15s %30s %30s".formatted(cols[0], cols[1], cols[2]));
-            for (Object value : table.values()) {
-                final CompositeData data = (CompositeData) value;
-                echo("%15s %30s %30s".formatted(data.get("id"), data.get("action"), data.get("info")));
+            if (table.isEmpty()) {
+                echo("(none)");
+            } else {
+                for (Object value : table.values()) {
+                    final CompositeData row = (CompositeData) value;
+                    final CompositeData data = (CompositeData) row.get("value");
+                    echo("%15s %30s %30s".formatted(data.get("id"), data.get("action"), data.get("info")));
+                }
             }
 
             echo("\nRunning queries");
@@ -293,9 +298,14 @@ public class JMXClient {
                     connection.getAttribute(name, "RunningQueries");
             cols = new String[] { "ID", "Type", "Key", "Terminating" };
             echo("%10s %10s %30s %s".formatted(cols[0], cols[1], cols[2], cols[3]));
-            for (Object o : table.values()) {
-                final CompositeData data = (CompositeData) o;
-                echo("%15s %15s %30s %6s".formatted(data.get("id"), data.get("sourceType"), data.get("sourceKey"), data.get("terminating")));
+            if (table.isEmpty()) {
+                echo("(none)");
+            } else {
+                for (Object o : table.values()) {
+                    final CompositeData row = (CompositeData) o;
+                    final CompositeData data = (CompositeData) row.get("value");
+                    echo("%15s %15s %30s %6s".formatted(data.get("id"), data.get("sourceType"), data.get("sourceKey"), data.get("terminating")));
+                }
             }
         } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
             error(e);

--- a/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
@@ -21,26 +21,11 @@
  */
 package org.exist.management.client;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.net.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Predicate;
-import javax.management.*;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.TransformerException;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,6 +33,29 @@ import org.exist.storage.BrokerPool;
 import org.exist.util.UUIDGenerator;
 import org.exist.util.serializer.DOMSerializer;
 import org.w3c.dom.Element;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A servlet to monitor the database. It returns status information for the database based on the JMX interface. For
@@ -69,6 +77,7 @@ import org.w3c.dom.Element;
  * If the ping takes longer than the timeout, you'll instead find an element &lt;jmx:error&gt; in the returned XML. In
  * this case, additional information on running queries, memory consumption and database locks will be provided.
  * <p>
+ *
  * @author wolf
  */
 public class JMXServlet extends HttpServlet {
@@ -86,9 +95,8 @@ public class JMXServlet extends HttpServlet {
         defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
     }
 
-    private JMXtoXML client;
     private final Set<String> localhostAddresses = new HashSet<>();
-
+    private JMXtoXML client;
     private Path dataDir;
     private Path tokenFile;
 
@@ -149,7 +157,8 @@ public class JMXServlet extends HttpServlet {
                 }
             } catch (final InstanceNotFoundException e) {
                 throw new ServletException("mbean " + mbean + " not found: " + e.getMessage(), e);
-            } catch (final MalformedObjectNameException | IntrospectionException | ReflectionException | MBeanException e) {
+            } catch (final MalformedObjectNameException | IntrospectionException | ReflectionException |
+                           MBeanException e) {
                 throw new ServletException(e.getMessage(), e);
             }
         } else {

--- a/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
@@ -21,20 +21,42 @@
  */
 package org.exist.management.client;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.management.ManagementFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exist.management.Cache;
+import org.exist.management.CacheManager;
+import org.exist.management.impl.BinaryValues;
+import org.exist.management.impl.CollectionCache;
+import org.exist.management.impl.Database;
+import org.exist.management.impl.DiskUsage;
+import org.exist.management.impl.LockTable;
+import org.exist.management.impl.ProcessReport;
+import org.exist.management.impl.SanityReport;
+import org.exist.management.impl.SystemInfo;
+import org.exist.start.CompatibleJavaVersionCheck;
+import org.exist.start.StartException;
+import org.exist.util.NamedThreadFactory;
+import org.exist.util.serializer.DOMSerializer;
+import org.exist.xquery.Expression;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 
-import static java.lang.management.ManagementFactory.CLASS_LOADING_MXBEAN_NAME;
-import static java.lang.management.ManagementFactory.MEMORY_MXBEAN_NAME;
-import static java.lang.management.ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME;
-import static java.lang.management.ManagementFactory.RUNTIME_MXBEAN_NAME;
-import static java.lang.management.ManagementFactory.THREAD_MXBEAN_NAME;
-
-import java.net.MalformedURLException;
-import java.util.*;
-import java.util.concurrent.*;
-import javax.management.*;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.TabularData;
@@ -44,21 +66,30 @@ import javax.management.remote.JMXServiceURL;
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.exist.dom.QName;
-import org.exist.management.Cache;
-import org.exist.management.CacheManager;
-import org.exist.management.impl.*;
-import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.start.CompatibleJavaVersionCheck;
-import org.exist.start.StartException;
-import org.exist.util.NamedThreadFactory;
-import org.exist.util.serializer.DOMSerializer;
-import org.exist.xquery.Expression;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
+import static java.lang.management.ManagementFactory.CLASS_LOADING_MXBEAN_NAME;
+import static java.lang.management.ManagementFactory.MEMORY_MXBEAN_NAME;
+import static java.lang.management.ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME;
+import static java.lang.management.ManagementFactory.RUNTIME_MXBEAN_NAME;
+import static java.lang.management.ManagementFactory.THREAD_MXBEAN_NAME;
 
 /**
  * Utility class to output database status information from eXist's JMX interface as XML.
@@ -67,22 +98,21 @@ import org.xml.sax.SAXException;
  */
 public class JMXtoXML {
 
+    public static final String JMX_NAMESPACE = "http://exist-db.org/jmx";
+    public static final String JMX_PREFIX = "jmx";
+    public static final long PING_TIMEOUT = -99;
+    public static final int VERSION = 1;
     private final static Logger LOG = LogManager.getLogger(JMXtoXML.class);
-
     private final static Map<String, ObjectName[]> CATEGORIES = new TreeMap<>();
+    private static final Properties defaultProperties = new Properties();
+    private static final QName ROW_ELEMENT = new QName("row", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName JMX_ELEMENT = new QName("jmx", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName JMX_RESULT = new QName("result", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName JMX_RESULT_TYPE_ATTR = new QName("class", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName JMX_CONNECTION_ATTR = new QName("connection", XMLConstants.NULL_NS_URI);
+    private static final QName JMX_ERROR = new QName("error", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName VERSION_ATTR = new QName("version", XMLConstants.NULL_NS_URI);
 
-    private static void putCategory(final String categoryName, final String... objectNames) {
-        final ObjectName[] aryObjectNames = new ObjectName[objectNames.length];
-        try {
-            for (int i = 0; i < aryObjectNames.length; i++) {
-                aryObjectNames[i] = new ObjectName(objectNames[i]);
-            }
-        } catch (final MalformedObjectNameException | NullPointerException e) {
-            LOG.warn("Error in initialization: {}", e.getMessage(), e);
-        }
-
-        CATEGORIES.put(categoryName, aryObjectNames);
-    }
     static {
         // Java
         putCategory("memory", MEMORY_MXBEAN_NAME);
@@ -115,31 +145,49 @@ public class JMXtoXML {
         putCategory("all", "org.exist.*:*", "java.lang:*");
     }
 
-    private static final Properties defaultProperties = new Properties();
-
     static {
         defaultProperties.setProperty(OutputKeys.INDENT, "yes");
         defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
     }
 
-    public static final String JMX_NAMESPACE = "http://exist-db.org/jmx";
-    public static final String JMX_PREFIX = "jmx";
-
-    private static final QName ROW_ELEMENT = new QName("row", JMX_NAMESPACE, JMX_PREFIX);
-    private static final QName JMX_ELEMENT = new QName("jmx", JMX_NAMESPACE, JMX_PREFIX);
-    private static final QName JMX_RESULT = new QName("result", JMX_NAMESPACE, JMX_PREFIX);
-    private static final QName JMX_RESULT_TYPE_ATTR = new QName("class", JMX_NAMESPACE, JMX_PREFIX);
-    private static final QName JMX_CONNECTION_ATTR = new QName("connection", XMLConstants.NULL_NS_URI);
-    private static final QName JMX_ERROR = new QName("error", JMX_NAMESPACE, JMX_PREFIX);
-    private static final QName VERSION_ATTR = new QName("version", XMLConstants.NULL_NS_URI);
-
-    public static final long PING_TIMEOUT = -99;
-
-    public static final int VERSION = 1;
-
     private final MBeanServerConnection platformConnection = ManagementFactory.getPlatformMBeanServer();
     private MBeanServerConnection connection;
     private JMXServiceURL url;
+
+    private static void putCategory(final String categoryName, final String... objectNames) {
+        final ObjectName[] aryObjectNames = new ObjectName[objectNames.length];
+        try {
+            for (int i = 0; i < aryObjectNames.length; i++) {
+                aryObjectNames[i] = new ObjectName(objectNames[i]);
+            }
+        } catch (final MalformedObjectNameException | NullPointerException e) {
+            LOG.warn("Error in initialization: {}", e.getMessage(), e);
+        }
+
+        CATEGORIES.put(categoryName, aryObjectNames);
+    }
+
+    /**
+     * @param args program arguments
+     */
+    public static void main(final String[] args) {
+        try {
+            CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+        } catch (final StartException e) {
+            if (e.getMessage() != null && !e.getMessage().isEmpty()) {
+                System.err.println(e.getMessage());
+            }
+            System.exit(e.getErrorCode());
+        }
+
+        final JMXtoXML client = new JMXtoXML();
+        try {
+            client.connect("localhost", 1099);
+            System.out.println(client.generateReport(args));
+        } catch (final IOException | TransformerException e) {
+            e.printStackTrace();
+        }
+    }
 
     /**
      * Connect to the local JMX instance.
@@ -178,10 +226,10 @@ public class JMXtoXML {
      * "instances", "disk", "system", "caches", "locking", "processes", "sanity", "all".
      *
      * @param categories array of categories to include in the report
-     * @throws TransformerException in case of serialization errors
      * @return string containing an XML report
+     * @throws TransformerException in case of serialization errors
      */
-    public String generateReport(final String categories[]) throws TransformerException {
+    public String generateReport(final String[] categories) throws TransformerException {
         final Element root = generateXMLReport(null, categories);
         final StringWriter writer = new StringWriter();
         final DOMSerializer streamer = new DOMSerializer(writer, defaultProperties);
@@ -223,27 +271,6 @@ public class JMXtoXML {
         }
     }
 
-    private static class Ping implements Callable<Long> {
-        private final String instance;
-        private final MBeanServerConnection connection;
-
-        public Ping(final String instance, final MBeanServerConnection connection) {
-            this.instance = instance;
-            this.connection = connection;
-        }
-
-        @Override
-        public Long call() {
-            try {
-                final ObjectName name = SanityReport.getName(instance);
-                return (Long) connection.invoke(name, "ping", new Object[]{Boolean.TRUE}, new String[]{boolean.class.getName()});
-            } catch (final Exception e) {
-                LOG.warn(e.getMessage(), e);
-                return (long) SanityReport.PING_ERROR;
-            }
-        }
-    }
-
     /**
      * Retrieve JMX output for the given categories and return it as an XML DOM. Valid categories are "memory",
      * "instances", "disk", "system", "caches", "locking", "processes", "sanity", "all".
@@ -252,7 +279,7 @@ public class JMXtoXML {
      * @param categories the categories to generate the report for
      * @return xml report
      */
-    public Element generateXMLReport(final String errcode, final String categories[]) {
+    public Element generateXMLReport(final String errcode, final String[] categories) {
         final MemTreeBuilder builder = new MemTreeBuilder((Expression) null);
 
         try {
@@ -292,18 +319,19 @@ public class JMXtoXML {
         try {
             final Object dir = connection.getAttribute(new ObjectName("org.exist.management.exist:type=DiskUsage"), "DataDirectory");
             return dir == null ? null : dir.toString();
-        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException | IOException | MalformedObjectNameException e) {
+        } catch (final MBeanException | AttributeNotFoundException | InstanceNotFoundException | ReflectionException |
+                       IOException | MalformedObjectNameException e) {
             return null;
         }
     }
 
-    public Element invoke(final String objectName, final String operation, String[] args) throws InstanceNotFoundException, MalformedObjectNameException, MBeanException, IOException, ReflectionException, IntrospectionException {
+    public Element invoke(final String objectName, final String operation, final String[] args) throws InstanceNotFoundException, MalformedObjectNameException, MBeanException, IOException, ReflectionException, IntrospectionException {
         final ObjectName name = new ObjectName(objectName);
         MBeanServerConnection conn = connection;
         MBeanInfo info;
         try {
             info = conn.getMBeanInfo(name);
-        } catch (InstanceNotFoundException e) {
+        } catch (final InstanceNotFoundException e) {
             conn = platformConnection;
             info = conn.getMBeanInfo(name);
         }
@@ -314,7 +342,7 @@ public class JMXtoXML {
                 final Object[] params = new Object[sig.length];
                 final String[] types = new String[sig.length];
                 for (int i = 0; i < sig.length; i++) {
-                    String type = sig[i].getType();
+                    final String type = sig[i].getType();
                     types[i] = type;
                     params[i] = mapParameter(type, args[i]);
                 }
@@ -375,7 +403,7 @@ public class JMXtoXML {
             builder.addAttribute(new QName("name", XMLConstants.NULL_NS_URI), name.toString());
 
             final MBeanAttributeInfo[] beanAttribs = info.getAttributes();
-            for (MBeanAttributeInfo beanAttrib : beanAttribs) {
+            for (final MBeanAttributeInfo beanAttrib : beanAttribs) {
                 if (beanAttrib.isReadable()) {
                     try {
                         final QName attrQName = new QName(beanAttrib.getName(), JMX_NAMESPACE, JMX_PREFIX);
@@ -396,12 +424,11 @@ public class JMXtoXML {
     private void serializeObject(final MemTreeBuilder builder, final Object object) throws SAXException {
         switch (object) {
             case null -> {
-                return;
             }
-            case TabularData tabularData -> serialize(builder, tabularData);
-            case CompositeData[] compositeData -> serialize(builder, compositeData);
-            case CompositeData compositeData -> serialize(builder, compositeData);
-            case Object[] objects -> serialize(builder, objects);
+            case final TabularData tabularData -> serialize(builder, tabularData);
+            case final CompositeData[] compositeData -> serialize(builder, compositeData);
+            case final CompositeData compositeData -> serialize(builder, compositeData);
+            case final Object[] objects -> serialize(builder, objects);
             default -> builder.characters(object.toString());
         }
 
@@ -458,25 +485,17 @@ public class JMXtoXML {
         };
     }
 
-    /**
-     * @param args program arguments
-     */
-    public static void main(final String[] args) {
-        try {
-            CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
-        } catch (final StartException e) {
-            if (e.getMessage() != null && !e.getMessage().isEmpty()) {
-                System.err.println(e.getMessage());
-            }
-            System.exit(e.getErrorCode());
-        }
+    private record Ping(String instance, MBeanServerConnection connection) implements Callable<Long> {
 
-        final JMXtoXML client = new JMXtoXML();
-        try {
-            client.connect("localhost", 1099);
-            System.out.println(client.generateReport(args));
-        } catch (final IOException | TransformerException e) {
-            e.printStackTrace();
+        @Override
+            public Long call() {
+                try {
+                    final ObjectName name = SanityReport.getName(instance);
+                    return (Long) connection.invoke(name, "ping", new Object[]{Boolean.TRUE}, new String[]{boolean.class.getName()});
+                } catch (final Exception e) {
+                    LOG.warn(e.getMessage(), e);
+                    return (long) SanityReport.PING_ERROR;
+                }
+            }
         }
-    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/ActiveBroker.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ActiveBroker.java
@@ -25,34 +25,6 @@ package org.exist.management.impl;
 /**
  * Owner and process information on a broker.
  */
-public class ActiveBroker {
+public record ActiveBroker(String owner, int referenceCount, String stack, String stackAcquired) {
 
-    private final String owner;
-    private final int referenceCount;
-    private final String stack;
-    private final String stackAcquired;
-
-    public ActiveBroker(final String owner, final int referenceCount, final String stack, final String stackAcquired) {
-
-        this.owner = owner;
-        this.referenceCount = referenceCount;
-        this.stack = stack;
-        this.stackAcquired = stackAcquired;
-    }
-
-    public String getOwner() {
-        return owner;
-    }
-
-    public int getReferenceCount() {
-        return referenceCount;
-    }
-
-    public String getStack() {
-        return stack;
-    }
-
-    public String getStackAcquired() {
-        return stackAcquired;
-    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryInputStreamCacheInfo.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryInputStreamCacheInfo.java
@@ -38,7 +38,7 @@ public class BinaryInputStreamCacheInfo {
     private final long size;
 
     public BinaryInputStreamCacheInfo(final CacheType cacheType, final long created, final Optional<Path> file,
-            final long size) {
+                                      final long size) {
         this.created = created;
         this.cacheType = cacheType;
         this.file = file;

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 
 public record BinaryValues(String instanceId) implements BinaryValuesMXBean {
     public BinaryValues(final BrokerPool instanceId) {
-        this.instanceId = instanceId.getId();
+        this(instanceId.getId());
     }
 
     public static String getAllInstancesQuery() {

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
@@ -36,11 +36,25 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * JMX MBean exposing information about active binary value input-stream caches
+ * for a specific database instance.
+ */
 public record BinaryValues(String instanceId) implements BinaryValuesMXBean {
+    /**
+     * Create a new BinaryValues MBean for the given broker pool.
+     *
+     * @param instanceId the broker pool representing the database instance
+     */
     public BinaryValues(final BrokerPool instanceId) {
         this(instanceId.getId());
     }
 
+    /**
+     * Return a JMX object-name query that matches all BinaryValues MBeans across all instances.
+     *
+     * @return the wildcard query string
+     */
     public static String getAllInstancesQuery() {
         return getName("*");
     }
@@ -73,7 +87,7 @@ public record BinaryValues(String instanceId) implements BinaryValuesMXBean {
                                 Optional.of(streamCache.getFilePath()), cache.getLength());
                 case null, default ->
                         result = new BinaryInputStreamCacheInfo(CacheType.MEMORY, cacheInstance.getRegistered(),
-                                Optional.empty(), cache.getLength());
+                                Optional.empty(), cache.getLength()); // DW: This might be a null cache
             }
 
             results.add(result);

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
@@ -21,13 +21,13 @@
  */
 package org.exist.management.impl;
 
+import org.exist.management.impl.BinaryInputStreamCacheInfo.CacheType;
 import org.exist.storage.BrokerPool;
 import org.exist.util.io.FileFilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCacheMonitor;
 import org.exist.util.io.FilterInputStreamCacheMonitor.FilterInputStreamCacheInfo;
 import org.exist.util.io.MemoryMappedFileFilterInputStreamCache;
-import org.exist.management.impl.BinaryInputStreamCacheInfo.CacheType;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -36,11 +36,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public class BinaryValues implements BinaryValuesMXBean {
-    private final String instanceId;
-
-    public BinaryValues(final BrokerPool pool) {
-        this.instanceId = pool.getId();
+public record BinaryValues(String instanceId) implements BinaryValuesMXBean {
+    public BinaryValues(final BrokerPool instanceId) {
+        this.instanceId = instanceId.getId();
     }
 
     public static String getAllInstancesQuery() {
@@ -57,11 +55,6 @@ public class BinaryValues implements BinaryValuesMXBean {
     }
 
     @Override
-    public String getInstanceId() {
-        return instanceId;
-    }
-
-    @Override
     public List<BinaryInputStreamCacheInfo> getCacheInstances() {
         final FilterInputStreamCacheMonitor monitor = FilterInputStreamCacheMonitor.getInstance();
         final Collection<FilterInputStreamCacheInfo> cacheInstances = monitor.getActive();
@@ -72,12 +65,15 @@ public class BinaryValues implements BinaryValuesMXBean {
             final BinaryInputStreamCacheInfo result;
             final FilterInputStreamCache cache = cacheInstance.getCache();
             switch (cache) {
-                case FileFilterInputStreamCache streamCache1 -> result = new BinaryInputStreamCacheInfo(CacheType.FILE, cacheInstance.getRegistered(),
-                        Optional.of(streamCache1.getFilePath()), cache.getLength());
-                case MemoryMappedFileFilterInputStreamCache streamCache -> result = new BinaryInputStreamCacheInfo(CacheType.MEMORY_MAPPED_FILE, cacheInstance.getRegistered(),
-                        Optional.of(streamCache.getFilePath()), cache.getLength());
-                case null, default -> result = new BinaryInputStreamCacheInfo(CacheType.MEMORY, cacheInstance.getRegistered(),
-                        Optional.empty(), cache.getLength());
+                case final FileFilterInputStreamCache streamCache1 ->
+                        result = new BinaryInputStreamCacheInfo(CacheType.FILE, cacheInstance.getRegistered(),
+                                Optional.of(streamCache1.getFilePath()), cache.getLength());
+                case final MemoryMappedFileFilterInputStreamCache streamCache ->
+                        result = new BinaryInputStreamCacheInfo(CacheType.MEMORY_MAPPED_FILE, cacheInstance.getRegistered(),
+                                Optional.of(streamCache.getFilePath()), cache.getLength());
+                case null, default ->
+                        result = new BinaryInputStreamCacheInfo(CacheType.MEMORY, cacheInstance.getRegistered(),
+                                Optional.empty(), cache.getLength());
             }
 
             results.add(result);

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryValuesMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryValuesMXBean.java
@@ -24,6 +24,14 @@ package org.exist.management.impl;
 
 import java.util.List;
 
+/**
+ * JMX MXBean interface for monitoring active binary value input-stream caches.
+ */
 public interface BinaryValuesMXBean extends PerInstanceMBean {
+    /**
+     * Get information about all currently active binary input-stream cache instances.
+     *
+     * @return list of cache instance information
+     */
     List<BinaryInputStreamCacheInfo> getCacheInstances();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
+++ b/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
@@ -59,6 +59,11 @@ public class CollectionCache implements CollectionCacheMXBean {
     }
 
     @Override
+    public long getMaxCacheSize() {
+        return instance.getCollectionsCache().getMaxCacheSize();
+    }
+
+    @Override
     public org.exist.collections.CollectionCache.Statistics getStatistics() {
         return instance.getCollectionsCache().getStatistics();
     }

--- a/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
+++ b/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
@@ -54,7 +54,7 @@ public class CollectionCache implements CollectionCacheMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return instance.getId();
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/CollectionCacheMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/CollectionCacheMXBean.java
@@ -32,6 +32,13 @@ import org.exist.collections.CollectionCache;
 public interface CollectionCacheMXBean extends PerInstanceMBean {
 
     /**
+     * Get the maximum size of the Collection Cache in bytes.
+     *
+     * @return maximum size of the Collection Cache in bytes
+     */
+    long getMaxCacheSize();
+
+    /**
      * Get a statistics snapshot of the Collection Cache
      *
      * @return Statistics for the Collection Cache

--- a/exist-core/src/main/java/org/exist/management/impl/Database.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Database.java
@@ -21,15 +21,15 @@
  */
 package org.exist.management.impl;
 
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-
-import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
 
 public class Database implements DatabaseMXBean {
 
@@ -53,7 +53,7 @@ public class Database implements DatabaseMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return pool.getId();
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/Database.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Database.java
@@ -31,14 +31,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * JMX MBean exposing runtime information about a database instance
+ * (broker pool status, memory usage, uptime, etc.).
+ */
 public class Database implements DatabaseMXBean {
 
     private final BrokerPool pool;
 
+    /**
+     * Create a new Database MBean wrapper.
+     *
+     * @param pool the broker pool representing the database instance
+     */
     public Database(final BrokerPool pool) {
         this.pool = pool;
     }
 
+    /**
+     * Return a JMX object-name query that matches all Database MBeans across all instances.
+     *
+     * @return the wildcard query string
+     */
     public static String getAllInstancesQuery() {
         return getName("*");
     }
@@ -126,6 +140,12 @@ public class Database implements DatabaseMXBean {
         return pool.getConfiguration().getExistHome().map(p -> p.toAbsolutePath().toString()).orElse(null);
     }
 
+    /**
+     * Produce a partial stack trace (up to 20 frames) for the given thread.
+     *
+     * @param thread the thread whose stack trace should be captured
+     * @return a string containing the stack trace frames
+     */
     public String printStackTrace(final Thread thread) {
         final StackTraceElement[] stackElements = thread.getStackTrace();
         final StringWriter writer = new StringWriter();

--- a/exist-core/src/main/java/org/exist/management/impl/DatabaseMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/DatabaseMXBean.java
@@ -36,7 +36,7 @@ public interface DatabaseMXBean extends PerInstanceMBean {
     int getActiveBrokers();
 
     int getTotalBrokers();
-    
+
     long getReservedMem();
 
     long getCacheMem();
@@ -45,7 +45,7 @@ public interface DatabaseMXBean extends PerInstanceMBean {
 
     List<ActiveBroker> getActiveBrokersMap();
 
-    public long getUptime();
+    long getUptime();
 
-    public String getExistHome();
+    String getExistHome();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/DatabaseMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/DatabaseMXBean.java
@@ -23,29 +23,90 @@ package org.exist.management.impl;
 
 import java.util.List;
 
+/**
+ * JMX MXBean interface exposing runtime information about a database instance.
+ */
 public interface DatabaseMXBean extends PerInstanceMBean {
 
+    /**
+     * Get the current status of the database.
+     *
+     * @return a string describing the database status
+     */
     String getStatus();
 
+    /**
+     * Initiate a graceful shutdown of the database instance.
+     */
     void shutdown();
 
+    /**
+     * Get the maximum number of brokers that may be active simultaneously.
+     *
+     * @return maximum broker count
+     */
     int getMaxBrokers();
 
+    /**
+     * Get the number of brokers currently available (not in use).
+     *
+     * @return available broker count
+     */
     int getAvailableBrokers();
 
+    /**
+     * Get the number of brokers currently in active use.
+     *
+     * @return active broker count
+     */
     int getActiveBrokers();
 
+    /**
+     * Get the total number of brokers that have been created.
+     *
+     * @return total broker count
+     */
     int getTotalBrokers();
 
+    /**
+     * Get the amount of memory (in bytes) reserved for the database.
+     *
+     * @return reserved memory in bytes
+     */
     long getReservedMem();
 
+    /**
+     * Get the total memory (in bytes) currently used by all page caches.
+     *
+     * @return cache memory in bytes
+     */
     long getCacheMem();
 
+    /**
+     * Get the maximum memory (in bytes) allocated to the collection cache.
+     *
+     * @return collection cache memory in bytes
+     */
     long getCollectionCacheMem();
 
+    /**
+     * Get details of all currently active brokers.
+     *
+     * @return list of active broker information
+     */
     List<ActiveBroker> getActiveBrokersMap();
 
+    /**
+     * Get the time (in milliseconds) that the database has been running.
+     *
+     * @return uptime in milliseconds
+     */
     long getUptime();
 
+    /**
+     * Get the absolute path of the eXist-db home directory.
+     *
+     * @return the eXist home path, or {@code null} if not configured
+     */
     String getExistHome();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/DiskUsage.java
+++ b/exist-core/src/main/java/org/exist/management/impl/DiskUsage.java
@@ -21,23 +21,22 @@
  */
 package org.exist.management.impl;
 
-import java.io.IOException;
-import java.nio.file.FileStore;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.stream.Stream;
-
+import com.evolvedbinary.j8fu.function.FunctionE;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.journal.Journal;
 import org.exist.util.Configuration;
 import org.exist.util.FileUtils;
-import com.evolvedbinary.j8fu.function.FunctionE;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Class DiskUsage. Retrieves data from the java File object
@@ -78,7 +77,7 @@ public class DiskUsage implements DiskUsageMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/DiskUsageMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/DiskUsageMXBean.java
@@ -39,21 +39,66 @@ public interface DiskUsageMXBean extends PerInstanceMBean {
      */
     String NOT_CONFIGURED = "NOT_CONFIGURED";
 
+    /**
+     * Get the absolute path of the data directory.
+     *
+     * @return the data directory path, or {@link #NOT_CONFIGURED} if not set
+     */
     String getDataDirectory();
 
+    /**
+     * Get the usable space (in bytes) on the file store containing the data directory.
+     *
+     * @return usable space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getDataDirectoryUsableSpace();
 
+    /**
+     * Get the total space (in bytes) on the file store containing the data directory.
+     *
+     * @return total space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getDataDirectoryTotalSpace();
 
+    /**
+     * Get the space (in bytes) used by database data files in the data directory.
+     *
+     * @return used space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getDataDirectoryUsedSpace();
 
+    /**
+     * Get the absolute path of the journal directory.
+     *
+     * @return the journal directory path, or {@link #NOT_CONFIGURED} if not set
+     */
     String getJournalDirectory();
 
+    /**
+     * Get the usable space (in bytes) on the file store containing the journal directory.
+     *
+     * @return usable space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getJournalDirectoryUsableSpace();
 
+    /**
+     * Get the total space (in bytes) on the file store containing the journal directory.
+     *
+     * @return total space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getJournalDirectoryTotalSpace();
 
+    /**
+     * Get the space (in bytes) used by journal files in the journal directory.
+     *
+     * @return used space in bytes, or {@link #NO_VALUE} if unavailable
+     */
     long getJournalDirectoryUsedSpace();
 
+    /**
+     * Get the number of journal files present in the journal directory.
+     *
+     * @return journal file count, or {@link #NO_VALUE} if unavailable
+     */
     long getJournalDirectoryNumberOfFiles();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/Error.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Error.java
@@ -25,22 +25,6 @@ package org.exist.management.impl;
 /**
  * Represents a sanity check error
  */
-public class Error {
+public record Error(String errcode, String description) {
 
-    private final String errcode;
-    private final String description;
-
-    public Error(final String errcode, final String description) {
-
-        this.errcode = errcode;
-        this.description = description;
-    }
-
-    public String getErrcode() {
-        return errcode;
-    }
-
-    public String getDescription() {
-        return description;
-    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/ExistMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ExistMBean.java
@@ -33,7 +33,6 @@ public interface ExistMBean {
      * Get the name of the MBean.
      *
      * @return the name of the mbean.
-     *
      * @throws MalformedObjectNameException if the name cannot be constructed.
      */
     ObjectName getName() throws MalformedObjectNameException;

--- a/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
+++ b/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
@@ -36,12 +36,18 @@ import javax.management.MBeanServerFactory;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Real implementation of interface {@link org.exist.management.Agent}
  * which registers MBeans with the MBeanServer.
- *
+ * <p>
  * Note that the agent will be constructed via reflection by the
  * {@link org.exist.management.AgentFactory}
  */
@@ -93,7 +99,7 @@ public final class JMXAgent implements Agent {
             try {
                 addMBean(perInstanceMBean);
             } catch (final DatabaseConfigurationException e) {
-                LOG.warn("Exception while registering JMX MBean: {}, for database: {}.", 
+                LOG.warn("Exception while registering JMX MBean: {}, for database: {}.",
                         perInstanceMBean.getClass().getName(), instance.getId(), e);
             }
         }
@@ -116,8 +122,8 @@ public final class JMXAgent implements Agent {
     public synchronized void addMBean(final PerInstanceMBean mbean) throws DatabaseConfigurationException {
         try {
             addMBean(mbean.getName(), mbean);
-            if (mbean.getInstanceId() != null) {
-                Deque<ObjectName> stack = registeredMBeans.computeIfAbsent(mbean.getInstanceId(), k -> new ArrayDeque<>());
+            if (mbean.instanceId() != null) {
+                final Deque<ObjectName> stack = registeredMBeans.computeIfAbsent(mbean.instanceId(), k -> new ArrayDeque<>());
                 stack.push(mbean.getName());
             }
             beanInstances.put(mbean.getName(), mbean);
@@ -144,7 +150,7 @@ public final class JMXAgent implements Agent {
             if (server.isRegistered(name)) {
                 server.unregisterMBean(name);
             }
-        } catch (final InstanceNotFoundException | MBeanRegistrationException  e) {
+        } catch (final InstanceNotFoundException | MBeanRegistrationException e) {
             LOG.warn("Problem unregistering mbean: {}", e.getMessage(), e);
         }
     }

--- a/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
+++ b/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
@@ -108,6 +108,9 @@ public final class JMXAgent implements Agent {
     @Override
     public synchronized void closeDBInstance(final BrokerPool instance) {
         final Deque<ObjectName> stack = registeredMBeans.get(instance.getId());
+        if (stack == null) {
+            return;
+        }
         while (!stack.isEmpty()) {
             final ObjectName on = stack.pop();
             if (LOG.isDebugEnabled()) {

--- a/exist-core/src/main/java/org/exist/management/impl/Job.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Job.java
@@ -25,27 +25,6 @@ package org.exist.management.impl;
 /**
  * Detail information on a job.
  */
-public class Job {
+public record Job(String id, String action, String info) {
 
-    private final String id;
-    private final String action;
-    private final String info;
-
-    public Job(final String id, final String action, final String info) {
-        this.id = id;
-        this.action = action;
-        this.info = info;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getAction() {
-        return action;
-    }
-
-    public String getInfo() {
-        return info;
-    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/Lock.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Lock.java
@@ -37,6 +37,12 @@ public class Lock {
     private final String[] waitingForRead;
     private final String[] waitingForWrite;
 
+    /**
+     * Create a Lock snapshot from the given waiting thread name and lock info.
+     *
+     * @param waitingThread the name of the thread waiting to acquire the lock
+     * @param info          the lock information
+     */
     public Lock(final String waitingThread, final LockInfo info) {
 
         this.waitingThread = waitingThread;
@@ -48,30 +54,65 @@ public class Lock {
         this.waitingForWrite = info.getWaitingForWrite();
     }
 
+    /**
+     * Get the name of the thread waiting to acquire the lock.
+     *
+     * @return the waiting thread name
+     */
     public String getWaitingThread() {
         return waitingThread;
     }
 
+    /**
+     * Get the type of the lock (e.g. collection or document).
+     *
+     * @return the lock type string
+     */
     public String getLockType() {
         return lockType;
     }
 
+    /**
+     * Get the mode of the lock (e.g. read or write).
+     *
+     * @return the lock mode string
+     */
     public String getLockMode() {
         return lockMode;
     }
 
+    /**
+     * Get the identifier of the resource being locked.
+     *
+     * @return the lock target identifier
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Get the names of the threads currently holding the lock.
+     *
+     * @return array of owner thread names
+     */
     public String[] getOwner() {
         return owner;
     }
 
+    /**
+     * Get the names of the threads waiting to acquire a read lock.
+     *
+     * @return array of thread names waiting for a read lock
+     */
     public String[] getWaitingForRead() {
         return waitingForRead;
     }
 
+    /**
+     * Get the names of the threads waiting to acquire a write lock.
+     *
+     * @return array of thread names waiting for a write lock
+     */
     public String[] getWaitingForWrite() {
         return waitingForWrite;
     }

--- a/exist-core/src/main/java/org/exist/management/impl/Lock.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Lock.java
@@ -37,7 +37,7 @@ public class Lock {
     private final String[] waitingForRead;
     private final String[] waitingForWrite;
 
-    public Lock(String waitingThread, LockInfo info) {
+    public Lock(final String waitingThread, final LockInfo info) {
 
         this.waitingThread = waitingThread;
         this.lockType = info.getLockType();

--- a/exist-core/src/main/java/org/exist/management/impl/LockTable.java
+++ b/exist-core/src/main/java/org/exist/management/impl/LockTable.java
@@ -21,6 +21,7 @@
  */
 package org.exist.management.impl;
 
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.BrokerPool;
@@ -29,7 +30,6 @@ import org.exist.storage.lock.Lock.LockType;
 import org.exist.storage.lock.LockTable.LockCountTraces;
 import org.exist.storage.lock.LockTable.LockModeOwner;
 import org.exist.storage.lock.LockTableUtils;
-import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -49,6 +49,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class LockTable implements LockTableMXBean {
 
+    private final static Logger LOCK_LOG = LogManager.getLogger(org.exist.storage.lock.LockTable.class);
     private final BrokerPool pool;
 
     public LockTable(final BrokerPool brokerPool) {
@@ -69,7 +70,7 @@ public class LockTable implements LockTableMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return pool.getId();
     }
 
@@ -111,8 +112,6 @@ public class LockTable implements LockTableMXBean {
         }
     }
 
-    private final static Logger LOCK_LOG = LogManager.getLogger(org.exist.storage.lock.LockTable.class);
-
     @Override
     public void dumpToLog() {
         LOCK_LOG.info(LockTableUtils.stateToString(pool.getLockManager().getLockTable(), false));
@@ -126,7 +125,7 @@ public class LockTable implements LockTableMXBean {
     @Override
     public void xmlDumpToLog() {
         try (final UnsynchronizedByteArrayOutputStream bos = new UnsynchronizedByteArrayOutputStream();
-                final Writer writer = new OutputStreamWriter(bos)) {
+             final Writer writer = new OutputStreamWriter(bos)) {
             LockTableUtils.stateToXml(pool.getLockManager().getLockTable(), false, writer);
             LOCK_LOG.info(new String(bos.toByteArray(), UTF_8));
         } catch (final IOException | XMLStreamException e) {

--- a/exist-core/src/main/java/org/exist/management/impl/LockTableMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/LockTableMXBean.java
@@ -50,19 +50,43 @@ public interface LockTableMXBean extends PerInstanceMBean {
      */
     Map<String, Map<Lock.LockType, List<LockModeOwner>>> getAttempting();
 
+    /**
+     * Dump a summary of the current lock table state to the system console.
+     */
     void dumpToConsole();
 
+    /**
+     * Dump a summary of the current lock table state to the log.
+     */
     void dumpToLog();
 
+    /**
+     * Dump an XML representation of the current lock table state to the system console.
+     */
     void xmlDumpToConsole();
 
+    /**
+     * Dump an XML representation of the current lock table state to the log.
+     */
     void xmlDumpToLog();
 
+    /**
+     * Dump a full (verbose) representation of the current lock table state to the system console.
+     */
     void fullDumpToConsole();
 
+    /**
+     * Dump a full (verbose) representation of the current lock table state to the log.
+     */
     void fullDumpToLog();
 
+    /**
+     * Dump a full (verbose) XML representation of the current lock table state to the system console.
+     */
     void xmlFullDumpToConsole();
 
+    /**
+     * Dump a full (verbose) XML representation of the current lock table state to the log.
+     */
     void xmlFullDumpToLog();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
@@ -22,6 +22,15 @@
 
 package org.exist.management.impl;
 
+/**
+ * Extension of {@link ExistMBean} for MBeans that are scoped to a specific
+ * database instance.
+ */
 public interface PerInstanceMBean extends ExistMBean {
+    /**
+     * Get the identifier of the database instance this MBean belongs to.
+     *
+     * @return the database instance identifier
+     */
     String instanceId();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
@@ -23,5 +23,5 @@
 package org.exist.management.impl;
 
 public interface PerInstanceMBean extends ExistMBean {
-    String getInstanceId();
+    String instanceId();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReport.java
@@ -21,22 +21,20 @@
  */
 package org.exist.management.impl;
 
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.TreeMap;
-
 import org.exist.scheduler.ScheduledJobInfo;
 import org.exist.scheduler.Scheduler;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.ProcessMonitor;
+import org.exist.storage.ProcessMonitor.QueryHistory;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.XQueryWatchDog;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-
-import org.exist.storage.ProcessMonitor.QueryHistory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class ProcessReport implements ProcessReportMXBean {
     private final String instanceId;
@@ -63,7 +61,7 @@ public class ProcessReport implements ProcessReportMXBean {
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return instanceId;
     }
 
@@ -109,7 +107,7 @@ public class ProcessReport implements ProcessReportMXBean {
     @Override
     public void killQuery(final int id) {
         final XQueryWatchDog[] watchdogs = processMonitor.getRunningXQueries();
-        for (XQueryWatchDog watchdog : watchdogs) {
+        for (final XQueryWatchDog watchdog : watchdogs) {
             final XQueryContext context = watchdog.getContext();
 
             if (id == context.hashCode()) {
@@ -132,6 +130,11 @@ public class ProcessReport implements ProcessReportMXBean {
         return history;
     }
 
+    @Override
+    public long getHistoryTimespan() {
+        return processMonitor.getHistoryTimespan();
+    }
+
     /**
      * Sets the time span (in milliseconds) for which the stats for an executed query should
      * be kept in the recent query history.
@@ -144,8 +147,8 @@ public class ProcessReport implements ProcessReportMXBean {
     }
 
     @Override
-    public long getHistoryTimespan() {
-        return processMonitor.getHistoryTimespan();
+    public long getMinTime() {
+        return processMonitor.getMinTime();
     }
 
     /**
@@ -160,8 +163,8 @@ public class ProcessReport implements ProcessReportMXBean {
     }
 
     @Override
-    public long getMinTime() {
-        return processMonitor.getMinTime();
+    public boolean getTrackRequestURI() {
+        return processMonitor.getTrackRequestURI();
     }
 
     /**
@@ -174,11 +177,6 @@ public class ProcessReport implements ProcessReportMXBean {
     @Override
     public void setTrackRequestURI(final boolean track) {
         processMonitor.setTrackRequestURI(track);
-    }
-
-    @Override
-    public boolean getTrackRequestURI() {
-        return processMonitor.getTrackRequestURI();
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
@@ -47,6 +47,8 @@ ProcessReportMXBean extends PerInstanceMBean {
      */
     void configure(long minTimeRecorded, long historyTimespan, boolean trackURI);
 
+    long getHistoryTimespan();
+
     /**
      * Sets the time span (in milliseconds) for which the stats for an executed query should
      * be kept in the recent query history.
@@ -55,7 +57,7 @@ ProcessReportMXBean extends PerInstanceMBean {
      */
     void setHistoryTimespan(long time);
 
-    long getHistoryTimespan();
+    long getMinTime();
 
     /**
      * Sets the minimum execution time of queries recorded in the recent query history.
@@ -65,7 +67,7 @@ ProcessReportMXBean extends PerInstanceMBean {
      */
     void setMinTime(long time);
 
-    long getMinTime();
+    boolean getTrackRequestURI();
 
     /**
      * Enable request tracking: for every executed query, try to figure out which HTTP
@@ -76,57 +78,33 @@ ProcessReportMXBean extends PerInstanceMBean {
      */
     void setTrackRequestURI(boolean track);
 
-    boolean getTrackRequestURI();
-
-    class QueryKey implements Comparable<QueryKey> {
-        private final int id;
-        private final String key;
-
-        public QueryKey(final int id, final String key) {
-            this.id = id;
-            this.key = key;
-        }
-
-        public int getId() {
-            return id;
-        }
-
-        public String getKey() {
-            return key;
-        }
+    record QueryKey(int id, String key) implements Comparable<QueryKey> {
 
         @Override
-        public boolean equals(final Object other) {
-            if (this == other) {
-                return true;
-            }
-            if (other == null || getClass() != other.getClass()) {
-                return false;
-            }
+            public boolean equals(final Object other) {
+                if (this == other) {
+                    return true;
+                }
+                if (other == null || getClass() != other.getClass()) {
+                    return false;
+                }
 
-            QueryKey queryKey = (QueryKey) other;
-            if (id != queryKey.id) {
-                return false;
+                final QueryKey queryKey = (QueryKey) other;
+                if (id != queryKey.id) {
+                    return false;
+                }
+                return key.equals(queryKey.key);
             }
-            return key.equals(queryKey.key);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = id;
-            result = 31 * result + key.hashCode();
-            return result;
-        }
 
         @Override
-        public int compareTo(final QueryKey other) {
-            if (other == null) {
-                return 1;
+            public int compareTo(final QueryKey other) {
+                if (other == null) {
+                    return 1;
+                }
+                if (id != other.id) {
+                    return Integer.compare(id, other.id);
+                }
+                return key.compareTo(other.key);
             }
-            if (id != other.id) {
-              return Integer.compare(id,  other.id);
-            }
-            return key.compareTo(other.key);
         }
-    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
@@ -79,7 +79,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     }
 
     public static String getAllInstancesQuery() {
-        return "org.exist.management." + '*' + ":type=SanityReport";
+        return "org.exist.management." + '*' + ".tasks:type=SanityReport";
     }
 
     public static ObjectName getName(final String instanceId) throws MalformedObjectNameException {

--- a/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
@@ -21,10 +21,6 @@
  */
 package org.exist.management.impl;
 
-import java.util.*;
-
-import javax.management.*;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
@@ -40,19 +36,28 @@ import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 
-public class SanityReport extends NotificationBroadcasterSupport implements SanityReportMXBean {
+import javax.management.AttributeChangeNotification;
+import javax.management.MBeanNotificationInfo;
+import javax.management.MalformedObjectNameException;
+import javax.management.Notification;
+import javax.management.NotificationBroadcasterSupport;
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
 
-    private final static Logger LOG = LogManager.getLogger(SanityReport.class.getName());
+public class SanityReport extends NotificationBroadcasterSupport implements SanityReportMXBean {
 
     public final static String STATUS_OK = "OK";
     public final static String STATUS_FAIL = "FAIL";
-
     public final static StringSource TEST_XQUERY = new StringSource("<r>{current-dateTime()}</r>");
-
     public final static int PING_WAITING = -1;
     public final static int PING_ERROR = -2;
-
-    private static List<ErrorReport> NO_ERRORS = new LinkedList<>();
+    private final static Logger LOG = LogManager.getLogger(SanityReport.class.getName());
+    private static final List<ErrorReport> NO_ERRORS = new LinkedList<>();
 
     private int seqNum = 0;
 
@@ -72,9 +77,9 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
 
     private List<ErrorReport> errors = NO_ERRORS;
 
-    private BrokerPool pool;
+    private final BrokerPool pool;
 
-    public SanityReport(BrokerPool pool) {
+    public SanityReport(final BrokerPool pool) {
         this.pool = pool;
     }
 
@@ -92,7 +97,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     }
 
     @Override
-    public String getInstanceId() {
+    public String instanceId() {
         return pool.getId();
     }
 
@@ -145,7 +150,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     }
 
     @Override
-    public void triggerCheck(String output, String backup, String incremental) {
+    public void triggerCheck(final String output, final String backup, final String incremental) {
         try {
             this.output = output;
             final SystemTask task = new ConsistencyCheckTask();
@@ -171,7 +176,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     }
 
     @Override
-    public long ping(boolean checkQueryEngine) {
+    public long ping(final boolean checkQueryEngine) {
         final long start = System.currentTimeMillis();
         lastPingRespTime = -1;
         lastActionInfo = "Ping";
@@ -216,7 +221,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
         return lastPingRespTime;
     }
 
-    private Properties parseParameter(String output, String backup, String incremental) {
+    private Properties parseParameter(final String output, final String backup, final String incremental) {
         final Properties properties = new Properties();
         final boolean doBackup = "YES".equalsIgnoreCase(backup);
 
@@ -225,7 +230,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
             properties.put("backup", backup);
         }
 
-        if (incremental != null && ("YES".equalsIgnoreCase(incremental) || "no".equalsIgnoreCase(incremental))) {
+        if (("YES".equalsIgnoreCase(incremental) || "no".equalsIgnoreCase(incremental))) {
             properties.put("incremental", incremental);
         }
 
@@ -238,7 +243,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
         return properties;
     }
 
-    protected void updateErrors(List<ErrorReport> errorList) {
+    protected void updateErrors(final List<ErrorReport> errorList) {
         try {
             if (errorList == null || errorList.isEmpty()) {
                 taskstatus.setStatus(TaskStatus.Status.STOPPED_OK);
@@ -253,7 +258,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
 
     }
 
-    protected void changeStatus(TaskStatus status) {
+    protected void changeStatus(final TaskStatus status) {
         status.setStatusChangeTime();
         switch (status.getStatus()) {
             case INIT:
@@ -285,7 +290,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
         }
     }
 
-    protected void updateStatus(int percentage) {
+    protected void updateStatus(final int percentage) {
         try {
             final int oldPercentage = taskstatus.getPercentage();
             taskstatus.setPercentage(percentage);

--- a/exist-core/src/main/java/org/exist/management/impl/SanityReportMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SanityReportMXBean.java
@@ -37,10 +37,10 @@ public interface SanityReportMXBean extends PerInstanceMBean {
     String getStatus();
 
     long getPingTime();
-    
+
     List<Error> getErrors();
 
     void triggerCheck(String output, String backup, String incremental);
-    
+
     long ping(boolean checkQueryEngine);
 }

--- a/exist-core/src/main/java/org/exist/management/impl/SystemInfo.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SystemInfo.java
@@ -21,17 +21,16 @@
  */
 package org.exist.management.impl;
 
-import java.nio.charset.Charset;
-import java.util.Locale;
-
 import org.exist.SystemProperties;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import java.nio.charset.Charset;
+import java.util.Locale;
 
 /**
  * Class SystemInfo
- * 
+ *
  * @author wessels
  * @author ljo
  */
@@ -46,17 +45,17 @@ public class SystemInfo implements SystemInfoMXBean {
 
     @Override
     public String getProductName() {
-        return SystemProperties.getInstance().getSystemProperty("product-name","eXist");
+        return SystemProperties.getInstance().getSystemProperty("product-name", "eXist");
     }
 
     @Override
     public String getProductVersion() {
-        return SystemProperties.getInstance().getSystemProperty("product-version","unknown");
+        return SystemProperties.getInstance().getSystemProperty("product-version", "unknown");
     }
 
     @Override
     public String getProductBuild() {
-        return SystemProperties.getInstance().getSystemProperty("product-build","unknown");
+        return SystemProperties.getInstance().getSystemProperty("product-build", "unknown");
     }
 
     @Override
@@ -76,6 +75,6 @@ public class SystemInfo implements SystemInfoMXBean {
 
     @Override
     public String getOperatingSystem() {
-         return System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch");
+        return System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch");
     }
 }


### PR DESCRIPTION
repair JMX client. 

**Actions**
- [ ] Check each CLI parameter for NPEs and other issues.
- [ ] Check if we can think of implementation with less null checks.
- [ ] If data is not available, do not display 0 but N/A or alike.
- [ ] Discuss: additional improvements in this PR or additional PR. @line-o 


**arguments**
- [x] -a, --address <string>                     RMI address of the server
- [x] -c, --cache                                displays server statistics on cache 
- [x] -d, --db                                   display general info about the db 
- [x] -h, --help <argument-to-print-help-for>    <argument-to-print-help-for>: an argument to print help for
- [x] -i, --instance <string>                    The ID of the database instance to 
- [x] -j, --jobs                                 retrieve sanity check report from 
- [ ] -l, --locks                                lock manager: display locking 
- [x] -m, --memory                               display info on free and total 
- [x] -p, --port <integer>                       RMI port of the server
- [x] -s, --report                               retrieve sanity check report from 
- [x] -w, --wait <integer>                       while displaying server statistics: 

**ToDo:**
- [ ]  Need help for proving the locks are reported.
- [x] next PR: reformat etc for java21 like style
- [x] check jmx servlet - monex does not start loading data immediately 