### PR TITLE
[feature] Add roaster and existdb-openapi to autodeploy packages (prerequisite for eXide #794)

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -796,6 +796,9 @@
                                     <abbrev>eXide</abbrev>
                                 </package>
                                 <package>
+                                    <abbrev>existdb-openapi</abbrev>
+                                </package>
+                                <package>
                                     <abbrev>exist-documentation</abbrev>
                                 </package>
                                 <package>
@@ -809,6 +812,9 @@
                                 </package>
                                 <package>
                                     <abbrev>packageservice</abbrev>
+                                </package>
+                                <package>
+                                    <abbrev>roaster</abbrev>
                                 </package>
                                 <package>
                                     <abbrev>semver-xq</abbrev>


### PR DESCRIPTION
This PR is a prerequisite for [eXist-db/eXide#794](https://github.com/eXist-db/eXide/pull/794) - which will initiate eXide 4.x.

This is because a fresh eXist 7 install autodeploys both eXist's bundled XARs and eXide on first boot. eXide 4.x (from #794) declares new dependencies on `roaster` and `existdb-openapi` in its `expath-pkg.xml`. 

This PR adds those dependencies to autodeploy.

### Related

- eXide modernization PR (downstream consumer): https://github.com/eXist-db/eXide/pull/794
- existdb-openapi (formerly `exist-api`): https://github.com/eXist-db/existdb-openapi
- roaster: https://github.com/eXist-db/roaster
