### PR TITLE
[bugfix] Apply attribute-value escape rules to xmlns URI literals (+7 XQTS HEAD)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/AttributeConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/AttributeConstructor.java
@@ -115,14 +115,27 @@ public class AttributeConstructor extends NodeConstructor {
 	
 	/**
 	 * If this is a namespace declaration attribute, return
-	 * the single string value of the attribute.
+	 * the concatenated string value of all literal segments.
+	 *
+	 * Namespace declaration attribute values may be split across
+	 * multiple content segments by the parser when they contain
+	 * escaped characters (EscapeQuot "", EscapeApos '', doubled
+	 * braces {{ }}). Per XQuery 3.1 §3.9.1.2, an EnclosedExpr in
+	 * an xmlns value is rejected with XQST0022, so contents here
+	 * are always strings.
 	 *
 	 * @return the string value
 	 */
 	public String getLiteralValue() {
 		if(contents.isEmpty())
 			{return "";}
-		return (String)contents.getFirst();
+		if(contents.size() == 1)
+			{return (String)contents.getFirst();}
+		final StringBuilder buf = new StringBuilder();
+		for(final Object next : contents) {
+			buf.append((String)next);
+		}
+		return buf.toString();
 	}
 	
 	/* (non-Javadoc)

--- a/exist-core/src/test/java/org/exist/xquery/XmlnsUriEscapeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XmlnsUriEscapeTest.java
@@ -1,0 +1,119 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import com.evolvedbinary.j8fu.Either;
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.test.XQueryCompilationTest;
+import org.exist.xquery.value.Sequence;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests XQuery 3.1 attribute-value normalization on namespace declaration
+ * attribute values (xmlns and xmlns:prefix).
+ *
+ * Per XQuery 3.1 §3.9.1.2 (Namespace Declaration Attributes), namespace
+ * declaration attribute values are processed by rule 1 of §3.9.1.1:
+ *   - {{ -> {
+ *   - }} -> }
+ *   - EscapeQuot ("") -> "
+ *   - EscapeApos ('') -> '
+ *   - predefined entity refs and char refs are expanded
+ *
+ * Covers XQTS prod-DirElemContent.namespace cluster C:
+ * DirectConElemNamespace-3, -4, -5, -6,
+ * K2-DirectConElemNamespace-59, -65, -75.
+ */
+public class XmlnsUriEscapeTest extends XQueryCompilationTest {
+
+    private static String stringResult(final Either<XPathException, Sequence> r) throws XPathException {
+        assertTrue("query returned an error: " + (r.isLeft() ? r.left().get().getMessage() : ""), r.isRight());
+        return r.right().get().getStringValue();
+    }
+
+    @Test
+    public void escapeQuotInPrefixedXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // K2 DirectConElemNamespace-4 shape: "" -> "
+        final String query = "namespace-uri(<p:e xmlns:p=\"http://ns.example.com/ns?val=\"\"asd\"/>)";
+        assertEquals("http://ns.example.com/ns?val=\"asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void multipleEscapeQuotInPrefixedXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // DirectConElemNamespace-3 shape: """""" -> """
+        final String query = "namespace-uri(<p:e xmlns:p=\"http://ns.example.com/ns?val=\"\"\"\"\"\"asd\"/>)";
+        assertEquals("http://ns.example.com/ns?val=\"\"\"asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void escapeAposInPrefixedXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // DirectConElemNamespace-5 shape: '''''' -> '''
+        final String query = "namespace-uri(<p:e xmlns:p='http://ns.example.com/ns?val=''''''asd'/>)";
+        assertEquals("http://ns.example.com/ns?val='''asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void escapeAposInDefaultXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // DirectConElemNamespace-6 shape: '' -> ' (default xmlns)
+        final String query = "namespace-uri(<e xmlns='http://ns.example.com/ns?val=''asd'/>)";
+        assertEquals("http://ns.example.com/ns?val='asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void doubleBracesInPrefixedXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // K2-DirectConElemNamespace-59 shape: {{{{{{}}}}}} -> {{{}}}
+        final String query = "namespace-uri(<p:e xmlns:p=\"http://example.com/{{{{{{}}}}}}asd\"/>)";
+        assertEquals("http://example.com/{{{}}}asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void mixedDoubleBracesInPrefixedXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // K2-DirectConElemNamespace-65 shape: {{}}{{{{}}}} -> {}{{}}
+        final String query = "namespace-uri-for-prefix(\"p\", <e xmlns:p=\"http://example.com/{{}}{{{{}}}}\"/>)";
+        assertEquals("http://example.com/{}{{}}", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void doubleBracesInDefaultXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // K2-DirectConElemNamespace-75 shape: {{1}} -> {1}
+        final String query = "namespace-uri(<e xmlns=\"http://example.com/{{1}}\"/>)";
+        assertEquals("http://example.com/{1}", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void predefinedEntityRefInXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // &quot; entity ref expansion in xmlns URI
+        final String query = "namespace-uri(<p:e xmlns:p=\"http://example.com/?val=&quot;asd\"/>)";
+        assertEquals("http://example.com/?val=\"asd", stringResult(executeQuery(query)));
+    }
+
+    @Test
+    public void ampersandEntityRefInXmlnsUri() throws EXistException, PermissionDeniedException, XPathException {
+        // &amp; entity ref expansion in xmlns URI
+        final String query = "namespace-uri(<p:e xmlns:p=\"http://example.com/?a=1&amp;b=2\"/>)";
+        assertEquals("http://example.com/?a=1&b=2", stringResult(executeQuery(query)));
+    }
+}


### PR DESCRIPTION
## Summary

Namespace declaration attribute values (`xmlns="..."`, `xmlns:p="..."`) whose URI literal contained an `EscapeQuot` (`\"\"`), `EscapeApos` (`''`), or doubled braces (`{{` / `}}`) were silently truncated at the first character preceding the escape. The fix concatenates all literal segments of the attribute value (entity / character references were already being expanded by `StringValue.expand` on each segment).

Closes 7 XQTS `prod-DirElemContent.namespace` failures (HEAD catalogue):
`DirectConElemNamespace-3`, `-4`, `-5`, `-6`, `K2-DirectConElemNamespace-59`, `-65`, `-75`.

## Root cause

For `xmlns:p=\"http://ns.example.com/ns?val=\"\"asd\"`, the parser produces three `ATTRIBUTE_CONTENT` tokens: `http://ns.example.com/ns?val=`, `\"` (from `ESCAPE_QUOT`), and `asd`. `AttributeConstructor.addValue` appends each one. `getLiteralValue()` then returned only `contents.getFirst()`, so the in-scope namespace URI became `http://ns.example.com/ns?val=`. The fix concatenates the segments. An `EnclosedExpr` inside an `xmlns` value is rejected at parse time (`XQST0022`), so namespace-declaration contents are always strings.

## What changed

- `exist-core/src/main/java/org/exist/xquery/AttributeConstructor.java` — `getLiteralValue()` now concatenates all segments in `contents` (preserving the single-segment fast path).
- `exist-core/src/test/java/org/exist/xquery/XmlnsUriEscapeTest.java` — 9 new JUnit tests covering each escape rule on both prefixed and default `xmlns`.

## Spec references

[XQuery 3.1 § 3.9.1.2 — Namespace Declaration Attributes](https://www.w3.org/TR/xquery-31/#id-namespaces):

> The value of the namespace declaration attribute (a DirAttributeValue) is processed as follows. If the DirAttributeValue contains an EnclosedExpr, a static error is raised [err:XQST0022]. Otherwise, it is processed as described in rule 1 of 3.9.1.1 Attributes.

[XQuery 3.1 § 3.9.1.1 — Attributes, rule 1](https://www.w3.org/TR/xquery-31/#id-attributes):

> Each consecutive sequence of literal characters in the attribute content is processed as a string literal containing those characters, with the following exceptions:
> a. Each occurrence of two consecutive `{` characters is replaced by a single `{` character.
> b. Each occurrence of two consecutive `}` characters is replaced by a single `}` character.
> c. Each occurrence of EscapeQuot is replaced by a single `\"` character.
> d. Each occurrence of EscapeApos is replaced by a single `'` character.
>
> Attribute value normalization is then applied to normalize whitespace and expand character references and predefined entity references.

## XQTS HEAD `prod-DirElemContent.namespace` (fresh runner)

| | Before | After | Δ |
|---|---:|---:|---:|
| Pass | 98 | 105 | +7 |
| Fail | 35 | 28 | −7 |
| Pass rate | 74.2% | 78.9% | +4.7pp |

### Per-test before/after

| Test case | Before | After |
|---|---|---|
| `DirectConElemNamespace-3` (`\"\"\"\"\"\"` → `\"\"\"`) | FAIL — actual `http://ns.example.com/ns?val=` | PASS |
| `DirectConElemNamespace-4` (`\"\"` → `\"`) | FAIL — actual `http://ns.example.com/ns?val=` | PASS |
| `DirectConElemNamespace-5` (`''''''` → `'''`) | FAIL — actual `http://ns.example.com/ns?val=` | PASS |
| `DirectConElemNamespace-6` (default `xmlns`, `''` → `'`) | FAIL | PASS |
| `K2-DirectConElemNamespace-59` (`{{{{{{}}}}}}` → `{{{}}}`) | FAIL — actual `http://example.com/` | PASS |
| `K2-DirectConElemNamespace-65` (`{{}}{{{{}}}}` → `{}{{}}`) | FAIL | PASS |
| `K2-DirectConElemNamespace-75` (default `xmlns`, `{{1}}` → `{1}`) | FAIL | PASS |

No newly failing tests; entity-reference (`&quot;`, `&amp;`) handling was already correct and remains so (verified by 2 of the new JUnit cases).

This PR addresses **sub-cluster C** of the `prod-DirElemContent.namespace` triage. Other clusters (in-scope-namespace tree-walk, schema-type tests, parser error-code mapping) are out of scope.

## Test plan

- [x] `mvn test -pl exist-core -Dtest=XmlnsUriEscapeTest` — 9/9 pass
- [x] `mvn test -pl exist-core -Dtest='NamespaceUpdateTest,FunctionTypeInElementContentTest,XPathQueryTest,XPathTest,DOMTest,ConstructedNodesTest,xquery.xquery3.XQuery3Tests'` — 1188/1188 pass (5 skipped, pre-existing)
- [x] XQTS HEAD spot-check on `prod-DirElemContent.namespace`: 35→28 fails, the 7 named cluster-C tests flip PASS, no new failures
- [x] Codacy PMD on changed file: clean