### PR TITLE
[bugfix] preceding::/following:: axis predicate evaluation (audit extract from v2/xq4-axes)

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -802,6 +802,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
                         if (contextId != Expression.IGNORE_CONTEXT
+                                && contextId != Expression.NO_CONTEXT_ID
                                 && nodes[j].getContext() != null
                                 && reference.getContext() != null
                                 && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {
@@ -856,6 +857,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
                         if (contextId != Expression.IGNORE_CONTEXT
+                                && contextId != Expression.NO_CONTEXT_ID
                                 && nodes[j].getContext() != null
                                 && reference.getContext() != null
                                 && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {

--- a/exist-core/src/test/xquery/axes-persistent-nodes.xqm
+++ b/exist-core/src/test/xquery/axes-persistent-nodes.xqm
@@ -104,6 +104,25 @@ function axpn:preceding-with-predicate-db-map() {
 
 declare
     %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
+function axpn:preceding-with-context-predicate-db-flwor() {
+    for $w in doc("/db/test/test.xml")//w[exists(.)]
+    let $preceding-page := $w/preceding::pb[1]
+    return
+        if ($preceding-page) then
+            $w/@id || ":" || $preceding-page/@id
+        else
+            $w/@id || ":PRECEDING_PB_NOT_FOUND"
+};
+
+declare
+    %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
+function axpn:preceding-with-context-predicate-db-map() {
+    doc("/db/test/test.xml")//w[exists(.)]
+        ! (./@id || ":" || (./preceding::pb[1]/@id, "PRECEDING_PB_NOT_FOUND")[1])
+};
+
+declare
+    %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
 function axpn:preceding-without-predicate-flwor() {
     for $w in doc("/db/test/test.xml")//w
     let $preceding-page := $w/preceding::pb[1]
@@ -158,6 +177,25 @@ declare
     %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
 function axpn:following-with-predicate-db-map() {
     doc("/db/test/test.xml")//w[true()]
+        ! (./@id || ":" || (./following::pb[1]/@id, "FOLLOWING_PB_NOT_FOUND")[1])
+};
+
+declare
+    %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
+function axpn:following-with-context-predicate-db-flwor() {
+    for $w in doc("/db/test/test.xml")//w[exists(.)]
+    let $following-page := $w/following::pb[1]
+    return
+        if ($following-page) then
+            $w/@id || ":" || $following-page/@id
+        else
+            $w/@id || ":FOLLOWING_PB_NOT_FOUND"
+};
+
+declare
+    %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
+function axpn:following-with-context-predicate-db-map() {
+    doc("/db/test/test.xml")//w[exists(.)]
         ! (./@id || ":" || (./following::pb[1]/@id, "FOLLOWING_PB_NOT_FOUND")[1])
 };
 


### PR DESCRIPTION
## Summary

Unbundles the XQ 3.1-mandatory `preceding::`/`following::` axis-predicate bug fix from PR #6209's foundation commit, which originally bundled the bug fix with the new XQuery 4.0 `*-or-self` combined-axes feature. Per the 2026-05-10 v2/* extraction audit, the bug fix half is 3.1-mandatory and belongs on `develop` directly for 7.0; the 4.0 axes feature stays in `v2/xq4-axes` for a post-7.0 cycle.

## The bug

In `NewArrayNodeSet.selectPreceding` and `selectFollowing`, a dedup guard checks

```java
nodes[j].getContext().getContextId() == reference.getContext().getContextId()
```

to suppress an already-tagged duplicate across outer-loop iterations. When the caller passes `Expression.NO_CONTEXT_ID` (-1), two unrelated proxies whose `getContextId()` both happen to be the default -1 collide spuriously, and the second hit is silently dropped via `continue` -- causing `preceding::pb[1]` / `following::pb[1]` to return `PRECEDING_PB_NOT_FOUND` / `FOLLOWING_PB_NOT_FOUND` for context nodes after the first, whenever the outer call site passes `NO_CONTEXT_ID`.

The trigger is a path step whose intermediate predicate attaches contextIds to the outer set -- e.g. `doc(...)//w[exists(.)]/preceding::pb[1]`. The companion predicate `[true()]` is folded by the optimizer and does not attach contextIds, so the existing `[true()]` regression tests on `develop` (added for issue #4085) did not catch this corner.

The fix excludes `NO_CONTEXT_ID` from triggering the dedup, matching the intent of the symmetric `copyContext` branch immediately below (which already treats `NO_CONTEXT_ID` as ''copy reference context wholesale'' rather than ''tag with id'').

## What changed

- `exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java` -- two `contextId != Expression.NO_CONTEXT_ID` guards added to the dedup conditions in `selectPreceding` and `selectFollowing`
- `exist-core/src/test/xquery/axes-persistent-nodes.xqm` -- 4 new XQSuite regression tests (`preceding-with-context-predicate-db-flwor`, `preceding-with-context-predicate-db-map`, `following-with-context-predicate-db-flwor`, `following-with-context-predicate-db-map`) using `//w[exists(.)]` as the context-tagging predicate

Net: +40 / -0 lines.

## What's NOT in this PR (stays in v2/xq4-axes)

- XQ 4.0 `following-or-self`, `following-sibling-or-self`, `preceding-or-self`, `preceding-sibling-or-self` axes (entirely 4.0 territory)
- Grammar additions in `XQuery.g` and `XQueryTree.g` for the 4.0 axes
- New axis constants in `Constants.java` (14-17)
- `LocationStep.getOrSelfAxis()` dispatch method and new switch cases in `LocationStep.eval` / `Predicate`
- `XQ4AxesTest.java` and `xquery4/xq4-axes.xql` (4.0 feature coverage)

## Verification

- New regression tests fail on plain `develop` (4 failures, all 4 new test cases): `w2/w3/w5` -> `PRECEDING_PB_NOT_FOUND` / `FOLLOWING_PB_NOT_FOUND`
- With the fix applied: 16/16 pass (12 pre-existing `[true()]` tests + 4 new `[exists(.)]` tests)
- Targeted JUnit run (axis + XPath + axis-performance regression suites): 158/158 pass, 4 pre-existing skips
- `mvn install -pl exist-core -am -DskipTests` green
- Codacy PMD on `NewArrayNodeSet.java`: only pre-existing warnings (NPath, SimplifyBooleanReturns) -- no new issues introduced by the 2-line addition
- Full module test gate via the shared lock script was attempted but interrupted by concurrent-session BrokerPool contention (the canonical "Database is read-only" pattern documented in our session-staggering notes). CI will run a clean full gate.

## Spec references

- W3C XPath 3.1 §3.3.2 Predicates: https://www.w3.org/TR/xpath-31/#id-predicates
- W3C XPath 3.1 §3.3.4 Axes: https://www.w3.org/TR/xpath-31/#axes

## Source

Unbundled from `joewiz:v2/xq4-axes` (PR #6209). The 4.0 axes feature commits stay in #6209 for a post-7.0 cycle; this commit ships only the 3.1-mandatory `NewArrayNodeSet` bug fix and its regression tests.

## Test plan

- [x] Regression test added (4 new XQSuite cases in `axes-persistent-nodes.xqm`); proven to fail without the fix and pass with it
- [x] `mvn install -pl exist-core -am -DskipTests` green
- [x] Targeted JUnit on axis + XPath classes (158/158 pass)
- [x] Codacy PMD: no new warnings
- [ ] CI gate

closes #6347 

🤖 Generated with [Claude Code](https://claude.com/claude-code)