### PR TITLE
[bugfix] fn:format-number: preserve full xs:decimal precision

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -844,7 +844,8 @@ public class FnFormatNumbers extends BasicFunction {
             }
         }
 
-        adjustedNumber = new DecimalValue(this, adjustedNumber.convertTo(Type.DECIMAL).toJavaObject(BigDecimal.class).multiply(BigDecimal.ONE, MathContext.DECIMAL64)).round(new IntegerValue(this, subPicture.getMaximumFractionalPartSize())).abs();
+        // Preserve full BigDecimal precision (XQTS numberformat63/64 require >16 sig digits for xs:decimal/xs:integer inputs); a previous MathContext.DECIMAL64 cap truncated to 16. xs:double inputs already arrive via BigDecimal.valueOf, so the canonical representation is preserved.
+        adjustedNumber = new DecimalValue(this, adjustedNumber.convertTo(Type.DECIMAL).toJavaObject(BigDecimal.class)).round(new IntegerValue(this, subPicture.getMaximumFractionalPartSize())).abs();
 
         /* we can now start formatting for display */
 


### PR DESCRIPTION
## Summary

`fn:format-number` was truncating high-precision `xs:decimal` / `xs:integer` inputs to 16 significant digits before formatting, because the final BigDecimal coercion ran `multiply(BigDecimal.ONE, MathContext.DECIMAL64)`. Multiplying by ONE is otherwise a no-op — the `MathContext` was the only effect, and it was strictly destructive.

Removing the `MathContext.DECIMAL64` cap preserves full precision. The subsequent `.round(maxFractionalPartSize)` still handles the user-requested fractional-part size.

`xs:double` inputs are unaffected: `DoubleValue.toDecimalValue()` already uses `BigDecimal.valueOf(value)`, which yields the canonical short representation (e.g. `0.1` rather than the 50-digit exact bit-pattern decimal). So no regression there.

## What changed

- `FnFormatNumbers.format()` line 605: drop the `multiply(BigDecimal.ONE, MathContext.DECIMAL64)` from the final adjusted-number coercion.
- One-line diff (plus a single-sentence comment explaining the rationale).

## Spec references

- [XPath/XQuery 3.1 §4.7.3 fn:format-number](https://www.w3.org/TR/xpath-functions-31/#func-format-number)
- The relevant XQTS test cases (`numberformat63`/`numberformat64`) accept *either* full-precision output *or* `FOAR0002` per their `<any-of>` assertion. We now produce the full-precision output, matching what Saxon and BaseX return.

## XQTS 3.1 fn-format-number — before / after

Measured locally with the runner JAR built from this branch's exist-core, against `qt3tests-master`:

| Suite | Pass / Tests | % |
|-------|-------------:|--:|
| before (`65a1d3ded3`, gap-analysis run 2026-05-09) | 74 / 77 | 96.1% |
| after (this PR @ `bc327814fe`) | 78 / 78 | 100% |

Net delta from this commit alone: **+2** (numberformat63, numberformat64). The third previous failure, `numberformat901err`, was the `declare default decimal-format` parser case — that one was fixed independently by #6339 (merged ~2026-05-10) and is included in the post-numbers above. The +1 in test count is unrelated drift in the upstream qt3tests catalog.

## Test plan

- [x] `mvn install -pl exist-core -am -DskipTests` — clean build
- [x] `mvn test -pl exist-core -Dtest='NumberTests,XQuery3Tests,XPathQueryTest'` — 1,322 tests, 0 failures, 6 skipped (pre-existing)
- [x] XQTS 3.1 fn-format-number: 78 / 78
- [x] Codacy PMD on changed file: no new warnings introduced (4 pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)