### PR TITLE
[bugfix] make sure that in both jansi related JAR files the Mac native code are signed

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -222,7 +222,7 @@
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
             <version>4.1.3</version>
-            <classifier>jdk11</classifier>
+            <classifier>${jline.classifier}</classifier>
         </dependency>
 
         <dependency>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1027,6 +1027,7 @@
                                         <argument>${jansi.version}</argument>
                                         <argument>${project.build.directory}/jansi-native</argument>
                                         <argument>${mac.codesign.identity}</argument>
+                                        <argument>${jline.classifier}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
+++ b/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
@@ -37,37 +37,45 @@
 # $2 is the jansi version
 # $3 is temp work directory
 # $4 the mac codesign identity
+# $5 is the jline classifier (e.g. jdk11)
 
 
 set -e
 #set -x  ## enable to help debug
 
-# ensure a clean temp work directory
-if [ -d "${3}/org" ]
-then
-  rm -rf "${3}/org"
-fi
-
-# for each native arch
-archs=('arm64' 'x86' 'x86_64')
-for arch in ${archs[@]}
+# for each jar file
+for jar in "${1}/jansi-${2}.jar" "${1}/jline-${2}-${5}.jar"
 do
-  # create the temp output dirs
-  mkdir -p "${3}/org/jline/nativ/Mac/${arch}"
+  # ensure a clean temp work directory for each jar
+  if [ -d "${3}/org" ]
+  then
+    rm -rf "${3}/org"
+  fi
 
-  # switch to temp output dir
-  pushd "${3}"
+  # for each native arch
+  archs=('arm64' 'x86' 'x86_64')
+  for arch in "${archs[@]}"
+  do
+    # create the temp output dirs
+    mkdir -p "${3}/org/jline/nativ/Mac/${arch}"
 
-  # extract the native files
-  jar -xf "${1}/jansi-${2}.jar" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # switch to temp output dir
+    pushd "${3}"
 
-  # test if the file is unsigned, and sign if needed
-  /usr/bin/codesign --verbose --test-requirement="=anchor trusted" --verify "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib" || /usr/bin/codesign --verbose --force --timestamp --sign "${4}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # extract the native files
+    jar -xf "${jar}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
-  # overwrite the file in the jar
-  jar -uf "${1}/jansi-${2}.jar" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # test if the file is unsigned, and sign if needed
+    /usr/bin/codesign --verbose --test-requirement="=anchor trusted" \
+                      --verify "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib" || \
+                      /usr/bin/codesign --verbose --force --timestamp --sign "${4}" \
+                      "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
-  # switch back from temp output dir
-  popd
+    # overwrite the file in the jar
+    jar -uf "${jar}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
+    # switch back from temp output dir
+    popd
+
+  done
 done

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -125,6 +125,7 @@
         <icu.version>76.1</icu.version>
         <izpack.version>5.2.5</izpack.version>
         <jansi.version>4.1.3</jansi.version>
+        <jline.classifier>jdk11</jline.classifier>
         <jaxb.api.version>4.0.5</jaxb.api.version>
         <jaxb.impl.version>4.0.2</jaxb.impl.version>
         <eclipse.angus-activation.version>2.0.3</eclipse.angus-activation.version>


### PR DESCRIPTION
Make sure that in both jansi related JAR files the Mac native code are signed.

```
mvn clean install -DskipTests -Pcodesign-mac-app 
```

gives the following error

```
[ERROR] test-requirement: code failed to satisfy specified code requirement(s)
[ERROR] Developer ID Application: Evolved Binary Ltd: no identity found
[ERROR] Command execution failed.
```

1. what is the purpose - is it needed at al?
2. why is EB there :-)

<img width="2118" height="404" alt="image" src="https://github.com/user-attachments/assets/96b0311b-d2c4-4696-9e92-9ca8c83dc8ba" />
