### PR TITLE
[hotfix] null guard for JMX

### DIFF
--- a/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
@@ -36,6 +36,7 @@ import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpoint;
 import jakarta.websocket.server.ServerEndpointConfig;
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -88,6 +89,7 @@ public class EvalWebSocketEndpoint {
             queryExecutorService.shutdown();
             queryExecutorService = null;
         }
+        sessions.clear();
     }
 
     /**
@@ -216,14 +218,16 @@ public class EvalWebSocketEndpoint {
 
     @OnError
     public void onError(final Session session, final Throwable error) {
-        if (error.getMessage() != null && error.getMessage().contains("Text message size")) {
-            LOG.warn("WebSocket message exceeds {}MB buffer limit: {}", MAX_TEXT_MESSAGE_SIZE / (1024 * 1024), error.getMessage());
-        } else {
-            LOG.warn("WebSocket eval error: {}", error.getMessage(), error);
-        }
         final EvalSession evalSession = sessions.remove(session);
         if (evalSession != null) {
             evalSession.cancelAll();
+        }
+        if (error instanceof ClosedChannelException) {
+            LOG.debug("WebSocket eval client disconnected abruptly: session {}", session.getId());
+        } else if (error.getMessage() != null && error.getMessage().contains("Text message size")) {
+            LOG.warn("WebSocket message exceeds {}MB buffer limit: {}", MAX_TEXT_MESSAGE_SIZE / (1024 * 1024), error.getMessage());
+        } else {
+            LOG.warn("WebSocket eval error: {}", error.getMessage(), error);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
@@ -308,6 +308,9 @@ public class JMXtoXML {
 
             for (final String category : categories) {
                 final ObjectName[] names = CATEGORIES.get(category);
+                if (names == null) {
+                    continue;
+                }
                 for (final ObjectName name : names) {
                     queryMBeans(builder, name);
                 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/websocket/WebSocketEndpoint.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/websocket/WebSocketEndpoint.java
@@ -35,7 +35,8 @@ import jakarta.websocket.*;
 import jakarta.websocket.server.ServerEndpoint;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Iterator;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -63,6 +64,7 @@ public class WebSocketEndpoint {
     private static final Logger LOG = LogManager.getLogger(WebSocketEndpoint.class);
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
     private static final Map<Session, String> sessions = new ConcurrentHashMap<>();
+    private static final ByteBuffer PING_PAYLOAD = ByteBuffer.allocate(0);
 
     private static volatile boolean initialized = false;
     private static ScheduledExecutorService heartbeatService = null;
@@ -109,19 +111,29 @@ public class WebSocketEndpoint {
                 monitorService.shutdown();
                 monitorService = null;
             }
+            sessions.clear();
             initialized = false;
         }
     }
 
     @OnOpen
     public void openSession(final Session session) {
-        session.setMaxIdleTimeout(10000);
         sessions.put(session, DEFAULT_CHANNEL);
     }
 
     @OnClose
     public void closeSession(final Session session, final CloseReason closeReason) {
         sessions.remove(session);
+    }
+
+    @OnError
+    public void onError(final Session session, final Throwable throwable) {
+        sessions.remove(session);
+        if (throwable instanceof ClosedChannelException) {
+            LOG.debug("WebSocket client disconnected abruptly: session {}", session.getId());
+        } else {
+            LOG.warn("WebSocket error on session {}: {}", session.getId(), throwable.getMessage(), throwable);
+        }
     }
 
     @OnMessage
@@ -142,7 +154,16 @@ public class WebSocketEndpoint {
     }
 
     static void pingAll() {
-        sendAll(null, "ping");
+        for (final Session session : sessions.keySet()) {
+            try {
+                session.getBasicRemote().sendPing(PING_PAYLOAD.duplicate());
+            } catch (final ClosedChannelException e) {
+                sessions.remove(session);
+            } catch (final IOException e) {
+                LOG.debug("Ping failed, removing session {}: {}", session.getId(), e.getMessage());
+                sessions.remove(session);
+            }
+        }
     }
 
     /**
@@ -161,6 +182,8 @@ public class WebSocketEndpoint {
                     switch (entry.getValue()) {
                         case String s -> gen.writeStringField(key, s);
                         case Integer i -> gen.writeNumberField(key, i);
+                        case Long l -> gen.writeNumberField(key, l);
+                        case Double d -> gen.writeNumberField(key, d);
                         case Boolean b -> gen.writeBooleanField(key, b);
                         case null -> gen.writeNullField(key);
                         default -> gen.writeStringField(key, entry.getValue().toString());
@@ -181,18 +204,16 @@ public class WebSocketEndpoint {
      * @param message the message text
      */
     public static void sendAll(final String toChannel, final String message) {
-        final Iterator<Map.Entry<Session, String>> iterator = sessions.entrySet().iterator();
-        while (iterator.hasNext()) {
-            try {
-                final Map.Entry<Session, String> entry = iterator.next();
-                final Session session = entry.getKey();
-                final String channel = entry.getValue();
-
-                if (toChannel == null || (!channel.equals(DEFAULT_CHANNEL) && toChannel.equals(channel))) {
+        for (final Map.Entry<Session, String> entry : sessions.entrySet()) {
+            final Session session = entry.getKey();
+            final String channel = entry.getValue();
+            if (toChannel == null || (!channel.equals(DEFAULT_CHANNEL) && toChannel.equals(channel))) {
+                try {
                     session.getBasicRemote().sendText(message);
+                } catch (final IOException e) {
+                    LOG.debug("Removing disconnected WebSocket session: {}", e.getMessage());
+                    sessions.remove(session);
                 }
-            } catch (final IOException e) {
-                LOG.error("Error sending message via websocket: {}", e.getMessage(), e);
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -1047,28 +1047,23 @@ public class EvalWebSocketEndpointTest {
         final Session monitorSession = container.connectToServer(new Endpoint() {
             @Override
             public void onOpen(final Session session, final EndpointConfig config) {
+                try {
+                    session.getBasicRemote().sendText("{\"channel\": \"_monitor\"}");
+                    subscribedLatch.countDown();
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
-                    private boolean subscribed = false;
                     @Override
                     public void onMessage(final String message) {
-                        if (!subscribed && "ping".equals(message)) {
-                            try {
-                                session.getBasicRemote().sendText("{\"channel\": \"_monitor\"}");
-                                subscribed = true;
-                                subscribedLatch.countDown();
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
+                        try {
+                            final Map<String, Object> parsed = parseJson(message);
+                            if ("monitor".equals(parsed.get("type"))) {
+                                monitorMessages.add(parsed);
+                                monitorEventLatch.countDown();
                             }
-                        } else if (subscribed && !"ping".equals(message)) {
-                            try {
-                                final Map<String, Object> parsed = parseJson(message);
-                                if ("monitor".equals(parsed.get("type"))) {
-                                    monitorMessages.add(parsed);
-                                    monitorEventLatch.countDown();
-                                }
-                            } catch (final IOException e) {
-                                // ignore parse errors for pings etc.
-                            }
+                        } catch (final IOException e) {
+                            // ignore non-JSON frames
                         }
                     }
                 });

--- a/exist-core/src/test/java/org/exist/xquery/functions/websocket/WebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/websocket/WebSocketEndpointTest.java
@@ -45,31 +45,23 @@ public class WebSocketEndpointTest {
     public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
 
     @Test
-    public void connectAndReceiveHeartbeat() throws Exception {
+    public void connectAndHeartbeatKeepsSessionOpen() throws Exception {
         final int port = existWebServer.getPort();
         final URI wsUri = new URI("ws://localhost:" + port + "/ws");
-
-        final CountDownLatch messageLatch = new CountDownLatch(1);
-        final AtomicReference<String> receivedMessage = new AtomicReference<>();
 
         final WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         final Session session = container.connectToServer(new Endpoint() {
             @Override
             public void onOpen(final Session session, final EndpointConfig config) {
-                session.addMessageHandler(new MessageHandler.Whole<String>() {
-                    @Override
-                    public void onMessage(final String message) {
-                        receivedMessage.set(message);
-                        messageLatch.countDown();
-                    }
-                });
             }
         }, ClientEndpointConfig.Builder.create().build(), wsUri);
 
         try {
-            // should receive a heartbeat ping within 1 second
-            assertTrue("Should receive a message within 2s", messageLatch.await(2, TimeUnit.SECONDS));
-            assertEquals("ping", receivedMessage.get());
+            // The heartbeat sends WebSocket PING control frames every 500ms.
+            // They are handled transparently by the WS layer and do not fire onMessage.
+            // The observable effect is that the session stays open.
+            Thread.sleep(1500);
+            assertTrue("Session should remain open after heartbeat interval", session.isOpen());
         } finally {
             session.close();
         }
@@ -88,24 +80,17 @@ public class WebSocketEndpointTest {
         final Session session = container.connectToServer(new Endpoint() {
             @Override
             public void onOpen(final Session session, final EndpointConfig config) {
+                try {
+                    session.getBasicRemote().sendText("{\"channel\": \"test-channel\"}");
+                    subscribedLatch.countDown();
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
                 session.addMessageHandler(new MessageHandler.Whole<String>() {
-                    private boolean subscribed = false;
-
                     @Override
                     public void onMessage(final String message) {
-                        if (!subscribed && "ping".equals(message)) {
-                            // after first ping, subscribe to a channel
-                            try {
-                                session.getBasicRemote().sendText("{\"channel\": \"test-channel\"}");
-                                subscribed = true;
-                                subscribedLatch.countDown();
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
-                            }
-                        } else if (subscribed && !"ping".equals(message)) {
-                            receivedMessage.set(message);
-                            messageLatch.countDown();
-                        }
+                        receivedMessage.set(message);
+                        messageLatch.countDown();
                     }
                 });
             }
@@ -141,19 +126,12 @@ public class WebSocketEndpointTest {
         final Session session = container.connectToServer(new Endpoint() {
             @Override
             public void onOpen(final Session session, final EndpointConfig config) {
-                session.addMessageHandler(new MessageHandler.Whole<String>() {
-                    @Override
-                    public void onMessage(final String message) {
-                        if ("ping".equals(message)) {
-                            try {
-                                session.getBasicRemote().sendText("{\"channel\": \"count-test\"}");
-                                subscribedLatch.countDown();
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
-                            }
-                        }
-                    }
-                });
+                try {
+                    session.getBasicRemote().sendText("{\"channel\": \"count-test\"}");
+                    subscribedLatch.countDown();
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }, ClientEndpointConfig.Builder.create().build(), wsUri);
 


### PR DESCRIPTION
Two small fixes revealed by testing all new apps together. 

Non-vector instances shouldn't experience monex induced NPE warnings

eXide should handle web socket sessions more gracefully

see eXist-db/monex#398
see eXist-db/eXide#794

