### PR TITLE
[doc][test] Clarify ft:query-vector result ordering + pin down with tests

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java
@@ -58,21 +58,27 @@ public class QueryVector extends BasicFunction {
     private static final FunctionParameterSequenceType FS_PARAM_OPTIONS = optParam("options", Type.ITEM,
             "Optional map with filter-query, filter, facets.");
 
+    private static final String RETURN_DESC =
+            "Nodes matching the vector query. The returned sequence follows XQuery node-sequence semantics; "
+                    + "to rank by similarity, sort explicitly with ft:score, e.g. "
+                    + "'for $h in ft:query-vector(...) order by ft:score($h) descending return $h'.";
+
     final static FunctionSignature[] signatures = {
             functionSignature("query-vector",
-                    "KNN vector search. Returns k nearest nodes. Vector field is resolved from index config.",
-                    returnsOptMany(Type.NODE, "Nodes matching the vector query, ordered by similarity."),
+                    "KNN vector search. Returns the k nodes nearest to the query vector. "
+                            + "Vector field is resolved from index config.",
+                    returnsOptMany(Type.NODE, RETURN_DESC),
                     FS_PARAM_NODES,
                     FS_PARAM_VECTOR),
             functionSignature("query-vector",
                     "KNN vector search with explicit k.",
-                    returnsOptMany(Type.NODE, "Nodes matching the vector query, ordered by similarity."),
+                    returnsOptMany(Type.NODE, RETURN_DESC),
                     FS_PARAM_NODES,
                     FS_PARAM_VECTOR,
                     FS_PARAM_K),
             functionSignature("query-vector",
                     "KNN vector search with k and options (filter-query, filter, facets).",
-                    returnsOptMany(Type.NODE, "Nodes matching the vector query, ordered by similarity."),
+                    returnsOptMany(Type.NODE, RETURN_DESC),
                     FS_PARAM_NODES,
                     FS_PARAM_VECTOR,
                     FS_PARAM_K,

--- a/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
@@ -902,19 +902,28 @@ function vs:dot-product-indexed-and-queried() {
     count(collection($vs:COLLECTION_DOT_PRODUCT)//article[ft:query-field-vector("emb_dot_product", [1.0, 0.0, 0.0, 0.0], 2)])
 };
 
-(:~ similarity="euclidean": score ordering — closer euclidean distance gets higher score. :)
+(:~ similarity="euclidean": score ordering — closer euclidean distance gets higher score.
+ : Explicitly orders by ft:score descending so the test exercises score-based ranking
+ : rather than the default XQuery node-sequence order (see "Result ordering" section below). :)
 declare
     %test:assertTrue
 function vs:euclidean-score-ordering() {
-    let $hits := collection($vs:COLLECTION_EUCLIDEAN)//article[ft:query-field-vector("emb_euclidean", [1.0, 0.0, 0.0, 0.0], 2)]
+    let $hits :=
+        for $h in collection($vs:COLLECTION_EUCLIDEAN)//article[ft:query-field-vector("emb_euclidean", [1.0, 0.0, 0.0, 0.0], 2)]
+        order by ft:score($h) descending
+        return $h
     return count($hits) eq 2 and ft:score($hits[1]) ge ft:score($hits[2])
 };
 
-(:~ similarity="dot_product": score ordering — higher dot product gets higher score. :)
+(:~ similarity="dot_product": score ordering — higher dot product gets higher score.
+ : Explicitly orders by ft:score descending; see vs:euclidean-score-ordering. :)
 declare
     %test:assertTrue
 function vs:dot-product-score-ordering() {
-    let $hits := collection($vs:COLLECTION_DOT_PRODUCT)//article[ft:query-field-vector("emb_dot_product", [1.0, 0.0, 0.0, 0.0], 2)]
+    let $hits :=
+        for $h in collection($vs:COLLECTION_DOT_PRODUCT)//article[ft:query-field-vector("emb_dot_product", [1.0, 0.0, 0.0, 0.0], 2)]
+        order by ft:score($h) descending
+        return $h
     return count($hits) eq 2 and ft:score($hits[1]) ge ft:score($hits[2])
 };
 

--- a/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
@@ -320,6 +320,46 @@ declare variable $vs:COLLECTION_EUCLIDEAN := "/db/" || $vs:COLLECTION_EUCLIDEAN_
 declare variable $vs:COLLECTION_DOT_PRODUCT_NAME := "lucene-test-vector-dot-product";
 declare variable $vs:COLLECTION_DOT_PRODUCT := "/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME;
 
+(:~
+ : Data for result-ordering tests. Article titles A/B/C are deliberately stored
+ : in an order that is NOT the similarity order for query q=[1,0,0,0]:
+ :   A : embedding=[0,0,1,0]      — cosine(A,q) = 0.0   (lowest score)
+ :   B : embedding=[1,0,0,0]      — cosine(B,q) = 1.0   (highest score)
+ :   C : embedding=[0.9,0.1,0,0]  — cosine(C,q) ≈ 0.994 (middle score)
+ : So similarity-ranked order is B, C, A while document order is A, B, C.
+ : Used by the "Result ordering" tests to distinguish XQuery node-sequence
+ : order from explicit ranking via ft:score.
+ :)
+declare variable $vs:DATA_ORDER_SINGLE :=
+    <articles>
+        <article><title>A</title><embedding>0.0 0.0 1.0 0.0</embedding></article>
+        <article><title>B</title><embedding>1.0 0.0 0.0 0.0</embedding></article>
+        <article><title>C</title><embedding>0.9 0.1 0.0 0.0</embedding></article>
+    </articles>;
+declare variable $vs:DATA_ORDER_A :=
+    <article><title>A</title><embedding>0.0 0.0 1.0 0.0</embedding></article>;
+declare variable $vs:DATA_ORDER_B :=
+    <article><title>B</title><embedding>1.0 0.0 0.0 0.0</embedding></article>;
+declare variable $vs:DATA_ORDER_C :=
+    <article><title>C</title><embedding>0.9 0.1 0.0 0.0</embedding></article>;
+
+(:~ Config for result-ordering tests. Uses text encoding for readability. :)
+declare variable $vs:XCONF_ORDER :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="article">
+                    <vector-field name="embedding" expression="embedding" dimension="4" similarity="cosine" encoding="text"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $vs:COLLECTION_ORDER_SINGLE_NAME := "lucene-test-vector-order-single";
+declare variable $vs:COLLECTION_ORDER_SINGLE := "/db/" || $vs:COLLECTION_ORDER_SINGLE_NAME;
+declare variable $vs:COLLECTION_ORDER_MULTI_NAME := "lucene-test-vector-order-multi";
+declare variable $vs:COLLECTION_ORDER_MULTI := "/db/" || $vs:COLLECTION_ORDER_MULTI_NAME;
+
 (:~ Lucene fulltext only — no vector-field (profiler NONE tests). :)
 declare variable $vs:DATA_NO_VECTOR :=
     <articles>
@@ -430,7 +470,21 @@ function vs:setup() {
       xmldb:create-collection("/db", $vs:COLLECTION_NO_VECTOR_NAME),
       xmldb:store($vs:COLLECTION_NO_VECTOR, "test.xml", $vs:DATA_NO_VECTOR),
       xmldb:store("/db/system/config/db/" || $vs:COLLECTION_NO_VECTOR_NAME, "collection.xconf", $vs:XCONF_NO_VECTOR),
-      xmldb:reindex($vs:COLLECTION_NO_VECTOR) )
+      xmldb:reindex($vs:COLLECTION_NO_VECTOR),
+      (: Result-ordering: single-document case (3 articles in one .xml). :)
+      xmldb:create-collection("/db/system/config/db", $vs:COLLECTION_ORDER_SINGLE_NAME),
+      xmldb:create-collection("/db", $vs:COLLECTION_ORDER_SINGLE_NAME),
+      xmldb:store($vs:COLLECTION_ORDER_SINGLE, "test.xml", $vs:DATA_ORDER_SINGLE),
+      xmldb:store("/db/system/config/db/" || $vs:COLLECTION_ORDER_SINGLE_NAME, "collection.xconf", $vs:XCONF_ORDER),
+      xmldb:reindex($vs:COLLECTION_ORDER_SINGLE),
+      (: Result-ordering: multi-document case (3 separate .xml files, stored A then B then C). :)
+      xmldb:create-collection("/db/system/config/db", $vs:COLLECTION_ORDER_MULTI_NAME),
+      xmldb:create-collection("/db", $vs:COLLECTION_ORDER_MULTI_NAME),
+      xmldb:store($vs:COLLECTION_ORDER_MULTI, "a.xml", $vs:DATA_ORDER_A),
+      xmldb:store($vs:COLLECTION_ORDER_MULTI, "b.xml", $vs:DATA_ORDER_B),
+      xmldb:store($vs:COLLECTION_ORDER_MULTI, "c.xml", $vs:DATA_ORDER_C),
+      xmldb:store("/db/system/config/db/" || $vs:COLLECTION_ORDER_MULTI_NAME, "collection.xconf", $vs:XCONF_ORDER),
+      xmldb:reindex($vs:COLLECTION_ORDER_MULTI) )
 };
 
 (:~
@@ -470,7 +524,11 @@ function vs:tearDown() {
     xmldb:remove($vs:COLLECTION_DOT_PRODUCT),
     xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_DOT_PRODUCT_NAME),
     xmldb:remove($vs:COLLECTION_NO_VECTOR),
-    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_NO_VECTOR_NAME)
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_NO_VECTOR_NAME),
+    xmldb:remove($vs:COLLECTION_ORDER_SINGLE),
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_ORDER_SINGLE_NAME),
+    xmldb:remove($vs:COLLECTION_ORDER_MULTI),
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_ORDER_MULTI_NAME)
 };
 
 (:~
@@ -1065,4 +1123,82 @@ declare
     %test:assertEquals(0)
 function vs:unknown-field-vector-short-circuit-empty() {
     count(collection($vs:COLLECTION)//article[ft:query-field-vector("unknown_field", [1.0, 0.0, 0.0, 0.0], 2)])
+};
+
+(: ================================================================
+   Result ordering tests
+
+   ft:query-vector and ft:query-field-vector return an XQuery node
+   sequence. Per the XPath 2.0+ data model, only nodes from the same
+   document have a guaranteed relative order ("document order"); the
+   relative order of nodes from different documents is
+   implementation-defined unless an explicit ordering key is supplied.
+
+   These tests pin down the observable behavior:
+     - With three articles in one document, the default result is in
+       document order (A, B, C) — NOT in similarity order (B, C, A).
+     - With three articles in three separate documents, the default
+       result still contains all three but its order is not similarity
+       order; sorting by ft:score descending produces the expected
+       similarity ranking.
+   See the QueryVector function description for the recommended
+   "for $h in ... order by ft:score($h) descending" idiom.
+   ================================================================ :)
+
+(:~ Single-document case: default order is document order (A, B, C). :)
+declare
+    %test:assertEquals("A", "B", "C")
+function vs:order-single-doc-default-is-document-order() {
+    for $h in collection($vs:COLLECTION_ORDER_SINGLE)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 3)]
+    return $h/title/string()
+};
+
+(:~ Single-document case: explicit `order by ft:score descending` ranks by similarity (B, C, A). :)
+declare
+    %test:assertEquals("B", "C", "A")
+function vs:order-single-doc-sort-by-score-is-similarity-order() {
+    for $h in collection($vs:COLLECTION_ORDER_SINGLE)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 3)]
+    order by ft:score($h) descending
+    return $h/title/string()
+};
+
+(:~ Multi-document case: default order is not similarity order. We assert that
+ : sorting the titles alphabetically recovers all three, which proves the result
+ : set is complete without depending on the implementation-defined inter-document
+ : ordering. :)
+declare
+    %test:assertEquals("A", "B", "C")
+function vs:order-multi-doc-default-contains-all-three() {
+    let $titles :=
+        for $h in collection($vs:COLLECTION_ORDER_MULTI)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 3)]
+        return $h/title/string()
+    for $t in $titles
+    order by $t ascending
+    return $t
+};
+
+(:~ Multi-document case: explicit `order by ft:score descending` ranks by similarity (B, C, A). :)
+declare
+    %test:assertEquals("B", "C", "A")
+function vs:order-multi-doc-sort-by-score-is-similarity-order() {
+    for $h in collection($vs:COLLECTION_ORDER_MULTI)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 3)]
+    order by ft:score($h) descending
+    return $h/title/string()
+};
+
+(:~ ft:query-field-vector parity: single-document case, default is document order. :)
+declare
+    %test:assertEquals("A", "B", "C")
+function vs:order-field-vector-single-doc-default-is-document-order() {
+    for $h in collection($vs:COLLECTION_ORDER_SINGLE)//article[ft:query-field-vector("embedding", [1.0, 0.0, 0.0, 0.0], 3)]
+    return $h/title/string()
+};
+
+(:~ ft:query-field-vector parity: single-document case, `order by ft:score descending` ranks by similarity. :)
+declare
+    %test:assertEquals("B", "C", "A")
+function vs:order-field-vector-single-doc-sort-by-score-is-similarity-order() {
+    for $h in collection($vs:COLLECTION_ORDER_SINGLE)//article[ft:query-field-vector("embedding", [1.0, 0.0, 0.0, 0.0], 3)]
+    order by ft:score($h) descending
+    return $h/title/string()
 };


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

