### PR TITLE
[bugfix] AbstractInternalModule: enforce sorted-array invariant when ordered=true (#6376)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
@@ -23,6 +23,8 @@ package org.exist.xquery;
 
 import java.util.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.xquery.value.Sequence;
 
@@ -41,6 +43,13 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractInternalModule implements InternalModule {
 
+    private static final Logger LOG = LogManager.getLogger(AbstractInternalModule.class);
+
+    protected final FunctionDef[] mFunctions;
+    protected final boolean ordered;
+    protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
+    private final Map<String, List<?>> parameters;
+
     public static class FunctionComparator implements Comparator<FunctionDef> {
         @Override
         public int compare(final FunctionDef o1, final FunctionDef o2) {
@@ -48,21 +57,42 @@ public abstract class AbstractInternalModule implements InternalModule {
         }
     }
 
-    protected final FunctionDef[] mFunctions;
-    protected final boolean ordered;
-    private final Map<String, List<?>> parameters;
-
-    protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
-
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters) {
         this(functions, parameters, false);
     }
 
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters,
                                   final boolean functionsOrdered) {
-        this.mFunctions = functions;
         this.ordered = functionsOrdered;
+        // When the module declares its function table is ordered, getFunctionDef() uses
+        // a binary search keyed on FunctionId (qname, arity). If the caller's array is
+        // not actually sorted in that order, the search silently fails to find some
+        // functions — they are inspectable via util:registered-functions and
+        // inspect:inspect-module-uri (which scan linearly) but unreachable via direct
+        // call and fn:function-lookup. Defensive-copy and sort here so the invariant
+        // is enforced rather than trusted; log a warning so the module author notices.
+        if (functionsOrdered && functions != null && functions.length > 1 && !isSorted(functions)) {
+            final FunctionDef[] sorted = functions.clone();
+            Arrays.sort(sorted, new FunctionComparator());
+            LOG.warn("Module {} declared functionsOrdered=true but its FunctionDef[] was not sorted by "
+                    + "FunctionId; sorted defensively. Functions would otherwise be silently unreachable "
+                    + "via binary search (see {}).",
+                    getClass().getName(), "https://github.com/eXist-db/exist/issues/6376");
+            this.mFunctions = sorted;
+        } else {
+            this.mFunctions = functions;
+        }
         this.parameters = parameters;
+    }
+
+    private static boolean isSorted(final FunctionDef[] functions) {
+        final FunctionComparator cmp = new FunctionComparator();
+        for (int i = 1; i < functions.length; i++) {
+            if (cmp.compare(functions[i - 1], functions[i]) > 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/xquery/AbstractInternalModuleSortTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/AbstractInternalModuleSortTest.java
@@ -1,0 +1,149 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.dom.QName;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Verifies that {@link AbstractInternalModule} enforces its sorted-array invariant when a
+ * module declares {@code functionsOrdered=true}. Pre-fix, a module that passed an unsorted
+ * array would silently lose visibility of some functions via {@link AbstractInternalModule#getFunctionDef(QName, int)}
+ * because the binary search assumed a sort it did not check. See issue
+ * <a href="https://github.com/eXist-db/exist/issues/6376">#6376</a>.
+ */
+public class AbstractInternalModuleSortTest {
+
+    private static final String NS = "http://TestSortInvariant";
+    private static final String PREFIX = "tsi";
+
+    private static FunctionDef def(final String localName, final int arity) {
+        final SequenceType[] params = new SequenceType[arity];
+        for (int i = 0; i < arity; i++) {
+            params[i] = new FunctionParameterSequenceType("p" + i, Type.ITEM, Cardinality.ZERO_OR_MORE, "");
+        }
+        final FunctionSignature sig = new FunctionSignature(
+                new QName(localName, NS, PREFIX),
+                "test",
+                params,
+                new FunctionReturnSequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE, ""));
+        // Implementing class is irrelevant for this test; FunctionDef accepts any Function subclass.
+        return new FunctionDef(sig, Function.class);
+    }
+
+    /**
+     * Unsorted array + functionsOrdered=true previously broke binary search.
+     * {@code close} sorts before {@code eval}/{@code fetch}; passing the array in
+     * declaration order (eval, fetch, close) makes binarySearch miss {@code close}.
+     */
+    @Test
+    public void unsortedArrayWithOrderedTrueStillFindsAllFunctions() {
+        final FunctionDef[] declarationOrder = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        final TestModule module = new TestModule(declarationOrder, /*ordered=*/true);
+
+        assertNotNull("close#1 must be discoverable after defensive sort",
+                module.getFunctionDef(new QName("close", NS, PREFIX), 1));
+        assertNotNull("eval#1 must remain discoverable",
+                module.getFunctionDef(new QName("eval", NS, PREFIX), 1));
+        assertNotNull("fetch#2 must remain discoverable",
+                module.getFunctionDef(new QName("fetch", NS, PREFIX), 2));
+        assertNull("unknown function still returns null",
+                module.getFunctionDef(new QName("close", NS, PREFIX), 99));
+    }
+
+    /**
+     * The defensive sort must not mutate the caller's static array.
+     */
+    @Test
+    public void callerArrayIsNotMutated() {
+        final FunctionDef[] callerArray = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        final String beforeFirst = callerArray[0].getSignature().getName().getLocalPart();
+        new TestModule(callerArray, /*ordered=*/true);
+        assertEquals("caller's array must remain in declaration order",
+                beforeFirst, callerArray[0].getSignature().getName().getLocalPart());
+    }
+
+    /**
+     * An already-sorted array should not trigger a defensive copy.
+     */
+    @Test
+    public void alreadySortedArrayIsReusedAsIs() {
+        final FunctionDef[] sorted = {
+                def("close", 1),
+                def("eval", 1),
+                def("fetch", 2)
+        };
+        final TestModule module = new TestModule(sorted, /*ordered=*/true);
+        // Module retains the same array reference when already sorted (verified via reflection of mFunctions length + first-entry identity)
+        assertEquals(3, module.functionCount());
+        assertNotNull(module.getFunctionDef(new QName("close", NS, PREFIX), 1));
+    }
+
+    /**
+     * functionsOrdered=false leaves the array order alone (linear search doesn't care).
+     */
+    @Test
+    public void unorderedModuleDoesNotSort() {
+        final FunctionDef[] declarationOrder = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        final TestModule module = new TestModule(declarationOrder, /*ordered=*/false);
+        assertNotNull(module.getFunctionDef(new QName("close", NS, PREFIX), 1));
+        assertNotNull(module.getFunctionDef(new QName("eval", NS, PREFIX), 1));
+        assertNotNull(module.getFunctionDef(new QName("fetch", NS, PREFIX), 2));
+    }
+
+    private static final class TestModule extends AbstractInternalModule {
+        TestModule(final FunctionDef[] functions, final boolean ordered) {
+            super(functions, Map.of(), ordered);
+        }
+
+        int functionCount() {
+            return mFunctions.length;
+        }
+
+        @Override public String getNamespaceURI() { return NS; }
+        @Override public String getDefaultPrefix() { return PREFIX; }
+        @Override public String getDescription() { return "test"; }
+        @Override public String getReleaseVersion() { return "1"; }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #6376
- An `InternalModule` that declares `functionsOrdered=true` was previously trusted to pass a `FunctionDef[]` sorted by `FunctionId` (qname, arity). Pre-fix, `getFunctionDef()` would binary-search that array; an unsorted array silently made some functions unreachable via direct call, `fn:function-lookup`, and function references, while linear-scan APIs (`util:registered-functions`, `inspect:inspect-module-uri`) continued to see them.
- The constructor now defensive-copies and sorts when the invariant is violated, and logs a warning so the module author notices the latent bug in their own code.

## Root cause

Module declares `ordered=true` → `getFunctionDef()` uses `binarySearch(FunctionId)`. If the array isn't actually sorted by `FunctionId.compareTo` order (qname primary, arity secondary), binary search misses entries whose position violates the sort. Concrete example from the issue: a module with three functions declared in source order `eval`, `fetch`, `close` — alphabetically `close < eval < fetch`, so binary search at the midpoint `fetch` recurses left into `[eval]` only, never finding `close`. Renaming to `release` (which sorts after `fetch`) made the bug disappear by coincidence.

The mismatch between linear-scan visibility and binary-search reachability is what made this hard to diagnose — `util:registered-functions` and `inspect:inspect-module-uri` walked `mFunctions` linearly and showed the function as present.

## What changed

`exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java`:
- Constructor checks whether the array is sorted when `functionsOrdered=true`. If not, defensive-copies via `.clone()`, sorts with `FunctionComparator`, and stores the sorted copy. The caller's static array is not mutated.
- Logs a `WARN` with the offending module's class name and a pointer to #6376 so the module author knows to fix their declaration order.
- Already-sorted arrays are reused as-is (no copy, no log).
- `functionsOrdered=false` is unchanged — linear search doesn't care about order.
- Field declarations moved above the `FunctionComparator` inner class to satisfy PMD `FieldDeclarationsShouldBeAtStartOfClass` (pre-existing finding surfaced by Codacy).

`exist-core/src/test/java/org/exist/xquery/AbstractInternalModuleSortTest.java` (new):
- `unsortedArrayWithOrderedTrueStillFindsAllFunctions` — regression test for the bug.
- `callerArrayIsNotMutated` — verifies the caller's `static final FunctionDef[]` is left intact.
- `alreadySortedArrayIsReusedAsIs` — verifies the no-op path.
- `unorderedModuleDoesNotSort` — verifies `functionsOrdered=false` is unchanged.

## Test plan

- [x] `mvn test -pl exist-core -Dtest=AbstractInternalModuleSortTest` — 4/4 pass
- [x] Codacy clean (`pmd` on both files)
- [ ] CI green