### PR TITLE
[refactor] Rename XMLBackwardsCompatHandler to Saxon12CompatSAXFilter

### DIFF
--- a/exist-core/src/main/java/org/exist/util/Saxon12CompatSAXFilter.java
+++ b/exist-core/src/main/java/org/exist/util/Saxon12CompatSAXFilter.java
@@ -29,19 +29,31 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 
 /**
- * A SAX ContentHandler wrapper that suppresses duplicate startDocument/endDocument calls.
- * Saxon 12's LinkedTreeBuilder does not tolerate receiving startDocument more than once,
- * which can happen when eXist's Serializer sends document events that overlap with
- * explicitly-called startDocument/endDocument in the XSLT compilation pipeline.
+ * A SAX ContentHandler filter that adapts eXist's serializer output to Saxon 12's
+ * stricter SAX expectations. Saxon 12's {@code LinkedTreeBuilder} rejects two patterns
+ * that earlier Saxon versions tolerated:
+ *
+ * <ol>
+ *   <li>Duplicate {@link #startDocument()} calls — emitted when eXist's Serializer
+ *       sends its own document events on top of an explicit {@code startDocument}
+ *       from the XSLT compilation pipeline.</li>
+ *   <li>Namespace declarations for the implicit {@code xml} prefix
+ *       (URI {@code http://www.w3.org/XML/1998/namespace}) — eXist's persistent DOM
+ *       stores these in its namespace mappings, but Saxon 12 treats redeclaring the
+ *       xml namespace as an error.</li>
+ * </ol>
+ *
+ * This filter wraps a delegate handler and silently drops the offending events while
+ * passing everything else through unchanged.
  */
-public class XMLBackwardsCompatHandler implements ContentHandler {
+public class Saxon12CompatSAXFilter implements ContentHandler {
 
-    private static final Logger LOG = LogManager.getLogger(XMLBackwardsCompatHandler.class);
+    private static final Logger LOG = LogManager.getLogger(Saxon12CompatSAXFilter.class);
 
     private final ContentHandler delegate;
     private boolean documentStarted = false;
 
-    public XMLBackwardsCompatHandler(final ContentHandler delegate) {
+    public Saxon12CompatSAXFilter(final ContentHandler delegate) {
         this.delegate = delegate;
     }
 

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.exist.storage.serializers.Serializer;
-import org.exist.util.XMLBackwardsCompatHandler;
+import org.exist.util.Saxon12CompatSAXFilter;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;
@@ -96,7 +96,7 @@ public class EXistDbXMLReader implements XMLReader, Locator {
             // Filter out the implicit xml namespace that eXist's persistent DOM
             // stores in its namespace mappings. Saxon 12 rejects SAX events
             // declaring the XML namespace URI (http://www.w3.org/XML/1998/namespace).
-            final ContentHandler filtered = new XMLBackwardsCompatHandler(this.contentHandler);
+            final ContentHandler filtered = new Saxon12CompatSAXFilter(this.contentHandler);
             serializer.setSAXHandlers(filtered, null);
             serializer.toSAX(source.getDocument());
     

--- a/exist-core/src/main/java/org/exist/xslt/StylesheetResolverAndCompiler.java
+++ b/exist-core/src/main/java/org/exist/xslt/StylesheetResolverAndCompiler.java
@@ -44,7 +44,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
-import org.exist.util.XMLBackwardsCompatHandler;
+import org.exist.util.Saxon12CompatSAXFilter;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Constants;
 import org.xml.sax.ContentHandler;
@@ -160,7 +160,7 @@ public class StylesheetResolverAndCompiler implements Stylesheet {
     // Wrap the handler to suppress duplicate startDocument/endDocument events.
     // Serializer.toSAX() may send its own doc events (depending on GENERATE_DOC_EVENTS),
     // and Saxon 12 does not tolerate duplicate calls.
-    final ContentHandler guard = new XMLBackwardsCompatHandler(handler);
+    final ContentHandler guard = new Saxon12CompatSAXFilter(handler);
 
     final Serializer serializer = broker.borrowSerializer();
     try {


### PR DESCRIPTION
## Summary

Follow-up to #6212 picking up @line-o's [naming suggestion](https://github.com/eXist-db/exist/pull/6212#pullrequestreview-3308xxxxxx) from his approval review:

> *"Maybe the XMLBackwardsCompatHandler can get a more fitting name in the future"*

The original name didn't describe what the class actually does. It isn't about "backwards compatibility" in the XML-version sense — it's a SAX filter that adapts eXist's serializer output to Saxon 12's stricter SAX expectations:

1. Saxon 12's `LinkedTreeBuilder` rejects duplicate `startDocument` events
2. Saxon 12 rejects redeclaring the implicit `xml` namespace prefix

Both patterns occur naturally in eXist's pipeline (Serializer emits its own document events on top of explicit ones; persistent DOM stores xml-namespace mappings) and pre-date Saxon 12. This filter silently drops the offending events while passing everything else through.

## What Changed

| File | Change |
|---|---|
| `exist-core/src/main/java/org/exist/util/XMLBackwardsCompatHandler.java` → `Saxon12CompatSAXFilter.java` | Rename file + class |
| `exist-core/src/main/java/org/exist/util/Saxon12CompatSAXFilter.java` | Expanded Javadoc to name the two Saxon 12 SAX-strictness patterns the filter handles (duplicate startDocument + xml-namespace redeclaration) |
| `exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java` | Updated import + constructor call |
| `exist-core/src/main/java/org/exist/xslt/StylesheetResolverAndCompiler.java` | Updated import + constructor call |

Mechanical rename; behaviour unchanged.

## Test Plan

- [x] `mvn install -pl exist-core -am -DskipTests` — clean
- [x] `mvn test -pl exist-core -Dtest='xquery.xquery3.XQuery3Tests'` — 1030/1030 pass
- [ ] CI on this branch

## Related

- Parent PR: #6212 (Saxon-HE upgrade 9.9 → 12.5)
- Naming suggestion: @line-o's review comment on #6212