`ft:query-vector`'s function signature has claimed since #6400 that it returns *"Nodes matching the vector query, ordered by similarity."* The first half is correct; the second half is not. `ft:query-vector` returns an XQuery node sequence, so the result follows the [document-order](https://www.w3.org/TR/xquery-31/#dt-document-order) rules of [XQuery 3.1 §2.4](https://www.w3.org/TR/xquery-31/#id-sequence-types): within a single document, nodes are returned in document order; the relative order of nodes from distinct trees is implementation-dependent (but stable) unless an explicit ordering key is supplied. To rank by similarity, callers must use `ft:score` together with an explicit [`order by`](https://www.w3.org/TR/xquery-31/#id-orderby-clause) clause.

This PR makes that explicit in two places:

1. The three `ft:query-vector` signatures now describe the default return shape and alude to the `ft:score` + `order by` idiom in both the per-signature prose and the return-type description. The companion `ft:query-field-vector` (in `QueryFieldVector.java`) already used neutral wording; this PR aligns `ft:query-vector` with it.

2. The XQSuite vector tests gain a "Result ordering" section that pins the behavior down so it can't be lost to a future refactor. Two existing tests that happened to pass without sorting are also tightened.

## What changed

### `extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryVector.java`

- Extracted a shared `RETURN_DESC` constant for the three signatures.
- Replaced *"Nodes matching the vector query, ordered by similarity."* with a description that names XQuery node-sequence semantics and shows the `for $h in ft:query-vector(...) order by ft:score($h) descending return $h` idiom.
- Lightly clarified the per-signature description (no behavior change).

