### PR TITLE
[bugfix] fn:xml-to-json: scope StAX reader to input element (+26 XQTS HEAD)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -26,6 +26,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.InMemoryXMLStreamReader;
+import org.exist.dom.memtree.NodeImpl;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.value.*;
@@ -112,7 +115,7 @@ public class FunXmlToJson extends BasicFunction {
         try (
                 final JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer)
         ) {
-            reader = context.getXMLStreamReader(nodeValue);
+            reader = streamReaderFor(nodeValue);
             int previous = XMLStreamReader.START_DOCUMENT;
             int status = XMLStreamReader.START_DOCUMENT;
             while (reader.hasNext()) {
@@ -223,6 +226,24 @@ public class FunXmlToJson extends BasicFunction {
                 }
             }
         }
+    }
+
+    /**
+     * Construct a stream reader scoped to the input node's subtree.
+     * For in-memory element nodes, XQueryContext.getXMLStreamReader walks from the
+     * owner-document root, so when the input is an element nested inside a larger
+     * document (e.g. selected by XPath from a host XML file), traversal visits
+     * ancestor elements and the namespace check fires on them rather than on the
+     * actual JSON wrapper element. Scoping the reader to the input element fixes that.
+     */
+    private XMLStreamReader streamReaderFor(final NodeValue nodeValue) throws IOException, XMLStreamException {
+        if (nodeValue.getImplementationType() == NodeValue.IN_MEMORY_NODE
+                && nodeValue.getType() == Type.ELEMENT) {
+            final NodeImpl node = (NodeImpl) nodeValue;
+            final DocumentImpl ownerDoc = node.getOwnerDocument();
+            return new InMemoryXMLStreamReader(ownerDoc, node);
+        }
+        return context.getXMLStreamReader(nodeValue);
     }
 
     /**

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunXmlToJsonTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunXmlToJsonTest.java
@@ -1,0 +1,95 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for {@link FunXmlToJson} when the input is an element node
+ * nested inside a larger host document.
+ *
+ * Before the fix, fn:xml-to-json constructed its XMLStreamReader from the owner
+ * document root, so traversal visited ancestor elements (e.g. xsl:stylesheet)
+ * and raised FOJS0006 against those rather than the JSON wrapper element.
+ */
+public class FunXmlToJsonTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer SERVER = new ExistXmldbEmbeddedServer(true, true, true);
+
+    @Test
+    public void elementSelectedFromHostDocument() throws Exception {
+        final String query = """
+                let $host :=
+                    <stylesheet xmlns="http://www.w3.org/1999/XSL/Transform">
+                        <template name="t301">
+                            <variable name="in"><null xmlns="http://www.w3.org/2005/xpath-functions"/></variable>
+                        </template>
+                    </stylesheet>
+                return fn:xml-to-json($host//*:template[@name="t301"]/*:variable/*)
+                """;
+        assertEquals("null", runScalar(query));
+    }
+
+    @Test
+    public void mapSelectedFromHostDocument() throws Exception {
+        final String query = """
+                let $host :=
+                    <wrapper>
+                        <slot>
+                            <map xmlns="http://www.w3.org/2005/xpath-functions">
+                                <string key="a">1</string>
+                            </map>
+                        </slot>
+                    </wrapper>
+                return fn:xml-to-json($host//*:map)
+                """;
+        assertEquals("{\"a\":\"1\"}", runScalar(query));
+    }
+
+    @Test
+    public void stringSelectedFromHostDocument() throws Exception {
+        final String query = """
+                let $host :=
+                    <wrapper>
+                        <slot>
+                            <string xmlns="http://www.w3.org/2005/xpath-functions">hi</string>
+                        </slot>
+                    </wrapper>
+                return fn:xml-to-json($host//*:string)
+                """;
+        assertEquals("\"hi\"", runScalar(query));
+    }
+
+    private static String runScalar(final String query) throws Exception {
+        final XQueryService xq = SERVER.getRoot().getService(XQueryService.class);
+        final ResourceSet rs = xq.query(query);
+        assertEquals(1, rs.getSize());
+        return rs.getResource(0).getContent().toString();
+    }
+}


