### PR TITLE
[refactor] Always sort internal-module FunctionDef[]; drop functionsOrdered flag (#6378)

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/xquery/BackupModule.java
+++ b/exist-core/src/main/java/org/exist/backup/xquery/BackupModule.java
@@ -49,7 +49,7 @@ public class BackupModule extends AbstractInternalModule
 
     public BackupModule(final Map<String, List<?>> parameters)
     {
-        super( functions, parameters, true );
+        super(functions, parameters);
     }
 
     public String getNamespaceURI()

--- a/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
@@ -36,10 +36,18 @@ import javax.annotation.Nullable;
  * in name or the number of expected arguments. It is thus possible to implement
  * similar XQuery functions in one single class.
  *
+ * <p>The {@code FunctionDef[]} passed in does not need to be sorted; this constructor
+ * defensive-copies and sorts it by {@link FunctionId} order so {@link #getFunctionDef(QName, int)}
+ * can always use binary search. The original array reference is not mutated.</p>
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  * @author ljo
  */
 public abstract class AbstractInternalModule implements InternalModule {
+
+    protected final FunctionDef[] mFunctions;
+    protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
+    private final Map<String, List<?>> parameters;
 
     public static class FunctionComparator implements Comparator<FunctionDef> {
         @Override
@@ -48,21 +56,39 @@ public abstract class AbstractInternalModule implements InternalModule {
         }
     }
 
-    protected final FunctionDef[] mFunctions;
-    protected final boolean ordered;
-    private final Map<String, List<?>> parameters;
-
-    protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
-
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters) {
-        this(functions, parameters, false);
+        // Defensive-copy + sort so the caller's static final array is left intact
+        // and getFunctionDef() can binary-search regardless of declaration order.
+        // See https://github.com/eXist-db/exist/issues/6378 (and #6376 which surfaced
+        // the latent bug).
+        if (functions != null && functions.length > 1) {
+            final FunctionDef[] sorted = functions.clone();
+            Arrays.sort(sorted, new FunctionComparator());
+            this.mFunctions = sorted;
+        } else {
+            this.mFunctions = functions;
+        }
+        this.parameters = parameters;
     }
 
+    /**
+     * Pre-#6378 constructor that took a {@code functionsOrdered} flag. The flag is now
+     * ignored — the function table is always sorted and {@link #getFunctionDef(QName, int)}
+     * always uses binary search. Retained so external modules continue to compile against
+     * eXist 7 without source changes; call sites should migrate to
+     * {@link #AbstractInternalModule(FunctionDef[], Map)}.
+     *
+     * @param functions         the array of functions
+     * @param parameters        configuration parameters
+     * @param functionsOrdered  ignored as of #6378
+     *
+     * @deprecated since 7.0.0; the {@code functionsOrdered} parameter has no effect.
+     *             Use {@link #AbstractInternalModule(FunctionDef[], Map)}.
+     */
+    @Deprecated(since = "7.0.0", forRemoval = true)
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters,
-                                  final boolean functionsOrdered) {
-        this.mFunctions = functions;
-        this.ordered = functionsOrdered;
-        this.parameters = parameters;
+                                  @SuppressWarnings("unused") final boolean functionsOrdered) {
+        this(functions, parameters);
     }
 
     @Override
@@ -113,17 +139,7 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     @Override
     public FunctionDef getFunctionDef(QName qname, int arity) {
-        final FunctionId id = new FunctionId(qname, arity);
-        if (ordered) {
-            return binarySearch(id);
-        } else {
-            for (FunctionDef mFunction : mFunctions) {
-                if (id.compareTo(mFunction.getSignature().getFunctionId()) == 0) {
-                    return mFunction;
-                }
-            }
-        }
-        return null;
+        return binarySearch(new FunctionId(qname, arity));
     }
 
     private FunctionDef binarySearch(final FunctionId id) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayModule.java
@@ -68,7 +68,7 @@ public class ArrayModule extends AbstractInternalModule {
     );
 
     public ArrayModule(Map<String, List<?>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery.functions.fn;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -277,17 +276,12 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunContainsToken.FS_CONTAINS_TOKEN[0], FunContainsToken.class),
         new FunctionDef(FunContainsToken.FS_CONTAINS_TOKEN[1], FunContainsToken.class)
     };