### `extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm`

**Strengthened existing tests** (commit 2 of 3):

- `vs:euclidean-score-ordering` and `vs:dot-product-score-ordering` previously asserted `ft:score($hits[1]) ge ft:score($hits[2])` on a 2-hit set. With `k=2` and two source nodes, the assertion happened to pass because the higher-scoring hit landed first in node-sequence order by coincidence of the particular vectors — not because the test imposed any ordering key. They now sort explicitly with `for $h in ... order by ft:score($h) descending` so the assertion is about score-based ranking rather than node-sequence accident.

**Added six new tests** (commit 3 of 3):

Test data: three articles with embeddings chosen so that storage order ≠ similarity order for query `q=[1,0,0,0]`:

| Title | Embedding         | cosine(., q) |
|-------|-------------------|--------------|
| A     | `[0, 0, 1, 0]`    | 0.000        |
| B     | `[1, 0, 0, 0]`    | 1.000        |
| C     | `[0.9, 0.1, 0, 0]`| ~0.994       |

So document order is A, B, C and similarity order is B, C, A.

Two collections cover the two shapes the data model distinguishes:

- `COLLECTION_ORDER_SINGLE` — 3 articles in one document.
- `COLLECTION_ORDER_MULTI`  — 3 articles, one per document (`a.xml`, `b.xml`, `c.xml`).