### PR DESCRIPTION
## Summary

`fn:xml-to-json` raised `FOJS0006` against the wrong element when the input was an element selected from a host document (e.g. an XSLT stylesheet), because `XQueryContext.getXMLStreamReader(NodeValue)` walks from the owner-document root rather than from the passed node. Scoping the StAX reader to the input element fixes 46 XQTS HEAD test cases that all reported the same misleading error: `Element 'stylesheet' is not in the required namespace 'http://www.w3.org/2005/xpath-functions'`. Net XQTS gain: **+26 tests** (73/144 → 99/144 on fn-xml-to-json HEAD); some previously-masked format gaps surfaced but no regressions.

## What changed

**`exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java`**
- New private helper `streamReaderFor(NodeValue)` constructs an `InMemoryXMLStreamReader(ownerDoc, node)` when the input is an in-memory ELEMENT, so traversal starts at the input subtree (not the host document root).
- Documents and persistent nodes continue to route through the existing `context.getXMLStreamReader(nodeValue)` — no behavior change for other callers.

**`exist-core/src/test/java/org/exist/xquery/functions/fn/FunXmlToJsonTest.java`** (new)
- Three JUnit regression tests, each builds a host document, selects a nested JSON wrapper via XPath, asserts the JSON conversion: `elementSelectedFromHostDocument`, `mapSelectedFromHostDocument`, `stringSelectedFromHostDocument`.
- All three FAIL on develop tip; PASS with the fix (verified by stashing the fix and rerunning).

## Why a local helper instead of fixing `XQueryContext.getXMLStreamReader`

`XQueryContext.getXMLStreamReader(NodeValue)` has two callers: this one and `SerializerUtils.getSerializationOptions`. The fix could go in the context method (and would arguably be more correct — the method name implies subtree-scoping), but `SerializerUtils` relies on the current "walk from document root, advance to first START_ELEMENT" behavior. Localizing the fix to `FunXmlToJson` keeps the blast radius small and leaves `fn:serialize` untouched. The serialization helper would be a fine follow-up cleanup but doesn't need to ship in the same PR.

## Spec references

- [W3C XPath Functions 3.1 §18.5 fn:xml-to-json](https://www.w3.org/TR/xpath-functions-31/#func-xml-to-json)
- [W3C XPath Functions 3.1 §18.7 XML Representation of JSON](https://www.w3.org/TR/xpath-functions-31/#xml-representation-of-json)

## XQTS HEAD: fn-xml-to-json (before / after)

Measured against XQTS HEAD (W3C final 3.1 + corrections), HEAD-cap-3.1 patched runner, on `4f09d0accc`:

| Status | Tests | Pass | Fail | Skipped | Pass rate |
|--------|------:|-----:|-----:|--------:|----------:|
| develop tip (`4f09d0accc`) | 144 | 73 | 67 | 4 | 50.7% |
| this PR | 144 | 99 | 41 | 4 | 68.7% |
| **Delta** | — | **+26** | **-26** | 0 | **+18.0pp** |

All 46 "Element 'stylesheet' not in required namespace" failures are resolved. The 41 remaining failures are independent issues (over-permissive option/attribute validation, number normalization, escape handling). They are not in scope for this PR; a follow-up sweep is being drafted.

## Test plan

- [x] `mvn test -pl exist-core -Dtest='XQuery3Tests'` — 1011 tests, 0 failures, 0 errors (xml-to-json XQSuite tests intact)
- [x] `mvn test -pl exist-core -Dtest='FunXmlToJsonTest'` — 3/3 pass with fix; 3/3 ERROR without
- [x] XQTS HEAD fn-xml-to-json: 73 → 99 passing, no new failures
- [x] `codacy-cli analyze --tool pmd` on changed files — no new findings
- [ ] Reviewer: confirm there are no callers of `FunXmlToJson` that depend on document-wide traversal of a host document (none expected — function spec says single element/document input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)