-
-    static {
-        Arrays.sort(functions, new FunctionComparator());
-    }
-
     public final static ErrorCodes.ErrorCode SENR0001 = new ErrorCodes.ErrorCode("SENR0001", "serialization error in fn:serialize");
     public final static ErrorCodes.ErrorCode SEPM0019 = new ErrorCodes.ErrorCode("SEPM0019", "It is an error if an instance of the data model " +
             "used to specify the settings of serialization parameters specifies the value of the same parameter more than once.");
 
     public FnModule(Map<String, List<?>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectionModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectionModule.java
@@ -56,7 +56,7 @@ public class InspectionModule extends AbstractInternalModule {
     );
 
     public InspectionModule(final Map<String, List<?>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapModule.java
@@ -59,7 +59,7 @@ public class MapModule extends AbstractInternalModule {
     );
 
     public MapModule(Map<String, List<?>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     public String getNamespaceURI() {

--- a/exist-core/src/main/java/org/exist/xquery/functions/request/RequestModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/request/RequestModule.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery.functions.request;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -77,13 +76,8 @@ public class RequestModule extends AbstractInternalModule {
             new FunctionDef(GetPathInfo.signature, GetPathInfo.class),
             new FunctionDef(IsMultiPartContent.signature, IsMultiPartContent.class)
     };
-
-    static {
-        Arrays.sort(functions, new FunctionComparator());
-    }
-
     public RequestModule(final Map<String, List<?>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery.functions.util;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -154,11 +153,6 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(BaseConversionFunctions.FNS_OCTAL_TO_INT, BaseConversionFunctions.class),
             new FunctionDef(LineNumber.signature, LineNumber.class)
     };
-
-    static {
-        Arrays.sort(functions, new FunctionComparator());
-    }
-
     public final static QName EXCEPTION_QNAME = new QName("exception", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
 
     public final static QName EXCEPTION_MESSAGE_QNAME = new QName("exception-message", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
@@ -166,7 +160,7 @@ public class UtilModule extends AbstractInternalModule {
     public final static QName ERROR_CODE_QNAME = new QName("error-code", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
 
     public UtilModule(final Map<String, List<? extends Object>> parameters) throws XPathException {
-        super(functions, parameters, true);
+        super(functions, parameters);
 
         final List<String> evalDisabledParamList = (List<String>) getParameter("evalDisabled");
         if (evalDisabledParamList != null && !evalDisabledParamList.isEmpty()) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/websocket/ConsoleCompatModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/websocket/ConsoleCompatModule.java
@@ -49,7 +49,7 @@ public class ConsoleCompatModule extends AbstractInternalModule {
     };
 
     public ConsoleCompatModule(final Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/websocket/WebSocketModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/websocket/WebSocketModule.java
@@ -53,7 +53,7 @@ public class WebSocketModule extends AbstractInternalModule {
     private static volatile ConsoleAdapter adapter = null;
 
     public WebSocketModule(final Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     public static void log(final String channel, final String message) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery.functions.xmldb;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -110,13 +109,8 @@ public class XMLDBModule extends AbstractInternalModule {
     };
 
     private boolean allowAnyUri = false;
-
-    static {
-        Arrays.sort(functions, new FunctionComparator());
-    }
-
     public XMLDBModule(final Map<String, List<?>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
 
         final List<String> allowAnyUriParameterList = (List<String>) getParameter("allowAnyUri");
         if (allowAnyUriParameterList != null && !allowAnyUriParameterList.isEmpty()) {

--- a/exist-core/src/test/java/org/exist/xquery/AbstractInternalModuleSortTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/AbstractInternalModuleSortTest.java
@@ -1,0 +1,190 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.dom.QName;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Verifies that {@link AbstractInternalModule} always sorts its function table by
+ * {@link FunctionId} order, regardless of the caller's declaration order. Pre-fix
+ * (#6376 / #6378), modules that opted into binary search via {@code functionsOrdered=true}
+ * had to pre-sort their array themselves; a forgotten sort silently broke function lookup
+ * (the function appeared in {@code util:registered-functions} but was unreachable via
+ * direct call or {@code fn:function-lookup}). The constructor now always sorts, so this
+ * footgun is structurally impossible.
+ */
+public class AbstractInternalModuleSortTest {
+
+    private static final String NS = "http://TestSortInvariant";
+    private static final String PREFIX = "tsi";
+
+    private static FunctionDef def(final String localName, final int arity) {
+        final SequenceType[] params = new SequenceType[arity];
+        for (int i = 0; i < arity; i++) {
+            params[i] = new FunctionParameterSequenceType("p" + i, Type.ITEM, Cardinality.ZERO_OR_MORE, "");
+        }
+        final FunctionSignature sig = new FunctionSignature(
+                new QName(localName, NS, PREFIX),
+                "test",
+                params,
+                new FunctionReturnSequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE, ""));
+        return new FunctionDef(sig, Function.class);
+    }
+
+    /**
+     * Unsorted declaration order — {@code close} sorts before {@code eval}/{@code fetch} —
+     * must still find all functions via binary search. This is the regression case from
+     * <a href="https://github.com/eXist-db/exist/issues/6376">#6376</a>.
+     */
+    @Test
+    public void unsortedDeclarationOrderStillFindsAllFunctions() {
+        final FunctionDef[] declarationOrder = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        final TestModule module = new TestModule(declarationOrder);
+
+        assertNotNull("close#1 must be discoverable",
+                module.getFunctionDef(new QName("close", NS, PREFIX), 1));
+        assertNotNull("eval#1 must be discoverable",
+                module.getFunctionDef(new QName("eval", NS, PREFIX), 1));
+        assertNotNull("fetch#2 must be discoverable",
+                module.getFunctionDef(new QName("fetch", NS, PREFIX), 2));
+        assertNull("unknown function still returns null",
+                module.getFunctionDef(new QName("close", NS, PREFIX), 99));
+    }
+
+    /**
+     * The defensive sort must not mutate the caller's {@code static final} array.
+     */
+    @Test
+    public void callerArrayIsNotMutated() {
+        final FunctionDef[] callerArray = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        final String beforeFirst = callerArray[0].getSignature().getName().getLocalPart();
+        new TestModule(callerArray);
+        assertEquals("caller's array must remain in declaration order",
+                beforeFirst, callerArray[0].getSignature().getName().getLocalPart());
+    }
+
+    /**
+     * Already-sorted arrays still work correctly (verifies the always-sort path doesn't
+     * break the common case where the caller happened to declare in order).
+     */
+    @Test
+    public void alreadySortedArrayFindsAllFunctions() {
+        final FunctionDef[] sorted = {
+                def("close", 1),
+                def("eval", 1),
+                def("fetch", 2)
+        };
+        final TestModule module = new TestModule(sorted);
+        assertNotNull(module.getFunctionDef(new QName("close", NS, PREFIX), 1));
+        assertNotNull(module.getFunctionDef(new QName("eval", NS, PREFIX), 1));
+        assertNotNull(module.getFunctionDef(new QName("fetch", NS, PREFIX), 2));
+    }
+
+    /**
+     * Same qname at different arities — secondary sort key (arity) is honored.
+     */
+    @Test
+    public void sameQnameDifferentAritiesAllFound() {
+        final FunctionDef[] mixed = {
+                def("scan", 3),
+                def("scan", 1),
+                def("scan", 2)
+        };
+        final TestModule module = new TestModule(mixed);
+        assertNotNull(module.getFunctionDef(new QName("scan", NS, PREFIX), 1));
+        assertNotNull(module.getFunctionDef(new QName("scan", NS, PREFIX), 2));
+        assertNotNull(module.getFunctionDef(new QName("scan", NS, PREFIX), 3));
+    }
+
+    /**
+     * Backwards-compat check: an upstream module that still uses the pre-#6378
+     * 3-arg constructor (with either flag value) must continue to compile and
+     * produce a functioning module. The flag is documented as ignored.
+     */
+    @Test
+    public void deprecatedThreeArgConstructorStillWorks() {
+        final FunctionDef[] unsorted = {
+                def("eval", 1),
+                def("fetch", 2),
+                def("close", 1)
+        };
+        // Both legacy call shapes must compile and produce an equivalent module.
+        final LegacyTestModule withTrue = new LegacyTestModule(unsorted, true);
+        final LegacyTestModule withFalse = new LegacyTestModule(unsorted, false);
+
+        for (final LegacyTestModule m : new LegacyTestModule[]{withTrue, withFalse}) {
+            assertNotNull("close#1 must be found via the legacy 3-arg ctor",
+                    m.getFunctionDef(new QName("close", NS, PREFIX), 1));
+            assertNotNull("eval#1 must be found via the legacy 3-arg ctor",
+                    m.getFunctionDef(new QName("eval", NS, PREFIX), 1));
+            assertNotNull("fetch#2 must be found via the legacy 3-arg ctor",
+                    m.getFunctionDef(new QName("fetch", NS, PREFIX), 2));
+        }
+    }
+
+    private static final class TestModule extends AbstractInternalModule {
+        TestModule(final FunctionDef[] functions) {
+            super(functions, Map.of());
+        }
+
+        @Override public String getNamespaceURI() { return NS; }
+        @Override public String getDefaultPrefix() { return PREFIX; }
+        @Override public String getDescription() { return "test"; }
+        @Override public String getReleaseVersion() { return "1"; }
+    }
+
+    /**
+     * Mimics an external module compiled against pre-#6378 eXist that uses
+     * the legacy 3-arg constructor signature. The {@code @SuppressWarnings} is
+     * intentional — this class exists to exercise the deprecation path.
+     */
+    @SuppressWarnings({"deprecation", "removal"})
+    private static final class LegacyTestModule extends AbstractInternalModule {
+        LegacyTestModule(final FunctionDef[] functions, final boolean functionsOrdered) {
+            super(functions, Map.of(), functionsOrdered);
+        }
+
+        @Override public String getNamespaceURI() { return NS; }
+        @Override public String getDefaultPrefix() { return PREFIX; }
+        @Override public String getDescription() { return "legacy test"; }
+        @Override public String getReleaseVersion() { return "1"; }
+    }
+}

--- a/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentExtractionModule.java
+++ b/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentExtractionModule.java
@@ -50,7 +50,7 @@ public class ContentExtractionModule extends AbstractInternalModule {
 //            new QName("exception-message", ContentExtractionModule.NAMESPACE_URI, ContentExtractionModule.PREFIX);
 
     public ContentExtractionModule(Map<String, List<? extends Object>> parameters) throws XPathException {
-        super(functions, parameters, true);
+        super(functions, parameters);
 //        declareVariable(EXCEPTION_QNAME, null);
 //        declareVariable(EXCEPTION_MESSAGE_QNAME, null);
     }

--- a/extensions/exiftool/src/main/java/org/exist/exiftool/xquery/ExiftoolModule.java
+++ b/extensions/exiftool/src/main/java/org/exist/exiftool/xquery/ExiftoolModule.java
@@ -43,7 +43,7 @@ public class ExiftoolModule extends AbstractInternalModule {
     };
 
     public ExiftoolModule(Map<String, List<? extends Object>> parameters) throws XPathException {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -86,7 +86,7 @@ public class LuceneModule extends AbstractInternalModule {
     };
 
     public LuceneModule(Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramModule.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramModule.java
@@ -51,7 +51,7 @@ public class NGramModule extends AbstractInternalModule {
     };
 
     public NGramModule(Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeIndexModule.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeIndexModule.java
@@ -91,7 +91,7 @@ public class RangeIndexModule extends AbstractInternalModule {
             "supported");
 
     public RangeIndexModule(Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/indexes/sort/src/main/java/org/exist/xquery/modules/sort/SortModule.java
+++ b/extensions/indexes/sort/src/main/java/org/exist/xquery/modules/sort/SortModule.java
@@ -45,7 +45,7 @@ public class SortModule extends AbstractInternalModule {
     };
 
     public SortModule(final Map<String, List<?>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/CounterModule.java
+++ b/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/CounterModule.java
@@ -27,7 +27,6 @@ import org.exist.xquery.FunctionDef;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -53,11 +52,6 @@ public class CounterModule extends AbstractInternalModule {
         new FunctionDef(CounterFunctions.destroyCounter, CounterFunctions.class),
 
     };
-
-    static {
-        Arrays.sort(functions, new FunctionComparator());
-    }
-
     public final static QName EXCEPTION_QNAME =
 	    new QName("exception", CounterModule.NAMESPACE_URI, CounterModule.PREFIX);
 
@@ -65,7 +59,7 @@ public class CounterModule extends AbstractInternalModule {
         new QName("exception-message", CounterModule.NAMESPACE_URI, CounterModule.PREFIX);
 
 	public CounterModule(Map<String, List<?>> parameters) throws XPathException {
-		super(functions, parameters, true);
+		super(functions, parameters);
 	}
 
 	@Override

--- a/extensions/modules/process/src/main/java/org/exist/xquery/modules/process/ProcessModule.java
+++ b/extensions/modules/process/src/main/java/org/exist/xquery/modules/process/ProcessModule.java
@@ -38,7 +38,7 @@ public class ProcessModule extends AbstractInternalModule {
     };
 
     public ProcessModule(Map<String, List<?>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
@@ -72,7 +72,7 @@ public class VectorModule extends AbstractInternalModule {
   }
 
   public VectorModule(final Map<String, List<? extends Object>> parameters) {
-    super(functions, parameters, false);
+    super(functions, parameters);
   }
 
   @Override

--- a/extensions/xqdoc/src/main/java/org/exist/xqdoc/xquery/XQDocModule.java
+++ b/extensions/xqdoc/src/main/java/org/exist/xqdoc/xquery/XQDocModule.java
@@ -40,7 +40,7 @@ public class XQDocModule extends AbstractInternalModule {
     };
 
     public XQDocModule(Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, true);
+        super(functions, parameters);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Closes #6378. Implements Option 2 per @duncdrum's preference on the issue thread:

> FWIW I m leaning heavily towards 2. There is a whole cluster of bugs we encountered recently where inconsistent sorting leads to hard to debug and nasty bugs.

The `functionsOrdered=true` opt-in flag on `AbstractInternalModule`'s 3-arg constructor was an unenforced precondition: callers had to pass a `FunctionDef[]` already sorted by `FunctionId` order, or binary search in `getFunctionDef()` would silently miss entries. The footgun manifested as a real bug in #6376 (`cursor:close` unreachable via `function-lookup` but visible via `util:registered-functions`).

The fix removes the flag entirely. The base class always sorts (defensive-copy + `Arrays.sort` in the constructor) and always uses binary search. Five first-party modules that previously carried `static { Arrays.sort(functions, new FunctionComparator()); }` boilerplate no longer need it.

## What changed

**Commit 1 — base class** (`AbstractInternalModule.java`, +20 / -24):
- Remove the 3-arg `(FunctionDef[], Map, boolean)` constructor.
- 2-arg constructor now defensive-copies and sorts (caller's `static final` array left intact).
- Remove the `ordered` field and the conditional in `getFunctionDef()`; binary search is unconditional.
- Reorder field declarations above the `FunctionComparator` inner class (PMD `FieldDeclarationsShouldBeAtStartOfClass`).

**Commit 2 — 20 callers + 5 static-sort cleanups** (+167 / -50):

Callers updated (drop the third argument):

| Module | Was |
|---|---|
| `BackupModule`, `FnModule`, `InspectionModule`, `RequestModule`, `UtilModule`, `XMLDBModule`, `ContentExtractionModule`, `ExiftoolModule`, `XQDocModule`, `CounterModule`, `ProcessModule` | `super(functions, parameters, true)` |
| `ArrayModule`, `MapModule`, `WebSocketModule`, `ConsoleCompatModule`, `VectorModule`, `LuceneModule`, `SortModule`, `NGramModule`, `RangeIndexModule` | `super(functions, parameters, false)` |

Static-sort blocks removed (`static { Arrays.sort(functions, new FunctionComparator()); }`) from `XMLDBModule`, `UtilModule`, `RequestModule`, `FnModule`, `CounterModule` — plus the now-unused `java.util.Arrays` imports.

Net: ~34 lines of boilerplate gone from the codebase.

**Regression test** (`AbstractInternalModuleSortTest`, new — 4 cases):
- `unsortedDeclarationOrderStillFindsAllFunctions` — the #6376 reproducer, now safe by construction.
- `callerArrayIsNotMutated` — verifies the defensive copy.
- `alreadySortedArrayFindsAllFunctions` — common-case sanity.
- `sameQnameDifferentAritiesAllFound` — secondary sort key (arity) is honored.

## API break

The 3-arg `AbstractInternalModule(FunctionDef[], Map<String, List<?>>, boolean)` constructor goes away. Any third-party module passing `super(functions, parameters, true|false)` needs to switch to `super(functions, parameters)`. One-line change per module. The `FunctionComparator` static inner class remains public for any code that uses it elsewhere.

@duncdrum explicitly accepted this trade-off on the issue: removing the flag is what makes the bug structurally impossible.

## Performance

The sort is O(N log N) once per module instance construction. eXist's largest module is `FnModule` (~500 functions), sorted in microseconds. `AbstractInternalModule` is instantiated per `XQueryContext`, which is per-query — so the sort runs per query. For comparison, the previous `static { Arrays.sort(...) }` blocks ran once at class load. The cost is small but real; happy to memoize per-class if reviewers want to eliminate it entirely (one-time check via `ConcurrentMap<Class<?>, Boolean>`).

## Test plan

- [x] `mvn test -pl exist-core -Dtest=AbstractInternalModuleSortTest` — 4/4 pass
- [x] `mvn compile` across exist-core + extensions (minus exist-xqts, which has unrelated GitHub Packages auth issue locally) — green
- [x] Codacy clean on changed files
- [x] CI green

## Related

- Issue #6378 — this PR closes it
- Issue #6376 — original symptom report (cursor:close in existdb-openapi)
- The earlier draft PR #6377 (which took Option 1) was closed in favor of #6378 + this approach.