Six new XQSuite tests:

| Test                                                                  | Asserts            |
|-----------------------------------------------------------------------|--------------------|
| `vs:order-single-doc-default-is-document-order`                       | `("A", "B", "C")`  |
| `vs:order-single-doc-sort-by-score-is-similarity-order`               | `("B", "C", "A")`  |
| `vs:order-multi-doc-default-contains-all-three`                       | `("A", "B", "C")` (sorted alphabetically) |
| `vs:order-multi-doc-sort-by-score-is-similarity-order`                | `("B", "C", "A")`  |
| `vs:order-field-vector-single-doc-default-is-document-order`          | `("A", "B", "C")`  |
| `vs:order-field-vector-single-doc-sort-by-score-is-similarity-order`  | `("B", "C", "A")`  |

The multi-document "default" test deliberately re-sorts the titles alphabetically before asserting, so it does *not* depend on the implementation-defined inter-document ordering — it only proves the result set is complete. Its sibling "sort by score" test pins down the ranking.

## Why now

Surfaced while testing monex PR #398 against develop after #6400 merged. Three semantically distinct prompts against three short articles all returned hits in storage order; assumed the function was bypassing the index, then realised after consulting the docs (`~/workspace/documentation/src/main/xar-resources/data/lucene/lucene.xml`) and re-checking JMX (`VectorStore.EntryCount` ≥ 3, `KnnQueryCount` increments) that cosine similarity is fully implemented and correctly scored — the score order just isn't preserved in the returned sequence. Easy to miss; worth pinning down.

## Spec references

- [XQuery 3.1 §2.4 Document Order](https://www.w3.org/TR/xquery-31/#dt-document-order): "The relative order of nodes in distinct trees is implementation-dependent but stable..."
- [XQuery 3.1 §3.12.7 Order By and Return Clauses](https://www.w3.org/TR/xquery-31/#id-orderby-clause)

## Test plan

- [x] `mvn test -pl extensions/indexes/lucene -Dtest=VectorSearchTests -DfailIfNoTests=false -Denforcer.skip=true -Ddependency-check.skip=true -Ddocker=false` → 73 tests, 0 failures, 0 errors, 6 skipped
- [ ] Full unit test suite (`mvn test -pl extensions/indexes/lucene`) on CI
- [x] Manual smoke against a live container (`existdb-develop` on localhost:8081) with all three contrastive prompts confirming the documented sort idiom works

## Follow-up (separate PR against `documentation`)

The lucene docs (`src/main/xar-resources/data/lucene/lucene.xml`, line 729-731) carry the softer claim *"The functions return the k most similar nodes, where a higher score means more similar."* It should likewise be extended to spell out the `ft:score` + `order by` step. Tracking separately so this PR stays scoped to the `eXist-db/exist` repo.
