### PR TITLE
[build] update xqts runner dependency to 2.0.0-RC1

### DIFF
--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.exist-db</groupId>
             <artifactId>exist-xqts-runner_2.13</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0-RC1</version>
             <exclusions>
                 <!-- use the exist-core version of this project instead -->
                 <exclusion>


### PR DESCRIPTION
Merging this PR

- [x] fixes the XQTS workflow
- [x] allow us to see the _actual_ XQTS results since all changes since december 2025 are now running in CI
- [x] allow to publish exist-db to maven central as xqts-runner was the last SNAPSHOT dependency

see changes at https://github.com/eXist-db/exist-xqts-runner/releases/tag/2.0.0-RC1