### PR TITLE
[build] update xqts runner dependency to 2.0.0-RC2

### DIFF
--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.exist-db</groupId>
             <artifactId>exist-xqts-runner_2.13</artifactId>
-            <version>2.0.0-RC1</version>
+            <version>2.0.0-RC2</version>
             <exclusions>
                 <!-- use the exist-core version of this project instead -->
                 <exclusion>


### PR DESCRIPTION
Bump runner dependency to the latest released version 2.0.0-RC2