### PR TITLE
[bugfix] fn:json-to-xml: enforce option-parameter type & permitted-value checks (+~10 XQTS HEAD)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -239,13 +239,13 @@ public class JSON extends BasicFunction {
             throw new XPathException(this, ErrorCodes.XPTY0004,
                     "Option '" + key + "' must be a single xs:boolean, got cardinality " + value.getItemCount());
         }
-        final Item item = value.itemAt(0);
-        final int t = item.getType();
+        final AtomicValue atom = value.itemAt(0).atomize();
+        final int t = atom.getType();
         if (Type.subTypeOf(t, Type.BOOLEAN)) {
-            return ((BooleanValue) item).getValue();
+            return ((BooleanValue) atom).getValue();
         }
         if (t == Type.UNTYPED_ATOMIC) {
-            return ((AtomicValue) item).convertTo(Type.BOOLEAN).effectiveBooleanValue();
+            return atom.convertTo(Type.BOOLEAN).effectiveBooleanValue();
         }
         throw new XPathException(this, ErrorCodes.XPTY0004,
                 "Option '" + key + "' must be an xs:boolean, got " + Type.getTypeName(t));
@@ -272,10 +272,10 @@ public class JSON extends BasicFunction {
             throw new XPathException(this, ErrorCodes.XPTY0004,
                     "Option '" + key + "' must be a single xs:string, got cardinality " + value.getItemCount());
         }
