### PR TITLE
[bugfix] Restore getInstanceId() JavaBean naming on PerInstanceMBean (#6379)

### DIFF
--- a/exist-core/src/main/java/org/exist/management/Cache.java
+++ b/exist-core/src/main/java/org/exist/management/Cache.java
@@ -62,7 +62,7 @@ public class Cache implements CacheMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/CacheManager.java
+++ b/exist-core/src/main/java/org/exist/management/CacheManager.java
@@ -61,7 +61,7 @@ public class CacheManager implements CacheManagerMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
+++ b/exist-core/src/main/java/org/exist/management/impl/BinaryValues.java
@@ -51,6 +51,17 @@ public record BinaryValues(String instanceId) implements BinaryValuesMXBean {
     }
 
     /**
+     * Explicit JavaBean-style accessor required by the MBean attribute discovery,
+     * which relies on the {@code getXxx()} naming convention. The record's
+     * auto-generated {@link #instanceId()} accessor does not satisfy that convention,
+     * so we delegate to it here. See <a href="https://github.com/eXist-db/exist/issues/6379">#6379</a>.
+     */
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    /**
      * Return a JMX object-name query that matches all BinaryValues MBeans across all instances.
      *
      * @return the wildcard query string

--- a/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
+++ b/exist-core/src/main/java/org/exist/management/impl/CollectionCache.java
@@ -54,7 +54,7 @@ public class CollectionCache implements CollectionCacheMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return instance.getId();
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/Database.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Database.java
@@ -67,7 +67,7 @@ public class Database implements DatabaseMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return pool.getId();
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/DiskUsage.java
+++ b/exist-core/src/main/java/org/exist/management/impl/DiskUsage.java
@@ -77,7 +77,7 @@ public class DiskUsage implements DiskUsageMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
+++ b/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
@@ -125,8 +125,8 @@ public final class JMXAgent implements Agent {
     public synchronized void addMBean(final PerInstanceMBean mbean) throws DatabaseConfigurationException {
         try {
             addMBean(mbean.getName(), mbean);
-            if (mbean.instanceId() != null) {
-                final Deque<ObjectName> stack = registeredMBeans.computeIfAbsent(mbean.instanceId(), k -> new ArrayDeque<>());
+            if (mbean.getInstanceId() != null) {
+                final Deque<ObjectName> stack = registeredMBeans.computeIfAbsent(mbean.getInstanceId(), k -> new ArrayDeque<>());
                 stack.push(mbean.getName());
             }
             beanInstances.put(mbean.getName(), mbean);

--- a/exist-core/src/main/java/org/exist/management/impl/LockTable.java
+++ b/exist-core/src/main/java/org/exist/management/impl/LockTable.java
@@ -70,7 +70,7 @@ public class LockTable implements LockTableMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return pool.getId();
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
@@ -32,5 +32,5 @@ public interface PerInstanceMBean extends ExistMBean {
      *
      * @return the database instance identifier
      */
-    String instanceId();
+    String getInstanceId();
 }

--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReport.java
@@ -61,7 +61,7 @@ public class ProcessReport implements ProcessReportMXBean {
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return instanceId;
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
@@ -97,7 +97,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     }
 
     @Override
-    public String instanceId() {
+    public String getInstanceId() {
         return pool.getId();
     }
 

--- a/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
+++ b/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
@@ -86,6 +86,18 @@ public class JmxRemoteTest {
         assertThat(jmxXml, hasXPath("//jmx:LockTable").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:SanityReport").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:Database").withNamespaceContext(prefix2Uri));
+
+        // Regression guard for https://github.com/eXist-db/exist/issues/6379:
+        // PerInstanceMBean must expose InstanceId as a JMX attribute, which depends on the
+        // getInstanceId() JavaBean naming convention. Renaming the interface method (or any
+        // concrete implementation) to a bare name like instanceId() silently drops the
+        // attribute from MBeanInfo. Verify a representative sample of MXBeans that extend
+        // PerInstanceMBean still publish InstanceId.
+        assertThat(jmxXml, hasXPath("//jmx:Database/jmx:InstanceId").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:ProcessReport/jmx:InstanceId").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:CollectionCache/jmx:InstanceId").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:LockTable/jmx:InstanceId").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:SanityReport/jmx:InstanceId").withNamespaceContext(prefix2Uri));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #6379. Restores the `InstanceId` JMX attribute on all 9 MXBeans that extend `PerInstanceMBean`, which had been silently dropped by `9af8663a` (2026-05-11) when `getInstanceId()` was renamed to `instanceId()`. JMX uses JavaBean naming convention for attribute discovery — a bare-named `x()` is not an attribute.

@dizzzz confirmed the rename was unintentional in [#6379 comment](https://github.com/eXist-db/exist/issues/6379#issuecomment-4469709691).

## What changed

**Commit 1 — `bee8dbae79` (the fix):**

- `PerInstanceMBean.java` — restore `String getInstanceId();` in the interface contract.
- 8 concrete impl classes — restore `public String getInstanceId()`: `Database`, `CollectionCache`, `DiskUsage`, `LockTable`, `ProcessReport`, `SanityReport`, `Cache`, `CacheManager`.
- `JMXAgent.java` — update the 2 internal callers (`mbean.instanceId()` → `mbean.getInstanceId()`).
- `BinaryValues.java` — this is a Java `record` whose auto-generated `instanceId()` accessor matches the record component name but not the JavaBean convention. Added an explicit `getInstanceId()` delegate (`@Override public String getInstanceId() { return instanceId; }`) so the JMX contract is honored without losing the record-style modernization. **This is likely why the original rename happened** — Dannes converted `BinaryValues` to a record and the simplest way to satisfy the inherited interface was to rename the interface method. The delegate approach preserves both concerns.

**Commit 2 — `281996163e` (regression guard):**

- `JmxRemoteTest.checkContent()` gains 5 XPath assertions verifying `//jmx:<Bean>/jmx:InstanceId` is present on `Database`, `ProcessReport`, `CollectionCache`, `LockTable`, and `SanityReport`. Would have failed when `9af8663a` was merged.

## Scope clarification (vs. the issue body)

The issue flagged "broader risk" that other renamed methods in the same commit (`getPercentage`, `getOwner`, `getReferenceCount`, etc.) might have similarly broken JMX attributes. **Verified that risk did not materialize:** those renames were on plain classes / `CompositeData` helpers (`TaskStatus`, internal `Lock`/`Error`/`Job` classes), not on MBean/MXBean interfaces. JMX naming convention doesn't apply to them. Only `InstanceId` was affected at the JMX surface.

## Test plan

- [x] `mvn test -pl exist-core -Dtest=JmxRemoteTest` — 2/2 pass on the fix branch
- [x] `mvn compile -pl exist-core -am` — green
- [x] Codacy clean on all modified files (one pre-existing `AvoidThrowingRawExceptionTypes` in `LockTable.java` at lines 102/111/132/143 is unrelated to this change and out of scope for this PR)
- [ ] CI green