### PR TITLE
[bugfix] Direct constructor: push in-scope ns decls before walking enclosed exprs (+11 XQTS HEAD)

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -126,6 +126,53 @@ options {
         throw new XPathException(ast, message);
     }
 
+    /**
+     * Pre-scan a direct element constructor's AST for namespace declaration
+     * attributes (xmlns and xmlns:prefix) and push them onto the static
+     * context's in-scope namespaces before the rest of the constructor's
+     * children (attribute values and content) are walked.
+     *
+     * Per XQuery 3.1 section 3.9.1, namespace declarations on a direct
+     * element constructor are added to the statically known namespaces
+     * in the static context of the constructor, including its content
+     * and attribute values. Without this pre-scan, prefixed QNames inside
+     * enclosed expressions in attribute values or element content (e.g.
+     * "{1 cast as p:string}") fail QName resolution with XPST0081.
+     *
+     * The caller is responsible for having already issued a matching
+     * pushInScopeNamespaces() so that these declarations are popped at
+     * end of element.
+     */
+    private void prescanElementNamespaceDecls(XQueryAST elementAST) throws XPathException {
+        XQueryAST child = (XQueryAST) elementAST.getFirstChild();
+        while (child != null) {
+            if (child.getType() == ATTRIBUTE) {
+                final String attrName = child.getText();
+                String nsPrefix = null;
+                if (XMLConstants.XMLNS_ATTRIBUTE.equals(attrName)) {
+                    nsPrefix = "";
+                } else if (attrName != null && attrName.startsWith(XMLConstants.XMLNS_ATTRIBUTE + ":")) {
+                    nsPrefix = attrName.substring(XMLConstants.XMLNS_ATTRIBUTE.length() + 1);
+                }
+                if (nsPrefix != null) {
+                    final StringBuilder value = new StringBuilder();
+                    XQueryAST contentChild = (XQueryAST) child.getFirstChild();
+                    while (contentChild != null) {
+                        if (contentChild.getType() == ATTRIBUTE_CONTENT) {
+                            value.append(StringValue.expand(contentChild.getText()));
+                        }
+                        // LCURLY (enclosed expr) inside an xmlns value is a
+                        // separate spec violation; the existing post-walk
+                        // logic raises the appropriate error.
+                        contentChild = (XQueryAST) contentChild.getNextSibling();
+                    }
+                    staticContext.declareInScopeNamespace(nsPrefix, value.toString());
+                }
+            }
+            child = (XQueryAST) child.getNextSibling();
+        }
+    }
+
     private static class ForLetClause {
         XQueryAST ast;
         QName varName;
@@ -3832,6 +3879,11 @@ throws PermissionDeniedException, EXistException, XPathException
             c.setASTNode(e);
             step= c;
             staticContext.pushInScopeNamespaces();
+            // XQuery 3.1 section 3.9.1: namespace declaration attributes on a
+            // direct element constructor extend the static context for the
+            // constructor's content and attribute values. Push them now so
+            // that prefixed QNames inside enclosed expressions resolve.
+            prescanElementNamespaceDecls(e);
         }
         (
             #(

--- a/exist-core/src/test/java/org/exist/xquery/DirectElementConstructorInScopeNamespaceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/DirectElementConstructorInScopeNamespaceTest.java
@@ -1,0 +1,128 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.source.Source;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for XQuery 3.1 section 3.9.1: namespace declaration attributes on a
+ * direct element constructor must be added to the statically known
+ * namespaces of the constructor's content and attribute values, so prefixed
+ * QNames inside enclosed expressions resolve correctly.
+ *
+ * Covers prod-DirElemContent.namespace clusters A (prefixed names in
+ * enclosed exprs) and B (default-element namespace in enclosed exprs).
+ */
+public class DirectElementConstructorInScopeNamespaceTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    // Cluster A - prefixed namespace declaration on the element should be
+    // visible to enclosed expressions in attribute values.
+
+    @Test
+    public void prefixedCastInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<e a=\"{1 cast as p:string}\" xmlns:p=\"http://www.w3.org/2001/XMLSchema\"/>/@a/string()");
+        assertEquals("1", result);
+    }
+
+    @Test
+    public void prefixedTreatInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<e a=\"{1 treat as p:integer}\" xmlns:p=\"http://www.w3.org/2001/XMLSchema\"/>/@a/string()");
+        assertEquals("1", result);
+    }
+
+    @Test
+    public void prefixedInstanceOfInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<e a=\"{1 instance of p:integer}\" xmlns:p=\"http://www.w3.org/2001/XMLSchema\"/>/@a/string()");
+        assertEquals("true", result);
+    }
+
+    @Test
+    public void prefixedCastableInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<e a=\"{1 castable as p:integer}\" xmlns:p=\"http://www.w3.org/2001/XMLSchema\"/>/@a/string()");
+        assertEquals("true", result);
+    }
+
+    @Test
+    public void prefixedVariableNameInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<a attr=\"{let $p:name := 3 return $p:name}\" xmlns:p=\"urn:foo\"/>/@attr/string()");
+        assertEquals("3", result);
+    }
+
+    // Cluster B - default element namespace declaration should make
+    // unprefixed type references inside enclosed exprs resolve.
+
+    @Test
+    public void defaultNamespaceInstanceOfInsideAttributeValue() throws Exception {
+        final String result = executeStringValue(
+                "<e a=\"{1 instance of integer}\" xmlns=\"http://www.w3.org/2001/XMLSchema\"/>/@a/string()");
+        assertEquals("true", result);
+    }
+
+    // State-leakage guard: same prefix bound to different URIs in two
+    // sequential constructors must not bleed across.
+
+    @Test
+    public void prefixRedeclarationDoesNotLeak() throws Exception {
+        final String result = executeStringValue(
+                "let $a := <a xmlns:p=\"http://www.w3.org/2001/XMLSchema\">{1 instance of p:integer}</a>" +
+                        " let $b := <b xmlns:p=\"urn:other\">marker</b>" +
+                        " return concat($a/string(), '|', namespace-uri-for-prefix('p', $b))");
+        assertEquals("true|urn:other", result);
+    }
+
+    private String executeStringValue(final String query) throws Exception {
+        final Sequence result = executeXQuery(query);
+        return result.getStringValue();
+    }
+
+    private Sequence executeXQuery(final String query) throws Exception {
+        final Source source = new StringSource(query);
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        final XQuery xquery = brokerPool.getXQueryService();
+
+        try (final DBBroker broker = brokerPool.get(
+                Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+            final XQueryContext context = new XQueryContext(brokerPool);
+            final CompiledXQuery compiled = xquery.compile(context, source);
+            return xquery.execute(broker, compiled, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Direct element constructor namespace declarations must extend the static context of the constructor's content and attribute values per XQuery 3.1 §3.9.1. The tree walker previously only pushed these declarations *after* walking each attribute, so prefixed QNames inside enclosed expressions in attribute values raised `XPST0081` for valid expressions:

```xquery
<e a=\"{1 cast as p:string}\" xmlns:p=\"http://www.w3.org/2001/XMLSchema\"/>
<e a=\"{1 instance of integer}\" xmlns=\"http://www.w3.org/2001/XMLSchema\"/>
<a attr=\"{let \$p:name := 3 return \$p:name}\" xmlns:p=\"urn:foo\"/>
```

This change pre-scans the ELEMENT subtree for namespace declaration attributes (`xmlns` and `xmlns:*`) and pushes them onto the static context's in-scope namespaces immediately after `pushInScopeNamespaces()`, so `QName.parse()` calls inside the constructor body resolve correctly. The existing post-walk push for each attribute remains as a harmless no-op (re-declaring the same prefix/URI is idempotent in `XQueryContext.declareInScopeNamespace`).

## What changed

- `exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g`
  - New helper `prescanElementNamespaceDecls(XQueryAST)` walks the children of the ELEMENT node, finds ATTRIBUTE nodes whose name is `xmlns` or starts with `xmlns:`, extracts the literal value from their `ATTRIBUTE_CONTENT` children, and calls `staticContext.declareInScopeNamespace()`.
  - The `elementConstructor` rule calls this helper right after `pushInScopeNamespaces()`.
- `exist-core/src/test/java/org/exist/xquery/DirectElementConstructorInScopeNamespaceTest.java` — 7 reproducers covering cluster A (cast/treat/instance-of/castable/prefixed-variable-name in enclosed exprs), cluster B (default-element-namespace in enclosed exprs), and a state-leakage guard.

## Spec references

XQuery 3.1 §3.9.1 [Direct Element Constructors](https://www.w3.org/TR/xquery-31/#id-element-constructors):

> The namespace declaration attributes ... contribute to the in-scope namespaces of the constructed element, **and they are also added to the statically known namespaces in the static context** of the constructor (including its content and attribute values).

XQuery 3.1 §2.1.1 [Static Context](https://www.w3.org/TR/xquery-31/#dt-static-context):

> *Statically known namespaces.* This is a set of (prefix, URI) pairs that define all the statically known namespaces of an expression. The value of this component includes namespaces specified by the host language, by import schema declarations, by import module declarations, by namespace declarations on direct element constructors and by namespace declarations in the prolog.

## XQTS impact (HEAD)

| Test set | Baseline | New | Fixed | Regressions |
|---|---|---|---|---|
| `prod-DirElemContent.namespace` | 35 | 24 | **11** | 0 |
| `prod-DirElemConstructor` | 12 | 12 | 0 | 0 |

Newly passing in `prod-DirElemContent.namespace`:

```
K2-DirectConElemNamespace-14, -19, -20, -21, -22, -23, -29, -30, -31, -32, -33
```

The remaining 24 failures in `prod-DirElemContent.namespace` are unrelated to this cluster (XQST0046 invalid-URI-char detection, copy-namespaces edge cases, parser strictness on malformed input).

## Test plan

- [x] 7 JUnit reproducers (`DirectElementConstructorInScopeNamespaceTest`) — all green
- [x] `*ElementConstructor*`, `*Namespace*`, `*DirEl*`, `XPathQueryTest`, `XQuery3Tests`, `*CompAttr*` — 1173 tests, 0 failures
- [x] XQTS HEAD `prod-DirElemContent.namespace` — 11 newly passing, 0 regressions
- [x] XQTS HEAD `prod-DirElemConstructor` sanity — 0 regressions
- [x] State-leakage guard test (same prefix → different URIs in sequential constructors) passes
- [x] Codacy PMD clean on changed test file

Closes part of the prod-DirElemContent.namespace residual triage (clusters A + B).