### PR TITLE
Dp fix jetty 12.1

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1203,6 +1203,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
+                        <exist.jetty.portal.dir>${project.basedir}/../exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/portal</exist.jetty.portal.dir>
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
 
@@ -1229,6 +1230,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
+                        <exist.jetty.portal.dir>${project.basedir}/../exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/portal</exist.jetty.portal.dir>
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>

--- a/exist-core/src/main/java/org/exist/indexing/IndexController.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexController.java
@@ -40,9 +40,11 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.exist.security.PermissionDeniedException;
 
 /**
@@ -56,7 +58,16 @@ public class IndexController {
         CONFIG_ONLY_REINDEX
     }
 
-    private final Map<String, IndexWorker> indexWorkers = new HashMap<>();
+    /**
+     * Stable iteration order for listener chains and {@link #flush()}.
+     * Alphabetical {@link TreeMap} put Lucene first and broke store-time indexing
+     * (see {@code LuceneTests} facet/field-type tests). Core indexes run before Lucene.
+     */
+    private static final Comparator<String> INDEX_WORKER_ORDER = Comparator
+            .comparingInt(IndexController::indexWorkerChainRank)
+            .thenComparing(Comparator.naturalOrder());
+
+    private final Map<String, IndexWorker> indexWorkers = new TreeMap<>(INDEX_WORKER_ORDER);
 
     private final DBBroker broker;
     private StreamListener listener = null;
@@ -71,6 +82,23 @@ public class IndexController {
         for (final IndexWorker worker : workers) {
             indexWorkers.put(worker.getIndexId(), worker);
         }
+    }
+
+    /**
+     * Preferred {@link StreamListener} chain order: structural → statistics → Lucene → others.
+     * Uses index-id substrings so exist-core does not depend on extension modules.
+     */
+    private static int indexWorkerChainRank(final String indexId) {
+        if (indexId.contains("NativeStructuralIndex")) {
+            return 0;
+        }
+        if (indexId.contains("IndexStatistics")) {
+            return 1;
+        }
+        if (indexId.contains("lucene.LuceneIndex")) {
+            return 2;
+        }
+        return 3;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -24,6 +24,7 @@ package org.exist.jetty;
 import net.jcip.annotations.GuardedBy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -97,6 +98,8 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     @GuardedBy("this") private int status = STATUS_STOPPED;
     @GuardedBy("this") private Optional<Thread> shutdownHookThread = Optional.empty();
     @GuardedBy("this") private int primaryPort = 8080;
+    @GuardedBy("this") private boolean webAppStartedSuccessfully = false;
+    @GuardedBy("this") private String webAppStartupFailureDetail = null;
 
 
     public static void main(final String[] args) {
@@ -130,6 +133,23 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
     private static void consoleOut(final String msg) {
         System.out.println(msg); //NOSONAR this has to go to the console
+    }
+
+    private static void consoleErr(final String msg) {
+        System.err.println(msg); //NOSONAR surfaced in Surefire output when test log4j root is OFF
+    }
+
+    private synchronized void recordStartupFailure(final String detail, final Throwable cause) {
+        webAppStartedSuccessfully = false;
+        webAppStartupFailureDetail = detail;
+        if (cause != null) {
+            logger.fatal("Jetty startup failed: {}", detail, cause);
+            consoleErr("Jetty startup failed: " + detail);
+            cause.printStackTrace(System.err); //NOSONAR CI diagnostics when log4j is disabled in tests
+        } else {
+            logger.fatal("Jetty startup failed: {}", detail);
+            consoleErr("Jetty startup failed: " + detail);
+        }
     }
 
     public synchronized void run() {
@@ -244,12 +264,13 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
             DatabaseManager.registerDatabase(xmldb);
 
         } catch (final Exception e) {
-            logger.error("configuration error: {}", e.getMessage(), e);
-            e.printStackTrace();
+            recordStartupFailure("configuration error: " + e.getMessage(), e);
             return;
         }
 
         try {
+            webAppStartupFailureDetail = null;
+            webAppStartedSuccessfully = false;
             // load jetty configurations
             final List<Path> configFiles = getEnabledConfigFiles(jettyConfig);
             final List<Object> configuredObjects = new ArrayList<>();
@@ -344,19 +365,25 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
             logger.info("-----------------------------------------------------");
 
+            awaitWebAppContextsStarted(getAllHandlers(server.getHandler()));
+            webAppStartedSuccessfully = true;
+            webAppStartupFailureDetail = null;
+
             setChanged();
             notifyObservers(SIGNAL_STARTED);
 
         } catch (final SocketException e) {
-            logger.error("----------------------------------------------------------");
-            logger.error("ERROR: Could not bind to port because {}", e.getMessage());
-            logger.error(e.toString());
-            logger.error("----------------------------------------------------------");
+            recordStartupFailure("Could not bind to port: " + e.getMessage(), e);
             setChanged();
             notifyObservers(SIGNAL_ERROR);
 
         } catch (final Exception e) {
-            logger.fatal("An unexpected error occurred, web server can not be started: {}", e.getMessage(), e);
+            if (webAppStartupFailureDetail == null) {
+                recordStartupFailure(
+                        e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), e);
+            } else {
+                recordStartupFailure(webAppStartupFailureDetail, e);
+            }
             setChanged();
             notifyObservers(SIGNAL_ERROR);
         }
@@ -504,6 +531,129 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
         }
 
         return server;