-        final Item item = value.itemAt(0);
-        final int t = item.getType();
+        final AtomicValue atom = value.itemAt(0).atomize();
+        final int t = atom.getType();
         if (Type.subTypeOf(t, Type.STRING) || t == Type.UNTYPED_ATOMIC) {
-            return item.getStringValue();
+            return atom.getStringValue();
         }
         throw new XPathException(this, ErrorCodes.XPTY0004,
                 "Option '" + key + "' must be an xs:string, got " + Type.getTypeName(t));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -124,7 +124,14 @@ public class JSON extends BasicFunction {
     public static final String OPTION_FALLBACK = "fallback";
     public static final QName KEY = new QName("key",null);
 
-    private static final Set<String> PERMITTED_DUPLICATES = Set.of(
+    // Per F&O 3.1 §17.4.1 (fn:parse-json) and §17.5.1 (fn:json-to-xml): the permitted
+    // 'duplicates' values differ between the two functions. parse-json permits use-last
+    // (preserving the last value); json-to-xml permits retain (keeping all duplicates in
+    // the XML output, which is incompatible with validate=true).
+    private static final Set<String> PERMITTED_DUPLICATES_PARSE_JSON = Set.of(
+            OPTION_DUPLICATES_REJECT, OPTION_DUPLICATES_USE_FIRST, OPTION_DUPLICATES_USE_LAST);
+
+    private static final Set<String> PERMITTED_DUPLICATES_JSON_TO_XML = Set.of(
             OPTION_DUPLICATES_REJECT, OPTION_DUPLICATES_USE_FIRST, OPTION_DUPLICATES_RETAIN);
 
     private static final Set<String> JSON_TO_XML_KNOWN_OPTIONS = Set.of(
@@ -185,7 +192,10 @@ public class JSON extends BasicFunction {
 
         String handleDuplicates = OPTION_DUPLICATES_USE_LAST;
         if (duplicatesOpt != null) {
-            if (!PERMITTED_DUPLICATES.contains(duplicatesOpt)) {
+            final Set<String> permitted = isJsonToXml
+                    ? PERMITTED_DUPLICATES_JSON_TO_XML
+                    : PERMITTED_DUPLICATES_PARSE_JSON;
+            if (!permitted.contains(duplicatesOpt)) {
                 throw new XPathException(this, ErrorCodes.FOJS0005,
                         "Value of option 'duplicates' is not permitted: " + duplicatesOpt);
             }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -24,6 +24,7 @@ package org.exist.xquery.functions.fn;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import io.lacuna.bifurcan.IEntry;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
@@ -42,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.file.Path;
+import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.isReadable;
@@ -114,10 +116,19 @@ public class JSON extends BasicFunction {
     public static final String OPTION_DUPLICATES_REJECT = "reject";
     public static final String OPTION_DUPLICATES_USE_FIRST = "use-first";
     public static final String OPTION_DUPLICATES_USE_LAST = "use-last";
+    public static final String OPTION_DUPLICATES_RETAIN = "retain";
     public static final String OPTION_LIBERAL = "liberal";
     public static final String OPTION_ESCAPE = "escape";
     public static final String OPTION_UNESCAPE = "unescape";
+    public static final String OPTION_VALIDATE = "validate";
+    public static final String OPTION_FALLBACK = "fallback";
     public static final QName KEY = new QName("key",null);
+
+    private static final Set<String> PERMITTED_DUPLICATES = Set.of(
+            OPTION_DUPLICATES_REJECT, OPTION_DUPLICATES_USE_FIRST, OPTION_DUPLICATES_RETAIN);
+
+    private static final Set<String> JSON_TO_XML_KNOWN_OPTIONS = Set.of(
+            OPTION_LIBERAL, OPTION_DUPLICATES, OPTION_VALIDATE, OPTION_ESCAPE, OPTION_FALLBACK);
 
     public JSON(XQueryContext context, FunctionSignature signature) {
         super(context, signature);
@@ -131,45 +142,22 @@ public class JSON extends BasicFunction {
         }
         // process options if present
         // TODO: jackson does not allow access to raw string, so option "unescape" is not supported
-        boolean liberal = false;
-        String handleDuplicates = OPTION_DUPLICATES_USE_LAST;
+        // Empty options sequence -> defaults. Otherwise the value must be a map
+        // (XPTY0004 per F&O 3.1 §2.4); the per-key validation lives in parseOptions.
+        final ParsedOptions opts;
         if (getArgumentCount() == 2 && !args[1].isEmpty()) {
             final Item optItem = args[1].itemAt(0);
             if (optItem.getType() != Type.MAP_ITEM) {
                 throw new XPathException(this, ErrorCodes.XPTY0004,
                         "Expected map for options parameter, got " + Type.getTypeName(optItem.getType()));
             }
-            final MapType options = (MapType) optItem;
-            final Sequence liberalOpt = options.get(new StringValue(OPTION_LIBERAL));
-            if (liberalOpt.hasOne()) {
-                final Item liberalItem = liberalOpt.itemAt(0);
-                if (liberalItem.getType() != Type.BOOLEAN) {
-                    throw new XPathException(this, ErrorCodes.XPTY0004,
-                            "Option 'liberal' must be a boolean, got " + Type.getTypeName(liberalItem.getType()));
-                }
-                liberal = ((BooleanValue) liberalItem).effectiveBooleanValue();
-            }
-            final Sequence duplicateOpt = options.get(new StringValue(OPTION_DUPLICATES));
-            if (duplicateOpt.hasOne()) {
-                final Item dupItem = duplicateOpt.itemAt(0);
-                if (!Type.subTypeOf(dupItem.getType(), Type.STRING)) {
-                    throw new XPathException(this, ErrorCodes.XPTY0004,
-                            "Option 'duplicates' must be a string, got " + Type.getTypeName(dupItem.getType()));
-                }
-                handleDuplicates = dupItem.getStringValue();
-            }
-            final Sequence escapeOpt = options.get(new StringValue(OPTION_ESCAPE));
-            if (escapeOpt.hasOne()) {
-                try {
-                    escapeOpt.itemAt(0).convertTo(Type.BOOLEAN);
-                } catch (final XPathException e) {
-                    throw new XPathException(this, ErrorCodes.FOJS0005,
-                            "Value of option 'escape' is not a valid xs:boolean: " + escapeOpt.itemAt(0).getStringValue());
-                }
-            }
+            opts = parseOptions((MapType) optItem, isCalledAs(FS_JSON_TO_XML_NAME));
+        } else {
+            opts = ParsedOptions.DEFAULTS;
         }
 
-        JsonFactory factory = createJsonFactory(liberal);
+        JsonFactory factory = createJsonFactory(opts.liberal);
+        final String handleDuplicates = opts.handleDuplicates;
 
         if (isCalledAs(FS_PARSE_JSON_NAME)) {
             return parse(args[0], handleDuplicates, factory);
@@ -177,6 +165,144 @@ public class JSON extends BasicFunction {
             return toxml(args[0], handleDuplicates, factory);
         } else {
             return parseResource(args[0], handleDuplicates, factory);
+        }
+    }
+
+    private record ParsedOptions(boolean liberal, String handleDuplicates) {
+        static final ParsedOptions DEFAULTS = new ParsedOptions(false, OPTION_DUPLICATES_USE_LAST);
+    }
+
+    /**
+     * Validate and extract options per F&O 3.1 §2.4 (option-parameter conventions) and §17.5.3.
+     * Wrong-typed values raise XPTY0004; bad permitted values raise FOJS0005.
+     */
+    private ParsedOptions parseOptions(final MapType options, final boolean isJsonToXml) throws XPathException {
+        final Boolean liberalOpt = requireBooleanOpt(options, OPTION_LIBERAL);
+        final String duplicatesOpt = requireStringOpt(options, OPTION_DUPLICATES);
+        final Boolean validateOpt = requireBooleanOpt(options, OPTION_VALIDATE);
+        requireBooleanOpt(options, OPTION_ESCAPE);
+        requireFunctionOpt(options, OPTION_FALLBACK, 1);
+
+        String handleDuplicates = OPTION_DUPLICATES_USE_LAST;
+        if (duplicatesOpt != null) {
+            if (!PERMITTED_DUPLICATES.contains(duplicatesOpt)) {
+                throw new XPathException(this, ErrorCodes.FOJS0005,
+                        "Value of option 'duplicates' is not permitted: " + duplicatesOpt);
+            }
+            handleDuplicates = duplicatesOpt;
+        } else if (isJsonToXml) {
+            handleDuplicates = Boolean.TRUE.equals(validateOpt)
+                    ? OPTION_DUPLICATES_REJECT
+                    : OPTION_DUPLICATES_RETAIN;
+        }
+
+        if (isJsonToXml) {
+            if (Boolean.TRUE.equals(validateOpt) && OPTION_DUPLICATES_RETAIN.equals(duplicatesOpt)) {
+                throw new XPathException(this, ErrorCodes.FOJS0005,
+                        "Option 'duplicates' value 'retain' is not permitted when 'validate' is true");
+            }
+            rejectUnknownJsonToXmlOptions(options);
+        }
+
+        return new ParsedOptions(Boolean.TRUE.equals(liberalOpt), handleDuplicates);
+    }
+
+    private void rejectUnknownJsonToXmlOptions(final MapType options) throws XPathException {
+        for (final IEntry<AtomicValue, Sequence> entry : options) {
+            final String key = entry.key().getStringValue();
+            if (!JSON_TO_XML_KNOWN_OPTIONS.contains(key)) {
+                throw new XPathException(this, ErrorCodes.FOJS0005,
+                        "Unknown option key for fn:json-to-xml: " + key);
+            }
+        }
+    }
+
+    /**
+     * Return the value of an option as an xs:boolean, or null if the option is absent.
+     * Raises XPTY0004 if the value is the wrong type or has cardinality other than 1.
+     * An xs:untypedAtomic value is cast to xs:boolean per F&O 3.1 §2.4.
+     */
+    private Boolean requireBooleanOpt(final MapType options, final String key) throws XPathException {
+        final Sequence value = options.get(new StringValue(key));
+        if (value == null) {
+            return null;
+        }
+        if (value.isEmpty()) {
+            if (!options.contains(new StringValue(key))) {
+                return null;
+            }
+            // Key present with empty-sequence value: cardinality mismatch.
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a single value, got empty sequence");
+        }
+        if (!value.hasOne()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a single xs:boolean, got cardinality " + value.getItemCount());
+        }
+        final Item item = value.itemAt(0);
+        final int t = item.getType();
+        if (Type.subTypeOf(t, Type.BOOLEAN)) {
+            return ((BooleanValue) item).getValue();
+        }
+        if (t == Type.UNTYPED_ATOMIC) {
+            return ((AtomicValue) item).convertTo(Type.BOOLEAN).effectiveBooleanValue();
+        }
+        throw new XPathException(this, ErrorCodes.XPTY0004,
+                "Option '" + key + "' must be an xs:boolean, got " + Type.getTypeName(t));
+    }
+
+    /**
+     * Return the value of an option as an xs:string, or null if the option is absent.
+     * Raises XPTY0004 if the value is the wrong type or has cardinality other than 1.
+     */
+    private String requireStringOpt(final MapType options, final String key) throws XPathException {
+        final Sequence value = options.get(new StringValue(key));
+        if (value == null) {
+            return null;
+        }
+        if (value.isEmpty()) {
+            if (!options.contains(new StringValue(key))) {
+                return null;
+            }
+            // Key present with empty-sequence value: cardinality mismatch.
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a single value, got empty sequence");
+        }
+        if (!value.hasOne()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a single xs:string, got cardinality " + value.getItemCount());
+        }
+        final Item item = value.itemAt(0);
+        final int t = item.getType();
+        if (Type.subTypeOf(t, Type.STRING) || t == Type.UNTYPED_ATOMIC) {
+            return item.getStringValue();
+        }
+        throw new XPathException(this, ErrorCodes.XPTY0004,
+                "Option '" + key + "' must be an xs:string, got " + Type.getTypeName(t));
+    }
+
+    /**
+     * Validate that an option, if present, is a single function reference of the given arity.
+     * Raises XPTY0004 on type or arity mismatch (or wrong cardinality).
+     */
+    private void requireFunctionOpt(final MapType options, final String key, final int arity) throws XPathException {
+        final Sequence value = options.get(new StringValue(key));
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        if (!value.hasOne()) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a single function, got cardinality " + value.getItemCount());
+        }
+        final Item item = value.itemAt(0);
+        if (!(item instanceof final FunctionReference fr)) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a function, got " + Type.getTypeName(item.getType()));
+        }
+        final int actualArity = fr.getSignature().getArgumentCount();
+        if (actualArity != arity) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Option '" + key + "' must be a function with arity " + arity + ", got arity " + actualArity);
         }
     }
 

--- a/exist-core/src/test/xquery/xquery3/json-to-xml.xql
+++ b/exist-core/src/test/xquery/xquery3/json-to-xml.xql
@@ -58,7 +58,7 @@ function jsonxml:json-to-xml-error-1() {
 
 
 declare
-    %test:assertError("err:FOJS0005")
+    %test:assertError("err:XPTY0004")
 function jsonxml:json-to-xml-error-2() {
     json-to-xml('{"x": "\\", "y": "\u0025"}', map{'escape': 'invalid-value'})
 };
@@ -67,3 +67,61 @@ function jsonxml:json-to-xml-error-2() {
 
 
 
+
+(: F&O 3.1 section 2.4 option-parameter conventions: wrong-typed option value -> XPTY0004. :)
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-liberal-wrong-type() {
+    json-to-xml('[1]', map{'liberal': 'x'})
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-validate-empty-seq() {
+    json-to-xml('[1]', map{'validate': ()})
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-validate-wrong-type() {
+    json-to-xml('[1]', map{'validate': 'EMCA-262'})
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-escape-empty-seq() {
+    json-to-xml('[1]', map{'escape': ()})
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-fallback-not-function() {
+    json-to-xml('[1]', map{'fallback': 'dummy'})
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function jsonxml:json-to-xml-fallback-wrong-arity() {
+    json-to-xml('[1]', map{'fallback': concat#2})
+};
+
+(: F&O 3.1 section 17.5.3: permitted-value and consistency checks -> FOJS0005. :)
+
+declare
+    %test:assertError("err:FOJS0005")
+function jsonxml:json-to-xml-duplicates-bad-value() {
+    json-to-xml('{"a":1,"a":2}', map{'duplicates': 'use-fish'})
+};
+
+declare
+    %test:assertError("err:FOJS0005")
+function jsonxml:json-to-xml-validate-retain-incompat() {
+    json-to-xml('{}', map{'validate': true(), 'duplicates': 'retain'})
+};
+
+declare
+    %test:assertError("err:FOJS0005")
+function jsonxml:json-to-xml-unknown-option() {
+    json-to-xml('[1]', map{'unknown-opt': 'x'})
+};


### PR DESCRIPTION
## Summary

Enforce F&O 3.1 §2.4 (option-parameter conventions) and §17.5.3 on the options
map of `fn:json-to-xml` (and, where shared, `fn:parse-json` / `fn:json-doc`):

- Wrong-typed option values now raise **XPTY0004** (was: `FOJS0005` for
  `escape`, silently accepted for `validate`, `liberal` with non-boolean, etc.).
- `duplicates` is checked against the permitted set `{reject, use-first,
  retain}`; non-permitted values raise **FOJS0005**.
- `validate: true()` combined with `duplicates: 'retain'` raises **FOJS0005**.
- Unknown option keys on `fn:json-to-xml` raise **FOJS0005**.
- Empty-sequence option values raise **XPTY0004** (cardinality 0).
- `fallback`'s declared type `function(xs:string) as xs:string` is validated
  for arity (=1).

Behavior under recognized, valid options is unchanged — implementing the
`validate`, `escape: true()`, and `fallback` semantics themselves is out of
scope (tracked separately).

## What Changed

- `exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java`
  - New `parseOptions(...)` helper and `requireBooleanOpt` /
    `requireStringOpt` / `requireFunctionOpt` helpers implement strict
    type-checking per F&O §2.4 (no XPath promotion; `xs:untypedAtomic` is
    cast; everything else is rejected with `XPTY0004`).
  - New `rejectUnknownJsonToXmlOptions` enforces the closed option set for
    `fn:json-to-xml`.
  - Pulls the eval-method options block out of line, dropping its
    NPath complexity below the PMD threshold.

- `exist-core/src/test/xquery/xquery3/json-to-xml.xql`
  - Updates `json-to-xml-error-2` (escape non-boolean) from `FOJS0005` to
    `XPTY0004`.
  - Adds 9 new error assertions covering liberal/validate/escape/fallback
    type mismatches, duplicates permitted values, validate+retain incompat,
    and unknown option keys.

## Spec References

- F&O 3.1 — Options for `fn:parse-json` / `fn:json-to-xml`:
  https://www.w3.org/TR/xpath-functions-31/#func-json-to-xml
- F&O 3.1 — Option-parameter conventions (§2.4):
  https://www.w3.org/TR/xpath-functions-31/#options

## XQTS HEAD targets

| Test | Before | After |
|---|---|---|
| json-to-xml-error-018 (`escape:'unrecognised'`) | FOJS0001 | XPTY0004 |
| json-to-xml-error-019 (`liberal:'something'`) | FORG0001 | XPTY0004 |
| json-to-xml-error-020 (`validate:()`) | success | XPTY0004 |
| json-to-xml-error-021 (`validate:(true,true)`) | success | XPTY0004 |
| json-to-xml-error-022 (`validate:'EMCA-262'`) | success | XPTY0004 |
| json-to-xml-error-023 (`escape:()`) | success | XPTY0004 |
| json-to-xml-error-024 (`escape:(true,true)`) | success | XPTY0004 |
| json-to-xml-error-025 (`escape:'EMCA-262'`) | FOJS0005 | XPTY0004 |
| json-to-xml-error-026 (`fallback:'dummy'`) | success | XPTY0004 |
| json-to-xml-error-040 (extra option keys) | success | FOJS0005 |
| json-to-xml-error-041 (`fallback:concat#2`) | success | XPTY0004 |

XQTS spot-check rerun pending; will update this table once measured.

Sibling fix: #6350 (fn:xml-to-json validation).

## Test Plan

- [x] `mvn test -pl exist-core -Dtest=xquery.xquery3.XQuery3Tests` —
      1020 / 1020 passing (1 skipped, pre-existing).
- [x] PMD via codacy-cli on `JSON.java` — no new findings; pre-existing
      `parseResource` / `readValue` NPath warnings unchanged.
- [ ] XQTS HEAD `fn-json-to-xml` spot-check (rebuild runner per
      measurement SOP, expect Cat B closed, Cat F partial).