### PR TITLE
[bugfix] Preserve static context in union-step distribution

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -335,7 +335,16 @@ public class Optimizer extends DefaultExpressionVisitor {
                                        final Union innerUnion) {
         final PathExpr distributedLeft = distributeBranch(outer, unionStepIndex, innerUnion.getLeft());
         final PathExpr distributedRight = distributeBranch(outer, unionStepIndex, innerUnion.getRight());
-        final Union result = new Union(context, distributedLeft, distributedRight);
+        // Use the original outer PathExpr's static context, not the Optimizer's
+        // own context field. When the Optimizer is invoked over an imported
+        // module's AST, the two share the same module context — but when the
+        // outer PathExpr was constructed in a different module from the one
+        // currently driving the optimizer pass (e.g. a path inside a user
+        // function called by a higher-level query), `this.context` is the
+        // caller's context and lacks the namespace declarations needed to
+        // resolve the prefixed names baked into the inner steps. Re-analysis
+        // after the rewrite then raises a spurious XPST0081. See bug #TBD.
+        final Union result = new Union(outer.getContext(), distributedLeft, distributedRight);
         result.setLocation(innerUnion.getLine(), innerUnion.getColumn());
         return result;
     }
@@ -364,14 +373,17 @@ public class Optimizer extends DefaultExpressionVisitor {
      */
     private PathExpr distributeBranch(final PathExpr outer, final int unionStepIndex,
                                        final PathExpr branch) {
+        // See note in distributeOverUnion: take the static context from the
+        // outer path being rewritten, not the Optimizer's own context.
+        final XQueryContext outerContext = outer.getContext();
         if (branch.getLength() == 1 && branch.getExpression(0) instanceof final Union nested) {
             final Union distributedNested = distributeOverUnion(outer, unionStepIndex, nested);
-            final PathExpr wrap = new PathExpr(context);
+            final PathExpr wrap = new PathExpr(outerContext);
             wrap.setLocation(branch.getLine(), branch.getColumn());
             wrap.add(distributedNested);
             return wrap;
         }
-        final PathExpr distributed = new PathExpr(context);
+        final PathExpr distributed = new PathExpr(outerContext);
         distributed.setLocation(branch.getLine(), branch.getColumn());
         for (int j = 0; j < unionStepIndex; j++) {
             addStepWithParent(distributed, cloneLocationStepIfPossible(outer.getExpression(j)));
@@ -421,7 +433,8 @@ public class Optimizer extends DefaultExpressionVisitor {
     private Expression cloneLocationStepIfPossible(final Expression e) {
         if (e instanceof final LocationStep ls
                 && (ls.getPredicates() == null || ls.getPredicates().length == 0)) {
-            final LocationStep clone = new LocationStep(context, ls.getAxis(), ls.getTest());
+            // Preserve the step's own static context — see note in distributeOverUnion.
+            final LocationStep clone = new LocationStep(ls.getContext(), ls.getAxis(), ls.getTest());
             clone.setAbbreviated(ls.isAbbreviated());
             clone.setLocation(ls.getLine(), ls.getColumn());
             return clone;

--- a/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionStepDistributionOptimizerTest.java
@@ -22,6 +22,7 @@
 package org.exist.xquery;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xmldb.EXistResource;
 import org.exist.xmldb.EXistXQueryService;
 import org.exist.xquery.util.ExpressionDumper;
 import org.junit.AfterClass;
@@ -32,6 +33,7 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.CompiledExpression;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XQueryService;
@@ -486,5 +488,61 @@ public class UnionStepDistributionOptimizerTest {
         assertOptimizerParity(
                 "let $a := <el><el1/><el2 att='val'/><el3/></el> "
                         + "return $a/el2/(@*[1]|@*[1])/string()");
+    }
+
+    /**
+     * Regression test for a static-context leak in union-step distribution.
+     *
+     * <p>When the path with the parenthesised union step lives inside a
+     * library module that declares its own namespace prefix, and is called
+     * from an importing query that does <em>not</em> declare that prefix,
+     * the distribution rewrite previously built the new branches against the
+     * Optimizer's own {@code context} field rather than the originating
+     * expression's static context. Re-analysis then raised a spurious
+     * {@code XPST0081 "undeclared prefix"} — sometimes naming a prefix that
+     * isn't even used in the failing path. See bug #TBD.
+     *
+     * <p>The bug only surfaced with imported modules because the engine's
+     * existing single-module tests share one static context throughout.
+     */
+    @Test
+    public void unionDistributionPreservesImportedModuleStaticContext() throws XMLDBException {
+        final String moduleCollName = COLLECTION_NAME + "-mod";
+        final Collection root = server.getRoot();
+        final CollectionManagementService cms = root.getService(CollectionManagementService.class);
+        Collection modColl = null;
+        try {
+            modColl = cms.createCollection(moduleCollName);
+            final String moduleSource = """
+                    xquery version "3.1";
+                    module namespace cb="http://example.com/cb";
+                    declare namespace nsx="http://example.com/x";
+
+                    declare function cb:make() {
+                        <nsx:wrap><nsx:item><nsx:name>hi</nsx:name></nsx:item></nsx:wrap>
+                    };
+
+                    declare function cb:filter() {
+                        cb:make()/nsx:item/(nsx:name | nsx:other)
+                    };
+                    """;
+            final BinaryResource res = modColl.createResource("cb.xqm", BinaryResource.class);
+            ((EXistResource) res).setMimeType("application/xquery");
+            res.setContent(moduleSource.getBytes());
+            modColl.storeResource(res);
+
+            final XQueryService svc = root.getService(XQueryService.class);
+            final String caller = OPTIMIZE
+                    + "import module namespace cb=\"http://example.com/cb\" "
+                    + "at \"xmldb:exist:///db/" + moduleCollName + "/cb.xqm\";"
+                    + "cb:filter()";
+            final ResourceSet result = svc.query(caller);
+            assertEquals("cb:filter() should return one <nsx:name> element", 1, result.getSize());
+        } finally {
+            if (modColl != null) {
+                modColl.close();
+            }
+            cms.removeCollection(moduleCollName);
+        }
     }
 }


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

Fixes a regression introduced by #6310 (`929d29cb29` — "Run union-step distribution before descending into children"). The union-step distribution rewrite (`outer/(A|B|C)` → `outer/A | outer/B | outer/C`) built its new `PathExpr` / `Union` / `LocationStep` nodes against the `Optimizer`'s own `context` field instead of the originating expression's static context. When the rewrite applies to an imported library module whose parenthesised-union step uses a prefix declared only inside that module, and the caller doesn't redeclare the prefix, the distributed branches end up bound to the wrong context. Re-analysis then raises a spurious `err:XPST0081 undeclared prefix '<prefix>'` — sometimes naming an *unrelated* prefix from elsewhere in the source.

## Minimal repro

`/db/cb.xqm`:

```xquery
xquery version "3.1";
module namespace cb="http://example.com/cb";
declare namespace nsx="http://example.com/x";

declare function cb:make() {
    <nsx:wrap><nsx:item><nsx:name>hi</nsx:name></nsx:item></nsx:wrap>
};

declare function cb:filter() {
    cb:make()/nsx:item/(nsx:name | nsx:other)
};
```

Caller:

```xquery
xquery version "3.1";
import module namespace cb="http://example.com/cb" at "xmldb:exist:///db/cb.xqm";
cb:filter()
```

On develop pre-fix: `err:XPST0081 undeclared prefix 'nsx'`. On 6.4.1 or with this fix: `<nsx:name xmlns:nsx="http://example.com/x">hi</nsx:name>`.

The bug surfaces only with **imported** modules — the existing single-module tests in `UnionStepDistributionOptimizerTest` all share one static context end-to-end and so couldn't catch it.

## The fix

In `Optimizer.distributeOverUnion`, `distributeBranch`, and `cloneLocationStepIfPossible`, take the static context from the original expression rather than the Optimizer's own field:

- `new Union(outer.getContext(), ...)`
- `new PathExpr(outer.getContext())`
- `new LocationStep(ls.getContext(), ...)`

These come from the lexical site of the parenthesised union step and carry the correct namespace bindings.

## Test coverage

Adds `UnionStepDistributionOptimizerTest#unionDistributionPreservesImportedModuleStaticContext` — stores a `cb.xqm` module in the database and invokes `cb:filter()` from an importer that doesn't declare `nsx`. Verified to fail on the bad commit and pass with this fix.

## How this was found

Bisected from a 500 in `function-documentation` (`app.xqm:203` uses the same shape: `$module/xqdoc:module/xqdoc:comment/(xqdoc:author|xqdoc:version|xqdoc:since)`). The 500 reproduced on `existdb/existdb:latest` but not on `:release`. `git bisect run` over the 453 commits between `87460a1c21` (known good) and `origin/develop` (known bad) — 9 iterations of clean build + minimal repro — pointed at `929d29cb29`.

## Verification

- ✅ Minimal repro returns the expected node on the same docker image that previously 500'd
- ✅ `function-documentation/modules/app.xqm:203` renders cleanly
- ✅ Full **exist-core suite**: 6,834 tests, 0 failures, 0 errors (101 skipped — environment-dependent, identical to develop)
- ✅ **XQTS 3.1** (fix vs develop, same machine, same runner build): 1,394 vs 1,396 failures/errors. Of the ~100 tests that flip each direction (consistent with the runner's known thread-scheduling non-determinism), the *path-expression-area* delta is **+2 net improvements** (4 new failures, 6 newly passing). No optimizer/union-related regression.
- ✅ **XQTS HEAD**: both fix and develop runs hit the runner's 30-second shutdown-deadline force-exit (a known limitation noted in the runner's m2-isolation guide), so direct comparison isn't reliable. What did complete shows fewer failures with the fix (751 vs 1053) and fewer errors (90 vs 106).
- ✅ Regression test `unionDistributionPreservesImportedModuleStaticContext` fails on the bad commit, passes on this fix

## Risk assessment

Localised to three method bodies in `Optimizer.java`. No public API change. The rewrite still produces the same AST shape — only the static context attached to the new nodes changes, from the optimizer-pass context (potentially the wrong module) to the originating expression's context (always lexically correct). The change is strictly safer than the prior behaviour: when both contexts happened to be the same (the common single-module case), behaviour is unchanged; when they differ, prefix resolution now succeeds where it previously failed.