### PR TITLE
[refactor] fn:json-doc: tidy imports in dynamic-resource block

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -39,8 +39,10 @@ import org.exist.xquery.value.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.file.Path;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.isReadable;
 import static java.nio.file.Files.newInputStream;
 
@@ -229,8 +231,7 @@ public class JSON extends BasicFunction {
             String url = href.getStringValue();
 
             // Check dynamically available text resources first (XQTS runner registers these)
-            try (final java.io.Reader dynReader = context.getDynamicallyAvailableTextResource(
-                    url, java.nio.charset.StandardCharsets.UTF_8)) {
+            try (final Reader dynReader = context.getDynamicallyAvailableTextResource(url, UTF_8)) {
                 if (dynReader != null) {
                     final StringBuilder sb = new StringBuilder();
                     final char[] buf = new char[4096];


### PR DESCRIPTION
## Summary

- Tidy the imports in the `fn:json-doc` dynamic-resource block: use `import java.io.Reader` and `import static java.nio.charset.StandardCharsets.UTF_8` instead of fully-qualified names.
- No behavior change — a small readability follow-up.

## Background

PR #6261 originally added the dynamic-text-resource lookup to `fn:json-doc`. While that PR sat waiting for a rebase, the same feature was independently merged via 26b8baac3a (with FQNs). #6261 has now been closed as superseded. This PR picks up @reinhapa's only remaining suggestion from #6261 (static import for `UTF_8`) and applies it to the merged code.

## Test plan

- [x] `mvn compile -pl exist-core -am` succeeds.
- [ ] CI green.

[This response was co-authored with Claude Code. -Joe]
