### PR TITLE
[bugfix] StaticXQueryException: default error code to XPST0003

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/StaticXQueryException.java
+++ b/exist-core/src/main/java/org/exist/xquery/StaticXQueryException.java
@@ -21,12 +21,26 @@
  */
 package org.exist.xquery;
 
+import org.exist.xquery.ErrorCodes.ErrorCode;
+
 import java.io.Serial;
 
 public class StaticXQueryException extends XPathException
 {
     @Serial
     private static final long serialVersionUID = -8229758099980343418L;
+
+    /**
+     * Static-error exceptions default to XPST0003 (static syntax error) per
+     * the W3C XQuery 3.1 spec, rather than the generic {@link ErrorCodes#ERROR}
+     * inherited from {@link XPathException}. If a more specific error code was
+     * propagated from the cause (via {@link XPathErrorProvider}), it is preserved.
+     */
+    @Override
+    public ErrorCode getErrorCode() {
+        final ErrorCode code = super.getErrorCode();
+        return code == ErrorCodes.ERROR ? ErrorCodes.XPST0003 : code;
+    }
 
 	public StaticXQueryException(String message) {
         this(null, message);

--- a/exist-core/src/test/java/org/exist/xquery/StaticXQueryExceptionErrorCodeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/StaticXQueryExceptionErrorCodeTest.java
@@ -1,0 +1,136 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.source.Source;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Targeted regression tests for the XQTS prod-Literal sub-cluster where
+ * eXist's lexer/parser correctly rejected the query but reported the generic
+ * {@code ERROR} code instead of the W3C-mandated {@code XPST0003} static
+ * syntax error code.
+ *
+ * <p>Covers the lexer-error paths (unterminated string, invalid entity reference,
+ * invalid double literal exponent, invalid hexadecimal character reference)
+ * surfaced by tests such as {@code K-Literals-31}, {@code Literals006},
+ * {@code Literals051}, {@code K2-Literals-22}, {@code K-Literals-50}.
+ */
+public class StaticXQueryExceptionErrorCodeTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void unterminatedStringLiteral_Literals006() {
+        // "test  -- closing quote missing
+        assertStaticError("\"test");
+    }
+
+    @Test
+    public void mismatchedStringDelimiters_Literals008() {
+        // 'test"  -- opens with apostrophe, closes with double-quote
+        assertStaticError("'test\"");
+    }
+
+    @Test
+    public void invalidDoubleLiteralExponent_Literals051() {
+        assertStaticError("1ee2");
+    }
+
+    @Test
+    public void invalidDoubleLiteralUppercaseE_Literals052() {
+        assertStaticError("1EE2");
+    }
+
+    @Test
+    public void invalidEntityReferenceMissingSemicolon_KLiterals31() {
+        // "a string &;"  -- empty / invalid entity reference
+        assertStaticError("\"a string &;\"");
+    }
+
+    @Test
+    public void invalidDecimalCharRef_KLiterals32() {
+        // "a string &#;"  -- decimal char ref with no digits
+        assertStaticError("\"a string &#;\"");
+    }
+
+    @Test
+    public void invalidHexCharRef_KLiterals38() {
+        // "a string &#x;"  -- hex char ref with no digits
+        assertStaticError("\"a string &#x;\"");
+    }
+
+    @Test
+    public void unknownNamedEntity_KLiterals41() {
+        // "a string &unknown;"  -- not one of the five predefined entities
+        assertStaticError("\"a string &unknown;\"");
+    }
+
+    @Test
+    public void charRefOutsideStringLiteral_KLiterals50() {
+        // Character references are only allowed inside string literals
+        assertStaticError("1 &lt;= 3");
+    }
+
+    @Test
+    public void minusInHexCharRef_K2Literals22() {
+        assertStaticError("\"&#x-20;\"");
+    }
+
+    @Test
+    public void plusInDecimalCharRef_K2Literals25() {
+        assertStaticError("\"&#+20;\"");
+    }
+
+    @Test
+    public void trailingQuoteJunk_KLiterals24() {
+        // 33"  -- trailing unmatched double-quote
+        assertStaticError("33\"");
+    }
+
+    private void assertStaticError(final String query) {
+        try {
+            final Source source = new StringSource(query);
+            final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+            final XQuery xquery = brokerPool.getXQueryService();
+            final XQueryContext context = new XQueryContext(brokerPool);
+            xquery.compile(context, source);
+            fail("Expected XPST0003 but query compiled successfully: " + query);
+        } catch (final XPathException e) {
+            final String actual = e.getErrorCode() == null
+                    ? "<null>"
+                    : e.getErrorCode().getErrorQName().getLocalPart();
+            assertEquals("Wrong error code for query [" + query + "] (message: " + e.getMessage() + ")",
+                    "XPST0003", actual);
+        } catch (final Exception e) {
+            fail("Unexpected exception for query [" + query + "]: " + e.getClass().getName() + " - " + e.getMessage());
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/StaticXQueryExceptionErrorCodeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/StaticXQueryExceptionErrorCodeTest.java
@@ -48,69 +48,69 @@ public class StaticXQueryExceptionErrorCodeTest {
     public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
     @Test
-    public void unterminatedStringLiteral_Literals006() {
+    public void unterminatedStringLiteralLiterals006() {
         // "test  -- closing quote missing
         assertStaticError("\"test");
     }
 
     @Test
-    public void mismatchedStringDelimiters_Literals008() {
+    public void mismatchedStringDelimitersLiterals008() {
         // 'test"  -- opens with apostrophe, closes with double-quote
         assertStaticError("'test\"");
     }
 
     @Test
-    public void invalidDoubleLiteralExponent_Literals051() {
+    public void invalidDoubleLiteralExponentLiterals051() {
         assertStaticError("1ee2");
     }
 
     @Test
-    public void invalidDoubleLiteralUppercaseE_Literals052() {
+    public void invalidDoubleLiteralUppercaseELiterals052() {
         assertStaticError("1EE2");
     }
 
     @Test
-    public void invalidEntityReferenceMissingSemicolon_KLiterals31() {
+    public void invalidEntityReferenceMissingSemicolonKLiterals31() {
         // "a string &;"  -- empty / invalid entity reference
         assertStaticError("\"a string &;\"");
     }
 
     @Test
-    public void invalidDecimalCharRef_KLiterals32() {
+    public void invalidDecimalCharRefKLiterals32() {
         // "a string &#;"  -- decimal char ref with no digits
         assertStaticError("\"a string &#;\"");
     }
 
     @Test
-    public void invalidHexCharRef_KLiterals38() {
+    public void invalidHexCharRefKLiterals38() {
         // "a string &#x;"  -- hex char ref with no digits
         assertStaticError("\"a string &#x;\"");
     }
 
     @Test
-    public void unknownNamedEntity_KLiterals41() {
+    public void unknownNamedEntityKLiterals41() {
         // "a string &unknown;"  -- not one of the five predefined entities
         assertStaticError("\"a string &unknown;\"");
     }
 
     @Test
-    public void charRefOutsideStringLiteral_KLiterals50() {
+    public void charRefOutsideStringLiteralKLiterals50() {
         // Character references are only allowed inside string literals
         assertStaticError("1 &lt;= 3");
     }
 
     @Test
-    public void minusInHexCharRef_K2Literals22() {
+    public void minusInHexCharRefK2Literals22() {
         assertStaticError("\"&#x-20;\"");
     }
 
     @Test
-    public void plusInDecimalCharRef_K2Literals25() {
+    public void plusInDecimalCharRefK2Literals25() {
         assertStaticError("\"&#+20;\"");
     }
 
     @Test
-    public void trailingQuoteJunk_KLiterals24() {
+    public void trailingQuoteJunkKLiterals24() {
         // 33"  -- trailing unmatched double-quote
         assertStaticError("33\"");
     }


### PR DESCRIPTION
## Summary

Static-error exceptions currently inherit `ErrorCodes.ERROR` from `XPathException`, but the W3C XQuery 3.1 spec requires static syntax errors to be reported with `err:XPST0003`. Lexer- and parser-level failures (unterminated string literals, invalid double literal exponents, invalid entity / character references, mismatched delimiters) were already being rejected — just with the wrong error code — so XQTS test cases asserting `XPST0003` were failing.

This PR overrides `StaticXQueryException.getErrorCode()` to substitute `XPST0003` whenever the underlying code is still the default `ERROR`, while preserving any more specific code propagated from a cause via `XPathErrorProvider` (e.g. `XPST0081`, `XQST0033`).

## What Changed

- `exist-core/src/main/java/org/exist/xquery/StaticXQueryException.java` — override `getErrorCode()` to map `ERROR` → `XPST0003` while preserving more specific propagated codes.
- `exist-core/src/test/java/org/exist/xquery/StaticXQueryExceptionErrorCodeTest.java` — 12 JUnit reproducers covering the lexer-error shapes:
  - Unterminated string (`Literals006`, `Literals008`)
  - Invalid double exponent (`Literals051`, `Literals052`)
  - Invalid / missing entity references (`K-Literals-31/32/38/41`)
  - Character ref outside string (`K-Literals-50`)
  - Invalid hex/decimal char refs (`K2-Literals-22/25`)
  - Trailing quote junk (`K-Literals-24`)

## Spec References

- [W3C XQuery 3.1 § 2.3.2 Static Errors](https://www.w3.org/TR/xquery-31/#id-errors-and-optimization) — all static errors (lexical, syntactic, type, scope) carry `err:XPST0003` unless the spec defines a more specific code.

## XQTS HEAD prod-Literal before/after

Measured on develop @ `b6f42f358d` against `--xqts-version HEAD` with a freshly built runner JAR:

| | Tests | Pass | Fails | Errors | Pass% |
|---|---:|---:|---:|---:|---:|
| Before | 173 | 124 | 48 | 1 | 71.7% |
| After  | 171 | 159 | 11 | 1 | 93.0% |
| Δ      |  -2 | +35 | -37 | 0 | +21.3pp |

The 11 residuals are XPath-only entity-reference semantics tests (`Literals056a–061a`, `K-Literals-31a`, `K-Literals-47a`), library-module dispatch (`K2-Literals-35/36`), one wrong-error-code case where eXist's parser bails earlier than `XPDY0002` (`K2-Literals-37`), and one invalid-test-case error (`K-Literals-29`). All are outside the scope of this fix.

## Test Plan

- [x] `mvn test -pl exist-core -Dtest=StaticXQueryExceptionErrorCodeTest` — 12/12 pass
- [x] `mvn test -pl exist-core -Dtest='XPathQueryTest,XQueryTest,CompAttrConstructorErrorCodeTest'` — 265/265 pass (10 skipped, pre-existing)
- [x] XQTS HEAD prod-Literal spot-check: 49 → 12 fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)