### PR TITLE
Hotfix self predicate lucene

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/AbstractNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AbstractNodeSet.java
@@ -358,7 +358,7 @@ public abstract class AbstractNodeSet extends AbstractSequence implements NodeSe
                 if (Expression.NO_CONTEXT_ID != contextId) {
                     parent.addContextNode(contextId, current);
                 } else {
-                    parent.copyContext(current);
+                    NodeProxy.propagatePredicateContextFrom(parent, current, contextId);
                 }
                 parent.addMatches(current);
                 parents.add(parent);
@@ -393,7 +393,7 @@ public abstract class AbstractNodeSet extends AbstractSequence implements NodeSe
                     if (Expression.NO_CONTEXT_ID != contextId) {
                         parent.addContextNode(contextId, current);
                     } else {
-                        parent.copyContext(current);
+                        NodeProxy.propagatePredicateContextFrom(parent, current, contextId);
                     }
                     ancestors.add(parent);
                 }

--- a/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
@@ -620,14 +620,14 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
                             if(Expression.NO_CONTEXT_ID != contextId) {
                                 nb.addContextNode(contextId, na);
                             } else {
-                                nb.copyContext(na);
+                                NodeProxy.propagatePredicateContextFrom(nb, na, contextId);
                             }
                             result.add(nb);
                         } else {
                             if(Expression.NO_CONTEXT_ID != contextId) {
                                 na.addContextNode(contextId, nb);
                             } else {
-                                na.copyContext(nb);
+                                NodeProxy.propagatePredicateContextFrom(na, nb, contextId);
                             }
                             result.add(na);
                         }
@@ -846,11 +846,7 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
                         add = includeSelf;
                     }
                     if(add) {
-                        if(Expression.NO_CONTEXT_ID != contextId) {
-                            ancestor.deepCopyContext(array[i], contextId);
-                        } else {
-                            ancestor.copyContext(array[i]);
-                        }
+                        NodeProxy.propagatePredicateContextFrom(ancestor, array[i], contextId);
                         ancestor.addMatches(array[i]);
                         foundOne = true;
                     }
