### PR TITLE
[bugfix] AbstractDateTimeValue: allow subtype comparisons (closes #5478)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -397,7 +397,16 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
     }
 
     public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-        if (other.getType() == getType()) {
+        // Allow comparison when one type is a subtype of the other within the
+        // date/time hierarchy — e.g. xs:dateTime ↔ xs:dateTimeStamp per XSD 1.1
+        // §3.4.28, where xs:dateTimeStamp is a restriction of xs:dateTime.
+        // The underlying calendar comparison is correct for both, so a strict
+        // primitive-type equality check rejects valid comparisons. The
+        // AbstractDateTimeValue instance-check keeps this restricted to the
+        // date/time family (no accidental cross-comparison with, say, durations).
+        if (other instanceof AbstractDateTimeValue
+                && (Type.subTypeOf(getType(), other.getType())
+                        || Type.subTypeOf(other.getType(), getType()))) {
             // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
             final int r = getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
             if (r == DatatypeConstants.INDETERMINATE) {

--- a/exist-core/src/test/java/org/exist/xquery/value/DateTimeSubtypeCompareTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/DateTimeSubtypeCompareTest.java
@@ -28,6 +28,8 @@ import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Regression test for the date/time-family subtype comparison fix.
@@ -80,10 +82,10 @@ public class DateTimeSubtypeCompareTest {
                 "xs:date('2024-01-01') eq xs:time('12:00:00')";
         try {
             final ResourceSet rs = embedded.executeQuery(query);
-            org.junit.Assert.fail("Expected XPTY0004 for cross-sister-type comparison, got: "
+            fail("Expected XPTY0004 for cross-sister-type comparison, got: "
                     + (rs.getSize() > 0 ? rs.getResource(0).getContent() : "<empty>"));
         } catch (final XMLDBException e) {
-            org.junit.Assert.assertTrue("Expected XPTY0004 in: " + e.getMessage(),
+            assertTrue("Expected XPTY0004 in: " + e.getMessage(),
                     e.getMessage().contains("XPTY0004"));
         }
     }

--- a/exist-core/src/test/java/org/exist/xquery/value/DateTimeSubtypeCompareTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/DateTimeSubtypeCompareTest.java
@@ -1,0 +1,90 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.value;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for the date/time-family subtype comparison fix.
+ *
+ * <p>xs:dateTimeStamp is a restriction of xs:dateTime (XSD 1.1 §3.4.28). Per
+ * XPath/XQuery 3.1, comparing the two should succeed — the
+ * {@code AbstractDateTimeValue.compareTo} guard previously used strict
+ * primitive-type equality and rejected the cross-type case with XPTY0004.</p>
+ */
+public class DateTimeSubtypeCompareTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer embedded =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    /** xs:dateTimeStamp `le` xs:dateTime — the issue #5478 reproducer. */
+    @Test
+    public void dateTimeStampLeDateTime() throws XMLDBException {
+        final String query =
+                "declare function local:less($a as xs:string, $b as xs:dateTime) as xs:boolean { "
+                + "  if ($a='') then true() else xs:dateTime($a) <= $b "
+                + "}; "
+                + "local:less('2024-01-01T00:00:00Z', xs:dateTimeStamp('2024-02-01T00:00:00.000Z'))";
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("true", rs.getResource(0).getContent());
+    }
+
+    /** Reverse direction: xs:dateTime vs xs:dateTimeStamp. */
+    @Test
+    public void dateTimeGtDateTimeStamp() throws XMLDBException {
+        final String query =
+                "xs:dateTime('2024-02-01T00:00:00Z') gt xs:dateTimeStamp('2024-01-01T00:00:00.000Z')";
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("true", rs.getResource(0).getContent());
+    }
+
+    /** General-comparison (`=`) flavour. */
+    @Test
+    public void dateTimeStampGeneralEqDateTime() throws XMLDBException {
+        final String query =
+                "xs:dateTimeStamp('2024-01-01T00:00:00Z') = xs:dateTime('2024-01-01T00:00:00Z')";
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("true", rs.getResource(0).getContent());
+    }
+
+    /** Sister types must still be rejected. xs:date vs xs:time → XPTY0004. */
+    @Test
+    public void sisterTypesStillRejected() throws XMLDBException {
+        final String query =
+                "xs:date('2024-01-01') eq xs:time('12:00:00')";
+        try {
+            final ResourceSet rs = embedded.executeQuery(query);
+            org.junit.Assert.fail("Expected XPTY0004 for cross-sister-type comparison, got: "
+                    + (rs.getSize() > 0 ? rs.getResource(0).getContent() : "<empty>"));
+        } catch (final XMLDBException e) {
+            org.junit.Assert.assertTrue("Expected XPTY0004 in: " + e.getMessage(),
+                    e.getMessage().contains("XPTY0004"));
+        }
+    }
+}


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

## Summary

`xs:dateTimeStamp` is derived from `xs:dateTime` by restriction per XSD 1.1 §3.4.28. XPath/XQuery comparisons across the two should succeed, but `AbstractDateTimeValue.compareTo` guarded the calendar comparison with a strict primitive-type equality check (`other.getType() == getType()`) and rejected the cross-type case with XPTY0004.

Closes #5478.

## Reproducer (from the issue)

```xquery
declare function local:less($a as xs:string, $b as xs:dateTime) as xs:boolean
{
    if ($a = '') then true() else xs:dateTime($a) <= $b
};
local:less('2024-01-01T00:00:00Z',
           xs:dateTimeStamp('2024-02-01T00:00:00.000Z'))
```

Before this PR: `err:XPTY0004 Type error: cannot compare xs:dateTime to xs:dateTimeStamp`
After this PR: `true`

## What changed

One-line semantic change in `AbstractDateTimeValue.compareTo` plus a clarifying comment:

```diff
-        if (other.getType() == getType()) {
+        if (other instanceof AbstractDateTimeValue
+                && (Type.subTypeOf(getType(), other.getType())
+                        || Type.subTypeOf(other.getType(), getType()))) {
```

The bidirectional `subTypeOf` admits the dateTimeStamp ↔ dateTime case (each direction handles one side being the supertype), and the `instanceof` guard keeps the comparison restricted to the date/time family so cross-family pairs (e.g. xs:date vs xs:time) still raise XPTY0004. The underlying `getImplicitCalendar().compare(...)` was already correct for the shared structure — we just needed the guard to admit it.

`DateTimeStampValue.convertTo(Type.DATE_TIME)` already returns a plain `DateTimeValue` with the same calendar, so no further conversion plumbing is needed elsewhere.

## Test plan

**New regression test** (`DateTimeSubtypeCompareTest`, 4 cases):
- `dateTimeStampLeDateTime` — the issue reproducer
- `dateTimeGtDateTimeStamp` — reverse direction
- `dateTimeStampGeneralEqDateTime` — general-comparison `=` flavour
- `sisterTypesStillRejected` — negative check: `xs:date eq xs:time` still raises XPTY0004

All 4 pass on the fix branch; the first 3 fail on develop.

**XQuery3Tests (xqsuite)**: 1030/1030 pass.

**W3C XQTS 3.1 conformance** — ran `exist-xqts-runner` with `--xqts-version HEAD` (the live `qt3tests` master branch, i.e. the final 3.1 Recommendation plus errata corrections — *not* the older `--xqts-version 3.1` flag, which points at the 2013 pre-CR-draft archive) against 26 date/time-relevant test sets: `prod-CastExpr`, `prod-CastableExpr`, `fn-current-{date,dateTime,time}`, `fn-format-{date,dateTime,time}`, `fn-dateTime`, `op-{date,dateTime,time}-{equal,greater-than,less-than}`, `op-add-…`, `op-subtract-…`.

```
DEVELOP:  tests=4876 pass=4633 fail=42 err=4 skip=197
FIX:      tests=4876 pass=4633 fail=42 err=4 skip=197
DELTA:    +0 / +0 / +0 / +0 / +0
```

Zero regressions. Zero new passes either — expected, because the W3C 3.1 test catalog is XSD-1.0-flavoured and doesn't exercise the `xs:dateTimeStamp` / `xs:dateTime` cross-comparison this fix unblocks (`xs:dateTimeStamp` is an XSD 1.1 type).

## Related

- Closes #5478
- W3C XPath 3.1 §3.6 (Comparison expressions on dates and durations)
- XSD 1.1 §3.4.28 (xs:dateTimeStamp as restriction of xs:dateTime)
