### PR TITLE
Dp minor CI fixes

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -76,7 +76,7 @@ jobs:
       # NOTE (DP): When on master push release, when on develop push latest: Version is included automatically
       # TODO (DP): Confirm that releases triggered from maven publish images with the non SNAPSHOT version
       - name: Publish latest images
-        if: github.ref == 'refs/heads/develop'
+        if: github.repository == 'eXist-db/exist' && github.ref == 'refs/heads/develop'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -84,7 +84,7 @@ jobs:
         run: mvn --no-transfer-progress -q -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       - name: Publish release images
-        if: github.ref == 'refs/heads/master'
+        if: github.repository == 'eXist-db/exist' && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.DEV_JDK }}
       - uses: ./.github/actions/maven-cache
-      - run: mvn -V -B --no-transfer-progress --offline license:check
+      - run: mvn -V -B --no-transfer-progress license:check
         timeout-minutes: 10
   dependencies:
     name: Dependency checks

--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   prethink:
+    if: github.repository == 'eXist-db/exist'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ work/
 .idea/*
 !/.idea/runConfigurations
 *.iml
-.vscode
+.vscode/
+.cursor/
+.zed/
 
 # OS specific files
 .DS_Store
@@ -29,6 +31,7 @@ plans/
 .moderne/
 !.moderne/context/
 !.moderne/moderne.yml
+.github/instructions/
 
 # Debug logs (e.g. from reindex investigation)
 reindex-dbg.log


### PR DESCRIPTION
add more IDE config folders to gitignore …

If anybody uses moderne MCP with GitHub copilot we can unignore the instructions.

limit push actions on CI from running in forks

remove offline mode in license check, so new jars are downloadable from maven central for inspection.