### PR TITLE
[bugfix] RootNode: declare CONTEXT_ITEM dependency

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/RootNode.java
+++ b/exist-core/src/main/java/org/exist/xquery/RootNode.java
@@ -54,6 +54,20 @@ public class RootNode extends Step {
         super(context, Constants.SELF_AXIS);
     }
 
+    @Override
+    public int getDependencies() {
+        // Declare CONTEXT_ITEM so the optimizer does not hoist predicates
+        // containing only / out of their iteration context. The default
+        // (CONTEXT_SET) is not enough on its own — the predicate optimizer
+        // looks at CONTEXT_ITEM to decide whether a sub-expression can be
+        // evaluated once outside the iteration. Without this override an
+        // expression like fn:count(.[5 * /]) is evaluated with no context
+        // item, falls through to getStaticallyKnownDocuments(), and returns
+        // arbitrary content from the static-context default (which under
+        // admin includes /db/system).
+        return Dependency.CONTEXT_ITEM | Dependency.CONTEXT_SET;
+    }
+
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);       

--- a/exist-core/src/test/java/org/exist/xquery/RootNodeContextItemDependencyTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/RootNodeContextItemDependencyTest.java
@@ -1,0 +1,97 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for RootNode dependency declaration.
+ *
+ * <p>{@link RootNode} represents the lone-slash root-step ({@code /}). Without
+ * declaring {@link Dependency#CONTEXT_ITEM} the optimizer's predicate hoister
+ * treats expressions containing only {@code /} as context-independent and
+ * evaluates them once outside the iteration context. With no context item to
+ * resolve against, {@code RootNode.eval} falls through to the static-context
+ * default (all statically known documents) and returns whatever the broker is
+ * allowed to see — including {@code /db/system/security} content for admin
+ * users.</p>
+ *
+ * <p>These XPath cases come from W3C qt3tests {@code prod-PathExpr/PathExpr-1},
+ * {@code -2}, {@code -15} (Nicolae Brinza, 2009): "Leading lone slash syntax
+ * constraints". Per the spec, with the bid element as context item, {@code /}
+ * resolves to its document node; arithmetic produces a single numeric value;
+ * the positional predicate has no match; count is zero.</p>
+ */
+public class RootNodeContextItemDependencyTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /**
+     * {@code 5 * /} inside a positional predicate. With proper context flow,
+     * {@code /} resolves to the bid element's owner document (single item),
+     * {@code 5 * <bid>23</bid>} atomizes to {@code 5 * 23 = 115}, and the
+     * positional predicate {@code [115]} matches nothing.
+     */
+    @Test
+    public void loneSlashInArithmeticPredicate_multiplyOnRight() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $ctx := document { <bid>23</bid> }/bid return fn:count($ctx[5 * /])");
+        assertEquals(1, result.getSize());
+        assertEquals("0", result.getResource(0).getContent());
+    }
+
+    /**
+     * Mirror of the above with the operands swapped — {@code (/) * 5}.
+     */
+    @Test
+    public void loneSlashInArithmeticPredicate_multiplyOnLeft() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $ctx := document { <bid>23</bid> }/bid return fn:count($ctx[(/) * 5])");
+        assertEquals(1, result.getSize());
+        assertEquals("0", result.getResource(0).getContent());
+    }
+
+    /**
+     * Without the dependency fix, {@code /} in a hoisted predicate falls
+     * through to the static-context default — for an admin-level broker
+     * (the default in this test setup), that historically included
+     * {@code /db/system/security/exist/accounts/admin.xml}. Confirm the
+     * single-item document-node return path, not the multi-doc fallback,
+     * is the one that runs.
+     */
+    @Test
+    public void loneSlashInPredicate_resolvesToSingleOwnerDocument() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                "let $ctx := document { <bid>23</bid> }/bid " +
+                "return fn:count($ctx[fn:count(/) eq 1])");
+        assertEquals(1, result.getSize());
+        assertEquals("1", result.getResource(0).getContent());
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/RootNodeContextItemDependencyTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/RootNodeContextItemDependencyTest.java
@@ -60,7 +60,7 @@ public class RootNodeContextItemDependencyTest {
      * positional predicate {@code [115]} matches nothing.
      */
     @Test
-    public void loneSlashInArithmeticPredicate_multiplyOnRight() throws XMLDBException {
+    public void loneSlashInArithmeticPredicateMultiplyOnRight() throws XMLDBException {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $ctx := document { <bid>23</bid> }/bid return fn:count($ctx[5 * /])");
         assertEquals(1, result.getSize());
@@ -71,7 +71,7 @@ public class RootNodeContextItemDependencyTest {
      * Mirror of the above with the operands swapped — {@code (/) * 5}.
      */
     @Test
-    public void loneSlashInArithmeticPredicate_multiplyOnLeft() throws XMLDBException {
+    public void loneSlashInArithmeticPredicateMultiplyOnLeft() throws XMLDBException {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $ctx := document { <bid>23</bid> }/bid return fn:count($ctx[(/) * 5])");
         assertEquals(1, result.getSize());
@@ -87,7 +87,7 @@ public class RootNodeContextItemDependencyTest {
      * is the one that runs.
      */
     @Test
-    public void loneSlashInPredicate_resolvesToSingleOwnerDocument() throws XMLDBException {
+    public void loneSlashInPredicateResolvesToSingleOwnerDocument() throws XMLDBException {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $ctx := document { <bid>23</bid> }/bid " +
                 "return fn:count($ctx[fn:count(/) eq 1])");


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

A one-line dependency-declaration fix in `RootNode` (the lone-slash root step `/`), plus a regression test. Without this, the optimizer's predicate hoister treats predicates whose only context-dependent leaf is `/` as context-independent and evaluates them once outside the iteration. With no context item to resolve against, `RootNode.eval` falls through to the static-context default branch (`getStaticallyKnownDocuments()`), which returns every XML resource the broker can read. Under admin that includes content from `/db/system/security/`, which then atomizes to multiple untypedAtomics and breaks arithmetic in the predicate.

Surfaced while preparing the exist-xqts-runner "assertion fixes only" PR ([eXist-db/exist-xqts-runner#61](https://github.com/eXist-db/exist-xqts-runner/pull/61)), where commit 5 changes the runner's embedded server connection from `getBroker()` to `authenticate("admin", "")` — that change is a prerequisite for the in-flight EXPath File built-in PR (#6257). The runner change unblocks #6257; this fix removes the seven XQTS-HEAD regressions admin-context introduced.

## The fix

```diff
+    @Override
+    public int getDependencies() {
+        // Declare CONTEXT_ITEM so the optimizer does not hoist predicates
+        // containing only / out of their iteration context.
+        return Dependency.CONTEXT_ITEM | Dependency.CONTEXT_SET;
+    }
```

`RootNode` extends `Step` extends `AbstractExpression`, which returns `Dependency.DEFAULT_DEPENDENCIES = CONTEXT_SET`. The default isn't enough: the optimizer's predicate hoister looks at `CONTEXT_ITEM` specifically to decide whether a sub-expression can be evaluated once outside the iteration. `/` evaluation depends on the context item to resolve the owner document, so the override is the correct dependency declaration.

`RootNode.eval` is unchanged. Top-level `/` in queries with no `fn:doc()` still falls through to the static-context default in its no-context cases, so the long-standing "absolute path without fn:doc" eXist convention is preserved for legitimate uses (e.g. `//foo` at the top of a query).

## What it fixes

Per a measured before/after on XQTS HEAD against current `develop`, with two builds of exist-xqts-runner that differ only in broker authentication (guest vs admin):

| Test set | Test case | Without fix (admin) | With fix (admin) |
|---|---|---|---|
| `prod-PathExpr` | `PathExpr-1` | XPTY0004 "Too many operands at the right of *" | pass |
| `prod-PathExpr` | `PathExpr-2` | XPTY0004 | pass |
| `prod-PathExpr` | `PathExpr-15` | XPTY0004 | pass |
| `prod-StepExpr` | `Steps-leading-lone-slash-15` | XPTY0004 | pass |
| `prod-StepExpr` | `Steps-leading-lone-slash-17` | XPTY0004 | pass |
| `prod-StepExpr` | `Steps-leading-lone-slash-1a` | XPTY0004 | pass |

All six are "leading lone slash" XPath syntax-constraint tests from Nicolae Brinza's 2009 contributions, of the shape `fn:count(.[5 * /])` over a single-element document. The expected behavior per the spec, with the bid element as context item, is: `/` resolves to its owner document (single item), arithmetic produces a single numeric value, the positional predicate has no match, count is zero.

These tests pass under guest only because the static-context fallback returns the empty sequence there (guest can't read system collections). The fix removes the dependency on that accidental coincidence.

## The diagnosis trail

Instrumenting `OpNumeric.eval` with one `System.err.println` of the operands made the issue obvious:

```
Admin: op=* user=admin lcount=1 rcount=3 ctxSeq=null ctxItem=null
       rseq[0] type=xs:untypedAtomic val=/authentication/login
       rseq[1] type=xs:untypedAtomic val={RIPEMD160}<hash>
       rseq[2] type=xs:untypedAtomic val={RIPEMD160}<hash>

Guest: op=* user=guest lcount=1 rcount=0 ctxSeq=null ctxItem=null
```

`ctxItem=null` in both cases is the smoking gun: the predicate isn't being iterated per-item. The 3-item `rseq` under admin is `admin.xml` atomized through the static-doc fallback. The cause is the missing `CONTEXT_ITEM` dependency on `RootNode`.

The "all documents in scope under admin" behavior of `RootNode.eval` is a vendor-specific static-context default that the XPath 3.1 spec permits (§2.1.1 — static context can define a default context item). What's *not* permitted is the optimizer mistaking a context-dependent expression for a context-independent one; that's the actual bug.

## Test plan

- [x] New JUnit regression test `RootNodeContextItemDependencyTest` covers three positive cases that all pass with the fix and (2 of 3) error without it. The test uses an in-memory `<bid>23</bid>` document bound via `let $ctx := document {...}/bid` and exercises `fn:count($ctx[5 * /])`, `fn:count($ctx[(/) * 5])`, and `fn:count($ctx[fn:count(/) eq 1])`.
- [x] `mvn test -pl exist-core` — 6,592 tests, 0 failures, 0 errors, 106 skipped, 3:39 wall.
- [x] XQTS HEAD with the runner's admin-auth change applied: net effect is **+6 passes** (the six lone-slash tests above flipping from fail to pass), 0 regressions.

## Related

- exist-xqts-runner PR #61 — the upstream where admin auth first surfaces this (link will be updated once that PR is open)
- #6257 — EXPath File built-in extension, which requires admin context to operate; this fix is the precondition for shipping that.
