### PR TITLE
[feature] Add JMX MBeans and profiler support for vectors

### DIFF
--- a/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
@@ -65,7 +65,7 @@ import java.util.function.Predicate;
  * /exist/jmx?c=instances&amp;c=memory
  * <p>
  * If no parameter is specified, all categories will be returned. Valid categories are "memory", "instances", "disk",
- * "system", "caches", "locking", "processes", "sanity", "all".
+ * "system", "caches", "locking", "processes", "sanity", "vector", "all".
  * <p>
  * The servlet can also be used to test if the database is responsive by using parameter "operation=ping" and a timeout
  * (t=timeout-in-milliseconds). For example, the following call

--- a/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
@@ -35,6 +35,7 @@ import org.exist.management.impl.LockTable;
 import org.exist.management.impl.ProcessReport;
 import org.exist.management.impl.SanityReport;
 import org.exist.management.impl.SystemInfo;
+import org.exist.management.impl.VectorStore;
 import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
 import org.exist.util.NamedThreadFactory;
@@ -66,6 +67,9 @@ import javax.management.remote.JMXServiceURL;
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
@@ -106,6 +110,7 @@ public class JMXtoXML {
     private final static Map<String, ObjectName[]> CATEGORIES = new TreeMap<>();
     private static final Properties defaultProperties = new Properties();
     private static final QName ROW_ELEMENT = new QName("row", JMX_NAMESPACE, JMX_PREFIX);
+    private static final QName MODEL_ROW_ELEMENT = new QName("Model", JMX_NAMESPACE, JMX_PREFIX);
     private static final QName JMX_ELEMENT = new QName("jmx", JMX_NAMESPACE, JMX_PREFIX);
     private static final QName JMX_RESULT = new QName("result", JMX_NAMESPACE, JMX_PREFIX);
     private static final QName JMX_RESULT_TYPE_ATTR = new QName("class", JMX_NAMESPACE, JMX_PREFIX);
@@ -136,6 +141,10 @@ public class JMXtoXML {
         putCategory("binarystreamcaches", BinaryValues.getAllInstancesQuery());
         putCategory("processes", ProcessReport.getAllInstancesQuery());
         putCategory("sanity", SanityReport.getAllInstancesQuery());
+        putCategory("vector",
+                VectorStore.getAllInstancesQuery(),
+                "org.exist.management.*:type=VectorEmbedding"
+        );
 
         // Jetty
         putCategory("jetty.threads", "org.eclipse.jetty.util.thread:type=queuedthreadpool,*");
@@ -223,7 +232,7 @@ public class JMXtoXML {
 
     /**
      * Retrieve JMX output for the given categories and return a string of XML. Valid categories are "memory",
-     * "instances", "disk", "system", "caches", "locking", "processes", "sanity", "all".
+     * "instances", "disk", "system", "caches", "locking", "processes", "sanity", "vector", "all".
      *
      * @param categories array of categories to include in the report
      * @return string containing an XML report
@@ -425,6 +434,7 @@ public class JMXtoXML {
         switch (object) {
             case null -> {
             }
+            case final List<?> list -> serializeList(builder, list);
             case final TabularData tabularData -> serialize(builder, tabularData);
             case final CompositeData[] compositeData -> serialize(builder, compositeData);
             case final CompositeData compositeData -> serialize(builder, compositeData);
@@ -432,6 +442,41 @@ public class JMXtoXML {
             default -> builder.characters(object.toString());
         }
 
+    }
+
+    private void serializeList(final MemTreeBuilder builder, final List<?> data) throws SAXException {
+        for (final Object item : data) {
+            builder.startElement(MODEL_ROW_ELEMENT, null);
+            serializeJavaBean(builder, item);
+            builder.endElement();
+        }
+    }
+
+    private void serializeJavaBean(final MemTreeBuilder builder, final Object bean) throws SAXException {
+        if (bean == null) {
+            return;
+        }
+        if (bean instanceof CompositeData compositeData) {
+            serialize(builder, compositeData);
+            return;
+        }
+        try {
+            final BeanInfo info = Introspector.getBeanInfo(bean.getClass(), Object.class);
+            for (final PropertyDescriptor property : info.getPropertyDescriptors()) {
+                if (property.getReadMethod() == null || "class".equals(property.getName())) {
+                    continue;
+                }
+                final Object value = property.getReadMethod().invoke(bean);
+                final String propertyName = property.getName();
+                final String xmlName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+                final QName qname = new QName(xmlName, JMX_NAMESPACE, JMX_PREFIX);
+                builder.startElement(qname, null);
+                serializeObject(builder, value);
+                builder.endElement();
+            }
+        } catch (ReflectiveOperationException | java.beans.IntrospectionException e) {
+            builder.characters(bean.toString());
+        }
     }
 
     private void serialize(final MemTreeBuilder builder, final Object[] data) throws SAXException {

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
@@ -1,0 +1,113 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.impl;
+
+import org.exist.storage.BrokerPool;
+import org.exist.storage.vector.VectorStoreImpl;
+
+import javax.annotation.Nullable;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * JMX MBean exposing operational statistics for {@code vector.dbx}.
+ */
+public class VectorStore implements VectorStoreMXBean {
+
+    private final String instanceId;
+    @Nullable
+    private final VectorStoreImpl store;
+    private final Path vectorFile;
+
+    public VectorStore(final BrokerPool pool, @Nullable final VectorStoreImpl store, final Path dataDir) {
+        this.instanceId = pool.getId();
+        this.store = store;
+        this.vectorFile = dataDir.resolve(VectorStoreImpl.FILE_NAME);
+    }
+
+    public static String getAllInstancesQuery() {
+        return getName("*");
+    }
+
+    private static String getName(final String instanceId) {
+        return "org.exist.management." + instanceId + ":type=VectorStore";
+    }
+
+    @Override
+    public ObjectName getName() throws MalformedObjectNameException {
+        return new ObjectName(getName(instanceId));
+    }
+
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return store != null;
+    }
+
+    @Override
+    public String getFileName() {
+        return VectorStoreImpl.FILE_NAME;
+    }
+
+    @Override
+    public long getFileSize() {
+        if (!Files.isRegularFile(vectorFile)) {
+            return NO_FILE_SIZE;
+        }
+        try {
+            return Files.size(vectorFile);
+        } catch (final IOException e) {
+            return NO_FILE_SIZE;
+        }
+    }
+
+    @Override
+    public long getEntryCount() {
+        if (store == null) {
+            return 0;
+        }
+        try {
+            return store.getEntryCount();
+        } catch (final IOException e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public short getFormatVersion() {
+        return VectorStoreImpl.FILE_FORMAT_VERSION_ID;
+    }
+
+    @Override
+    public void resetEntryCountCache() {
+        if (store != null) {
+            store.resetEntryCountCache();
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
@@ -36,7 +36,7 @@ import java.nio.file.Path;
  */
 public class VectorStore implements VectorStoreMXBean {
 
-    private static final String PERSISTENCE_BACKEND = "vector.dbx";
+    private static final String STORAGE_BACKEND = "vector.dbx";
 
     private final String instanceId;
     @Nullable
@@ -73,8 +73,8 @@ public class VectorStore implements VectorStoreMXBean {
     }
 
     @Override
-    public String getPersistenceBackend() {
-        return PERSISTENCE_BACKEND;
+    public String getStorageBackend() {
+        return STORAGE_BACKEND;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStore.java
@@ -36,6 +36,8 @@ import java.nio.file.Path;
  */
 public class VectorStore implements VectorStoreMXBean {
 
+    private static final String PERSISTENCE_BACKEND = "vector.dbx";
+
     private final String instanceId;
     @Nullable
     private final VectorStoreImpl store;
@@ -71,6 +73,16 @@ public class VectorStore implements VectorStoreMXBean {
     }
 
     @Override
+    public String getPersistenceBackend() {
+        return PERSISTENCE_BACKEND;
+    }
+
+    @Override
+    public boolean isEntryCountKnown() {
+        return store != null;
+    }
+
+    @Override
     public String getFileName() {
         return VectorStoreImpl.FILE_NAME;
     }
@@ -90,12 +102,12 @@ public class VectorStore implements VectorStoreMXBean {
     @Override
     public long getEntryCount() {
         if (store == null) {
-            return 0;
+            return ENTRY_COUNT_UNKNOWN;
         }
         try {
             return store.getEntryCount();
         } catch (final IOException e) {
-            return 0;
+            return ENTRY_COUNT_UNKNOWN;
         }
     }
 

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
@@ -44,11 +44,11 @@ public interface VectorStoreMXBean extends PerInstanceMBean {
     boolean isAvailable();
 
     /**
-     * Persistence backend represented by this MBean.
+     * Storage backend represented by this MBean.
      *
      * @return {@code vector.dbx}
      */
-    String getPersistenceBackend();
+    String getStorageBackend();
 
     /**
      * Whether {@link #getEntryCount()} is known for this instance.

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
@@ -1,0 +1,76 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.impl;
+
+/**
+ * JMX MXBean interface for the dense vector persistence layer ({@code vector.dbx}).
+ */
+public interface VectorStoreMXBean extends PerInstanceMBean {
+
+    /**
+     * No file size could be determined.
+     */
+    long NO_FILE_SIZE = -1;
+
+    /**
+     * Whether the vector store is available for this database instance.
+     *
+     * @return {@code true} when {@code vector.dbx} is open
+     */
+    boolean isAvailable();
+
+    /**
+     * The vector store file name (always {@code vector.dbx}).
+     *
+     * @return file name
+     */
+    String getFileName();
+
+    /**
+     * Size of {@code vector.dbx} on disk in bytes.
+     *
+     * @return file size, or {@link #NO_FILE_SIZE} when missing or unreadable
+     */
+    long getFileSize();
+
+    /**
+     * Number of vector entries in the store.
+     * <p>
+     * Maintained incrementally on {@code put}/{@code remove}; the first read may
+     * scan the BTree if the counter has not yet been initialized.
+     *
+     * @return entry count, or {@code 0} when unavailable
+     */
+    long getEntryCount();
+
+    /**
+     * Format version of {@code vector.dbx}.
+     *
+     * @return format version id
+     */
+    short getFormatVersion();
+
+    /**
+     * Force a refresh of the cached entry count on the next {@link #getEntryCount()} call.
+     */
+    void resetEntryCountCache();
+}

--- a/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/VectorStoreMXBean.java
@@ -32,11 +32,30 @@ public interface VectorStoreMXBean extends PerInstanceMBean {
     long NO_FILE_SIZE = -1;
 
     /**
+     * Entry count could not be determined (store unavailable or scan failed).
+     */
+    long ENTRY_COUNT_UNKNOWN = -1;
+
+    /**
      * Whether the vector store is available for this database instance.
      *
      * @return {@code true} when {@code vector.dbx} is open
      */
     boolean isAvailable();
+
+    /**
+     * Persistence backend represented by this MBean.
+     *
+     * @return {@code vector.dbx}
+     */
+    String getPersistenceBackend();
+
+    /**
+     * Whether {@link #getEntryCount()} is known for this instance.
+     *
+     * @return {@code false} when the store is unavailable or counting failed
+     */
+    boolean isEntryCountKnown();
 
     /**
      * The vector store file name (always {@code vector.dbx}).
@@ -58,7 +77,7 @@ public interface VectorStoreMXBean extends PerInstanceMBean {
      * Maintained incrementally on {@code put}/{@code remove}; the first read may
      * scan the BTree if the counter has not yet been initialized.
      *
-     * @return entry count, or {@code 0} when unavailable
+     * @return entry count, or {@link #ENTRY_COUNT_UNKNOWN} when unavailable
      */
     long getEntryCount();
 

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
@@ -28,26 +28,8 @@ import javax.annotation.Nullable;
  */
 public final class VectorOperationMetrics {
 
-    /**
-     * Vector operation kinds tracked by JMX metrics.
-     */
-    public enum Operation {
-        EMBED,
-        KNN
-    }
-
-    /**
-     * Receives vector operation timing events.
-     */
-    @FunctionalInterface
-    public interface Recorder {
-        Recorder NOOP = (operation, durationNanos) -> {
-        };
-
-        void record(Operation operation, long durationNanos);
-    }
-
-    private static volatile Recorder recorder = Recorder.NOOP;
+    @Nullable
+    private static volatile Recorder recorder;
 
     private VectorOperationMetrics() {
     }
@@ -67,7 +49,7 @@ public final class VectorOperationMetrics {
      * @param durationNanos wall time in nanoseconds
      */
     public static void recordEmbed(final long durationNanos) {
-        recorder.record(Operation.EMBED, durationNanos);
+        activeRecorder().record(Operation.EMBED, durationNanos);
     }
 
     /**
@@ -76,6 +58,30 @@ public final class VectorOperationMetrics {
      * @param durationNanos wall time in nanoseconds
      */
     public static void recordKnn(final long durationNanos) {
-        recorder.record(Operation.KNN, durationNanos);
+        activeRecorder().record(Operation.KNN, durationNanos);
+    }
+
+    private static Recorder activeRecorder() {
+        final Recorder current = recorder;
+        return current != null ? current : Recorder.NOOP;
+    }
+
+    /**
+     * Vector operation kinds tracked by JMX metrics.
+     */
+    public enum Operation {
+        EMBED,
+        KNN
+    }
+
+    /**
+     * Receives vector operation timing events.
+     */
+    @FunctionalInterface
+    public interface Recorder {
+        Recorder NOOP = (operation, durationNanos) -> {
+        };
+
+        void record(Operation operation, long durationNanos);
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
@@ -21,49 +21,90 @@
  */
 package org.exist.storage.vector;
 
+import org.exist.xquery.XQueryContext;
+
 import javax.annotation.Nullable;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Optional bridge for vector workload metrics. Defaults to no-op until the vector extension registers a recorder.
+ * Optional per-instance bridge for vector workload metrics. Defaults to no-op until the vector extension registers recorders.
  */
 public final class VectorOperationMetrics {
 
-    @Nullable
-    private static volatile Recorder recorder;
+    private static final ConcurrentHashMap<String, Recorder> RECORDERS = new ConcurrentHashMap<>();
 
     private VectorOperationMetrics() {
     }
 
     /**
-     * Register the metrics recorder supplied by the vector extension.
+     * Register the metrics recorder supplied by the vector extension for a database instance.
      *
-     * @param newRecorder recorder implementation, or {@code null} to restore the no-op recorder
+     * @param instanceId broker pool instance id
+     * @param newRecorder recorder implementation, or {@code null} to remove the recorder
      */
-    public static void register(@Nullable final Recorder newRecorder) {
-        recorder = newRecorder != null ? newRecorder : Recorder.NOOP;
+    public static void register(final String instanceId, @Nullable final Recorder newRecorder) {
+        if (newRecorder == null) {
+            unregister(instanceId);
+        } else {
+            RECORDERS.put(instanceId, newRecorder);
+        }
     }
 
     /**
-     * Record an embedding call duration.
+     * Remove the metrics recorder for a database instance.
      *
-     * @param durationNanos wall time in nanoseconds
+     * @param instanceId broker pool instance id
      */
-    public static void recordEmbed(final long durationNanos) {
-        activeRecorder().record(Operation.EMBED, durationNanos);
+    public static void unregister(final String instanceId) {
+        RECORDERS.remove(instanceId);
     }
 
     /**
-     * Record a KNN query duration.
+     * Record an embedding call duration for a database instance.
      *
+     * @param instanceId broker pool instance id
      * @param durationNanos wall time in nanoseconds
      */
-    public static void recordKnn(final long durationNanos) {
-        activeRecorder().record(Operation.KNN, durationNanos);
+    public static void recordEmbed(final String instanceId, final long durationNanos) {
+        recorderFor(instanceId).record(Operation.EMBED, durationNanos);
     }
 
-    private static Recorder activeRecorder() {
-        final Recorder current = recorder;
-        return current != null ? current : Recorder.NOOP;
+    /**
+     * Record a KNN query duration for a database instance.
+     *
+     * @param instanceId broker pool instance id
+     * @param durationNanos wall time in nanoseconds
+     */
+    public static void recordKnn(final String instanceId, final long durationNanos) {
+        recorderFor(instanceId).record(Operation.KNN, durationNanos);
+    }
+
+    /**
+     * Record an embedding call duration for the database instance associated with the query context.
+     *
+     * @param context active XQuery context
+     * @param durationNanos wall time in nanoseconds
+     */
+    public static void recordEmbed(final XQueryContext context, final long durationNanos) {
+        recordEmbed(instanceId(context), durationNanos);
+    }
+
+    /**
+     * Record a KNN query duration for the database instance associated with the query context.
+     *
+     * @param context active XQuery context
+     * @param durationNanos wall time in nanoseconds
+     */
+    public static void recordKnn(final XQueryContext context, final long durationNanos) {
+        recordKnn(instanceId(context), durationNanos);
+    }
+
+    private static String instanceId(final XQueryContext context) {
+        return context.getBroker().getBrokerPool().getId();
+    }
+
+    private static Recorder recorderFor(final String instanceId) {
+        return RECORDERS.getOrDefault(instanceId, Recorder.NOOP);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorOperationMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.vector;
+
+import javax.annotation.Nullable;
+
+/**
+ * Optional bridge for vector workload metrics. Defaults to no-op until the vector extension registers a recorder.
+ */
+public final class VectorOperationMetrics {
+
+    /**
+     * Vector operation kinds tracked by JMX metrics.
+     */
+    public enum Operation {
+        EMBED,
+        KNN
+    }
+
+    /**
+     * Receives vector operation timing events.
+     */
+    @FunctionalInterface
+    public interface Recorder {
+        Recorder NOOP = (operation, durationNanos) -> {
+        };
+
+        void record(Operation operation, long durationNanos);
+    }
+
+    private static volatile Recorder recorder = Recorder.NOOP;
+
+    private VectorOperationMetrics() {
+    }
+
+    /**
+     * Register the metrics recorder supplied by the vector extension.
+     *
+     * @param newRecorder recorder implementation, or {@code null} to restore the no-op recorder
+     */
+    public static void register(@Nullable final Recorder newRecorder) {
+        recorder = newRecorder != null ? newRecorder : Recorder.NOOP;
+    }
+
+    /**
+     * Record an embedding call duration.
+     *
+     * @param durationNanos wall time in nanoseconds
+     */
+    public static void recordEmbed(final long durationNanos) {
+        recorder.record(Operation.EMBED, durationNanos);
+    }
+
+    /**
+     * Record a KNN query duration.
+     *
+     * @param durationNanos wall time in nanoseconds
+     */
+    public static void recordKnn(final long durationNanos) {
+        recorder.record(Operation.KNN, durationNanos);
+    }
+}

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorStoreImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorStoreImpl.java
@@ -32,11 +32,14 @@ import org.exist.storage.index.BFile;
 import org.exist.storage.txn.Txn;
 import org.exist.util.FileUtils;
 import org.exist.util.FixedByteArray;
+import org.exist.xquery.TerminatedException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * BFile-backed implementation of VectorStore.
@@ -50,11 +53,63 @@ public class VectorStoreImpl implements VectorStore {
     public static final byte VECTOR_DBX_ID = 0x20;
 
     private final BFile bfile;
+    /** {@code -1} means not yet initialized; use lazy BTree scan on first read. */
+    private final AtomicLong entryCount = new AtomicLong(-1);
 
     public VectorStoreImpl(final BrokerPool pool, final Path dataDir) throws DBException {
         final Path file = dataDir.resolve(FILE_NAME);
         this.bfile = new BFile(pool, VECTOR_DBX_ID, FILE_FORMAT_VERSION_ID, true, file,
                 pool.getCacheManager(), 1.25, 0.03);
+    }
+
+    /**
+     * Returns the number of entries in the store, maintaining an incremental counter when possible.
+     * The first call may scan the BTree ({@code O(n)}).
+     */
+    public long getEntryCount() throws IOException {
+        final long cached = entryCount.get();
+        if (cached >= 0) {
+            return cached;
+        }
+        return initializeEntryCount();
+    }
+
+    /**
+     * Clears the cached entry count so the next {@link #getEntryCount()} rescans the BTree.
+     */
+    public void resetEntryCountCache() {
+        entryCount.set(-1);
+    }
+
+    Path getFilePath() {
+        return bfile.getFile();
+    }
+
+    private long initializeEntryCount() throws IOException {
+        try {
+            final long count = bfile.getKeys().size();
+            entryCount.compareAndSet(-1, count);
+            return entryCount.get() >= 0 ? entryCount.get() : count;
+        } catch (final BTreeException | TerminatedException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void adjustEntryCount(final long delta) {
+        final long cached = entryCount.get();
+        if (cached >= 0) {
+            entryCount.addAndGet(delta);
+        }
+    }
+
+    private int countKeysWithPrefix(final String docPath) throws IOException {
+        try {
+            final Value prefix = new Value(docPath + "!");
+            final ArrayList<Value> keys = bfile.findKeys(new IndexQuery(IndexQuery.TRUNC_RIGHT, prefix));
+            return keys.size();
+        } catch (final BTreeException | TerminatedException e) {
+            throw new IOException(e);
+        }
     }
 
     private static Value key(final String docPath, final NodeId nodeId) {
@@ -72,20 +127,33 @@ public class VectorStoreImpl implements VectorStore {
     @Override
     public void put(final Txn transaction, final String docPath, final NodeId nodeId, final byte[] vector) throws IOException {
         final Value k = key(docPath, nodeId);
+        final boolean existed = bfile.get(k) != null;
         final FixedByteArray v = new FixedByteArray(vector, 0, vector.length);
         bfile.put(transaction, k, v, true);
+        if (!existed) {
+            adjustEntryCount(1);
+        }
     }
 
     @Override
     public void remove(final Txn transaction, final String docPath, final NodeId nodeId) throws IOException {
-        bfile.remove(transaction, key(docPath, nodeId));
+        final Value k = key(docPath, nodeId);
+        final boolean existed = bfile.get(k) != null;
+        bfile.remove(transaction, k);
+        if (existed) {
+            adjustEntryCount(-1);
+        }
     }
 
     @Override
     public void removeByDocument(final Txn transaction, final String docPath) throws IOException {
         try {
+            final int removed = countKeysWithPrefix(docPath);
             final Value prefix = new Value(docPath + "!");
             bfile.removeAll(transaction, new IndexQuery(IndexQuery.TRUNC_RIGHT, prefix));
+            if (removed > 0) {
+                adjustEntryCount(-removed);
+            }
         } catch (final BTreeException e) {
             throw new IOException(e);
         }

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
@@ -47,6 +47,7 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
 
     private Path dataDir;
     private VectorStoreImpl vectorStore;
+    private BrokerPool brokerPool;
 
     @Override
     public void configure(final Configuration configuration) throws BrokerPoolServiceException {
@@ -58,6 +59,7 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
 
     @Override
     public void prepare(final BrokerPool pool) throws BrokerPoolServiceException {
+        this.brokerPool = pool;
         try {
             this.vectorStore = new VectorStoreImpl(pool, dataDir);
         } catch (final DBException e) {
@@ -89,8 +91,23 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
         }
     }
 
+    private static void unregisterVectorExtensionJmx(@Nullable final BrokerPool pool) {
+        if (pool == null) {
+            return;
+        }
+        try {
+            final Class<?> lifecycle = Class.forName("org.exist.vector.VectorExtensionLifecycle");
+            lifecycle.getMethod("onBrokerPoolShutdown", BrokerPool.class).invoke(null, pool);
+        } catch (final ClassNotFoundException e) {
+            LOG.debug("Vector extension not present; VectorEmbedding JMX cleanup skipped");
+        } catch (final ReflectiveOperationException e) {
+            LOG.warn("Failed to unregister VectorEmbedding JMX state: {}", e.getMessage(), e);
+        }
+    }
+
     @Override
     public void shutdown() {
+        unregisterVectorExtensionJmx(brokerPool);
         if (this.vectorStore != null) {
             try {
                 this.vectorStore.close();
@@ -99,6 +116,7 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
             }
             this.vectorStore = null;
         }
+        this.brokerPool = null;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
@@ -75,6 +75,18 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
                 LOG.warn("Failed to register VectorStore JMX MBean: {}", e.getMessage(), e);
             }
         }
+        registerVectorExtensionJmx(systemBroker.getBrokerPool());
+    }
+
+    private static void registerVectorExtensionJmx(final BrokerPool pool) {
+        try {
+            final Class<?> lifecycle = Class.forName("org.exist.vector.VectorExtensionLifecycle");
+            lifecycle.getMethod("onBrokerPoolStartSystem", BrokerPool.class).invoke(null, pool);
+        } catch (final ClassNotFoundException e) {
+            LOG.debug("Vector extension not present; VectorEmbedding JMX MBean not registered");
+        } catch (final ReflectiveOperationException e) {
+            LOG.warn("Failed to register VectorEmbedding JMX MBean: {}", e.getMessage(), e);
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/vector/VectorStoreServiceImpl.java
@@ -23,6 +23,8 @@ package org.exist.storage.vector;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.management.AgentFactory;
+import org.exist.management.impl.VectorStore;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.BrokerPoolService;
 import org.exist.storage.BrokerPoolServiceException;
@@ -30,6 +32,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
+import org.exist.util.DatabaseConfigurationException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -43,7 +46,7 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
     private static final Logger LOG = LogManager.getLogger(VectorStoreServiceImpl.class);
 
     private Path dataDir;
-    private VectorStore vectorStore;
+    private VectorStoreImpl vectorStore;
 
     @Override
     public void configure(final Configuration configuration) throws BrokerPoolServiceException {
@@ -65,6 +68,13 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
     @Override
     public void startSystem(final DBBroker systemBroker, final Txn transaction) throws BrokerPoolServiceException {
         LOG.info("Opened Vector Store. file={}", dataDir.relativize(dataDir.resolve(VectorStoreImpl.FILE_NAME)));
+        if (vectorStore != null) {
+            try {
+                AgentFactory.getInstance().addMBean(new VectorStore(systemBroker.getBrokerPool(), vectorStore, dataDir));
+            } catch (final DatabaseConfigurationException e) {
+                LOG.warn("Failed to register VectorStore JMX MBean: {}", e.getMessage(), e);
+            }
+        }
     }
 
     @Override
@@ -81,7 +91,7 @@ public class VectorStoreServiceImpl implements VectorStoreService, BrokerPoolSer
 
     @Override
     @Nullable
-    public VectorStore getVectorStore() {
+    public org.exist.storage.vector.VectorStore getVectorStore() {
         return vectorStore;
     }
 }

--- a/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
+++ b/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
@@ -46,6 +46,7 @@ import static org.exist.management.client.JMXtoXML.JMX_NAMESPACE;
 import static org.exist.management.client.JMXtoXML.JMX_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import static org.xmlunit.matchers.HasXPathMatcher.hasXPath;
 
 public class JmxRemoteTest {
@@ -112,6 +113,23 @@ public class JmxRemoteTest {
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:Available").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:FileName").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:EntryCount").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:EntryCountKnown").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:PersistenceBackend").withNamespaceContext(prefix2Uri));
+    }
+
+    @Test
+    public void vectorCategoryIncludesVectorEmbeddingWhenExtensionPresent() throws IOException {
+        assumeTrue("Vector extension not on classpath", isVectorExtensionPresent());
+
+        final Request request = Request.Get(getServerUri() + "?c=vector");
+        final String jmxXml = withHttpExecutor(executor -> executor.execute(request).returnContent().asString());
+
+        final Map<String, String> prefix2Uri = new HashMap<>();
+        prefix2Uri.put(JMX_PREFIX, JMX_NAMESPACE);
+
+        assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding/jmx:ModelCount").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding/jmx:PersistenceBackend").withNamespaceContext(prefix2Uri));
     }
 
     @Test
@@ -141,5 +159,14 @@ public class JmxRemoteTest {
             final Executor executor = Executor.newInstance(client);
             return fn.apply(executor);
         });
+    }
+
+    private static boolean isVectorExtensionPresent() {
+        try {
+            Class.forName("org.exist.vector.VectorExtensionLifecycle");
+            return true;
+        } catch (final ClassNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
+++ b/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
@@ -114,7 +114,7 @@ public class JmxRemoteTest {
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:FileName").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:EntryCount").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:EntryCountKnown").withNamespaceContext(prefix2Uri));
-        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:PersistenceBackend").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:StorageBackend").withNamespaceContext(prefix2Uri));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class JmxRemoteTest {
 
         assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding").withNamespaceContext(prefix2Uri));
         assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding/jmx:ModelCount").withNamespaceContext(prefix2Uri));
-        assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding/jmx:PersistenceBackend").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorEmbedding/jmx:KnnBackend").withNamespaceContext(prefix2Uri));
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
+++ b/exist-core/src/test/java/org/exist/management/JmxRemoteTest.java
@@ -101,6 +101,20 @@ public class JmxRemoteTest {
     }
 
     @Test
+    public void vectorCategoryIncludesVectorStore() throws IOException {
+        final Request request = Request.Get(getServerUri() + "?c=vector");
+        final String jmxXml = withHttpExecutor(executor -> executor.execute(request).returnContent().asString());
+
+        final Map<String, String> prefix2Uri = new HashMap<>();
+        prefix2Uri.put(JMX_PREFIX, JMX_NAMESPACE);
+
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:Available").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:FileName").withNamespaceContext(prefix2Uri));
+        assertThat(jmxXml, hasXPath("//jmx:VectorStore/jmx:EntryCount").withNamespaceContext(prefix2Uri));
+    }
+
+    @Test
     public void checkBasicRequest() throws IOException {
         final Request request = Request.Get(getServerUri())
                 .addHeader(new BasicHeader("Accept", ContentType.APPLICATION_XML.toString()));

--- a/exist-core/src/test/java/org/exist/storage/vector/VectorStoreImplTest.java
+++ b/exist-core/src/test/java/org/exist/storage/vector/VectorStoreImplTest.java
@@ -1,0 +1,116 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.vector;
+
+import org.exist.numbering.NodeId;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class VectorStoreImplTest {
+
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private VectorStoreImpl store;
+
+    @Before
+    public void setUp() {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final VectorStore vectorStore = pool.getVectorStore();
+        assertNotNull(vectorStore);
+        assertTrue(vectorStore instanceof VectorStoreImpl);
+        store = (VectorStoreImpl) vectorStore;
+        store.resetEntryCountCache();
+    }
+
+    @Test
+    public void entryCountTracksPutAndRemove() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager mgr = pool.getTransactionManager();
+        final NodeId nodeId = pool.getNodeFactory().createInstance();
+
+        assertEquals(0, store.getEntryCount());
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.put(txn, "/db/test/doc.xml", nodeId, new byte[]{0, 0, 0, 0});
+            mgr.commit(txn);
+        }
+        assertEquals(1, store.getEntryCount());
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.put(txn, "/db/test/doc.xml", nodeId, new byte[]{1, 0, 0, 0});
+            mgr.commit(txn);
+        }
+        assertEquals(1, store.getEntryCount());
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.remove(txn, "/db/test/doc.xml", nodeId);
+            mgr.commit(txn);
+        }
+        assertEquals(0, store.getEntryCount());
+    }
+
+    @Test
+    public void removeByDocumentAdjustsEntryCount() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager mgr = pool.getTransactionManager();
+        final NodeId nodeId1 = pool.getNodeFactory().createInstance(1);
+        final NodeId nodeId2 = pool.getNodeFactory().createInstance(2);
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.put(txn, "/db/test/doc2.xml", nodeId1, new byte[]{0, 0, 0, 0});
+            store.put(txn, "/db/test/doc2.xml", nodeId2, new byte[]{1, 0, 0, 0});
+            mgr.commit(txn);
+        }
+        assertEquals(2, store.getEntryCount());
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.removeByDocument(txn, "/db/test/doc2.xml");
+            mgr.commit(txn);
+        }
+        assertEquals(0, store.getEntryCount());
+    }
+
+    @Test
+    public void resetEntryCountCacheForcesRescan() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager mgr = pool.getTransactionManager();
+        final NodeId nodeId = pool.getNodeFactory().createInstance();
+
+        try (final Txn txn = mgr.beginTransaction()) {
+            store.put(txn, "/db/test/doc3.xml", nodeId, new byte[]{0, 0, 0, 0});
+            mgr.commit(txn);
+        }
+        assertEquals(1, store.getEntryCount());
+        store.resetEntryCountCache();
+        assertTrue(store.getEntryCount() >= 1);
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -899,6 +899,54 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         return null;
     }
 
+    /**
+     * Returns true when the Lucene configuration for {@code docs} declares a
+     * {@code vector-field} with the given name.
+     */
+    public boolean hasVectorIndexForField(final DocumentSet docs, final String fieldName) {
+        if (fieldName == null || fieldName.isEmpty()) {
+            return false;
+        }
+        final LuceneConfig config = getLuceneConfig(broker, docs);
+        for (final LuceneIndexConfig idxConf : config.getIndexConfigurations()) {
+            if (findVectorField(idxConf, fieldName) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true when at least one resolved index qname has a {@code vector-field}
+     * in the Lucene configuration for {@code docs}.
+     */
+    public boolean hasVectorIndexForQNames(final DocumentSet docs, @Nullable final List<QName> qnames)
+            throws IOException {
+        final LuceneConfig config = getLuceneConfig(broker, docs);
+        final List<QName> definedIndexes = getDefinedIndexes(qnames);
+        for (final QName qname : definedIndexes) {
+            final LuceneIndexConfig idxConf = config.getIndexConfigForQName(qname);
+            if (getFirstVectorField(idxConf) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private static LuceneVectorFieldConfig findVectorField(@Nullable final LuceneIndexConfig idxConf,
+            final String fieldName) {
+        if (idxConf == null) {
+            return null;
+        }
+        for (final AbstractFieldConfig fc : idxConf.getFacetsAndFields()) {
+            if (fc instanceof LuceneVectorFieldConfig vfc && fieldName.equals(vfc.getName())) {
+                return vfc;
+            }
+        }
+        return null;
+    }
+
     /** Build filter to restrict KNN to docs in the document set (index is shared across collections). */
     private Query buildDocsFilterQuery(final DocumentSet docs) {
         if (docs == null || docs.getDocumentCount() == 0) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryFieldVector.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryFieldVector.java
@@ -25,6 +25,7 @@ import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
+import org.exist.storage.vector.VectorOperationMetrics;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.AbstractMapType;
@@ -115,8 +116,22 @@ public class QueryFieldVector extends BasicFunction {
         }
 
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        final PerformanceStats.IndexOptimizationLevel optimizationLevel =
+                index != null && index.hasVectorIndexForField(docs, field)
+                        ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
+                        : PerformanceStats.IndexOptimizationLevel.NONE;
+
+        final long start = System.currentTimeMillis();
         try {
-            return index.searchVector(getExpressionId(), docs, contextSet, field, vector, k, options);
+            final Sequence result = index.searchVector(getExpressionId(), docs, contextSet, field, vector, k, options);
+            final long duration = System.currentTimeMillis() - start;
+            if (optimizationLevel == PerformanceStats.IndexOptimizationLevel.OPTIMIZED) {
+                VectorOperationMetrics.recordKnn(duration * 1_000_000L);
+            }
+            if (context.getProfiler().traceFunctions()) {
+                context.getProfiler().traceIndexUsage(context, "lucene-vector", this, optimizationLevel, duration);
+            }
+            return result;
         } catch (IOException e) {
             throw new XPathException(this, "Vector search failed: " + e.getMessage(), e);
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryFieldVector.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryFieldVector.java
@@ -25,7 +25,6 @@ import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
-import org.exist.storage.vector.VectorOperationMetrics;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.AbstractMapType;
@@ -93,17 +92,19 @@ public class QueryFieldVector extends BasicFunction {
             throw new XPathException(this, "Second argument must be an array of numbers");
         }
 
-        int k = 10;
-        QueryOptions options = new QueryOptions();
+        int kValue = 10;
+        QueryOptions queryOptions = new QueryOptions();
         if (args.length >= 3 && !args[2].isEmpty()) {
-            k = args[2].itemAt(0).toJavaObject(Integer.class);
-            if (k <= 0) {
-                k = 10;
+            kValue = args[2].itemAt(0).toJavaObject(Integer.class);
+            if (kValue <= 0) {
+                kValue = 10;
             }
         }
         if (args.length >= 4 && !args[3].isEmpty()) {
-            options = parseOptions(args[3]);
+            queryOptions = parseOptions(args[3]);
         }
+        final int k = kValue;
+        final QueryOptions options = queryOptions;
 
         DocumentSet docs;
         NodeSet contextSet;
@@ -117,24 +118,10 @@ public class QueryFieldVector extends BasicFunction {
 
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
         final PerformanceStats.IndexOptimizationLevel optimizationLevel =
-                index != null && index.hasVectorIndexForField(docs, field)
-                        ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
-                        : PerformanceStats.IndexOptimizationLevel.NONE;
+                VectorSearchSupport.optimizationLevelForField(index, docs, field);
 
-        final long start = System.currentTimeMillis();
-        try {
-            final Sequence result = index.searchVector(getExpressionId(), docs, contextSet, field, vector, k, options);
-            final long duration = System.currentTimeMillis() - start;
-            if (optimizationLevel == PerformanceStats.IndexOptimizationLevel.OPTIMIZED) {
-                VectorOperationMetrics.recordKnn(duration * 1_000_000L);
-            }
-            if (context.getProfiler().traceFunctions()) {
-                context.getProfiler().traceIndexUsage(context, "lucene-vector", this, optimizationLevel, duration);
-            }
-            return result;
-        } catch (IOException e) {
-            throw new XPathException(this, "Vector search failed: " + e.getMessage(), e);
-        }
+        return VectorSearchSupport.execute(this, context, index, optimizationLevel,
+                () -> index.searchVector(getExpressionId(), docs, contextSet, field, vector, k, options));
     }
 
     private static float[] arrayToFloats(final Sequence seq) throws XPathException {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
@@ -26,7 +26,6 @@ import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
-import org.exist.storage.vector.VectorOperationMetrics;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.AbstractMapType;
@@ -109,31 +108,13 @@ public class QueryVector extends BasicFunction {
         final NodeSet nodes = nodesSeq.toNodeSet();
         final DocumentSet docs = nodes.getDocumentSet();
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        final List<QName> qnames = resolveQNames(nodes, index);
+        final List<QName> qnames = index != null ? resolveQNames(nodes, index) : getQNamesFromNodes(nodes);
 
-        final PerformanceStats.IndexOptimizationLevel optimizationLevel;
-        try {
-            optimizationLevel = index != null && index.hasVectorIndexForQNames(docs, qnames)
-                    ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
-                    : PerformanceStats.IndexOptimizationLevel.NONE;
-        } catch (IOException e) {
-            throw new XPathException(this, "Failed to check vector index config: " + e.getMessage(), e);
-        }
+        final PerformanceStats.IndexOptimizationLevel optimizationLevel =
+                VectorSearchSupport.optimizationLevelForQNames(this, index, docs, qnames);
 
-        final long start = System.currentTimeMillis();
-        try {
-            final Sequence result = index.searchVector(getExpressionId(), docs, nodes, qnames, vector, k, options);
-            final long duration = System.currentTimeMillis() - start;
-            if (optimizationLevel == PerformanceStats.IndexOptimizationLevel.OPTIMIZED) {
-                VectorOperationMetrics.recordKnn(duration * 1_000_000L);
-            }
-            if (context.getProfiler().traceFunctions()) {
-                context.getProfiler().traceIndexUsage(context, "lucene-vector", this, optimizationLevel, duration);
-            }
-            return result;
-        } catch (IOException e) {
-            throw new XPathException(this, "Vector search failed: " + e.getMessage(), e);
-        }
+        return VectorSearchSupport.execute(this, context, index, optimizationLevel,
+                () -> index.searchVector(getExpressionId(), docs, nodes, qnames, vector, k, options));
     }
 
     private static int parseK(final Sequence[] args) throws XPathException {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
@@ -26,6 +26,7 @@ import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
+import org.exist.storage.vector.VectorOperationMetrics;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.AbstractMapType;
@@ -110,8 +111,26 @@ public class QueryVector extends BasicFunction {
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
         final List<QName> qnames = resolveQNames(nodes, index);
 
+        final PerformanceStats.IndexOptimizationLevel optimizationLevel;
         try {
-            return index.searchVector(getExpressionId(), docs, nodes, qnames, vector, k, options);
+            optimizationLevel = index != null && index.hasVectorIndexForQNames(docs, qnames)
+                    ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
+                    : PerformanceStats.IndexOptimizationLevel.NONE;
+        } catch (IOException e) {
+            throw new XPathException(this, "Failed to check vector index config: " + e.getMessage(), e);
+        }
+
+        final long start = System.currentTimeMillis();
+        try {
+            final Sequence result = index.searchVector(getExpressionId(), docs, nodes, qnames, vector, k, options);
+            final long duration = System.currentTimeMillis() - start;
+            if (optimizationLevel == PerformanceStats.IndexOptimizationLevel.OPTIMIZED) {
+                VectorOperationMetrics.recordKnn(duration * 1_000_000L);
+            }
+            if (context.getProfiler().traceFunctions()) {
+                context.getProfiler().traceIndexUsage(context, "lucene-vector", this, optimizationLevel, duration);
+            }
+            return result;
         } catch (IOException e) {
             throw new XPathException(this, "Vector search failed: " + e.getMessage(), e);
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/VectorSearchSupport.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/VectorSearchSupport.java
@@ -1,0 +1,99 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.lucene;
+
+import org.exist.dom.persistent.DocumentSet;
+import org.exist.dom.persistent.NodeSet;
+import org.exist.indexing.lucene.LuceneIndexWorker;
+import org.exist.storage.vector.VectorOperationMetrics;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.PerformanceStats;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Shared profiler and metrics handling for vector KNN query functions.
+ */
+final class VectorSearchSupport {
+
+    private VectorSearchSupport() {
+    }
+
+    @FunctionalInterface
+    interface VectorSearch {
+        Sequence search() throws IOException, XPathException;
+    }
+
+    static Sequence execute(final BasicFunction fn, final XQueryContext context,
+            @Nullable final LuceneIndexWorker index,
+            final PerformanceStats.IndexOptimizationLevel optimizationLevel,
+            final VectorSearch search) throws XPathException {
+        if (optimizationLevel == PerformanceStats.IndexOptimizationLevel.NONE) {
+            final long start = System.nanoTime();
+            if (context.getProfiler().traceFunctions()) {
+                context.getProfiler().traceIndexUsage(context, "lucene-vector", fn, optimizationLevel,
+                        (System.nanoTime() - start) / 1_000_000L);
+            }
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        final long start = System.nanoTime();
+        try {
+            final Sequence result = search.search();
+            final long durationNanos = System.nanoTime() - start;
+            VectorOperationMetrics.recordKnn(durationNanos);
+            if (context.getProfiler().traceFunctions()) {
+                context.getProfiler().traceIndexUsage(context, "lucene-vector", fn,
+                        optimizationLevel, durationNanos / 1_000_000L);
+            }
+            return result;
+        } catch (IOException e) {
+            throw new XPathException(fn, "Vector search failed: " + e.getMessage(), e);
+        }
+    }
+
+    static PerformanceStats.IndexOptimizationLevel optimizationLevelForField(@Nullable final LuceneIndexWorker index,
+            final DocumentSet docs, final String field) {
+        return index != null && index.hasVectorIndexForField(docs, field)
+                ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
+                : PerformanceStats.IndexOptimizationLevel.NONE;
+    }
+
+    static PerformanceStats.IndexOptimizationLevel optimizationLevelForQNames(final BasicFunction fn,
+            @Nullable final LuceneIndexWorker index, final DocumentSet docs,
+            @Nullable final java.util.List<org.exist.dom.QName> qnames) throws XPathException {
+        if (index == null) {
+            return PerformanceStats.IndexOptimizationLevel.NONE;
+        }
+        try {
+            return index.hasVectorIndexForQNames(docs, qnames)
+                    ? PerformanceStats.IndexOptimizationLevel.OPTIMIZED
+                    : PerformanceStats.IndexOptimizationLevel.NONE;
+        } catch (IOException e) {
+            throw new XPathException(fn, "Failed to check vector index config: " + e.getMessage(), e);
+        }
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/VectorSearchSupport.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/VectorSearchSupport.java
@@ -64,7 +64,7 @@ final class VectorSearchSupport {
         try {
             final Sequence result = search.search();
             final long durationNanos = System.nanoTime() - start;
-            VectorOperationMetrics.recordKnn(durationNanos);
+            VectorOperationMetrics.recordKnn(context, durationNanos);
             if (context.getProfiler().traceFunctions()) {
                 context.getProfiler().traceIndexUsage(context, "lucene-vector", fn,
                         optimizationLevel, durationNanos / 1_000_000L);

--- a/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
@@ -24,6 +24,7 @@ xquery version "3.1";
 module namespace vs="http://exist-db.org/xquery/vector-search/test";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace stats="http://exist-db.org/xquery/profiling";
 
 (:~
  : Test data for vector search. dimension=4.
@@ -319,6 +320,26 @@ declare variable $vs:COLLECTION_EUCLIDEAN := "/db/" || $vs:COLLECTION_EUCLIDEAN_
 declare variable $vs:COLLECTION_DOT_PRODUCT_NAME := "lucene-test-vector-dot-product";
 declare variable $vs:COLLECTION_DOT_PRODUCT := "/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME;
 
+(:~ Lucene fulltext only — no vector-field (profiler NONE tests). :)
+declare variable $vs:DATA_NO_VECTOR :=
+    <articles>
+        <article><title>Doc 1</title></article>
+    </articles>;
+
+declare variable $vs:XCONF_NO_VECTOR :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="article">
+                    <field name="title" expression="title"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $vs:COLLECTION_NO_VECTOR_NAME := "lucene-test-vector-no-index";
+declare variable $vs:COLLECTION_NO_VECTOR := "/db/" || $vs:COLLECTION_NO_VECTOR_NAME;
+
 (:~
  : setUp: create config chain, main collection (base64 + range for filters), text collection,
  : dim-mismatch collection, embedding=local collections, reindex.
@@ -404,7 +425,12 @@ function vs:setup() {
       xmldb:create-collection("/db", $vs:COLLECTION_DOT_PRODUCT_NAME),
       xmldb:store($vs:COLLECTION_DOT_PRODUCT, "test.xml", $vs:DATA_TEXT),
       xmldb:store("/db/system/config/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME, "collection.xconf", $vs:XCONF_DOT_PRODUCT),
-      xmldb:reindex($vs:COLLECTION_DOT_PRODUCT) )
+      xmldb:reindex($vs:COLLECTION_DOT_PRODUCT),
+      xmldb:create-collection("/db/system/config/db", $vs:COLLECTION_NO_VECTOR_NAME),
+      xmldb:create-collection("/db", $vs:COLLECTION_NO_VECTOR_NAME),
+      xmldb:store($vs:COLLECTION_NO_VECTOR, "test.xml", $vs:DATA_NO_VECTOR),
+      xmldb:store("/db/system/config/db/" || $vs:COLLECTION_NO_VECTOR_NAME, "collection.xconf", $vs:XCONF_NO_VECTOR),
+      xmldb:reindex($vs:COLLECTION_NO_VECTOR) )
 };
 
 (:~
@@ -442,7 +468,9 @@ function vs:tearDown() {
     xmldb:remove($vs:COLLECTION_EUCLIDEAN),
     xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_EUCLIDEAN_NAME),
     xmldb:remove($vs:COLLECTION_DOT_PRODUCT),
-    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME)
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME),
+    xmldb:remove($vs:COLLECTION_NO_VECTOR),
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_NO_VECTOR_NAME)
 };
 
 (:~
@@ -985,4 +1013,40 @@ function vs:config-invalid-similarity-no-vector-hits() {
                 <vector-field name="cfg_bad_sim" expression="embedding" dimension="4" similarity="invalid" encoding="text"/>
             </text></lucene></index>
         </collection>)
+};
+
+(: ================================================================
+   Profiler optimization-level tests
+   ================================================================ :)
+
+(:~ ft:query-vector on collection without vector-field config reports NONE. :)
+declare
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'lucene-vector'][@optimization-level eq 'NONE']")
+function vs:profiler-none-when-no-vector-config() {
+    collection($vs:COLLECTION_NO_VECTOR)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 2)]
+};
+
+(:~ ft:query-field-vector with unknown field name reports NONE. :)
+declare
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'lucene-vector'][@optimization-level eq 'NONE']")
+function vs:profiler-none-when-unknown-field() {
+    collection($vs:COLLECTION)//article[ft:query-field-vector("unknown_field", [1.0, 0.0, 0.0, 0.0], 2)]
+};
+
+(:~ ft:query-vector with configured vector-field reports OPTIMIZED. :)
+declare
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'lucene-vector'][@optimization-level eq 'OPTIMIZED']")
+function vs:profiler-optimized-when-vector-config-present() {
+    collection($vs:COLLECTION)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 2)]
+};
+
+(:~ ft:query-field-vector with configured field name reports OPTIMIZED. :)
+declare
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type eq 'lucene-vector'][@optimization-level eq 'OPTIMIZED']")
+function vs:profiler-optimized-query-field-vector() {
+    collection($vs:COLLECTION)//article[ft:query-field-vector("embedding", [1.0, 0.0, 0.0, 0.0], 2)]
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
@@ -1050,3 +1050,10 @@ declare
 function vs:profiler-optimized-query-field-vector() {
     collection($vs:COLLECTION)//article[ft:query-field-vector("embedding", [1.0, 0.0, 0.0, 0.0], 2)]
 };
+
+(:~ Unknown vector field short-circuits to empty (no Lucene KNN on missing config). :)
+declare
+    %test:assertEquals(0)
+function vs:unknown-field-vector-short-circuit-empty() {
+    count(collection($vs:COLLECTION)//article[ft:query-field-vector("unknown_field", [1.0, 0.0, 0.0, 0.0], 2)])
+};

--- a/extensions/vector/pom.xml
+++ b/extensions/vector/pom.xml
@@ -97,6 +97,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <systemPropertyVariables>
+                        <exist.home>${project.basedir}/../../exist-core/target/test-classes</exist.home>
+                        <log4j.configurationFile>${project.basedir}/../../exist-core/target/test-classes/log4j2.xml</log4j.configurationFile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
@@ -39,11 +39,12 @@ public class VectorEmbedding implements VectorEmbeddingMXBean {
     private static final String PERSISTENCE_BACKEND = "lucene";
 
     private final String instanceId;
-    private final VectorMetrics metrics = VectorMetrics.getInstance();
+    private final VectorMetrics metrics;
     private final boolean available;
 
     public VectorEmbedding(final BrokerPool pool) {
         this.instanceId = pool.getId();
+        this.metrics = VectorMetrics.forInstance(instanceId);
         this.available = true;
     }
 

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
@@ -36,11 +36,15 @@ import java.util.List;
  */
 public class VectorEmbedding implements VectorEmbeddingMXBean {
 
+    private static final String PERSISTENCE_BACKEND = "lucene";
+
     private final String instanceId;
     private final VectorMetrics metrics = VectorMetrics.getInstance();
+    private final boolean available;
 
     public VectorEmbedding(final BrokerPool pool) {
         this.instanceId = pool.getId();
+        this.available = true;
     }
 
     public static String getAllInstancesQuery() {
@@ -63,17 +67,22 @@ public class VectorEmbedding implements VectorEmbeddingMXBean {
 
     @Override
     public boolean isAvailable() {
-        return true;
+        return available;
+    }
+
+    @Override
+    public String getPersistenceBackend() {
+        return PERSISTENCE_BACKEND;
     }
 
     @Override
     public int getModelCount() {
-        return getModels().size();
+        return VectorModelDiagnostics.getModelCount();
     }
 
     @Override
     public int getReadyModelCount() {
-        return VectorModelDiagnostics.countReadyModels(getModels());
+        return VectorModelDiagnostics.getReadyModelCount();
     }
 
     @Override
@@ -109,6 +118,16 @@ public class VectorEmbedding implements VectorEmbeddingMXBean {
     @Override
     public long getKnnLastTimeNanos() {
         return metrics.getKnnLastTimeNanos();
+    }
+
+    @Override
+    public void resetMetrics() {
+        metrics.reset();
+    }
+
+    @Override
+    public void refreshModels() {
+        VectorModelDiagnostics.refreshModels();
     }
 
     @Override

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
@@ -36,18 +36,28 @@ import java.util.List;
  */
 public class VectorEmbedding implements VectorEmbeddingMXBean {
 
-    private static final String PERSISTENCE_BACKEND = "lucene";
+    private static final String KNN_BACKEND = "lucene";
 
     private final String instanceId;
     private final VectorMetrics metrics;
     private final boolean available;
 
+    /**
+     * Creates a new VectorEmbedding MBean for the given broker pool.
+     *
+     * @param pool the broker pool instance
+     */
     public VectorEmbedding(final BrokerPool pool) {
         this.instanceId = pool.getId();
         this.metrics = VectorMetrics.forInstance(instanceId);
         this.available = true;
     }
 
+    /**
+     * Returns the JMX ObjectName query string matching all vector embedding MBeans.
+     *
+     * @return query string for all instances
+     */
     public static String getAllInstancesQuery() {
         return getName("*");
     }
@@ -72,8 +82,8 @@ public class VectorEmbedding implements VectorEmbeddingMXBean {
     }
 
     @Override
-    public String getPersistenceBackend() {
-        return PERSISTENCE_BACKEND;
+    public String getKnnBackend() {
+        return KNN_BACKEND;
     }
 
     @Override

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbedding.java
@@ -1,0 +1,118 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.impl;
+
+import org.exist.storage.BrokerPool;
+import org.exist.vector.VectorEmbeddingService;
+import org.exist.vector.VectorMetrics;
+import org.exist.vector.VectorModelDiagnostics;
+import org.exist.vector.VectorModelInfo;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.util.List;
+
+/**
+ * JMX MBean for vector embedding workload and model diagnostics.
+ */
+public class VectorEmbedding implements VectorEmbeddingMXBean {
+
+    private final String instanceId;
+    private final VectorMetrics metrics = VectorMetrics.getInstance();
+
+    public VectorEmbedding(final BrokerPool pool) {
+        this.instanceId = pool.getId();
+    }
+
+    public static String getAllInstancesQuery() {
+        return getName("*");
+    }
+
+    private static String getName(final String instanceId) {
+        return "org.exist.management." + instanceId + ":type=VectorEmbedding";
+    }
+
+    @Override
+    public ObjectName getName() throws MalformedObjectNameException {
+        return new ObjectName(getName(instanceId));
+    }
+
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public int getModelCount() {
+        return getModels().size();
+    }
+
+    @Override
+    public int getReadyModelCount() {
+        return VectorModelDiagnostics.countReadyModels(getModels());
+    }
+
+    @Override
+    public int getLoadedProviderCount() {
+        return VectorEmbeddingService.getInstance().getLoadedProviderCount();
+    }
+
+    @Override
+    public long getEmbedCallCount() {
+        return metrics.getEmbedCallCount();
+    }
+
+    @Override
+    public long getEmbedTotalTimeNanos() {
+        return metrics.getEmbedTotalTimeNanos();
+    }
+
+    @Override
+    public long getEmbedLastTimeNanos() {
+        return metrics.getEmbedLastTimeNanos();
+    }
+
+    @Override
+    public long getKnnQueryCount() {
+        return metrics.getKnnQueryCount();
+    }
+
+    @Override
+    public long getKnnTotalTimeNanos() {
+        return metrics.getKnnTotalTimeNanos();
+    }
+
+    @Override
+    public long getKnnLastTimeNanos() {
+        return metrics.getKnnLastTimeNanos();
+    }
+
+    @Override
+    public List<VectorModelInfo> getModels() {
+        return VectorModelDiagnostics.collectModels();
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
@@ -31,11 +31,19 @@ import java.util.List;
 public interface VectorEmbeddingMXBean extends PerInstanceMBean {
 
     /**
-     * Whether the vector embedding extension is loaded for this instance.
+     * Whether the vector embedding extension registered this MBean at database startup.
      *
-     * @return {@code true} when the extension registered this MBean
+     * @return {@code true} when the vector extension is loaded
      */
     boolean isAvailable();
+
+    /**
+     * Persistence backend monitored by this MBean ({@code lucene} KNN index vs {@code vector.dbx}).
+     * Vector embeddings may also be stored in Lucene when {@code vector-store="lucene"}.
+     *
+     * @return {@code lucene} for KNN workload metrics
+     */
+    String getPersistenceBackend();
 
     /**
      * Total configured models (registry + built-ins).
@@ -69,6 +77,16 @@ public interface VectorEmbeddingMXBean extends PerInstanceMBean {
     long getKnnTotalTimeNanos();
 
     long getKnnLastTimeNanos();
+
+    /**
+     * Resets embed and KNN workload counters to zero.
+     */
+    void resetMetrics();
+
+    /**
+     * Refreshes the cached model diagnostics snapshot.
+     */
+    void refreshModels();
 
     /**
      * Diagnostic rows for configured and built-in models.

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
@@ -38,12 +38,23 @@ public interface VectorEmbeddingMXBean extends PerInstanceMBean {
     boolean isAvailable();
 
     /**
-     * Persistence backend monitored by this MBean ({@code lucene} KNN index vs {@code vector.dbx}).
-     * Vector embeddings may also be stored in Lucene when {@code vector-store="lucene"}.
+     * Search backend used for KNN queries tracked by this MBean.
+     * <p>
+     * This value describes the Lucene index used for {@code ft:query-vector} and related KNN
+     * functions, not where embeddings are persisted at index time. KNN search always runs against
+     * Lucene {@code KnnFloatVectorField} data regardless of collection configuration.
+     * </p>
+     * <p>
+     * Index-time persistence is controlled per collection by {@code vector-store} on
+     * {@code collection.xconf}: {@code vector-store="lucene"} stores embeddings in Lucene only;
+     * {@code vector-store="db"} (default) also mirrors them in {@code vector.dbx}. See
+     * {@link VectorStoreMXBean#getStorageBackend()} and the {@code VectorStore} MBean for
+     * {@code vector.dbx} file statistics.
+     * </p>
      *
      * @return {@code lucene} for KNN workload metrics
      */
-    String getPersistenceBackend();
+    String getKnnBackend();
 
     /**
      * Total configured models (registry + built-ins).
@@ -66,16 +77,46 @@ public interface VectorEmbeddingMXBean extends PerInstanceMBean {
      */
     int getLoadedProviderCount();
 
+    /**
+     * Total embedding call count for this database instance.
+     *
+     * @return embed call count
+     */
     long getEmbedCallCount();
 
+    /**
+     * Total accumulated embedding time in nanoseconds.
+     *
+     * @return total time in nanoseconds
+     */
     long getEmbedTotalTimeNanos();
 
+    /**
+     * Last embedding call duration in nanoseconds.
+     *
+     * @return last duration in nanoseconds
+     */
     long getEmbedLastTimeNanos();
 
+    /**
+     * Total KNN query count for this database instance.
+     *
+     * @return KNN query count
+     */
     long getKnnQueryCount();
 
+    /**
+     * Total accumulated KNN query time in nanoseconds.
+     *
+     * @return total time in nanoseconds
+     */
     long getKnnTotalTimeNanos();
 
+    /**
+     * Last KNN query duration in nanoseconds.
+     *
+     * @return last duration in nanoseconds
+     */
     long getKnnLastTimeNanos();
 
     /**

--- a/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
+++ b/extensions/vector/src/main/java/org/exist/management/impl/VectorEmbeddingMXBean.java
@@ -1,0 +1,79 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.impl;
+
+import org.exist.vector.VectorModelInfo;
+
+import java.util.List;
+
+/**
+ * JMX MXBean interface for vector embedding operations and model diagnostics.
+ */
+public interface VectorEmbeddingMXBean extends PerInstanceMBean {
+
+    /**
+     * Whether the vector embedding extension is loaded for this instance.
+     *
+     * @return {@code true} when the extension registered this MBean
+     */
+    boolean isAvailable();
+
+    /**
+     * Total configured models (registry + built-ins).
+     *
+     * @return model count
+     */
+    int getModelCount();
+
+    /**
+     * Models with {@code status == available}.
+     *
+     * @return ready model count
+     */
+    int getReadyModelCount();
+
+    /**
+     * Number of cached embedding providers.
+     *
+     * @return loaded provider count
+     */
+    int getLoadedProviderCount();
+
+    long getEmbedCallCount();
+
+    long getEmbedTotalTimeNanos();
+
+    long getEmbedLastTimeNanos();
+
+    long getKnnQueryCount();
+
+    long getKnnTotalTimeNanos();
+
+    long getKnnLastTimeNanos();
+
+    /**
+     * Diagnostic rows for configured and built-in models.
+     *
+     * @return model information rows
+     */
+    List<VectorModelInfo> getModels();
+}

--- a/extensions/vector/src/main/java/org/exist/vector/HttpVectorProvider.java
+++ b/extensions/vector/src/main/java/org/exist/vector/HttpVectorProvider.java
@@ -54,6 +54,9 @@ public final class HttpVectorProvider implements VectorEmbeddingProvider {
   private static final Logger LOG = LogManager.getLogger(HttpVectorProvider.class);
   private static final ObjectMapper JSON = new ObjectMapper();
 
+  /**
+   * Supported HTTP embedding API types.
+   */
   public enum ApiType {
     OPENAI,
     COHERE
@@ -232,6 +235,9 @@ public final class HttpVectorProvider implements VectorEmbeddingProvider {
 
   /**
    * Returns true if the path/URL indicates an external HTTP embedding API.
+   *
+   * @param pathOrUrl the path or URL to check
+   * @return true if the URL targets a supported HTTP embedding API
    */
   public static boolean isHttpApiUrl(final String pathOrUrl) {
     return pathOrUrl != null && detectApiType(pathOrUrl) != null;
@@ -239,6 +245,10 @@ public final class HttpVectorProvider implements VectorEmbeddingProvider {
 
   /**
    * Returns default dimension for known HTTP embedding models.
+   *
+   * @param type    the API type (OpenAI or Cohere)
+   * @param modelId the model identifier
+   * @return the default dimension for the model
    */
   public static int getDefaultDimension(final ApiType type, final String modelId) {
     if (type == ApiType.OPENAI) {

--- a/extensions/vector/src/main/java/org/exist/vector/ModelPathResolver.java
+++ b/extensions/vector/src/main/java/org/exist/vector/ModelPathResolver.java
@@ -56,6 +56,8 @@ public final class ModelPathResolver {
   /**
    * Base directory for resolving relative model paths and for the ONNX cache.
    * Uses BrokerPool exist home if available, then exist.home, then user.dir.
+   *
+   * @return the base directory path
    */
   @Nonnull
   static Path getVectorBase() {

--- a/extensions/vector/src/main/java/org/exist/vector/ModelRegistry.java
+++ b/extensions/vector/src/main/java/org/exist/vector/ModelRegistry.java
@@ -48,10 +48,21 @@ public final class ModelRegistry {
   private static volatile ModelRegistry instance;
   private final Map<String, ModelEntry> entries = new HashMap<>();
 
+  /**
+   * A registered model with configured path and dimension.
+   */
   public static final class ModelEntry {
+    /** The resolved model path. */
     public final String path;
+    /** The configured embedding dimension. */
     public final int dimension;
 
+    /**
+     * Creates a model entry.
+     *
+     * @param path      the model path
+     * @param dimension the embedding dimension
+     */
     public ModelEntry(final String path, final int dimension) {
       this.path = path;
       this.dimension = dimension;
@@ -135,6 +146,9 @@ public final class ModelRegistry {
 
   /**
    * Returns the registry entry for the model ID, or null if not configured.
+   *
+   * @param modelId the model identifier
+   * @return the registry entry, or null if not found
    */
   @Nullable
   public ModelEntry get(@Nonnull final String modelId) {
@@ -143,6 +157,8 @@ public final class ModelRegistry {
 
   /**
    * Returns all registered model IDs.
+   *
+   * @return set of registered model IDs
    */
   @Nonnull
   public Set<String> getModelIds() {
@@ -153,6 +169,11 @@ public final class ModelRegistry {
    * Resolves path and dimension. When pathOrUrl is null/empty and the registry
    * has an entry for modelId, use the registry path and dimension. Otherwise
    * use the given path (or default "onnx-models/" + modelId) and defaultDimension.
+   *
+   * @param modelId         the model identifier
+   * @param pathOrUrl       the path or URL, may be null/empty to use registry
+   * @param defaultDimension fallback dimension when registry has no entry
+   * @return resolved path and dimension
    */
   public Resolved resolve(@Nonnull final String modelId, @Nullable final String pathOrUrl, final int defaultDimension) {
     final boolean useDefaultPath = pathOrUrl == null || pathOrUrl.isEmpty();
@@ -164,10 +185,21 @@ public final class ModelRegistry {
     return new Resolved(path, defaultDimension);
   }
 
+  /**
+   * Result of resolving a model path and dimension.
+   */
   public static final class Resolved {
+    /** The resolved model path. */
     public final String path;
+    /** The resolved embedding dimension. */
     public final int dimension;
 
+    /**
+     * Creates a resolved result.
+     *
+     * @param path      the resolved path
+     * @param dimension the resolved dimension
+     */
     Resolved(final String path, final int dimension) {
       this.path = path;
       this.dimension = dimension;

--- a/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
@@ -62,4 +62,17 @@ public final class VectorEmbeddingJmx {
             LOG.warn("Failed to register VectorEmbedding JMX MBean for instance {}: {}", instanceId, e.getMessage(), e);
         }
     }
+
+    /**
+     * Clear registration state for the given broker pool so a subsequent startup can register again.
+     * JMX deregistration is handled by {@link org.exist.management.AgentFactory#closeDBInstance}.
+     *
+     * @param pool the broker pool
+     */
+    public static void unregister(final BrokerPool pool) {
+        if (pool == null) {
+            return;
+        }
+        REGISTERED.remove(pool.getId());
+    }
 }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
@@ -65,7 +65,7 @@ public final class VectorEmbeddingJmx {
 
     /**
      * Clear registration state for the given broker pool so a subsequent startup can register again.
-     * JMX deregistration is handled by {@link org.exist.management.AgentFactory#closeDBInstance}.
+     * JMX deregistration is handled by {@link org.exist.management.Agent#closeDBInstance}.
      *
      * @param pool the broker pool
      */

--- a/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingJmx.java
@@ -1,0 +1,65 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.management.AgentFactory;
+import org.exist.management.impl.VectorEmbedding;
+import org.exist.storage.BrokerPool;
+import org.exist.util.DatabaseConfigurationException;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registers the {@link VectorEmbedding} JMX MBean once per database instance.
+ */
+public final class VectorEmbeddingJmx {
+
+    private static final Logger LOG = LogManager.getLogger(VectorEmbeddingJmx.class);
+    private static final Set<String> REGISTERED = ConcurrentHashMap.newKeySet();
+
+    private VectorEmbeddingJmx() {
+    }
+
+    /**
+     * Register the VectorEmbedding MBean for the given broker pool if not already registered.
+     *
+     * @param pool the broker pool
+     */
+    public static void registerIfAbsent(final BrokerPool pool) {
+        if (pool == null) {
+            return;
+        }
+        final String instanceId = pool.getId();
+        if (!REGISTERED.add(instanceId)) {
+            return;
+        }
+        try {
+            AgentFactory.getInstance().addMBean(new VectorEmbedding(pool));
+        } catch (final DatabaseConfigurationException e) {
+            REGISTERED.remove(instanceId);
+            LOG.warn("Failed to register VectorEmbedding JMX MBean for instance {}: {}", instanceId, e.getMessage(), e);
+        }
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingService.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingService.java
@@ -47,6 +47,8 @@ public final class VectorEmbeddingService {
 
   /**
    * Returns the singleton instance.
+   *
+   * @return the singleton instance
    */
   @Nonnull
   public static VectorEmbeddingService getInstance() {
@@ -65,6 +67,11 @@ public final class VectorEmbeddingService {
   /**
    * Returns a provider for the given model ID. Delegates to
    * {@link #getProvider(String, String, int, String)} with null apiKey.
+   *
+   * @param modelId   model identifier
+   * @param pathOrUrl local path, HuggingFace URL, or API base URL
+   * @param dimension expected embedding dimension
+   * @return provider, or null if the model could not be loaded
    */
   @Nullable
   public VectorEmbeddingProvider getProvider(@Nonnull final String modelId,

--- a/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingService.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorEmbeddingService.java
@@ -163,4 +163,13 @@ public final class VectorEmbeddingService {
     final String cacheKey = modelId + ":" + modelPath.toAbsolutePath();
     cache.remove(cacheKey);
   }
+
+  /**
+   * Returns the number of providers currently cached by this service.
+   *
+   * @return cache size
+   */
+  public int getLoadedProviderCount() {
+    return cache.size();
+  }
 }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
@@ -47,4 +47,14 @@ public final class VectorExtensionLifecycle {
         });
         VectorEmbeddingJmx.registerIfAbsent(pool);
     }
+
+    /**
+     * Clears vector extension JMX registration state when the broker pool shuts down.
+     *
+     * @param pool the broker pool
+     */
+    public static void onBrokerPoolShutdown(final BrokerPool pool) {
+        VectorOperationMetrics.register(null);
+        VectorEmbeddingJmx.unregister(pool);
+    }
 }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
@@ -38,10 +38,14 @@ public final class VectorExtensionLifecycle {
      * @param pool the broker pool
      */
     public static void onBrokerPoolStartSystem(final BrokerPool pool) {
-        VectorOperationMetrics.register((operation, durationNanos) -> {
+        if (pool == null) {
+            return;
+        }
+        final String instanceId = pool.getId();
+        VectorOperationMetrics.register(instanceId, (operation, durationNanos) -> {
             switch (operation) {
-                case EMBED -> VectorMetrics.getInstance().recordEmbed(durationNanos);
-                case KNN -> VectorMetrics.getInstance().recordKnnQuery(durationNanos);
+                case EMBED -> VectorMetrics.forInstance(instanceId).recordEmbed(durationNanos);
+                case KNN -> VectorMetrics.forInstance(instanceId).recordKnnQuery(durationNanos);
                 default -> throw new IllegalStateException("Unsupported vector operation: " + operation);
             }
         });
@@ -54,7 +58,12 @@ public final class VectorExtensionLifecycle {
      * @param pool the broker pool
      */
     public static void onBrokerPoolShutdown(final BrokerPool pool) {
-        VectorOperationMetrics.register(null);
+        if (pool == null) {
+            return;
+        }
+        final String instanceId = pool.getId();
+        VectorOperationMetrics.unregister(instanceId);
+        VectorMetrics.removeInstance(instanceId);
         VectorEmbeddingJmx.unregister(pool);
     }
 }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorExtensionLifecycle.java
@@ -1,0 +1,50 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.exist.storage.BrokerPool;
+import org.exist.storage.vector.VectorOperationMetrics;
+
+/**
+ * Startup hooks for the vector extension invoked reflectively from exist-core.
+ */
+public final class VectorExtensionLifecycle {
+
+    private VectorExtensionLifecycle() {
+    }
+
+    /**
+     * Registers JMX beans and the metrics bridge when the vector extension is on the classpath.
+     *
+     * @param pool the broker pool
+     */
+    public static void onBrokerPoolStartSystem(final BrokerPool pool) {
+        VectorOperationMetrics.register((operation, durationNanos) -> {
+            switch (operation) {
+                case EMBED -> VectorMetrics.getInstance().recordEmbed(durationNanos);
+                case KNN -> VectorMetrics.getInstance().recordKnnQuery(durationNanos);
+                default -> throw new IllegalStateException("Unsupported vector operation: " + operation);
+            }
+        });
+        VectorEmbeddingJmx.registerIfAbsent(pool);
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
@@ -62,38 +62,78 @@ public final class VectorMetrics {
         INSTANCES.remove(instanceId);
     }
 
+    /**
+     * Records an embedding call duration.
+     *
+     * @param durationNanos wall time in nanoseconds
+     */
     public void recordEmbed(final long durationNanos) {
         embedCallCount.increment();
         embedTotalTimeNanos.add(durationNanos);
         embedLastTimeNanos.set(durationNanos);
     }
 
+    /**
+     * Records a KNN query duration.
+     *
+     * @param durationNanos wall time in nanoseconds
+     */
     public void recordKnnQuery(final long durationNanos) {
         knnQueryCount.increment();
         knnTotalTimeNanos.add(durationNanos);
         knnLastTimeNanos.set(durationNanos);
     }
 
+    /**
+     * Returns the total embedding call count.
+     *
+     * @return embed call count
+     */
     public long getEmbedCallCount() {
         return embedCallCount.sum();
     }
 
+    /**
+     * Returns the total accumulated embedding time in nanoseconds.
+     *
+     * @return total time in nanoseconds
+     */
     public long getEmbedTotalTimeNanos() {
         return embedTotalTimeNanos.sum();
     }
 
+    /**
+     * Returns the last embedding call duration in nanoseconds.
+     *
+     * @return last duration in nanoseconds
+     */
     public long getEmbedLastTimeNanos() {
         return embedLastTimeNanos.get();
     }
 
+    /**
+     * Returns the total KNN query count.
+     *
+     * @return KNN query count
+     */
     public long getKnnQueryCount() {
         return knnQueryCount.sum();
     }
 
+    /**
+     * Returns the total accumulated KNN query time in nanoseconds.
+     *
+     * @return total time in nanoseconds
+     */
     public long getKnnTotalTimeNanos() {
         return knnTotalTimeNanos.sum();
     }
 
+    /**
+     * Returns the last KNN query duration in nanoseconds.
+     *
+     * @return last duration in nanoseconds
+     */
     public long getKnnLastTimeNanos() {
         return knnLastTimeNanos.get();
     }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
@@ -81,4 +81,16 @@ public final class VectorMetrics {
     public long getKnnLastTimeNanos() {
         return knnLastTimeNanos.get();
     }
+
+    /**
+     * Resets all embed and KNN counters to zero.
+     */
+    public void reset() {
+        embedCallCount.reset();
+        embedTotalTimeNanos.reset();
+        embedLastTimeNanos.set(0);
+        knnQueryCount.reset();
+        knnTotalTimeNanos.reset();
+        knnLastTimeNanos.set(0);
+    }
 }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
@@ -1,0 +1,84 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Lightweight counters for vector embedding and KNN query operations.
+ */
+public final class VectorMetrics {
+
+    private static final VectorMetrics INSTANCE = new VectorMetrics();
+
+    private final LongAdder embedCallCount = new LongAdder();
+    private final LongAdder embedTotalTimeNanos = new LongAdder();
+    private final AtomicLong embedLastTimeNanos = new AtomicLong();
+
+    private final LongAdder knnQueryCount = new LongAdder();
+    private final LongAdder knnTotalTimeNanos = new LongAdder();
+    private final AtomicLong knnLastTimeNanos = new AtomicLong();
+
+    private VectorMetrics() {
+    }
+
+    public static VectorMetrics getInstance() {
+        return INSTANCE;
+    }
+
+    public void recordEmbed(final long durationNanos) {
+        embedCallCount.increment();
+        embedTotalTimeNanos.add(durationNanos);
+        embedLastTimeNanos.set(durationNanos);
+    }
+
+    public void recordKnnQuery(final long durationNanos) {
+        knnQueryCount.increment();
+        knnTotalTimeNanos.add(durationNanos);
+        knnLastTimeNanos.set(durationNanos);
+    }
+
+    public long getEmbedCallCount() {
+        return embedCallCount.sum();
+    }
+
+    public long getEmbedTotalTimeNanos() {
+        return embedTotalTimeNanos.sum();
+    }
+
+    public long getEmbedLastTimeNanos() {
+        return embedLastTimeNanos.get();
+    }
+
+    public long getKnnQueryCount() {
+        return knnQueryCount.sum();
+    }
+
+    public long getKnnTotalTimeNanos() {
+        return knnTotalTimeNanos.sum();
+    }
+
+    public long getKnnLastTimeNanos() {
+        return knnLastTimeNanos.get();
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorMetrics.java
@@ -21,15 +21,16 @@
  */
 package org.exist.vector;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
- * Lightweight counters for vector embedding and KNN query operations.
+ * Lightweight per-database-instance counters for vector embedding and KNN query operations.
  */
 public final class VectorMetrics {
 
-    private static final VectorMetrics INSTANCE = new VectorMetrics();
+    private static final ConcurrentHashMap<String, VectorMetrics> INSTANCES = new ConcurrentHashMap<>();
 
     private final LongAdder embedCallCount = new LongAdder();
     private final LongAdder embedTotalTimeNanos = new LongAdder();
@@ -42,8 +43,23 @@ public final class VectorMetrics {
     private VectorMetrics() {
     }
 
-    public static VectorMetrics getInstance() {
-        return INSTANCE;
+    /**
+     * Returns metrics for the given database instance id.
+     *
+     * @param instanceId broker pool instance id
+     * @return metrics counters for the instance
+     */
+    public static VectorMetrics forInstance(final String instanceId) {
+        return INSTANCES.computeIfAbsent(instanceId, id -> new VectorMetrics());
+    }
+
+    /**
+     * Removes metrics state for a shut-down database instance.
+     *
+     * @param instanceId broker pool instance id
+     */
+    public static void removeInstance(final String instanceId) {
+        INSTANCES.remove(instanceId);
     }
 
     public void recordEmbed(final long durationNanos) {

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelConstants.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelConstants.java
@@ -78,6 +78,9 @@ public final class VectorModelConstants {
 
   /**
    * Returns the default dimension for a model ID, or 384 if unknown.
+   *
+   * @param modelId the model identifier
+   * @return the default dimension, or 384 if unknown
    */
   public static int getDefaultDimension(final String modelId) {
     return KNOWN_DIMENSIONS.getOrDefault(modelId, 384);
@@ -85,6 +88,9 @@ public final class VectorModelConstants {
 
   /**
    * Returns the default dimension for an OpenAI model, or 1536 if unknown.
+   *
+   * @param modelId the model identifier
+   * @return the default dimension, or 1536 if unknown
    */
   public static int getOpenAIDefaultDimension(final String modelId) {
     return OPENAI_DIMENSIONS.getOrDefault(modelId, 1536);
@@ -92,6 +98,9 @@ public final class VectorModelConstants {
 
   /**
    * Returns the default dimension for a Cohere model, or 1024 if unknown.
+   *
+   * @param modelId the model identifier
+   * @return the default dimension, or 1024 if unknown
    */
   public static int getCohereDefaultDimension(final String modelId) {
     return COHERE_DIMENSIONS.getOrDefault(modelId, 1024);
@@ -99,6 +108,8 @@ public final class VectorModelConstants {
 
   /**
    * Returns the immutable, ordered list of built-in model IDs.
+   *
+   * @return the list of known model IDs
    */
   public static List<String> getKnownModelIds() {
     return KNOWN_MODEL_IDS;

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
@@ -33,25 +33,62 @@ import java.util.Set;
  */
 public final class VectorModelDiagnostics {
 
+    /** Default TTL for cached model snapshots (JMX polling). */
+    private static final long CACHE_TTL_MS = 60_000L;
+
+    private static volatile CachedSnapshot cache;
+
     private VectorModelDiagnostics() {
+    }
+
+    private record CachedSnapshot(List<VectorModelInfo> models, long timestampMs) {
     }
 
     /**
      * Collect diagnostic information for registry entries and built-in models.
+     * Results are cached briefly to avoid repeated filesystem probes under JMX polling.
      *
      * @return model rows sorted by id
      */
     public static List<VectorModelInfo> collectModels() {
-        final ModelRegistry registry = ModelRegistry.getInstance();
-        final Set<String> registryIds = registry.getModelIds();
-        final Set<String> allIds = new HashSet<>(registryIds);
-        allIds.addAll(VectorModelConstants.getKnownModelIds());
-
-        final List<VectorModelInfo> models = new ArrayList<>(allIds.size());
-        for (final String id : allIds.stream().sorted().toList()) {
-            models.add(describeModel(id, registryIds));
+        final long now = System.currentTimeMillis();
+        final CachedSnapshot current = cache;
+        if (current != null && now - current.timestampMs() < CACHE_TTL_MS) {
+            return current.models();
         }
-        return models;
+        final List<VectorModelInfo> models = collectModelsUncached();
+        final CachedSnapshot snapshot = new CachedSnapshot(List.copyOf(models), now);
+        cache = snapshot;
+        return snapshot.models();
+    }
+
+    /**
+     * Returns model count from a single cached snapshot.
+     */
+    public static int getModelCount() {
+        return collectModels().size();
+    }
+
+    /**
+     * Returns ready model count from a single cached snapshot.
+     */
+    public static int getReadyModelCount() {
+        return countReadyModels(collectModels());
+    }
+
+    /**
+     * Clears the cached model snapshot. The next {@link #collectModels()} rebuilds it.
+     */
+    public static void invalidateCache() {
+        cache = null;
+    }
+
+    /**
+     * Forces a fresh model snapshot and returns it.
+     */
+    public static List<VectorModelInfo> refreshModels() {
+        invalidateCache();
+        return collectModels();
     }
 
     public static int countReadyModels(final List<VectorModelInfo> models) {
@@ -62,6 +99,19 @@ public final class VectorModelDiagnostics {
             }
         }
         return ready;
+    }
+
+    private static List<VectorModelInfo> collectModelsUncached() {
+        final ModelRegistry registry = ModelRegistry.getInstance();
+        final Set<String> registryIds = registry.getModelIds();
+        final Set<String> allIds = new HashSet<>(registryIds);
+        allIds.addAll(VectorModelConstants.getKnownModelIds());
+
+        final List<VectorModelInfo> models = new ArrayList<>(allIds.size());
+        for (final String id : allIds.stream().sorted().toList()) {
+            models.add(describeModel(id, registryIds));
+        }
+        return models;
     }
 
     private static VectorModelInfo describeModel(final String id, final Set<String> registryIds) {

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
@@ -1,0 +1,107 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Shared model diagnostics for {@code vector:diagnostics()} and the {@code VectorEmbedding} JMX MBean.
+ */
+public final class VectorModelDiagnostics {
+
+    private VectorModelDiagnostics() {
+    }
+
+    /**
+     * Collect diagnostic information for registry entries and built-in models.
+     *
+     * @return model rows sorted by id
+     */
+    public static List<VectorModelInfo> collectModels() {
+        final ModelRegistry registry = ModelRegistry.getInstance();
+        final Set<String> registryIds = registry.getModelIds();
+        final Set<String> allIds = new HashSet<>(registryIds);
+        allIds.addAll(VectorModelConstants.getKnownModelIds());
+
+        final List<VectorModelInfo> models = new ArrayList<>(allIds.size());
+        for (final String id : allIds.stream().sorted().toList()) {
+            models.add(describeModel(id, registryIds));
+        }
+        return models;
+    }
+
+    public static int countReadyModels(final List<VectorModelInfo> models) {
+        int ready = 0;
+        for (final VectorModelInfo model : models) {
+            if ("available".equals(model.getStatus())) {
+                ready++;
+            }
+        }
+        return ready;
+    }
+
+    private static VectorModelInfo describeModel(final String id, final Set<String> registryIds) {
+        final String source;
+        if (registryIds.contains(id) && VectorModelConstants.getKnownModelIds().contains(id)) {
+            source = "registry+builtin";
+        } else if (registryIds.contains(id)) {
+            source = "registry";
+        } else {
+            source = "builtin";
+        }
+
+        final ModelRegistry.Resolved resolved = ModelRegistry.getInstance().resolve(id, null, VectorModelConstants.getDefaultDimension(id));
+        final String path = resolved.path;
+        final int dim = resolved.dimension;
+
+        final String status;
+        final String message;
+        if (path.startsWith("http://") || path.startsWith("https://")) {
+            status = "http";
+            message = "HTTP/API model; availability depends on remote endpoint and API key configuration.";
+        } else {
+            final Path p = ModelPathResolver.resolve(id, path);
+            if (p != null) {
+                status = "available";
+                message = null;
+            } else {
+                status = "missing";
+                message = "Model directory not found under exist.home; ensure " + path
+                        + " exists with model.onnx and tokenizer.json or adjust conf.xml/vector-field model-path.";
+            }
+        }
+
+        return new VectorModelInfo(id, source, path, dim, status, message, deriveProvider(status, path));
+    }
+
+    private static String deriveProvider(final String status, final String path) {
+        if ("http".equals(status) || path.startsWith("http://") || path.startsWith("https://")) {
+            return "HTTP";
+        }
+        return "ONNX";
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelDiagnostics.java
@@ -64,6 +64,8 @@ public final class VectorModelDiagnostics {
 
     /**
      * Returns model count from a single cached snapshot.
+     *
+     * @return total model count
      */
     public static int getModelCount() {
         return collectModels().size();
@@ -71,6 +73,8 @@ public final class VectorModelDiagnostics {
 
     /**
      * Returns ready model count from a single cached snapshot.
+     *
+     * @return ready model count
      */
     public static int getReadyModelCount() {
         return countReadyModels(collectModels());
@@ -85,12 +89,20 @@ public final class VectorModelDiagnostics {
 
     /**
      * Forces a fresh model snapshot and returns it.
+     *
+     * @return fresh model information rows
      */
     public static List<VectorModelInfo> refreshModels() {
         invalidateCache();
         return collectModels();
     }
 
+    /**
+     * Counts how many models are in available status.
+     *
+     * @param models the model list to scan
+     * @return number of available models
+     */
     public static int countReadyModels(final List<VectorModelInfo> models) {
         int ready = 0;
         for (final VectorModelInfo model : models) {

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelInfo.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelInfo.java
@@ -37,6 +37,17 @@ public class VectorModelInfo {
     private final String message;
     private final String provider;
 
+    /**
+     * Creates a model diagnostic row.
+     *
+     * @param id        model identifier
+     * @param source    source label (registry, builtin, or registry+builtin)
+     * @param path      resolved model path
+     * @param dimension embedding dimension
+     * @param status    availability status
+     * @param message   status detail message, may be null
+     * @param provider  provider type (ONNX or HTTP)
+     */
     public VectorModelInfo(final String id, final String source, final String path, final int dimension,
                            final String status, @Nullable final String message, final String provider) {
         this.id = id;
@@ -48,31 +59,66 @@ public class VectorModelInfo {
         this.provider = provider;
     }
 
+    /**
+     * Returns the model identifier.
+     *
+     * @return model id
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the source label.
+     *
+     * @return source label
+     */
     public String getSource() {
         return source;
     }
 
+    /**
+     * Returns the resolved model path.
+     *
+     * @return model path
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * Returns the embedding dimension.
+     *
+     * @return dimension
+     */
     public int getDimension() {
         return dimension;
     }
 
+    /**
+     * Returns the availability status.
+     *
+     * @return status string
+     */
     public String getStatus() {
         return status;
     }
 
+    /**
+     * Returns the status detail message, if any.
+     *
+     * @return message or null
+     */
     @Nullable
     public String getMessage() {
         return message;
     }
 
+    /**
+     * Returns the provider type.
+     *
+     * @return provider type (ONNX or HTTP)
+     */
     public String getProvider() {
         return provider;
     }

--- a/extensions/vector/src/main/java/org/exist/vector/VectorModelInfo.java
+++ b/extensions/vector/src/main/java/org/exist/vector/VectorModelInfo.java
@@ -1,0 +1,79 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import javax.annotation.Nullable;
+
+/**
+ * Diagnostic row for a configured or built-in vector embedding model.
+ */
+public class VectorModelInfo {
+
+    private final String id;
+    private final String source;
+    private final String path;
+    private final int dimension;
+    private final String status;
+    @Nullable
+    private final String message;
+    private final String provider;
+
+    public VectorModelInfo(final String id, final String source, final String path, final int dimension,
+                           final String status, @Nullable final String message, final String provider) {
+        this.id = id;
+        this.source = source;
+        this.path = path;
+        this.dimension = dimension;
+        this.status = status;
+        this.message = message;
+        this.provider = provider;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public int getDimension() {
+        return dimension;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @Nullable
+    public String getMessage() {
+        return message;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+}

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
@@ -49,6 +49,7 @@ import static org.exist.xquery.modules.vector.VectorModule.functionSignature;
  *   <li>path — resolved configuration path (relative string)</li>
  *   <li>dimension — configured or default dimension</li>
  *   <li>status — "available" | "missing" | "http"</li>
+ *   <li>provider — "ONNX" | "HTTP"</li>
  *   <li>message — optional hint when status != "available"</li>
  * </ul>
  */
@@ -79,6 +80,7 @@ public class Diagnostics extends BasicFunction {
       builder.addAttribute(new QName("path", null, null), model.getPath());
       builder.addAttribute(new QName("dimension", null, null), Integer.toString(model.getDimension()));
       builder.addAttribute(new QName("status", null, null), model.getStatus());
+      builder.addAttribute(new QName("provider", null, null), model.getProvider());
       final String message = model.getMessage();
       if (message != null && !message.isEmpty()) {
         builder.addAttribute(new QName("message", null, null), message);

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
@@ -22,6 +22,8 @@
 package org.exist.xquery.modules.vector;
 
 import org.exist.dom.QName;
+import org.exist.vector.VectorModelDiagnostics;
+import org.exist.vector.VectorModelInfo;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -31,16 +33,9 @@ import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
-import org.exist.xquery.value.StringValue;
-import org.exist.xquery.value.IntegerValue;
-import org.exist.vector.ModelPathResolver;
-import org.exist.vector.ModelRegistry;
-import org.exist.vector.VectorModelConstants;
 
 import javax.annotation.Nullable;
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 import static org.exist.xquery.modules.vector.VectorModule.functionSignature;
 
@@ -74,50 +69,18 @@ public class Diagnostics extends BasicFunction {
   @Override
   public Sequence eval(final Sequence[] args, @Nullable final Sequence contextSequence) {
     final ValueSequence result = new ValueSequence();
-    final ModelRegistry registry = ModelRegistry.getInstance();
-    final Set<String> registryIds = registry.getModelIds();
-    final Set<String> allIds = new HashSet<>(registryIds);
-    allIds.addAll(VectorModelConstants.getKnownModelIds());
-
-    for (final String id : allIds) {
-      String source;
-      if (registryIds.contains(id) && VectorModelConstants.getKnownModelIds().contains(id)) {
-        source = "registry+builtin";
-      } else if (registryIds.contains(id)) {
-        source = "registry";
-      } else {
-        source = "builtin";
-      }
-
-      final ModelRegistry.Resolved resolved = registry.resolve(id, null, VectorModelConstants.getDefaultDimension(id));
-      final String path = resolved.path;
-      final int dim = resolved.dimension;
-
-      String status;
-      String message = "";
-      if (path.startsWith("http://") || path.startsWith("https://")) {
-        status = "http";
-        message = "HTTP/API model; availability depends on remote endpoint and API key configuration.";
-      } else {
-        Path p = ModelPathResolver.resolve(id, path);
-        if (p != null) {
-          status = "available";
-        } else {
-          status = "missing";
-          message = "Model directory not found under exist.home; ensure " + path + " exists with model.onnx and tokenizer.json or adjust conf.xml/vector-field model-path.";
-        }
-      }
-
+    for (final VectorModelInfo model : VectorModelDiagnostics.collectModels()) {
       context.pushDocumentContext();
       final org.exist.dom.memtree.MemTreeBuilder builder = context.getDocumentBuilder();
       builder.startDocument();
       final int nodeNr = builder.startElement(MODEL_QNAME, null);
-      builder.addAttribute(new QName("id", null, null), id);
-      builder.addAttribute(new QName("source", null, null), source);
-      builder.addAttribute(new QName("path", null, null), path);
-      builder.addAttribute(new QName("dimension", null, null), Integer.toString(dim));
-      builder.addAttribute(new QName("status", null, null), status);
-      if (!message.isEmpty()) {
+      builder.addAttribute(new QName("id", null, null), model.getId());
+      builder.addAttribute(new QName("source", null, null), model.getSource());
+      builder.addAttribute(new QName("path", null, null), model.getPath());
+      builder.addAttribute(new QName("dimension", null, null), Integer.toString(model.getDimension()));
+      builder.addAttribute(new QName("status", null, null), model.getStatus());
+      final String message = model.getMessage();
+      if (message != null && !message.isEmpty()) {
         builder.addAttribute(new QName("message", null, null), message);
       }
       builder.endElement();
@@ -129,4 +92,3 @@ public class Diagnostics extends BasicFunction {
     return result;
   }
 }
-

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Diagnostics.java
@@ -49,7 +49,7 @@ import static org.exist.xquery.modules.vector.VectorModule.functionSignature;
  *   <li>path — resolved configuration path (relative string)</li>
  *   <li>dimension — configured or default dimension</li>
  *   <li>status — "available" | "missing" | "http"</li>
- *   <li>provider — "ONNX" | "HTTP"</li>
+ *   <li>provider — "ONNX" | "HTTP" (uppercase by convention)</li>
  *   <li>message — optional hint when status != "available"</li>
  * </ul>
  */

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
@@ -35,6 +35,7 @@ import org.exist.xquery.value.Type;
 import org.exist.vector.VectorEmbeddingProvider;
 import org.exist.vector.VectorEmbeddingService;
 import org.exist.vector.VectorModelConstants;
+import org.exist.storage.vector.VectorOperationMetrics;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -96,7 +97,9 @@ public class Embed extends BasicFunction {
       if (provider == null) {
         throw new XPathException(this, VectorModule.EXVECTOR0001, "Failed to load embedding model: " + model);
       }
+      final long start = System.nanoTime();
       final float[] vec = provider.embed(text, true);
+      VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
       if (vec == null || vec.length == 0) {
         throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result");
       }

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
@@ -105,7 +105,7 @@ public class Embed extends BasicFunction {
         }
         return floatsToArray(vec);
       } finally {
-        VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
+        VectorOperationMetrics.recordEmbed(context, System.nanoTime() - start);
       }
     } catch (final NoClassDefFoundError e) {
       throw new XPathException(this, VectorModule.EXVECTOR0003, "Vector embedding module not available: " + e.getMessage());

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Embed.java
@@ -98,12 +98,15 @@ public class Embed extends BasicFunction {
         throw new XPathException(this, VectorModule.EXVECTOR0001, "Failed to load embedding model: " + model);
       }
       final long start = System.nanoTime();
-      final float[] vec = provider.embed(text, true);
-      VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
-      if (vec == null || vec.length == 0) {
-        throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result");
+      try {
+        final float[] vec = provider.embed(text, true);
+        if (vec == null || vec.length == 0) {
+          throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result");
+        }
+        return floatsToArray(vec);
+      } finally {
+        VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
       }
-      return floatsToArray(vec);
     } catch (final NoClassDefFoundError e) {
       throw new XPathException(this, VectorModule.EXVECTOR0003, "Vector embedding module not available: " + e.getMessage());
     }

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
@@ -36,6 +36,7 @@ import org.exist.xquery.value.Type;
 import org.exist.vector.VectorEmbeddingProvider;
 import org.exist.vector.VectorEmbeddingService;
 import org.exist.vector.VectorModelConstants;
+import org.exist.storage.vector.VectorOperationMetrics;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -108,7 +109,9 @@ public class EmbedBatch extends BasicFunction {
     final List<Sequence> resultArrays = new ArrayList<>();
     for (final SequenceIterator it = textsSeq.iterate(); it.hasNext(); ) {
       final String text = it.nextItem().getStringValue();
+      final long start = System.nanoTime();
       final float[] vec = provider.embed(text, true);
+      VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
       if (vec == null || vec.length == 0) {
         throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result for text: "
             + (text.length() > 50 ? text.substring(0, 50) + "..." : text));

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
@@ -110,13 +110,16 @@ public class EmbedBatch extends BasicFunction {
     for (final SequenceIterator it = textsSeq.iterate(); it.hasNext(); ) {
       final String text = it.nextItem().getStringValue();
       final long start = System.nanoTime();
-      final float[] vec = provider.embed(text, true);
-      VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
-      if (vec == null || vec.length == 0) {
-        throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result for text: "
-            + (text.length() > 50 ? text.substring(0, 50) + "..." : text));
+      try {
+        final float[] vec = provider.embed(text, true);
+        if (vec == null || vec.length == 0) {
+          throw new XPathException(this, VectorModule.EXVECTOR0002, "Embedding returned empty result for text: "
+              + (text.length() > 50 ? text.substring(0, 50) + "..." : text));
+        }
+        resultArrays.add(floatsToArray(vec).toSequence());
+      } finally {
+        VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
       }
-      resultArrays.add(floatsToArray(vec).toSequence());
     }
     return new ArrayType(this, context, resultArrays);
   }

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/EmbedBatch.java
@@ -118,7 +118,7 @@ public class EmbedBatch extends BasicFunction {
         }
         resultArrays.add(floatsToArray(vec).toSequence());
       } finally {
-        VectorOperationMetrics.recordEmbed(System.nanoTime() - start);
+        VectorOperationMetrics.recordEmbed(context, System.nanoTime() - start);
       }
     }
     return new ArrayType(this, context, resultArrays);

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Models.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/Models.java
@@ -21,6 +21,8 @@
  */
 package org.exist.xquery.modules.vector;
 
+import org.exist.vector.VectorModelDiagnostics;
+import org.exist.vector.VectorModelInfo;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -30,8 +32,6 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
-import org.exist.vector.ModelRegistry;
-import org.exist.vector.VectorModelConstants;
 
 import javax.annotation.Nullable;
 
@@ -40,14 +40,7 @@ import static org.exist.xquery.modules.vector.VectorModule.functionSignature;
 /**
  * vector:models() — List embedding model identifiers.
  * <p>
- * Returns (1) models from the {@code <vector-models>} section in conf.xml, plus
- * (2) built-in models with known dimensions (ONNX and HTTP API). To use models
- * not in the built-in list, add them to conf.xml:
- * <pre>
- * &lt;vector-models&gt;
- *   &lt;model id="my-model" path="onnx-models/my-model" dimension="384"/&gt;
- * &lt;/vector-models&gt;
- * </pre>
+ * Returns models from {@link VectorModelDiagnostics} (registry + built-ins).
  */
 public class Models extends BasicFunction {
 
@@ -64,14 +57,8 @@ public class Models extends BasicFunction {
   @Override
   public Sequence eval(final Sequence[] args, @Nullable final Sequence contextSequence) {
     final ValueSequence result = new ValueSequence();
-    final java.util.Set<String> registryIds = ModelRegistry.getInstance().getModelIds();
-    for (final String model : registryIds) {
-      result.add(new StringValue(this, model));
-    }
-    for (final String model : VectorModelConstants.getKnownModelIds()) {
-      if (!registryIds.contains(model)) {
-        result.add(new StringValue(this, model));
-      }
+    for (final VectorModelInfo model : VectorModelDiagnostics.collectModels()) {
+      result.add(new StringValue(this, model.getId()));
     }
     return result;
   }

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
@@ -25,11 +25,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.exist.dom.QName;
+import org.exist.storage.vector.VectorOperationMetrics;
+import org.exist.vector.VectorEmbeddingJmx;
+import org.exist.vector.VectorMetrics;
 import org.exist.xquery.AbstractInternalModule;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
 import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 
@@ -73,6 +78,17 @@ public class VectorModule extends AbstractInternalModule {
 
   public VectorModule(final Map<String, List<? extends Object>> parameters) {
     super(functions, parameters);
+    VectorOperationMetrics.register((operation, durationNanos) -> {
+      switch (operation) {
+        case EMBED -> VectorMetrics.getInstance().recordEmbed(durationNanos);
+        case KNN -> VectorMetrics.getInstance().recordKnnQuery(durationNanos);
+      }
+    });
+  }
+
+  @Override
+  public void prepare(final XQueryContext context) throws XPathException {
+    VectorEmbeddingJmx.registerIfAbsent(context.getBroker().getBrokerPool());
   }
 
   @Override

--- a/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
+++ b/extensions/vector/src/main/java/org/exist/xquery/modules/vector/VectorModule.java
@@ -25,15 +25,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.exist.dom.QName;
-import org.exist.storage.vector.VectorOperationMetrics;
-import org.exist.vector.VectorEmbeddingJmx;
-import org.exist.vector.VectorMetrics;
 import org.exist.xquery.AbstractInternalModule;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
 import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
@@ -78,17 +74,6 @@ public class VectorModule extends AbstractInternalModule {
 
   public VectorModule(final Map<String, List<? extends Object>> parameters) {
     super(functions, parameters);
-    VectorOperationMetrics.register((operation, durationNanos) -> {
-      switch (operation) {
-        case EMBED -> VectorMetrics.getInstance().recordEmbed(durationNanos);
-        case KNN -> VectorMetrics.getInstance().recordKnnQuery(durationNanos);
-      }
-    });
-  }
-
-  @Override
-  public void prepare(final XQueryContext context) throws XPathException {
-    VectorEmbeddingJmx.registerIfAbsent(context.getBroker().getBrokerPool());
   }
 
   @Override

--- a/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
@@ -1,0 +1,60 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.exist.management.impl.VectorEmbedding;
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VectorEmbeddingJmxTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer SERVER = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void registersVectorEmbeddingAtBrokerPoolStartup() throws Exception {
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName query = new ObjectName(VectorEmbedding.getAllInstancesQuery());
+        final Set<ObjectName> names = server.queryNames(query, null);
+        assertFalse("VectorEmbedding MBean should be registered at broker pool startup", names.isEmpty());
+    }
+
+    @Test
+    public void vectorEmbeddingMBeanReportsAvailable() throws Exception {
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName query = new ObjectName(VectorEmbedding.getAllInstancesQuery());
+        final Set<ObjectName> names = server.queryNames(query, null);
+        assertFalse(names.isEmpty());
+        final ObjectName name = names.iterator().next();
+        assertTrue(server.getAttribute(name, "Available").equals(Boolean.TRUE));
+        assertTrue(server.getAttribute(name, "PersistenceBackend").equals("lucene"));
+    }
+}

--- a/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
@@ -56,7 +56,7 @@ public class VectorEmbeddingJmxTest {
         assertFalse(names.isEmpty());
         final ObjectName name = names.iterator().next();
         assertTrue(server.getAttribute(name, "Available").equals(Boolean.TRUE));
-        assertTrue(server.getAttribute(name, "PersistenceBackend").equals("lucene"));
+        assertTrue(server.getAttribute(name, "KnnBackend").equals("lucene"));
     }
 
     @Test

--- a/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorEmbeddingJmxTest.java
@@ -22,6 +22,7 @@
 package org.exist.vector;
 
 import org.exist.management.impl.VectorEmbedding;
+import org.exist.storage.BrokerPool;
 import org.exist.test.ExistEmbeddedServer;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -56,5 +57,21 @@ public class VectorEmbeddingJmxTest {
         final ObjectName name = names.iterator().next();
         assertTrue(server.getAttribute(name, "Available").equals(Boolean.TRUE));
         assertTrue(server.getAttribute(name, "PersistenceBackend").equals("lucene"));
+    }
+
+    @Test
+    public void unregisterAllowsReregistrationAfterBrokerPoolRestart() throws Exception {
+        final BrokerPool pool = SERVER.getBrokerPool();
+        VectorEmbeddingJmx.unregister(pool);
+        VectorEmbeddingJmx.registerIfAbsent(pool);
+
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        final ObjectName query = new ObjectName(VectorEmbedding.getAllInstancesQuery());
+        assertFalse("VectorEmbedding MBean should be present after re-registration", server.queryNames(query, null).isEmpty());
+
+        SERVER.restart();
+
+        assertFalse("VectorEmbedding MBean should be present after broker pool restart",
+                server.queryNames(query, null).isEmpty());
     }
 }

--- a/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
@@ -31,6 +31,7 @@ public class VectorMetricsTest {
     @Test
     public void recordsEmbedAndKnnCounters() {
         final VectorMetrics metrics = VectorMetrics.getInstance();
+        metrics.reset();
         metrics.recordEmbed(100);
         metrics.recordEmbed(200);
         metrics.recordKnnQuery(50);
@@ -41,6 +42,16 @@ public class VectorMetricsTest {
         assertEquals(1, metrics.getKnnQueryCount());
         assertEquals(50, metrics.getKnnTotalTimeNanos());
         assertEquals(50, metrics.getKnnLastTimeNanos());
+    }
+
+    @Test
+    public void resetClearsCounters() {
+        final VectorMetrics metrics = VectorMetrics.getInstance();
+        metrics.recordEmbed(100);
+        metrics.recordKnnQuery(50);
+        metrics.reset();
+        assertEquals(0, metrics.getEmbedCallCount());
+        assertEquals(0, metrics.getKnnQueryCount());
     }
 
     @Test

--- a/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
@@ -21,16 +21,25 @@
  */
 package org.exist.vector;
 
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 public class VectorMetricsTest {
 
+    @After
+    public void tearDown() {
+        VectorMetrics.removeInstance("metrics-a");
+        VectorMetrics.removeInstance("metrics-b");
+        VectorMetrics.removeInstance("metrics-reset");
+    }
+
     @Test
     public void recordsEmbedAndKnnCounters() {
-        final VectorMetrics metrics = VectorMetrics.getInstance();
+        final VectorMetrics metrics = VectorMetrics.forInstance("metrics-reset");
         metrics.reset();
         metrics.recordEmbed(100);
         metrics.recordEmbed(200);
@@ -46,12 +55,29 @@ public class VectorMetricsTest {
 
     @Test
     public void resetClearsCounters() {
-        final VectorMetrics metrics = VectorMetrics.getInstance();
+        final VectorMetrics metrics = VectorMetrics.forInstance("metrics-reset");
         metrics.recordEmbed(100);
         metrics.recordKnnQuery(50);
         metrics.reset();
         assertEquals(0, metrics.getEmbedCallCount());
         assertEquals(0, metrics.getKnnQueryCount());
+    }
+
+    @Test
+    public void instancesAreIsolatedById() {
+        final VectorMetrics first = VectorMetrics.forInstance("metrics-a");
+        final VectorMetrics second = VectorMetrics.forInstance("metrics-b");
+        assertNotSame(first, second);
+
+        first.reset();
+        second.reset();
+        first.recordEmbed(100);
+        second.recordKnnQuery(50);
+
+        assertEquals(1, first.getEmbedCallCount());
+        assertEquals(0, first.getKnnQueryCount());
+        assertEquals(0, second.getEmbedCallCount());
+        assertEquals(1, second.getKnnQueryCount());
     }
 
     @Test

--- a/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorMetricsTest.java
@@ -1,0 +1,52 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VectorMetricsTest {
+
+    @Test
+    public void recordsEmbedAndKnnCounters() {
+        final VectorMetrics metrics = VectorMetrics.getInstance();
+        metrics.recordEmbed(100);
+        metrics.recordEmbed(200);
+        metrics.recordKnnQuery(50);
+
+        assertEquals(2, metrics.getEmbedCallCount());
+        assertEquals(300, metrics.getEmbedTotalTimeNanos());
+        assertEquals(200, metrics.getEmbedLastTimeNanos());
+        assertEquals(1, metrics.getKnnQueryCount());
+        assertEquals(50, metrics.getKnnTotalTimeNanos());
+        assertEquals(50, metrics.getKnnLastTimeNanos());
+    }
+
+    @Test
+    public void collectModelsIncludesBuiltins() {
+        final var models = VectorModelDiagnostics.collectModels();
+        assertTrue(models.size() >= 1);
+        assertTrue(models.stream().anyMatch(model -> model.getId() != null && !model.getId().isEmpty()));
+    }
+}

--- a/extensions/vector/src/test/java/org/exist/vector/VectorModelDiagnosticsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorModelDiagnosticsTest.java
@@ -1,0 +1,73 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.exist.storage.vector.VectorOperationMetrics;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class VectorModelDiagnosticsTest {
+
+    @After
+    public void tearDown() {
+        VectorModelDiagnostics.invalidateCache();
+    }
+
+    @Test
+    public void cachesModelSnapshotWithinTtl() {
+        final var first = VectorModelDiagnostics.collectModels();
+        final var second = VectorModelDiagnostics.collectModels();
+        assertSame(first, second);
+    }
+
+    @Test
+    public void refreshModelsRebuildsSnapshot() {
+        final var first = VectorModelDiagnostics.collectModels();
+        final var refreshed = VectorModelDiagnostics.refreshModels();
+        assertEquals(first.size(), refreshed.size());
+    }
+
+    @Test
+    public void modelCountUsesSingleSnapshot() {
+        final int count = VectorModelDiagnostics.getModelCount();
+        final int ready = VectorModelDiagnostics.getReadyModelCount();
+        assertTrue(count >= ready);
+    }
+
+    @Test
+    public void diagnosticsMatchesModelsFunctionIds() {
+        final Set<String> diagnosticIds = new HashSet<>();
+        for (final VectorModelInfo model : VectorModelDiagnostics.collectModels()) {
+            diagnosticIds.add(model.getId());
+        }
+        final Set<String> registryIds = new HashSet<>(ModelRegistry.getInstance().getModelIds());
+        registryIds.addAll(VectorModelConstants.getKnownModelIds());
+        assertEquals(registryIds, diagnosticIds);
+    }
+}

--- a/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
@@ -21,43 +21,79 @@
  */
 package org.exist.vector;
 
+import org.exist.storage.BrokerPool;
 import org.exist.storage.vector.VectorOperationMetrics;
+import org.exist.test.ExistEmbeddedServer;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class VectorOperationMetricsTest {
 
-    @Before
+    @ClassRule
+    public static final ExistEmbeddedServer SERVER = new ExistEmbeddedServer(true, true);
+
     @After
     public void resetMetrics() {
-        VectorMetrics.getInstance().reset();
-        VectorOperationMetrics.register(null);
+        final String instanceId = SERVER.getBrokerPool().getId();
+        VectorMetrics.forInstance(instanceId).reset();
     }
 
     @Test
     public void bridgeRecordsKnnViaLifecycleHook() {
-        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
-        VectorOperationMetrics.recordKnn(42);
-        assertEquals(1, VectorMetrics.getInstance().getKnnQueryCount());
-        assertEquals(42, VectorMetrics.getInstance().getKnnTotalTimeNanos());
+        final String instanceId = SERVER.getBrokerPool().getId();
+        VectorOperationMetrics.recordKnn(instanceId, 42);
+        assertEquals(1, VectorMetrics.forInstance(instanceId).getKnnQueryCount());
+        assertEquals(42, VectorMetrics.forInstance(instanceId).getKnnTotalTimeNanos());
     }
 
     @Test
     public void bridgeRecordsEmbedViaLifecycleHook() {
-        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
-        VectorOperationMetrics.recordEmbed(99);
-        assertEquals(1, VectorMetrics.getInstance().getEmbedCallCount());
-        assertEquals(99, VectorMetrics.getInstance().getEmbedTotalTimeNanos());
+        final String instanceId = SERVER.getBrokerPool().getId();
+        VectorOperationMetrics.recordEmbed(instanceId, 99);
+        assertEquals(1, VectorMetrics.forInstance(instanceId).getEmbedCallCount());
+        assertEquals(99, VectorMetrics.forInstance(instanceId).getEmbedTotalTimeNanos());
+    }
+
+    @Test
+    public void bridgeRoutesMetricsByInstanceId() {
+        VectorOperationMetrics.register("bridge-a", (operation, durationNanos) -> {
+            switch (operation) {
+                case EMBED -> VectorMetrics.forInstance("bridge-a").recordEmbed(durationNanos);
+                case KNN -> VectorMetrics.forInstance("bridge-a").recordKnnQuery(durationNanos);
+                default -> throw new IllegalStateException("Unsupported vector operation: " + operation);
+            }
+        });
+        VectorOperationMetrics.register("bridge-b", (operation, durationNanos) -> {
+            switch (operation) {
+                case EMBED -> VectorMetrics.forInstance("bridge-b").recordEmbed(durationNanos);
+                case KNN -> VectorMetrics.forInstance("bridge-b").recordKnnQuery(durationNanos);
+                default -> throw new IllegalStateException("Unsupported vector operation: " + operation);
+            }
+        });
+
+        VectorOperationMetrics.recordEmbed("bridge-a", 10);
+        VectorOperationMetrics.recordEmbed("bridge-b", 20);
+
+        assertEquals(10, VectorMetrics.forInstance("bridge-a").getEmbedTotalTimeNanos());
+        assertEquals(20, VectorMetrics.forInstance("bridge-b").getEmbedTotalTimeNanos());
+
+        VectorOperationMetrics.unregister("bridge-a");
+        VectorOperationMetrics.unregister("bridge-b");
+        VectorMetrics.removeInstance("bridge-a");
+        VectorMetrics.removeInstance("bridge-b");
     }
 
     @Test
     public void shutdownHookClearsMetricsBridge() {
-        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
-        VectorExtensionLifecycle.onBrokerPoolShutdown(null);
-        VectorOperationMetrics.recordEmbed(50);
-        assertEquals(0, VectorMetrics.getInstance().getEmbedCallCount());
+        final BrokerPool pool = SERVER.getBrokerPool();
+        final String instanceId = pool.getId();
+        VectorExtensionLifecycle.onBrokerPoolShutdown(pool);
+        VectorOperationMetrics.recordEmbed(instanceId, 50);
+        assertEquals(0, VectorMetrics.forInstance(instanceId).getEmbedCallCount());
+
+        VectorExtensionLifecycle.onBrokerPoolStartSystem(pool);
     }
 }

--- a/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
@@ -52,4 +52,12 @@ public class VectorOperationMetricsTest {
         assertEquals(1, VectorMetrics.getInstance().getEmbedCallCount());
         assertEquals(99, VectorMetrics.getInstance().getEmbedTotalTimeNanos());
     }
+
+    @Test
+    public void shutdownHookClearsMetricsBridge() {
+        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
+        VectorExtensionLifecycle.onBrokerPoolShutdown(null);
+        VectorOperationMetrics.recordEmbed(50);
+        assertEquals(0, VectorMetrics.getInstance().getEmbedCallCount());
+    }
 }

--- a/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
+++ b/extensions/vector/src/test/java/org/exist/vector/VectorOperationMetricsTest.java
@@ -1,0 +1,55 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.vector;
+
+import org.exist.storage.vector.VectorOperationMetrics;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VectorOperationMetricsTest {
+
+    @Before
+    @After
+    public void resetMetrics() {
+        VectorMetrics.getInstance().reset();
+        VectorOperationMetrics.register(null);
+    }
+
+    @Test
+    public void bridgeRecordsKnnViaLifecycleHook() {
+        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
+        VectorOperationMetrics.recordKnn(42);
+        assertEquals(1, VectorMetrics.getInstance().getKnnQueryCount());
+        assertEquals(42, VectorMetrics.getInstance().getKnnTotalTimeNanos());
+    }
+
+    @Test
+    public void bridgeRecordsEmbedViaLifecycleHook() {
+        VectorExtensionLifecycle.onBrokerPoolStartSystem(null);
+        VectorOperationMetrics.recordEmbed(99);
+        assertEquals(1, VectorMetrics.getInstance().getEmbedCallCount());
+        assertEquals(99, VectorMetrics.getInstance().getEmbedTotalTimeNanos());
+    }
+}


### PR DESCRIPTION
Expose VectorStore and VectorEmbedding MBeans for Monex/status monitoring,
including model diagnostics shared with `vector:diagnostics()`. Instrument
embed/KNN workloads via VectorOperationMetrics, add the vector JMX category
to JMXtoXML, and report lucene-vector profiler optimization-level `NONE` when
no vector-field is configured.

see eXist-db/monex#398