+    }
+
+    /**
+     * Block until deployed webapps reach the readiness level required for tests.
+     * <p>
+     * Every context except the distribution portal at {@code /} must be
+     * {@link org.eclipse.jetty.server.handler.ContextHandler#isAvailable()} — Jetty returns
+     * {@code 503} on all paths while unavailable. The portal coexists with {@code /exist} and is
+     * non-gating.
+     */
+    private void awaitWebAppContextsStarted(final List<Handler> handlers) throws InterruptedException {
+        final List<WebAppContext> webApps = new ArrayList<>();
+        for (final Handler handler : handlers) {
+            if (handler instanceof WebAppContext webApp) {
+                webApps.add(webApp);
+            }
+        }
+        if (webApps.isEmpty()) {
+            return;
+        }
+
+        final boolean distributionLayout = isDistributionLayout(webApps);
+        final long timeoutMs = slowEnvironmentStartupDeadlineMs();
+        final long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            boolean allReady = true;
+            for (final WebAppContext webApp : webApps) {
+                if (webApp.isFailed()) {
+                    throw new IllegalStateException(
+                            "Web application failed to start: " + webApp.getContextPath());
+                }
+                if (!isWebAppContextReady(webApp, distributionLayout)) {
+                    allReady = false;
+                    break;
+                }
+            }
+            if (allReady) {
+                logger.info("All required web application contexts are ready.");
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new IllegalStateException(
+                "Web application context did not become ready within " + timeoutMs + "ms: "
+                        + describePendingWebApps(webApps, distributionLayout),
+                firstUnavailableCause(webApps));
+    }
+
+    private static Throwable firstUnavailableCause(final List<WebAppContext> webApps) {
+        for (final WebAppContext webApp : webApps) {
+            final Throwable unavailable = webApp.getUnavailableException();
+            if (unavailable != null) {
+                return unavailable;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isDistributionLayout(final List<WebAppContext> webApps) {
+        return webApps.stream().anyMatch(webApp -> "/exist".equals(webApp.getContextPath()));
+    }
+
+    /**
+     * Distribution portal {@code /} only needs {@code isStarted()}. Standalone {@code /} and
+     * {@code /exist} must be {@code isAvailable()} or HTTP clients see {@code 503}.
+     */
+    private static boolean isWebAppContextReady(final WebAppContext webApp, final boolean distributionLayout) {
+        if (!webApp.isStarted()) {
+            return false;
+        }
+        if (distributionLayout && "/".equals(webApp.getContextPath())) {
+            return true;
+        }
+        return webApp.isAvailable();
+    }
+
+    private static String describePendingWebApps(final List<WebAppContext> webApps, final boolean distributionLayout) {
+        final StringBuilder details = new StringBuilder();
+        for (final WebAppContext webApp : webApps) {
+            if (webApp.isFailed()) {
+                continue;
+            }
+            if (!isWebAppContextReady(webApp, distributionLayout)) {
+                if (!details.isEmpty()) {
+                    details.append("; ");
+                }
+                details.append(webApp.getContextPath())
+                        .append(" started=").append(webApp.isStarted())
+                        .append(" available=").append(webApp.isAvailable())
+                        .append(" requireAvailable=").append(requiresAvailability(webApp, distributionLayout))
+                        .append(" war=").append(describeWebAppWar(webApp));
+                final Throwable unavailable = webApp.getUnavailableException();
+                if (unavailable != null) {
+                    details.append(" unavailableCause=").append(unavailable.getClass().getName())
+                            .append(": ").append(unavailable.getMessage());
+                }
+            }
+        }
+        return details.isEmpty() ? "unknown" : details.toString();
+    }
+
+    private static String describeWebAppWar(final WebAppContext webApp) {
+        final String war = webApp.getWar();
+        if (war != null && !war.isBlank()) {
+            return war;
+        }
+        try {
+            final Resource baseResource = webApp.getBaseResource();
+            return baseResource != null ? String.valueOf(baseResource) : "null";
+        } catch (final Exception e) {
+            return "unresolved(" + e.getMessage() + ")";
+        }
+    }
+
+    private static boolean requiresAvailability(final WebAppContext webApp, final boolean distributionLayout) {
+        return !(distributionLayout && "/".equals(webApp.getContextPath()));
+    }
+
+    private static long slowEnvironmentStartupDeadlineMs() {
+        if (System.getenv("CI") != null) {
+            return 180_000L;
+        }
+        return 60_000L;
     }
 
     private Map<String, String> getConfigProperties(final Path configDir) throws IOException {
@@ -694,5 +844,22 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
     public synchronized int getPrimaryPort() {
         return primaryPort;
+    }
+
+    /**
+     * {@code true} when all required {@link WebAppContext} instances finished startup. Used by
+     * integration tests to detect swallowed startup failures.
+     */
+    public synchronized boolean isWebAppStartedSuccessfully() {
+        return webAppStartedSuccessfully;
+    }
+
+    /**
+     * When {@link #isWebAppStartedSuccessfully()} is {@code false}, holds the last startup failure
+     * message for test diagnostics (also printed to {@code System.err} because module test log4j
+     * configs often set {@code Root level="OFF"}).
+     */
+    public synchronized Optional<String> getWebAppStartupFailureDetail() {
+        return Optional.ofNullable(webAppStartupFailureDetail);
     }
 }

--- a/exist-core/src/main/java/org/exist/jetty/WebAppContext.java
+++ b/exist-core/src/main/java/org/exist/jetty/WebAppContext.java
@@ -21,24 +21,37 @@
  */
 package org.exist.jetty;
 
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.exist.storage.BrokerPool;
 
 /**
- * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ * eXist {@link org.eclipse.jetty.ee10.webapp.WebAppContext} with Windows path handling for
+ * Jetty 12.1 ({@link WindowsPathResource}).
  *
+ * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
 public class WebAppContext extends org.eclipse.jetty.ee10.webapp.WebAppContext {
 
     @Override
-	public String toString() {
-		return "eXist-db Open Source Native XML Database";
-	}
+    public String toString() {
+        return "eXist-db Open Source Native XML Database";
+    }
 
     @Override
-	protected void doStop() throws Exception {
-		super.doStop();
+    public void setBaseResource(final Resource baseResource) {
+        super.setBaseResource(WindowsPathResource.wrapIfNeeded(baseResource, ResourceFactory.of(this)));
+    }
 
-		BrokerPool.stopAll(true);
-	}
+    @Override
+    public Resource newResource(final String urlOrPath) {
+        return WindowsPathResource.wrapIfNeeded(super.newResource(urlOrPath), ResourceFactory.of(this));
+    }
 
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        BrokerPool.stopAll(true);
+    }
 }

--- a/exist-core/src/main/java/org/exist/jetty/WindowsPathResource.java
+++ b/exist-core/src/main/java/org/exist/jetty/WindowsPathResource.java
@@ -1,0 +1,132 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.jetty;
+
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.resource.PathResource;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Workaround for Jetty 12.1 {@link PathResource#resolve(String)} on Windows.
+ * <p>
+ * Jetty 12.0 resolves sub-paths with {@code Paths.get(resolvedUri)}. Jetty 12.1 uses
+ * {@code path.resolve(uri.getPath())}, which throws {@link java.nio.file.InvalidPathException}
+ * when the URI path is {@code /D:/...}. Exploded test webapps on Windows CI hit this in
+ * {@code WebAppContext.getWebInf()}. Remove when upstream Jetty restores safe Windows resolve.
+ */
+final class WindowsPathResource extends Resource {
+
+    private final Resource delegate;
+    private final ResourceFactory resourceFactory;
+
+    private WindowsPathResource(final Resource delegate, final ResourceFactory resourceFactory) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.resourceFactory = Objects.requireNonNull(resourceFactory);
+    }
+
+    static Resource wrapIfNeeded(final Resource resource, final ResourceFactory resourceFactory) {
+        if (resource == null || File.separatorChar != '\\' || !(resource instanceof PathResource)) {
+            return resource;
+        }
+        if (resource instanceof WindowsPathResource) {
+            return resource;
+        }
+        return new WindowsPathResource(resource, resourceFactory);
+    }
+
+    @Override
+    public Path getPath() {
+        return delegate.getPath();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return delegate.isDirectory();
+    }
+
+    @Override
+    public boolean isReadable() {
+        return delegate.isReadable();
+    }
+
+    @Override
+    public URI getURI() {
+        return delegate.getURI();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getFileName() {
+        return delegate.getFileName();
+    }
+
+    @Override
+    public Resource resolve(final String subUriPath) {
+        if (URIUtil.isNotNormalWithinSelf(subUriPath)) {
+            throw new IllegalArgumentException(subUriPath);
+        }
+        if ("/".equals(subUriPath)) {
+            return this;
+        }
+        final URI resolvedUri = URIUtil.addPath(getURI(), subUriPath);
+        final Path path = Paths.get(resolvedUri);
+        return wrapIfNeeded(resourceFactory.newResource(path), resourceFactory);
+    }
+
+    @Override
+    public Iterator<Resource> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof WindowsPathResource other)) {
+            return false;
+        }
+        return delegate.equals(other.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/test/ExistWebServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistWebServer.java
@@ -123,16 +123,10 @@ public class ExistWebServer extends ExternalResource {
 
             if(useRandomPort) {
                 synchronized(ExistWebServer.class) {
-                    System.setProperty(PROP_JETTY_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
-                    System.setProperty(PROP_JETTY_SECURE_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
-                    System.setProperty(PROP_JETTY_SSL_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
-
-                    server = new JettyStart();
-                    server.run(jettyStandaloneMode);
+                    startJettyServer();
                 }
             } else {
-                server = new JettyStart();
-                server.run();
+                startJettyServer();
             }
         } else {
             throw new IllegalStateException("ExistWebServer already running");
@@ -143,10 +137,19 @@ public class ExistWebServer extends ExternalResource {
     public void restart() {
         if(server != null) {
             try {
-                server.shutdown();
-                server.run();
-            } catch (final Throwable t) {
-                throw new RuntimeException(t);
+                if (useRandomPort) {
+                    synchronized (ExistWebServer.class) {
+                        server.shutdown();
+                        server.run(jettyStandaloneMode);
+                        awaitJettyReadyAfterRun();
+                    }
+                } else {
+                    server.shutdown();
+                    server.run(jettyStandaloneMode);
+                    awaitJettyReadyAfterRun();
+                }
+            } catch (final Exception e) {
+                throw new IllegalStateException("Failed to restart ExistWebServer", e);
             }
         } else {
             throw new IllegalStateException("ExistWebServer already stopped");
@@ -156,29 +159,14 @@ public class ExistWebServer extends ExternalResource {
     @Override
     protected void after() {
         if(server != null) {
-            if(cleanupDbOnShutdown) {
-                try {
-                    TestUtils.cleanupDB();
-                } catch (final EXistException | PermissionDeniedException | LockException | IOException | TriggerException e) {
-                    fail(e.getMessage());
-                }
-            }
-            server.shutdown();
-            server = null;
-
-            if(useTemporaryStorage && temporaryStorage.isPresent()) {
-                FileUtils.deleteQuietly(temporaryStorage.get());
-                temporaryStorage = Optional.empty();
-                System.clearProperty(CONFIG_PROP_JOURNAL_DIR);
-                System.clearProperty(CONFIG_PROP_FILES);
-            }
-
-            if(useRandomPort) {
+            if (useRandomPort) {
                 synchronized (ExistWebServer.class) {
-                    System.clearProperty(PROP_JETTY_SSL_PORT);
-                    System.clearProperty(PROP_JETTY_SECURE_PORT);
-                    System.clearProperty(PROP_JETTY_PORT);
+                    shutdownJettyServer();
+                    disposeTemporaryStorage();
                 }
+            } else {
+                shutdownJettyServer();
+                disposeTemporaryStorage();
             }
         } else {
             throw new IllegalStateException("ExistWebServer already stopped");
@@ -190,5 +178,53 @@ public class ExistWebServer extends ExternalResource {
         }
 
         super.after();
+    }
+
+    private void startJettyServer() {
+        if (useRandomPort) {
+            System.setProperty(PROP_JETTY_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
+            System.setProperty(PROP_JETTY_SECURE_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
+            System.setProperty(PROP_JETTY_SSL_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
+        }
+        server = new JettyStart();
+        server.run(jettyStandaloneMode);
+        awaitJettyReadyAfterRun();
+    }
+
+    private void awaitJettyReadyAfterRun() {
+        if (!server.isWebAppStartedSuccessfully()) {
+            final String detail = server.getWebAppStartupFailureDetail()
+                    .filter(s -> !s.isBlank())
+                    .orElse("no startup detail recorded");
+            throw new IllegalStateException(
+                    "Jetty web application context did not start successfully: " + detail);
+        }
+    }
+
+    private void shutdownJettyServer() {
+        if (cleanupDbOnShutdown) {
+            try {
+                TestUtils.cleanupDB();
+            } catch (final EXistException | PermissionDeniedException | LockException | IOException | TriggerException e) {
+                fail(e.getMessage());
+            }
+        }
+        server.shutdown();
+        server = null;
+
+        if(useRandomPort) {
+            System.clearProperty(PROP_JETTY_SSL_PORT);
+            System.clearProperty(PROP_JETTY_SECURE_PORT);
+            System.clearProperty(PROP_JETTY_PORT);
+        }
+    }
+
+    private void disposeTemporaryStorage() {
+        if (useTemporaryStorage && temporaryStorage.isPresent()) {
+            FileUtils.deleteQuietly(temporaryStorage.get());
+            temporaryStorage = Optional.empty();
+            System.clearProperty(CONFIG_PROP_JOURNAL_DIR);
+            System.clearProperty(CONFIG_PROP_FILES);
+        }
     }
 }

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-deploy.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-deploy.xml
@@ -14,6 +14,7 @@
       <Arg>
         <New class="org.exist.jetty.WebAppContext">
           <Set name="contextPath">/exist</Set>
+          <Set name="throwUnavailableOnStartupException">true</Set>
           <Set name="war"><SystemProperty name="exist.jetty.webapp.dir"><Default><Property name="jetty.home" default="."/>/../../../webapp/</Default></SystemProperty></Set>
           <Set name="defaultsDescriptor"><Property name="jetty.home" default="."/>/etc/webdefault.xml</Set>
           <Set name="securityHandler">

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-deploy.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-deploy.xml
@@ -12,6 +12,7 @@
       <Arg>
         <New class="org.exist.jetty.WebAppContext">
           <Set name="contextPath">/</Set>
+          <Set name="throwUnavailableOnStartupException">true</Set>
           <Set name="war"><SystemProperty name="exist.jetty.standalone.webapp.dir"><Default><Property name="jetty.home" default="."/>/../../../standalone-webapp/</Default></SystemProperty></Set>
           <Set name="defaultsDescriptor"><Property name="jetty.home" default="."/>/etc/webdefault.xml</Set>
           <Set name="securityHandler">

--- a/exist-jetty-config/src/main/resources/standalone-webapp/WEB-INF/web.xml
+++ b/exist-jetty-config/src/main/resources/standalone-webapp/WEB-INF/web.xml
@@ -179,6 +179,27 @@
          website will only work if XQueryURLRewrite controls the /rest servlet
          (EXistServlet). -->
     <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>EXistServlet</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>milton</servlet-name>
+        <url-pattern>/webdav/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>RestXqServlet</servlet-name>
+        <url-pattern>/restxq/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>XQueryURLRewrite</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -128,7 +128,7 @@
         <jaxb.api.version>4.0.5</jaxb.api.version>
         <jaxb.impl.version>4.0.2</jaxb.impl.version>
         <eclipse.angus-activation.version>2.0.3</eclipse.angus-activation.version>
-        <jetty.version>12.0.35</jetty.version>
+        <jetty.version>12.1.9</jetty.version>
         <log4j.version>2.26.0</log4j.version>
         <lucene.version>10.4.0</lucene.version>
         <milton.version>1.8.1.3</milton.version>
@@ -151,7 +151,7 @@
 
         <!-- needed just for the license-maven-plugin in this module! -->
         <project.parent.relativePath>.</project.parent.relativePath>
-        
+
         <!-- Sonar cloud-->
         <sonar.projectKey>eXist-db_exist</sonar.projectKey>
         <sonar.organization>exist-db</sonar.organization>
@@ -1224,7 +1224,7 @@
                             <excludes>
                                 <exclude>FDB-backport-LGPL-21-ONLY-license.template.txt</exclude>
                                 <exclude>FDB-backport-LGPL-21-ONLY-license.xml.template.txt</exclude>
-                                <exclude>LGPL-21-license.template.txt</exclude>                    
+                                <exclude>LGPL-21-license.template.txt</exclude>
                                 <exclude>LGPL-21-license.txt</exclude>
                                 <exclude>LGPL-21-license.template.txt</exclude>
                                 <exclude>**/README.md</exclude>

--- a/extensions/debuggee/src/test/resources/standalone-webapp/WEB-INF/web.xml
+++ b/extensions/debuggee/src/test/resources/standalone-webapp/WEB-INF/web.xml
@@ -74,6 +74,19 @@
     </servlet>
 
     <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>EXistServlet</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>XQueryURLRewrite</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/RestBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/RestBinariesTest.java
@@ -171,6 +171,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         try(final UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get()) {
             marshaller.marshal(query, baos);
             response = executor.execute(Request.Post(getRestUrl() + "/db/")
+                    .connectTimeout(10000).socketTimeout(10000)
                     .bodyByteArray(baos.toByteArray(), ContentType.APPLICATION_XML)
             ).returnResponse();
         }

--- a/extensions/modules/persistentlogin/src/test/java/org/exist/xquery/modules/persistentlogin/LoginModuleIT.java
+++ b/extensions/modules/persistentlogin/src/test/java/org/exist/xquery/modules/persistentlogin/LoginModuleIT.java
@@ -67,40 +67,31 @@ public class LoginModuleIT {
     private static Collection root;
     private static HttpClient client;
 
-    /** Wait for server port to accept connections before XML-RPC. Windows CI can be slower to bind. */
-    private static void waitForServerReady(int port, int timeoutMs) throws InterruptedException {
-        final long deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
-            try (java.net.Socket s = new java.net.Socket()) {
-                s.connect(new java.net.InetSocketAddress("localhost", port), 1000);
-                return;
-            } catch (IOException e) {
-                Thread.sleep(500);
-            }
-        }
-    }
-
     @BeforeClass
-    public static void beforeClass() throws XMLDBException, InterruptedException {
+    public static void beforeClass() throws XMLDBException {
         final int port = existWebServer.getPort();
-        final boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
-        waitForServerReady(port, isWindows ? 60_000 : 30_000);
-
         final String uri = "xmldb:exist://localhost:" + port + "/xmlrpc" + XmldbURI.ROOT_COLLECTION;
         XMLDBException lastException = null;
         for (int i = 0; i < 20; i++) {
             try {
                 root = DatabaseManager.getCollection(uri, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+                lastException = null;
                 break;
-            } catch (XMLDBException e) {
+            } catch (final XMLDBException e) {
                 lastException = e;
                 if (i < 19) {
-                    Thread.sleep(500);
+                    try {
+                        Thread.sleep(500);
+                    } catch (final InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("Interrupted while waiting for XML-RPC", ie);
+                    }
                 }
             }
         }
         if (root == null) {
-            throw new AssertionError("Failed to connect to XML-RPC after 20 retries: " + (lastException != null ? lastException.getMessage() : ""));
+            throw new AssertionError("Failed to connect to XML-RPC: "
+                    + (lastException != null ? lastException.getMessage() : "unknown"));
         }
         final BinaryResource res = root.createResource(XQUERY_FILENAME, BinaryResource.class);
         ((EXistResource) res).setMimeType("application/xquery");

--- a/extensions/modules/persistentlogin/src/test/resources/standalone-webapp/WEB-INF/web.xml
+++ b/extensions/modules/persistentlogin/src/test/resources/standalone-webapp/WEB-INF/web.xml
@@ -74,6 +74,19 @@
     </servlet>
 
     <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>EXistServlet</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>XQueryURLRewrite</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>


### PR DESCRIPTION
There are two issues uncovered by the jetty bump. 

The first is a change affecting win path construction. Which puts `:` from eg. `D:\Documents...` into urls. Making them plain broken. 

The second is a hardened availability status check. Exist is running into, because we never checked for availability proper, just readiness. 

This is quite messy. I would like to have this cleaner. But so far my attempts at cleaning all lead to new test failures. So looking for help 