### PR TITLE
[bugfix] map:entry: missing-key lookup NPE (closes #6340)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
@@ -70,7 +70,7 @@ public class SingleKeyMapType extends AbstractMapType {
         if (sameKey(collator, this.key, key)) {
             return this.value;
         }
-        return null;
+        return Sequence.EMPTY_SEQUENCE;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/xquery/functions/map/MapEntryRegressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/map/MapEntryRegressionTest.java
@@ -1,0 +1,109 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.map;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for the map:entry bugs documented in
+ * <a href="https://github.com/eXist-db/exist/issues/6340">issue #6340</a>:
+ * NPE on missing-key lookup against a single-entry map produced by map:entry.
+ *
+ * <p>The NaN-key cases (XQTS map-entry-005 / map-entry-006) are also covered,
+ * mirroring the XQTS expectations: per XPath F&amp;O 3.1 maps can hold NaN keys,
+ * and looking up NaN finds the entry (op:same-key treats NaN as equal to NaN).</p>
+ */
+public class MapEntryRegressionTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server =
+            new ExistXmldbEmbeddedServer(true, true, true);
+
+    /** XQTS map-entry-003: looking up an absent key returned Java null and NPE'd in fn:empty. */
+    @Test
+    public void missingKeyLookupSequenceValueReturnsEmpty() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry("foo", ("x", "y", "z"))
+                return empty($result("bar"))
+                """));
+    }
+
+    /** XQTS map-entry-004: same NPE shape, untyped-atomic key + map value. */
+    @Test
+    public void missingKeyLookupUntypedAtomicKeyMapValueReturnsEmpty() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry(xs:untypedAtomic("foo"), map{})
+                return empty($result("bar"))
+                """));
+    }
+
+    /**
+     * XQTS map-entry-005: NaN can be stored in a map, and looking up by NaN
+     * (op:same-key treats NaN as equal to NaN) retrieves the entry.
+     */
+    @Test
+    public void nanKeyXsDoubleStoredAndLookedUp() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry(number('NaN'), 'NaN')
+                return map:size($result) eq 1 and exists($result(number('NaN')))
+                """));
+    }
+
+    /** XQTS map-entry-006: same as 005 but with xs:float NaN. */
+    @Test
+    public void nanKeyXsFloatStoredAndLookedUp() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry(xs:float('NaN'), 'NaN')
+                return map:size($result) eq 1 and exists($result(number('NaN')))
+                """));
+    }
+
+    /** Cross-type NaN: xs:float('NaN') and xs:double('NaN') are op:same-key. */
+    @Test
+    public void nanKeyCrossTypeLookup() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry(xs:float('NaN'), 'fNaN')
+                return $result(xs:double('NaN')) eq 'fNaN'
+                """));
+    }
+
+    /** map:get on a SingleKeyMapType with absent key returns (), not null. */
+    @Test
+    public void mapGetMissingKeySingleKeyMapReturnsEmpty() throws Exception {
+        assertEquals("true", run("""
+                let $result := map:entry("foo", "bar")
+                return empty(map:get($result, "baz"))
+                """));
+    }
+
+    private String run(final String query) throws Exception {
+        final XQueryService xqs = server.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query("xquery version \"3.1\";\n" + query);
+        return (String) result.getResource(0).getContent();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #6340. Surgical one-line fix: `SingleKeyMapType.get` returned Java `null` for keys that did not match the single entry's key. Callers using the function-call lookup syntax (`\$result(\"missing\")`) propagated that null through `DynamicCardinalityCheck` into `fn:empty` / `count`, raising NPE. The `?` lookup operator was already null-guarded in `Lookup.eval`, which masked the bug for the more idiomatic `?` syntax.

`MapType.get` already returns `Sequence.EMPTY_SEQUENCE` for absent keys; this aligns `SingleKeyMapType` with the same contract.

## Triage correction

Issue #6340 originally listed 4 bugs (2 NPE on missing-key, 2 NaN-key acceptance). Investigation showed:

- **The 2 NPE bugs are real** (XQTS `map-entry-003` and `map-entry-004` against final 3.1 Rec + corrections) — fixed here.
- **The 2 \"NaN-key\" failures are not bugs.** Per the final XPath F&O 3.1 Rec, NaN keys can be stored in maps and `op:same-key` treats NaN as equal to NaN. Saxon's 2014 XQTS revision (\"NaN can now be stored in the map\") updated the tests accordingly; eXist's current behaviour already matches that revision. The triage was looking at the pre-CR 2013 draft archive (the runner's `--xqts-version 3.1` archive), where `map-entry-005/006` still expect rejection. Per `feedback_xqts_3_1_vs_head_label_inversion.md`, HEAD is the canonical baseline for 7.0 conformance claims.

## What changed

- `exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java` — `get()` returns `Sequence.EMPTY_SEQUENCE` instead of `null` on key miss.
- `exist-core/src/test/java/org/exist/xquery/functions/map/MapEntryRegressionTest.java` — new, 6 cases: the 2 NPE shapes from XQTS `map-entry-003/004`, plus 4 sanity cases covering NaN-key store + lookup (xs:double, xs:float, cross-type) and \`map:get\` on `SingleKeyMapType`.

## XQTS deltas (`--xqts-version HEAD`, the final 3.1 Rec + corrections)

| Test set | Before | After |
|---|---|---|
| `map-entry` | 7 pass / 2 NPE | **9 / 9** |

Against the older `--xqts-version 3.1` (2013 pre-CR draft) archive: 2 pass + 3 fail + 2 NPE → 4 pass + 3 fail, where the remaining 3 are pre-CR-draft expectations the final spec abandoned (NaN rejection in `map-entry-005/006` and `map:collation()` in `map-entry-007`) — out of scope.

## Spec references

- XPath F&O 3.1 §17.1.4 [`map:entry`](https://www.w3.org/TR/xpath-functions-31/#func-map-entry)
- XDM 3.1 §3.10 [Maps](https://www.w3.org/TR/xpath-datamodel-31/#dt-map) — missing-key lookup returns the empty sequence

## Test plan

- [x] `MapEntryRegressionTest` 6/6 pass on patched build
- [x] `mvn test -pl exist-core -Dtest='*Map*,*map*'` — 143/143 map-related JUnit tests pass (0 failures, 0 errors)
- [x] XQTS `map-entry` against `--xqts-version HEAD`: 9/9 pass
- [x] XQTS broader `^map-` (11 sets, 220 tests) on HEAD: 200 pass / 18 fail / 2 errors — no regression vs develop baseline; remaining failures are pre-existing (`map-call`, `map-find`, `map-merge`, `map-put`, `map-remove`, `map-size` and the 2 known `map-contains-905` / `map-get-905` class-cast errors)
- [x] Codacy PMD on changed files: 0 violations
- [ ] Full `mvn test -pl exist-core` (lock-coordinated) — deferred to CI; the local test lock has been held continuously by parallel sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)