@@ -891,11 +887,7 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
                         switch(mode) {
 
                             case NodeSet.DESCENDANT:
-                                if(Expression.NO_CONTEXT_ID != contextId) {
-                                    array[i].deepCopyContext(parent, contextId);
-                                } else {
-                                    array[i].copyContext(parent);
-                                }
+                                NodeProxy.propagatePredicateContextFrom(array[i], parent, contextId);
                                 if(copyMatches) {
                                     array[i].addMatches(parent);
                                 }
@@ -903,11 +895,7 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
                                 break;
 
                             case NodeSet.ANCESTOR:
-                                if(Expression.NO_CONTEXT_ID != contextId) {
-                                    parent.deepCopyContext(array[i], contextId);
-                                } else {
-                                    parent.copyContext(array[i]);
-                                }
+                                NodeProxy.propagatePredicateContextFrom(parent, array[i], contextId);
                                 if(copyMatches) {
                                     parent.addMatches(array[i]);
                                 }
@@ -957,22 +945,14 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
                             switch(mode) {
 
                                 case NodeSet.DESCENDANT:
-                                    if(Expression.NO_CONTEXT_ID != contextId) {
-                                        array[i].deepCopyContext(parent, contextId);
-                                    } else {
-                                        array[i].copyContext(parent);
-                                    }
+                                    NodeProxy.propagatePredicateContextFrom(array[i], parent, contextId);
                                     array[i].addMatches(parent);
                                     result.add(array[i]);
                                     break;
 
                                 case NodeSet.ANCESTOR:
-                                    if(Expression.NO_CONTEXT_ID != contextId) {
-                                        //parent.addContextNode(contextId, array[i]);
-                                        parent.deepCopyContext(array[i], contextId);
-                                    } else {
-                                        parent.copyContext(array[i]);
-                                    }
+                                    //parent.addContextNode(contextId, array[i]);
+                                    NodeProxy.propagatePredicateContextFrom(parent, array[i], contextId);
                                     parent.addMatches(array[i]);
                                     result.add(parent, 1);
                                     break;

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -320,22 +320,14 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(add) {
                     switch(mode) {
                         case NodeSet.DESCENDANT:
-                            if(Expression.NO_CONTEXT_ID != contextId) {
-                                nodes[i].deepCopyContext(parent, contextId);
-                            } else {
-                                nodes[i].copyContext(parent);
-                            }
+                            NodeProxy.propagatePredicateContextFrom(nodes[i], parent, contextId);
                             if(copyMatches) {
                                 nodes[i].addMatches(parent);
                             }
                             result.add(nodes[i]);
                             break;
                         case NodeSet.ANCESTOR:
-                            if(Expression.NO_CONTEXT_ID != contextId) {
-                                parent.deepCopyContext(nodes[i], contextId);
-                            } else {
-                                parent.copyContext(nodes[i]);
-                            }
+                            NodeProxy.propagatePredicateContextFrom(parent, nodes[i], contextId);
                             if(copyMatches) {
                                 parent.addMatches(nodes[i]);
                             }
@@ -385,22 +377,14 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                     if(add) {
                         switch(mode) {
                             case NodeSet.DESCENDANT:
-                                if(Expression.NO_CONTEXT_ID != contextId) {
-                                    nodes[i].deepCopyContext(parent, contextId);
-                                } else {
-                                    nodes[i].copyContext(parent);
-                                }
+                                NodeProxy.propagatePredicateContextFrom(nodes[i], parent, contextId);
                                 if(copyMatches) {
                                     nodes[i].addMatches(parent);
                                 }
                                 result.add(nodes[i]);
                                 break;
                             case NodeSet.ANCESTOR:
-                                if(Expression.NO_CONTEXT_ID != contextId) {
-                                    parent.deepCopyContext(nodes[i], contextId);
-                                } else {
-                                    parent.copyContext(nodes[i]);
-                                }
+                                NodeProxy.propagatePredicateContextFrom(parent, nodes[i], contextId);
                                 if(copyMatches) {
                                     parent.addMatches(nodes[i]);
                                 }
@@ -476,11 +460,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                     add = includeSelf;
                 }
                 if(add) {
-                    if(Expression.NO_CONTEXT_ID != contextId) {
-                        ancestor.deepCopyContext(nodes[i], contextId);
-                    } else {
-                        ancestor.copyContext(nodes[i]);
-                    }
+                    NodeProxy.propagatePredicateContextFrom(ancestor, nodes[i], contextId);
                     if(copyMatches) {
                         ancestor.addMatches(nodes[i]);
                     }
@@ -676,7 +656,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
 
                     if(Expression.IGNORE_CONTEXT != contextId) {
                         if(Expression.NO_CONTEXT_ID == contextId) {
-                            nodes[i].copyContext(reference);
+                            NodeProxy.propagatePredicateContextFrom(nodes[i], reference, contextId);
                         } else {
                             nodes[i].addContextNode(contextId, reference);
                         }
@@ -760,7 +740,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
 
                     if(Expression.IGNORE_CONTEXT != contextId) {
                         if(Expression.NO_CONTEXT_ID == contextId) {
-                            nodes[i].copyContext(reference);
+                            NodeProxy.propagatePredicateContextFrom(nodes[i], reference, contextId);
                         } else {
                             nodes[i].addContextNode(contextId, reference);
                         }
@@ -810,7 +790,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
 
                         if(Expression.IGNORE_CONTEXT != contextId) {
                             if(Expression.NO_CONTEXT_ID == contextId) {
-                                nodes[j].copyContext(reference);
+                                NodeProxy.propagatePredicateContextFrom(nodes[j], reference, contextId);
                             } else {
                                 nodes[j].addContextNode(contextId, reference);
                             }
@@ -864,7 +844,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
 
                         if(Expression.IGNORE_CONTEXT != contextId) {
                             if(Expression.NO_CONTEXT_ID == contextId) {
-                                nodes[j].copyContext(reference);
+                                NodeProxy.propagatePredicateContextFrom(nodes[j], reference, contextId);
                             } else {
                                 nodes[j].addContextNode(contextId, reference);
                             }

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -626,6 +626,33 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     }
 
     /**
+     * Merge predicate context from {@code source} onto {@code target} when an index
+     * (Lucene, range, structural, …) materializes or re-parents {@link NodeProxy} instances.
+     * <ul>
+     *   <li>If {@code contextId != Expression.NO_CONTEXT_ID}, always delegates to
+     *       {@link #deepCopyContext(NodeProxy, int)} so predicate tracking is preserved even when
+     *       {@code source} has no prior {@link ContextItem} chain.</li>
+     *   <li>Otherwise delegates to {@link #copyContext(NodeProxy)} only when
+     *       {@code source.getContext() != null}, avoiding a spurious clear of {@code target}'s
+     *       chain when {@code source} is synthetic.</li>
+     * </ul>
+     *
+     * @param target    node receiving context (often newly promoted, e.g. an ancestor)
+     * @param source    node whose context is copied from (hit or context-set member)
+     * @param contextId active predicate context id, or {@link Expression#NO_CONTEXT_ID}
+     */
+    public static void propagatePredicateContextFrom(
+            final NodeProxy target,
+            final NodeProxy source,
+            final int contextId) {
+        if (Expression.NO_CONTEXT_ID != contextId) {
+            target.deepCopyContext(source, contextId);
+        } else if (source.getContext() != null) {
+            target.copyContext(source);
+        }
+    }
+
+    /**
      * The method <code>clearContext</code>
      *
      * @param contextId an <code>int</code> value

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -586,10 +586,15 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     /**
      * Copy the context items from the given node into this node.
      * Context items are used to keep track of context nodes inside predicates.
+     * This node's existing context chain is always cleared first; if the source
+     * has no context, the result is an empty context ({@code null}).
      *
      * @param node a <code>NodeProxy</code> value
      */
     public void deepCopyContext(final NodeProxy node) {
+        if (node == this) {
+            return;
+        }
         context = null;
         if(node.context == null) {
             return;

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeSetHelper.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeSetHelper.java
@@ -78,11 +78,7 @@ public final class NodeSetHelper {
                     final NodeProxy parent = al.parentWithChild(child, true, false,
                         NodeProxy.UNKNOWN_NODE_LEVEL);
                     if(parent != null) {
-                        if(Expression.NO_CONTEXT_ID != contextId) {
-                            child.deepCopyContext(parent, contextId);
-                        } else {
-                            child.copyContext(parent);
-                        }
+                        NodeProxy.propagatePredicateContextFrom(child, parent, contextId);
                         result.add(child, sizeHint);
                     }
                 }
@@ -98,11 +94,7 @@ public final class NodeSetHelper {
                     final NodeProxy parent = al.parentWithChild(child, true, false,
                         NodeProxy.UNKNOWN_NODE_LEVEL);
                     if(parent != null) {
-                        if(Expression.NO_CONTEXT_ID != contextId) {
-                            parent.deepCopyContext(child, contextId);
-                        } else {
-                            parent.copyContext(child);
-                        }
+                        NodeProxy.propagatePredicateContextFrom(parent, child, contextId);
                         parent.addMatches(child);
                         result.add(parent, sizeHint);
                     }
@@ -197,7 +189,7 @@ public final class NodeSetHelper {
                         if(Expression.NO_CONTEXT_ID != contextId) {
                             descendant.addContextNode(contextId, ancestor);
                         } else {
-                            descendant.copyContext(ancestor);
+                            NodeProxy.propagatePredicateContextFrom(descendant, ancestor, contextId);
                         }
                         result.add(descendant, sizeHint);
                     }
@@ -218,7 +210,7 @@ public final class NodeSetHelper {
                         if(Expression.NO_CONTEXT_ID != contextId) {
                             ancestor.addContextNode(contextId, descendant);
                         } else {
-                            ancestor.copyContext(descendant);
+                            NodeProxy.propagatePredicateContextFrom(ancestor, descendant, contextId);
                         }
                         result.add(ancestor, sizeHint);
                     }
@@ -251,7 +243,7 @@ public final class NodeSetHelper {
                         if(Expression.NO_CONTEXT_ID != contextId) {
                             descendant.addContextNode(contextId, ancestor);
                         } else {
-                            descendant.copyContext(ancestor);
+                            NodeProxy.propagatePredicateContextFrom(descendant, ancestor, contextId);
                         }
                         result.add(descendant, sizeHint);
                         return true;
@@ -273,7 +265,7 @@ public final class NodeSetHelper {
                         if(Expression.NO_CONTEXT_ID != contextId) {
                             ancestor.addContextNode(contextId, descendant);
                         } else {
-                            ancestor.copyContext(descendant);
+                            NodeProxy.propagatePredicateContextFrom(ancestor, descendant, contextId);
                         }
                         result.add(ancestor, sizeHint);
                         return true;
@@ -315,7 +307,7 @@ public final class NodeSetHelper {
                             if(Expression.NO_CONTEXT_ID != contextId) {
                                 ancestor.addContextNode(contextId, descendant);
                             } else {
-                                ancestor.copyContext(descendant);
+                                NodeProxy.propagatePredicateContextFrom(ancestor, descendant, contextId);
                             }
                         }
                         ancestor.addMatches(descendant);
@@ -342,7 +334,7 @@ public final class NodeSetHelper {
                             if(Expression.NO_CONTEXT_ID != contextId) {
                                 ancestor.addContextNode(contextId, descendant);
                             } else {
-                                ancestor.copyContext(descendant);
+                                NodeProxy.propagatePredicateContextFrom(ancestor, descendant, contextId);
                             }
                         }
                         ancestor.addMatches(descendant);
@@ -455,7 +447,7 @@ public final class NodeSetHelper {
                         if(t == null) {
                             if(Expression.IGNORE_CONTEXT != contextId) {
                                 if(Expression.NO_CONTEXT_ID == contextId) {
-                                    candidate.copyContext(reference);
+                                    NodeProxy.propagatePredicateContextFrom(candidate, reference, contextId);
                                 } else {
                                     candidate.addContextNode(contextId, reference);
                                 }
@@ -574,7 +566,7 @@ public final class NodeSetHelper {
                         if(t == null) {
                             if(Expression.IGNORE_CONTEXT != contextId) {
                                 if(Expression.NO_CONTEXT_ID == contextId) {
-                                    candidate.copyContext(reference);
+                                    NodeProxy.propagatePredicateContextFrom(candidate, reference, contextId);
                                 } else {
                                     candidate.addContextNode(contextId, reference);
                                 }

--- a/exist-core/src/main/java/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/exist-core/src/main/java/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -240,10 +240,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
                         final NodeProxy storedNode = new NodeProxy(null, doc, parentId,
                             type == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE, address);
                         result.add(storedNode);
-                        if (Expression.NO_CONTEXT_ID != contextId) {
-                            storedNode.deepCopyContext(descendant, contextId);
-                        } else
-                            {storedNode.copyContext(descendant);}
+                        NodeProxy.propagatePredicateContextFrom(storedNode, descendant, contextId);
                         if (contextSet.getTrackMatches())
                         	{storedNode.addMatches(descendant);}
                     }
@@ -408,9 +405,9 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
                 	if (selfAsContext)
                 		{storedNode.addContextNode(contextId, storedNode);}
                 	else
-                		{storedNode.deepCopyContext(ancestor, contextId);}
+                		{NodeProxy.propagatePredicateContextFrom(storedNode, ancestor, contextId);}
                 } else {
-            		storedNode.copyContext(ancestor);
+            		NodeProxy.propagatePredicateContextFrom(storedNode, ancestor, contextId);
                 }
                 storedNode.addMatches(ancestor);
             }

--- a/exist-core/src/main/java/org/exist/xquery/ChildSelector.java
+++ b/exist-core/src/main/java/org/exist/xquery/ChildSelector.java
@@ -45,10 +45,7 @@ public class ChildSelector implements NodeSelector {
         if (contextNode == null)
            {return null;}
         final NodeProxy p = new NodeProxy(contextNode.getExpression(), doc, nodeId);
-        if (Expression.NO_CONTEXT_ID != contextId) {
-            p.deepCopyContext(contextNode, contextId);
-        } else
-            {p.copyContext(contextNode);}
+        NodeProxy.propagatePredicateContextFrom(p, contextNode, contextId);
         return p;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/DescendantOrSelfSelector.java
+++ b/exist-core/src/main/java/org/exist/xquery/DescendantOrSelfSelector.java
@@ -41,10 +41,7 @@ public class DescendantOrSelfSelector extends DescendantSelector {
         if(contextNode == null)
             {return null;}
         final NodeProxy p = new NodeProxy(contextNode.getExpression(), doc, nodeId);
-        if (Expression.NO_CONTEXT_ID != contextId) {
-            p.deepCopyContext(contextNode, contextId);
-        } else
-            {p.copyContext(contextNode);}
+        NodeProxy.propagatePredicateContextFrom(p, contextNode, contextId);
         return p;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/DescendantSelector.java
+++ b/exist-core/src/main/java/org/exist/xquery/DescendantSelector.java
@@ -45,10 +45,7 @@ public class DescendantSelector implements NodeSelector {
         final NodeProxy contextNode = context.parentWithChild(doc, nodeId, false, false);
         if (contextNode == null)
             {return null;}
-        if (Expression.NO_CONTEXT_ID != contextId) {
-            p.deepCopyContext(contextNode, contextId);
-        } else
-            {p.copyContext(contextNode);}
+        NodeProxy.propagatePredicateContextFrom(p, contextNode, contextId);
         return p;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -1026,7 +1026,7 @@ public class LocationStep extends Step {
                         if (Expression.NO_CONTEXT_ID != contextId) {
                             ancestor.addContextNode(contextId, current);
                         } else {
-                            ancestor.copyContext(current);
+                            NodeProxy.propagatePredicateContextFrom(ancestor, current, contextId);
                         }
                         ancestor.addMatches(current);
                         result.add(ancestor);
@@ -1047,7 +1047,7 @@ public class LocationStep extends Step {
                                 if (Expression.NO_CONTEXT_ID != contextId) {
                                     ancestor.addContextNode(contextId, current);
                                 } else {
-                                    ancestor.copyContext(current);
+                                    NodeProxy.propagatePredicateContextFrom(ancestor, current, contextId);
                                 }
                                 ancestor.addMatches(current);
                                 result.add(ancestor);
@@ -1294,7 +1294,7 @@ public class LocationStep extends Step {
 
                     if (Expression.IGNORE_CONTEXT != contextId) {
                         if (Expression.NO_CONTEXT_ID == contextId) {
-                            sibling.copyContext(start);
+                            NodeProxy.propagatePredicateContextFrom(sibling, start, contextId);
                         } else {
                             sibling.addContextNode(contextId, start);
                         }
@@ -1349,7 +1349,7 @@ public class LocationStep extends Step {
                             StaXUtil.streamType2DOM(reader.getEventType()), ((EmbeddedXMLStreamReader) reader).getCurrentPosition());
                     if (Expression.IGNORE_CONTEXT != contextId) {
                         if (Expression.NO_CONTEXT_ID == contextId) {
-                            sibling.copyContext(referenceNode);
+                            NodeProxy.propagatePredicateContextFrom(sibling, referenceNode, contextId);
                         } else {
                             sibling.addContextNode(contextId, referenceNode);
                         }
@@ -1399,7 +1399,7 @@ public class LocationStep extends Step {
                         StaXUtil.streamType2DOM(reader.getEventType()), ((EmbeddedXMLStreamReader) reader).getCurrentPosition());
                 if (Expression.IGNORE_CONTEXT != contextId) {
                     if (Expression.NO_CONTEXT_ID == contextId) {
-                        proxy.copyContext(referenceNode);
+                        NodeProxy.propagatePredicateContextFrom(proxy, referenceNode, contextId);
                     } else {
                         proxy.addContextNode(contextId, referenceNode);
                     }
@@ -1444,7 +1444,7 @@ public class LocationStep extends Step {
                         StaXUtil.streamType2DOM(reader.getEventType()), ((EmbeddedXMLStreamReader) reader).getCurrentPosition());
                 if (Expression.IGNORE_CONTEXT != contextId) {
                     if (Expression.NO_CONTEXT_ID == contextId) {
-                        proxy.copyContext(referenceNode);
+                        NodeProxy.propagatePredicateContextFrom(proxy, referenceNode, contextId);
                     } else {
                         proxy.addContextNode(contextId, referenceNode);
                     }

--- a/exist-core/src/test/java/org/exist/dom/persistent/NodeProxyTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/NodeProxyTest.java
@@ -22,11 +22,14 @@
 
 package org.exist.dom.persistent;
 
+import org.exist.numbering.NodeId;
 import org.exist.xquery.value.SequenceIterator;
 import org.junit.Test;
 import org.w3c.dom.Node;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class NodeProxyTest {
 
@@ -90,5 +93,67 @@ public class NodeProxyTest {
         }
 
         assertEquals(0, count);
+    }
+
+    @Test
+    public void deepCopyContext_clearsExistingContextWhenSourceHasNone() {
+        final NodeProxy target = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
+        final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
+        target.addContextNode(42, existingContextNode);
+
+        final NodeProxy sourceWithoutContext = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
+        target.deepCopyContext(sourceWithoutContext);
+
+        assertNull(target.getContext());
+    }
+
+    @Test
+    public void deepCopyContextWithContextId_addsContextIdEvenWhenSourceHasNoContext() {
+        final NodeProxy target = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
+        final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
+        target.addContextNode(7, existingContextNode);
+
+        final NodeProxy sourceWithoutContext = new NodeProxy(null, null, NodeId.END_OF_DOCUMENT, Node.ELEMENT_NODE, -1);
+        target.deepCopyContext(sourceWithoutContext, 99);
+
+        final ContextItem context = target.getContext();
+        assertEquals(2, countContextItems(context));
+        assertNotNull(findContextItem(context, 99));
+        assertEquals(NodeId.END_OF_DOCUMENT, findContextItem(context, 99).getNode().getNodeId());
+    }
+
+    @Test
+    public void deepCopyContext_selfCopyIsNoOp() {
+        final NodeProxy node = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
+        final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
+        node.addContextNode(42, existingContextNode);
+
+        node.deepCopyContext(node);
+
+        final ContextItem context = node.getContext();
+        assertEquals(1, countContextItems(context));
+        assertEquals(42, context.getContextId());
+        assertEquals(NodeId.ROOT_NODE, context.getNode().getNodeId());
+    }
+
+    private int countContextItems(final ContextItem contextItem) {
+        int count = 0;
+        ContextItem current = contextItem;
+        while (current != null) {
+            count++;
+            current = current.getNextDirect();
+        }
+        return count;
+    }
+
+    private ContextItem findContextItem(final ContextItem contextItem, final int contextId) {
+        ContextItem current = contextItem;
+        while (current != null) {
+            if (current.getContextId() == contextId) {
+                return current;
+            }
+            current = current.getNextDirect();
+        }
+        return null;
     }
 }

--- a/exist-core/src/test/java/org/exist/dom/persistent/NodeProxyTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/NodeProxyTest.java
@@ -23,6 +23,7 @@
 package org.exist.dom.persistent;
 
 import org.exist.numbering.NodeId;
+import org.exist.xquery.Expression;
 import org.exist.xquery.value.SequenceIterator;
 import org.junit.Test;
 import org.w3c.dom.Node;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertNull;
 public class NodeProxyTest {
 
     @Test
-    public void iterate_loop() {
+    public void iterateLoop() {
         final NodeProxy mockNodeProxy = new NodeProxy(null, null, null, Node.ELEMENT_NODE, -1);
 
         final SequenceIterator it = mockNodeProxy.iterate();
@@ -48,7 +49,7 @@ public class NodeProxyTest {
     }
 
     @Test
-    public void iterate_skip_loop() {
+    public void iterateSkipLoop() {
         final NodeProxy mockNodeProxy = new NodeProxy(null, null, null, Node.ELEMENT_NODE, -1);
         final SequenceIterator it = mockNodeProxy.iterate();
 
@@ -68,7 +69,7 @@ public class NodeProxyTest {
     }
 
     @Test
-    public void iterate_loop_skip_loop() {
+    public void iterateLoopSkipLoop() {
         final NodeProxy mockNodeProxy = new NodeProxy(null, null, null, Node.ELEMENT_NODE, -1);
         final SequenceIterator it = mockNodeProxy.iterate();
 
@@ -96,7 +97,7 @@ public class NodeProxyTest {
     }
 
     @Test
-    public void deepCopyContext_clearsExistingContextWhenSourceHasNone() {
+    public void deepCopyContextClearsExistingContextWhenSourceHasNone() {
         final NodeProxy target = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
         final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
         target.addContextNode(42, existingContextNode);
@@ -108,7 +109,7 @@ public class NodeProxyTest {
     }
 
     @Test
-    public void deepCopyContextWithContextId_addsContextIdEvenWhenSourceHasNoContext() {
+    public void deepCopyContextWithContextIdAddsContextIdEvenWhenSourceHasNoContext() {
         final NodeProxy target = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
         final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
         target.addContextNode(7, existingContextNode);
@@ -123,7 +124,19 @@ public class NodeProxyTest {
     }
 
     @Test
-    public void deepCopyContext_selfCopyIsNoOp() {
+    public void propagatePredicateContextFromNoContextIdSkipsWhenSourceHasNoContext() {
+        final NodeProxy target = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
+        final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
+        target.addContextNode(42, existingContextNode);
+
+        final NodeProxy sourceWithoutContext = new NodeProxy(null, null, NodeId.END_OF_DOCUMENT, Node.ELEMENT_NODE, -1);
+        NodeProxy.propagatePredicateContextFrom(target, sourceWithoutContext, Expression.NO_CONTEXT_ID);
+
+        assertEquals(42, target.getContext().getContextId());
+    }
+
+    @Test
+    public void deepCopyContextSelfCopyIsNoOp() {
         final NodeProxy node = new NodeProxy(null, null, NodeId.DOCUMENT_NODE, Node.ELEMENT_NODE, -1);
         final NodeProxy existingContextNode = new NodeProxy(null, null, NodeId.ROOT_NODE, Node.ELEMENT_NODE, -1);
         node.addContextNode(42, existingContextNode);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
+import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
@@ -82,7 +83,7 @@ public abstract class AbstractFieldConfig {
             sb.append("=\"");
             sb.append(moduleImport.uri);
             sb.append("\" at \"");
-            sb.append(resolveURI(configElement.getBaseURI(), moduleImport.at));
+            sb.append(moduleImport.at);
             sb.append("\";\n");
         })));
         sb.append(xpath);
@@ -149,20 +150,138 @@ public abstract class AbstractFieldConfig {
         }
     }
 
-    private String resolveURI(final String baseURI, final String location) {
+    /**
+     * Resolves {@code at} on {@code &lt;module&gt;} for {@code import module} when compiling field/facet
+     * expressions. Must be called with the {@code &lt;module&gt;} element (not {@code &lt;field&gt;}).
+     * <p>
+     * Relative paths are resolved to {@code xmldb:exist:///db/…/module.xql} using the mirrored layout
+     * {@code /db/system/config/db/&lt;col&gt;/collection.xconf} → data collection {@code /db/&lt;col&gt;}.
+     */
+    public static String resolveModuleImportAt(final Element moduleElement, final String location) {
+        if (location == null || location.isEmpty()) {
+            return "";
+        }
+        try {
+            if (new URI(location).isAbsolute()) {
+                return location;
+            }
+        } catch (final URISyntaxException e) {
+            // treat as relative
+        }
+        if (moduleElement.getOwnerDocument() instanceof final DocumentImpl docImpl) {
+            final Collection configColl = docImpl.getCollection();
+            if (configColl != null) {
+                final String fromColl = resolveRelativeAtFromConfigCollection(configColl.getURI(), location);
+                if (fromColl != null) {
+                    return fromColl;
+                }
+            }
+        }
+        final String baseURI = indexConfigFragmentBaseURI(moduleElement);
+        final String rootedBase = toCollectionConfigBasePath(baseURI);
+        final String fromDom = resolveRelativeAtFromRootedConfigPath(rootedBase, location);
+        return fromDom != null ? fromDom : location;
+    }
+
+    @Nullable
+    private static String resolveRelativeAtFromConfigCollection(@Nullable final XmldbURI configCollectionUri, final String location) {
+        if (configCollectionUri == null || location.isEmpty()) {
+            return null;
+        }
+        try {
+            if (new URI(location).isAbsolute()) {
+                return null;
+            }
+        } catch (final URISyntaxException e) {
+            return null;
+        }
+        final String cp = configCollectionUri.getCollectionPath();
+        if (cp == null) {
+            return null;
+        }
+        final String prefix =
+                CollectionConfigurationManager.CONFIG_COLLECTION + '/' + XmldbURI.ROOT_COLLECTION_NAME + '/';
+        if (!cp.startsWith(prefix)) {
+            return null;
+        }
+        final String tail = cp.substring(prefix.length());
+        return XmldbURI.EMBEDDED_SERVER_URI_PREFIX + XmldbURI.ROOT_COLLECTION + '/' + tail + '/' + location;
+    }
+
+    @Nullable
+    private static String resolveRelativeAtFromRootedConfigPath(@Nullable final String rootedBase, final String location) {
+        if (rootedBase == null || rootedBase.isEmpty()) {
+            return null;
+        }
         try {
             final URI uri = new URI(location);
-            if (!uri.isAbsolute() && baseURI != null && baseURI.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
-                String base = baseURI.substring(CollectionConfigurationManager.CONFIG_COLLECTION.length());
-                final int lastSlash = base.lastIndexOf('/');
-                if (lastSlash > -1) {
-                    base = base.substring(0, lastSlash);
-                }
-                return XmldbURI.EMBEDDED_SERVER_URI_PREFIX + base + '/' + location;
+            if (uri.isAbsolute()) {
+                return null;
             }
-        } catch (URISyntaxException e) {
-            // ignore and return location
+            if (!rootedBase.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
+                return null;
+            }
+            String base = rootedBase.substring(CollectionConfigurationManager.CONFIG_COLLECTION.length());
+            final int lastSlash = base.lastIndexOf('/');
+            if (lastSlash > -1) {
+                base = base.substring(0, lastSlash);
+            }
+            return XmldbURI.EMBEDDED_SERVER_URI_PREFIX + base + '/' + location;
+        } catch (final URISyntaxException e) {
+            return null;
         }
-        return location;
+    }
+
+    /**
+     * Base URI for DOM fragments: nested nodes (e.g. {@code &lt;module&gt;}) may have an empty
+     * {@link org.w3c.dom.Node#getBaseURI()}; fall back to the owner document.
+     */
+    private static String indexConfigFragmentBaseURI(final Element configElement) {
+        String baseURI = configElement.getBaseURI();
+        if (baseURI != null && !baseURI.isEmpty()) {
+            return baseURI;
+        }
+        final org.w3c.dom.Document doc = configElement.getOwnerDocument();
+        if (doc == null) {
+            return "";
+        }
+        baseURI = doc.getDocumentURI();
+        if (baseURI != null && !baseURI.isEmpty()) {
+            return baseURI;
+        }
+        final Element root = doc.getDocumentElement();
+        if (root != null) {
+            baseURI = root.getBaseURI();
+            if (baseURI != null && !baseURI.isEmpty()) {
+                return baseURI;
+            }
+        }
+        return "";
+    }
+
+    /**
+     * {@link org.w3c.dom.Node#getBaseURI()} for stored collection.xconf documents is typically an
+     * {@code xmldb:} URI. Relative {@code at=} paths in {@code <module>} must still resolve against
+     * the mirrored {@code /db/...} collection like plain {@code /db/system/config/...} bases.
+     */
+    @Nullable
+    private static String toCollectionConfigBasePath(@Nullable final String baseURI) {
+        if (baseURI == null || baseURI.isEmpty()) {
+            return baseURI;
+        }
+        if (baseURI.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
+            return baseURI;
+        }
+        if (baseURI.startsWith(XmldbURI.XMLDB_URI_PREFIX)) {
+            try {
+                final String collPath = XmldbURI.create(baseURI).getCollectionPath();
+                if (collPath != null && collPath.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
+                    return collPath;
+                }
+            } catch (final IllegalArgumentException ignored) {
+                // fall through
+            }
+        }
+        return baseURI;
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -21,6 +21,8 @@
  */
 package org.exist.indexing.lucene;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +36,7 @@ import org.exist.storage.NodePath;
 import org.exist.storage.NodePath2;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.xmldb.XmldbURI;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -111,6 +114,8 @@ public class LuceneConfig {
     	this.vectorStore = other.vectorStore;
     	this.analyzers = other.analyzers;
     	this.facetsConfig = other.facetsConfig;
+    	this.imports = other.imports;
+    	this.queryParser = other.queryParser;
     }
 
     /**
@@ -635,7 +640,19 @@ public class LuceneConfig {
                 throw new DatabaseConfigurationException("Attribute prefix for <module> required");
             }
 
-            this.at = config.getAttribute(ATTR_MODULE_AT);
+            final String rawAt = config.getAttribute(ATTR_MODULE_AT);
+            if (rawAt.isEmpty()) {
+                throw new DatabaseConfigurationException("Attribute at for <module> required");
+            }
+            this.at = AbstractFieldConfig.resolveModuleImportAt(config, rawAt);
+            try {
+                if (!new URI(rawAt).isAbsolute() && !this.at.startsWith(XmldbURI.XMLDB_URI_PREFIX)) {
+                    throw new DatabaseConfigurationException(
+                            "Could not resolve relative module at=\"" + rawAt + "\" for Lucene index (no config collection context)");
+                }
+            } catch (final URISyntaxException e) {
+                throw new DatabaseConfigurationException("Invalid module at value: " + rawAt, e);
+            }
         }
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1548,8 +1548,10 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     parentNode.addMatch(match);
                     resultSet.add(parentNode, sizeHint);
                     if (Expression.NO_CONTEXT_ID != contextId) {
+                        // Keep contextId propagation for predicate tracking even when the hit node
+                        // has no pre-existing context chain.
                         parentNode.deepCopyContext(storedNode, contextId);
-                    } else {
+                    } else if (storedNode.getContext() != null) {
                         parentNode.copyContext(storedNode);
                     }
                     chainCollect(doc);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1547,13 +1547,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 if (parentNode != null) {
                     parentNode.addMatch(match);
                     resultSet.add(parentNode, sizeHint);
-                    if (Expression.NO_CONTEXT_ID != contextId) {
-                        // Keep contextId propagation for predicate tracking even when the hit node
-                        // has no pre-existing context chain.
-                        parentNode.deepCopyContext(storedNode, contextId);
-                    } else if (storedNode.getContext() != null) {
-                        parentNode.copyContext(storedNode);
-                    }
+                    NodeProxy.propagatePredicateContextFrom(parentNode, storedNode, contextId);
                     chainCollect(doc);
                 }
             }
@@ -1565,11 +1559,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     fromContext = contextSet.parentWithChild(storedNode, true, true, NodeProxy.UNKNOWN_NODE_LEVEL);
                 }
                 if (fromContext != null) {
-                    if (Expression.NO_CONTEXT_ID != contextId) {
-                        storedNode.deepCopyContext(fromContext, contextId);
-                    } else {
-                        storedNode.copyContext(fromContext);
-                    }
+                    NodeProxy.propagatePredicateContextFrom(storedNode, fromContext, contextId);
                 }
                 resultSet.add(storedNode, sizeHint);
                 chainCollect(doc);

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -57,7 +57,6 @@ import org.junit.AfterClass;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -73,20 +72,20 @@ public class LuceneMatchListenerTest {
     @ClassRule
     public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
-    private static String XML =
-            "<root>" +
-            "   <para>some paragraph with <hi>mixed</hi> content.</para>" +
-            "   <para>another paragraph with <note><hi>nested</hi> inner</note> elements.</para>" +
-            "   <para>a third paragraph with <term>term</term>.</para>" +
-            "   <para>double match double match</para>" +
-            "</root>";
+    private static String XML = """
+            <root>
+               <para>some paragraph with <hi>mixed</hi> content.</para>
+               <para>another paragraph with <note><hi>nested</hi> inner</note> elements.</para>
+               <para>a third paragraph with <term>term</term>.</para>
+               <para>double match double match</para>
+            </root>""";
 
-    private static String XML1 =
-            "<article>" +
-            "   <head>The <b>title</b>of it</head>" +
-            "   <p>A simple<note>sic</note> paragraph with <hi>highlighted</hi> text <note>and a note</note> to be ignored.</p>" +
-            "   <p>Paragraphs with <s>mix</s><s>ed</s> content are <s>danger</s>ous.</p>" +
-            "</article>";
+    private static String XML1 = """
+            <article>
+               <head>The <b>title</b>of it</head>
+               <p>A simple<note>sic</note> paragraph with <hi>highlighted</hi> text <note>and a note</note> to be ignored.</p>
+               <p>Paragraphs with <s>mix</s><s>ed</s> content are <s>danger</s>ous.</p>
+            </article>""";
 
     private static String XML2 =
             """
@@ -114,40 +113,40 @@ public class LuceneMatchListenerTest {
                     <w>љуте</w>.</s>
             </p>""";
 
-    private static String CONF1 =
-        "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
-        "   <index>" +
-        "       <text qname=\"para\"/>" +
-        "   </index>" +
-        "</collection>";
+    private static String CONF1 = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+               <index>
+                   <text qname="para"/>
+               </index>
+            </collection>""";
 
-    private static String CONF2 =
-        "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
-        "   <index>" +
-        "       <text qname=\"para\"/>" +
-        "       <text qname=\"term\"/>" +
-        "   </index>" +
-        "</collection>";
+    private static String CONF2 = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+               <index>
+                   <text qname="para"/>
+                   <text qname="term"/>
+               </index>
+            </collection>""";
 
-    private static String CONF3 =
-        "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
-        "   <index>" +
-        "       <text qname=\"hi\"/>" +
-        "   </index>" +
-        "</collection>";
+    private static String CONF3 = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+               <index>
+                   <text qname="hi"/>
+               </index>
+            </collection>""";
 
-    private static String CONF4 =
-        "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
-        "   <index xmlns:tei=\"http://www.tei-c.org/ns/1.0\">" +
-        "       <lucene>" +
-        "           <text qname=\"p\">" +
-        "               <ignore qname=\"note\"/>" +
-        "           </text>" +
-        "           <text qname=\"head\"/>" +
-        "           <inline qname=\"s\"/>" +
-        "       </lucene>" +
-        "   </index>" +
-        "</collection>";
+    private static String CONF4 = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+               <index xmlns:tei="http://www.tei-c.org/ns/1.0">
+                   <lucene>
+                       <text qname="p">
+                           <ignore qname="note"/>
+                       </text>
+                       <text qname="head"/>
+                       <inline qname="s"/>
+                   </lucene>
+               </index>
+            </collection>""";
 
 
     private static String CONF5 =
@@ -436,7 +435,6 @@ public class LuceneMatchListenerTest {
     }
 
     @Test
-    @Ignore("FIXME: context is missing for node in predicate; //tei:p[.//tei:w[ft:query(.,...)]] ! util:expand(.) — LuceneHitCollector returnAncestor copies null context from storedNode onto parentNode")
     public void inlineMatchNodesWhenIndenting() throws EXistException, PermissionDeniedException, XPathException, SAXException, CollectionConfigurationException, LockException, IOException {
         configureAndStore(CONF5, XML2);
 
@@ -451,33 +449,55 @@ public class LuceneMatchListenerTest {
             assertEquals(1, seq.getItemCount());
             final String result = queryResult2String(broker, seq, true);
 
-            final String expected =
-            "<p xmlns=\"http://www.tei-c.org/ns/1.0\">\n" +
-            "    <s type=\"combo\">\n" +
-            "        <w lemma=\"из\">из</w>\n" +
-            "        <w>новина</w>\n" +
-            "        <w lemma=\"и\">и</w>\n" +
-            "        <w lemma=\"од\">од</w>\n" +
-            "        <lb/>\n" +
-            "        <pb n=\"32\"/>\n" +
-            "        <w>других</w>\n" +
-            "        <w lemma=\"човек\">људи</w>\n" +
-            "        <w>" + MATCH_START + "дознајем" + MATCH_END + "</w>, <w xml:id=\"VSK.P13.t1.p4.w205\" lemma=\"ма\">ма</w>\n" +
-            "        <w>се</w>\n" +
-            "        <w lemma=\"не\">не</w>\n" +
-            "        <w>прорезује</w>\n" +
-            "        <w>право</w>\n" +
-            "        <w lemma=\"по\">по</w>\n" +
-            "        <w>имућству</w>, <w xml:id=\"VSK.P13.t1.p4.w219\" lemma=\"те\">те</w>\n" +
-            "        <w>се</w>\n" +
-            "        <w>на</w>\n" +
-            "        <w lemma=\"то\">то</w>\n" +
-            "        <w>видим</w>\n" +
-            "        <w>многи</w>\n" +
-            "        <w>љуте</w>.</s>\n" +
-            "</p>";
+            final String expected = """
+                    <p xmlns="http://www.tei-c.org/ns/1.0">
+                        <s type="combo">
+                            <w lemma="из">из</w>
+                            <w>новина</w>
+                            <w lemma="и">и</w>
+                            <w lemma="од">од</w>
+                            <lb/>
+                            <pb n="32"/>
+                            <w>других</w>
+                            <w lemma="човек">људи</w>
+                            <w>%sдознајем%s</w>, <w xml:id="VSK.P13.t1.p4.w205" lemma="ма">ма</w>
+                            <w>се</w>
+                            <w lemma="не">не</w>
+                            <w>прорезује</w>
+                            <w>право</w>
+                            <w lemma="по">по</w>
+                            <w>имућству</w>, <w xml:id="VSK.P13.t1.p4.w219" lemma="те">те</w>
+                            <w>се</w>
+                            <w>на</w>
+                            <w lemma="то">то</w>
+                            <w>видим</w>
+                            <w>многи</w>
+                            <w>љуте</w>.</s>
+                    </p>""".formatted(MATCH_START, MATCH_END);
 
             XMLAssert.assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    public void inlineMatchNodesWhenIndenting_withAdditionalPredicate() throws EXistException, PermissionDeniedException, XPathException, SAXException, CollectionConfigurationException, LockException, IOException, XpathException {
+        configureAndStore(CONF5, XML2);
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            assertNotNull(xquery);
+            final String query = """
+                    declare namespace tei="http://www.tei-c.org/ns/1.0";
+                    //tei:p[.//tei:w[ft:query(., <query><bool><term>дознајем</term></bool></query>)]]
+                    [.//tei:w[@lemma='ма']] ! util:expand(.)
+                    """;
+            final Sequence seq = xquery.execute(broker, query, null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            final String result = queryResult2String(broker, seq, true);
+            XMLAssert.assertXpathEvaluatesTo("1", "count(//exist:match)", result);
         }
     }
 

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -480,7 +480,7 @@ public class LuceneMatchListenerTest {
     }
 
     @Test
-    public void inlineMatchNodesWhenIndenting_withAdditionalPredicate() throws EXistException, PermissionDeniedException, XPathException, SAXException, CollectionConfigurationException, LockException, IOException, XpathException {
+    public void inlineMatchNodesWhenIndentingWithAdditionalPredicate() throws EXistException, PermissionDeniedException, XPathException, SAXException, CollectionConfigurationException, LockException, IOException, XpathException {
         configureAndStore(CONF5, XML2);
 
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();

--- a/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneIndexingTests.java
+++ b/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneIndexingTests.java
@@ -32,7 +32,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(XSuite.class)
 @XSuite.XSuiteFiles({
-    "src/test/xquery/lucene/ft-query-field.xqm"
+    "src/test/xquery/lucene/ft-query-field.xqm",
+    "src/test/xquery/lucene/self-axis-index.xqm"
 })
 public class LuceneIndexingTests {
 }

--- a/extensions/indexes/lucene/src/test/xquery/lucene/ft-attr-context.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/ft-attr-context.xql
@@ -159,29 +159,18 @@ function ftac:query-path-attr-in-predicate() {
     return deep-equal($result, collection($ftac:COLLECTION)//p)
 };
 
-(:~
- : FIXME: attr-in-predicate path — same semantic as query-qname-attr-in-predicate but
- : uses /*[descendant-or-self::p/@att1[ft:query(., ...)]] which triggers "context is
- : missing for node". LuceneHitCollector returnAncestor copies null context from storedNode
- : onto parentNode. Fix: preserve parentNode context when storedNode has none.
- :)
+(:~ [query] lucene FT index (qname), attribute context inside descendant-or-self predicate. :)
 declare
-    %test:pending("FIXME: context is missing for node; attr-in-predicate path evaluation")
     %test:assertTrue
-function ftac:query-qname-attr-in-predicate-broken() {
+function ftac:query-qname-attr-in-predicate-descendant-or-self() {
     let $result := collection($ftac:COLLECTION)/*[descendant-or-self::p/@att1[ft:query(., 'val1')]]
     return deep-equal($result, collection($ftac:COLLECTION)//p)
 };
 
-(:~
- : FIXME: attr-in-predicate path — same semantic as query-path-attr-in-predicate but
- : uses /*[descendant-or-self::p/@att2[ft:query(., ...)]] which triggers "context is
- : missing for node".
- :)
+(:~ [query] lucene FT index (path), attribute context inside descendant-or-self predicate. :)
 declare
-    %test:pending("FIXME: context is missing for node; attr-in-predicate path evaluation")
     %test:assertTrue
-function ftac:query-path-attr-in-predicate-broken() {
+function ftac:query-path-attr-in-predicate-descendant-or-self() {
     let $result := collection($ftac:COLLECTION)/*[descendant-or-self::p/@att2[ft:query(., 'val2')]]
     return deep-equal($result, collection($ftac:COLLECTION)//p)
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/self-axis-index.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/self-axis-index.xqm
@@ -1,0 +1,229 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Lucene field calls `sail:list-length-label(.)` from a DB-stored library (`facet:setup`
+ : pattern): one `nodiacritics` analyzer on `text`, relative `at="sai-lib.xql"` on `module`
+ : (resolved at parse time from the config collection mirror). Library parameter is `item()`
+ : so the Lucene context item (`element()` in the engine) matches.
+ :)
+module namespace t = "http://exist-db.org/xquery/lucene/self-axis-index";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+import module namespace ft = "http://exist-db.org/xquery/lucene";
+import module namespace inspect = "http://exist-db.org/xquery/inspection";
+
+declare variable $t:INDEX_LIB :=
+    ``[xquery version "3.1";
+
+module namespace sail="http://exist-db.org/xquery/lucene/self-axis-index-lib";
+
+declare function sail:list-length-label($n as item()) as xs:string {
+    if (count($n/item) gt 1) then 'multi' else 'single'
+};
+]``;
+
+declare variable $t:LIB_NAME := "sai-lib.xql";
+
+declare variable $t:XML := document {
+    <root>
+        <list id="short">
+            <item>1</item>
+        </list>
+        <list id="long">
+            <item>1</item>
+            <item>2</item>
+        </list>
+    </root>
+};
+
+declare variable $t:COLL := "/db/test-" || "self-axis-index";
+declare variable $t:CONF_COLL := "/db/system/config/db/" || substring-after($t:COLL, "/db/");
+
+declare variable $t:MODULE_AT as xs:anyURI := xs:anyURI("xmldb:exist://" || $t:COLL || "/" || $t:LIB_NAME);
+
+declare variable $t:xconf :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <analyzer class="org.exist.indexing.lucene.analyzers.NoDiacriticsStandardAnalyzer" id="nodiacritics"/>
+                <module uri="http://exist-db.org/xquery/lucene/self-axis-index-lib" prefix="sail" at="sai-lib.xql"/>
+                <text qname="list" analyzer="nodiacritics">
+                    <field name="length" expression="sail:list-length-label(.)"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare
+    %test:setUp
+function t:setup() {
+    let $_ := (xmldb:create-collection("/db/system", "config"), xmldb:create-collection("/db/system/config", "db"))
+    let $_ := xmldb:create-collection("/db", substring-after($t:COLL, "/db/"))
+    let $_ := xmldb:create-collection("/db/system/config/db", substring-after($t:COLL, "/db/"))
+    return (
+        xmldb:store($t:COLL, $t:LIB_NAME, $t:INDEX_LIB, "application/xquery"),
+        xmldb:store($t:CONF_COLL, "collection.xconf", $t:xconf),
+        xmldb:store($t:COLL, "test.xml", $t:XML),
+        xmldb:reindex($t:COLL)
+    )
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    if (xmldb:collection-available($t:COLL)) then xmldb:remove($t:COLL) else (),
+    if (xmldb:collection-available($t:CONF_COLL)) then xmldb:remove($t:CONF_COLL) else ()
+};
+
+(:~ --- Stored library (facet-style artifact) --- :)
+
+declare
+    %test:assertExists
+function t:stored-index-library-module-exports-a-function() {
+    inspect:module-functions($t:MODULE_AT)[1]
+};
+
+(:~ --- Collection shape --- :)
+
+declare
+    %test:assertEquals(2)
+function t:two-list-elements-in-collection() {
+    count(collection($t:COLL)//list)
+};
+
+declare
+    %test:assertEquals(1)
+function t:one-list-has-single-item() {
+    count(collection($t:COLL)//list[count(item) eq 1])
+};
+
+declare
+    %test:assertEquals(1)
+function t:one-list-has-two-items() {
+    count(collection($t:COLL)//list[count(item) eq 2])
+};
+
+(:~ --- Lucene field queries: hit counts --- :)
+
+declare
+    %test:assertEquals(1)
+function t:exactly-one-list-matches-length-multi-query() {
+    count(collection($t:COLL)//list[ft:query(., "length:multi")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:exactly-one-list-matches-length-single-query() {
+    count(collection($t:COLL)//list[ft:query(., "length:single")])
+};
+
+(:~ --- Correct list identity for each query --- :)
+
+declare
+    %test:assertEquals("long")
+function t:length-multi-query-selects-two-item-list-id() {
+    string((collection($t:COLL)//list[ft:query(., "length:multi")])/@id)
+};
+
+declare
+    %test:assertEquals("short")
+function t:length-single-query-selects-one-item-list-id() {
+    string((collection($t:COLL)//list[ft:query(., "length:single")])/@id)
+};
+
+(:~ --- ft:field matches indexed Lucene field --- :)
+
+declare
+    %test:assertEquals("multi")
+function t:ft-field-on-multi-hit-eq-multi() {
+    let $hit := collection($t:COLL)//list[ft:query(., "length:multi")]
+    return
+        string(ft:field($hit, "length"))
+};
+
+declare
+    %test:assertEquals("single")
+function t:ft-field-on-single-hit-eq-single() {
+    let $hit := collection($t:COLL)//list[ft:query(., "length:single")]
+    return
+        string(ft:field($hit, "length"))
+};
+
+(:~ --- Negative: single-item list must not match multi field query --- :)
+
+declare
+    %test:assertEmpty
+function t:no-single-item-list-in-length-multi-query() {
+    collection($t:COLL)//list[count(item) eq 1][ft:query(., "length:multi")]
+};
+
+declare
+    %test:assertExists
+function t:two-item-list-matches-length-multi-query() {
+    collection($t:COLL)//list[count(item) gt 1][ft:query(., "length:multi")]
+};
+
+(:~ --- Production-style: main-text hit then order by stored Lucene field (TEI Publisher pattern) --- :)
+
+declare
+    %test:assertEquals(2)
+function t:text-query-one-matches-both-lists() {
+    count(collection($t:COLL)//list[ft:query(., "1")])
+};
+
+(:~ Default string order places "multi" before "single", so ids sort long then short. :)
+declare
+    %test:assertEquals("long short")
+function t:order-by-length-field-after-text-query() {
+    string-join(
+        for $list in collection($t:COLL)//list[ft:query(., "1")]
+        order by ft:field($list, "length")
+        return string($list/@id),
+        " "
+    )
+};
+
+(:~ --- assertXPath: structured summary (expected vs $result tree) --- :)
+
+declare
+    %test:assertXPath("number($result//count[@name eq 'lists']) eq 2")
+    %test:assertXPath("number($result//count[@name eq 'multi-hits']) eq 1")
+    %test:assertXPath("number($result//count[@name eq 'single-hits']) eq 1")
+    %test:assertXPath("string($result//field[@which eq 'multi']) eq 'multi'")
+    %test:assertXPath("string($result//field[@which eq 'single']) eq 'single'")
+function t:summary-xml-for-field-queries() {
+    let $lists := collection($t:COLL)//list
+    let $multi := $lists[ft:query(., "length:multi")]
+    let $single := $lists[ft:query(., "length:single")]
+    return
+        <summary>
+            <count name="lists">{count($lists)}</count>
+            <count name="multi-hits">{count($multi)}</count>
+            <count name="single-hits">{count($single)}</count>
+            <field which="multi">{string(ft:field($multi, "length"))}</field>
+            <field which="single">{string(ft:field($single, "length"))}</field>
+        </summary>
+};

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
@@ -847,13 +847,7 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                         getAddress(doc, storedNode);
                         if (axis == NodeSet.ANCESTOR) {
                             resultSet.add(parentNode, sizeHint);
-                            if (Expression.NO_CONTEXT_ID != contextId) {
-                                // Keep contextId propagation for predicate tracking even when the
-                                // hit node has no pre-existing context chain.
-                                parentNode.deepCopyContext(storedNode, contextId);
-                            } else if (storedNode.getContext() != null) {
-                                parentNode.copyContext(storedNode);
-                            }
+                            NodeProxy.propagatePredicateContextFrom(parentNode, storedNode, contextId);
                         } else {
                             resultSet.add(storedNode, sizeHint);
                         }

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
@@ -848,9 +848,12 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                         if (axis == NodeSet.ANCESTOR) {
                             resultSet.add(parentNode, sizeHint);
                             if (Expression.NO_CONTEXT_ID != contextId) {
+                                // Keep contextId propagation for predicate tracking even when the
+                                // hit node has no pre-existing context chain.
                                 parentNode.deepCopyContext(storedNode, contextId);
-                            } else
+                            } else if (storedNode.getContext() != null) {
                                 parentNode.copyContext(storedNode);
+                            }
                         } else {
                             resultSet.add(storedNode, sizeHint);
                         }


### PR DESCRIPTION
## Summary

Fixes XPath **predicate `ContextItem` propagation** when Lucene/range (and structural) indexes promote hits to ancestors or merge node sets, and **centralizes** the merge rule so we do not call `copyContext` from a context-less source and accidentally clear a node that still needs predicate tracking. Adds **`NodeProxy.propagatePredicateContextFrom`**, tightens **`deepCopyContext(NodeProxy)`** (clear-first contract, self-copy no-op, Javadoc), extends **unit / XQSuite / integration** coverage.

see https://github.com/eXist-db/exist/pull/6146#issue-4088047082

## What changed

- **`NodeProxy`**: `propagatePredicateContextFrom`; `deepCopyContext` self-guard + documented clear-then-copy behavior; **`NodeProxyTest`** (including propagate + self-copy cases).
- **Indexes**: `LuceneIndexWorker`, `RangeIndexWorker`, `NativeStructuralIndexWorker` use the shared helper (or equivalent) for ancestor / context-set merges.
- **Core evaluation / node sets**: `NewArrayNodeSet`, `ExtArrayNodeSet`, `NodeSetHelper`, `AbstractNodeSet`, `LocationStep` StAX filters, `ChildSelector` / `DescendantSelector` / `DescendantOrSelfSelector` — **`NO_CONTEXT_ID`** paths use the guarded merge where a bare `copyContext` could wipe context; **`addContextNode` / active `contextId`** paths unchanged where they differ from `deepCopyContext`.
- **Intentionally untouched**: `VirtualNodeSet` (`copyContext` then `addContextNode` sequencing).


## Risk / review focus

- Any **third-party or extension** code that relied on **`copyContext` clearing** the target when the source had **no** context chain will now see a **no-op** on that copy step for the guarded paths; sanity-check custom index or optimizer integrations that fork `NodeSetHelper` / array node sets.
