### PR TITLE
[ci] Upgrade to latest 12.0 version of jetty

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -128,7 +128,7 @@
         <jaxb.api.version>4.0.5</jaxb.api.version>
         <jaxb.impl.version>4.0.2</jaxb.impl.version>
         <eclipse.angus-activation.version>2.0.3</eclipse.angus-activation.version>
-        <jetty.version>12.0.33</jetty.version>
+        <jetty.version>12.0.35</jetty.version>
         <log4j.version>2.26.0</log4j.version>
         <lucene.version>10.4.0</lucene.version>
         <milton.version>1.8.1.3</milton.version>


### PR DESCRIPTION
jetty 12.1.x requires additional yet unknown changes in eXist. This is a drop-in upgrade.