### PR TITLE
[bugfix] Track item type in AVLTreeNodeSet for correct return-type checks

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/AVLTreeNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AVLTreeNodeSet.java
@@ -24,6 +24,7 @@ package org.exist.dom.persistent;
 import org.exist.numbering.NodeId;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.SequenceIterator;
+import org.exist.xquery.value.Type;
 
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
@@ -35,6 +36,7 @@ public class AVLTreeNodeSet extends AbstractNodeSet {
     private Node root;
     private int size = 0;
     private int state = 0;
+    private int itemType = Type.ANY_TYPE;
 
     @Override
     public SequenceIterator iterate() {
@@ -61,6 +63,31 @@ public class AVLTreeNodeSet extends AbstractNodeSet {
     @Override
     public long getItemCountLong() {
         return size;
+    }
+
+    /**
+     * Refine the tracked itemType as nodes are added, mirroring the pattern
+     * used by {@link AbstractArrayNodeSet#checkItemType(int)}. The result is
+     * exposed via {@link #getItemType()} so that sequence-level type checks
+     * (function return types, variable declarations, instance-of, ...) see
+     * the tightest common supertype of the contained items rather than the
+     * unconditional {@link Type#NODE} returned by the {@link AbstractNodeSet}
+     * default.
+     */
+    private void checkItemType(final int type) {
+        if (itemType == Type.NODE || itemType == type) {
+            return;
+        }
+        if (itemType == Type.ANY_TYPE) {
+            itemType = type;
+        } else {
+            itemType = Type.NODE;
+        }
+    }
+
+    @Override
+    public int getItemType() {
+        return itemType == Type.ANY_TYPE ? Type.NODE : itemType;
     }
 
 
@@ -110,6 +137,7 @@ public class AVLTreeNodeSet extends AbstractNodeSet {
             return;
         }
 
+        checkItemType(proxy.getType());
         setHasChanged();
         if(root == null) {
             root = new Node(proxy);

--- a/exist-core/src/test/java/org/exist/xquery/IntersectElementReturnTypeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/IntersectElementReturnTypeTest.java
@@ -1,0 +1,123 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for issue #4255 — DynamicTypeCheck was comparing a DOM
+ * {@code short} node type (e.g. {@code Node.ELEMENT_NODE = 1}) against an
+ * eXist {@link org.exist.xquery.value.Type} int ({@code Type.ELEMENT = 60})
+ * for persistent {@code NodeProxy} items with an {@code UNKNOWN_NODE_TYPE}.
+ * That surfaced through {@code intersect} on persistent node sets when the
+ * result was assigned to a function declared {@code as element()}.
+ */
+public class IntersectElementReturnTypeTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer embedded =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    @BeforeClass
+    public static void store() throws XMLDBException {
+        embedded.executeQuery(
+                "xmldb:store('/db', 'issue4255.xml', <root><x/><y/><z/></root>)");
+    }
+
+    @AfterClass
+    public static void cleanup() throws XMLDBException {
+        try {
+            embedded.executeQuery("xmldb:remove('/db', 'issue4255.xml')");
+        } catch (final XMLDBException ignored) {
+        }
+    }
+
+    @Test
+    public void persistentIntersectAgainstElementReturnType() throws XMLDBException {
+        final String query = """
+                declare function local:f() as element() {
+                    let $root := doc('/db/issue4255.xml')/root
+                    let $seq1 := ($root/x, $root/y)
+                    let $seq2 := ($root/y, $root/z)
+                    return ($seq1 intersect $seq2)
+                };
+                local:f()
+                """;
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("<y/>", rs.getResource(0).getContent());
+    }
+
+    @Test
+    public void inMemoryIntersectAgainstElementReturnType() throws XMLDBException {
+        final String query = """
+                declare function local:f() as element() {
+                    let $root := <root><x/><y/><z/></root>
+                    let $seq1 := ($root/x, $root/y)
+                    let $seq2 := ($root/y, $root/z)
+                    return ($seq1 intersect $seq2)
+                };
+                local:f()
+                """;
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("<y/>", rs.getResource(0).getContent());
+    }
+
+    @Test
+    public void persistentUnionAgainstElementReturnType() throws XMLDBException {
+        // Sanity: same fix path should keep union working
+        final String query = """
+                declare function local:f() as element()+ {
+                    let $root := doc('/db/issue4255.xml')/root
+                    let $seq1 := ($root/x, $root/y)
+                    let $seq2 := ($root/y, $root/z)
+                    return ($seq1 union $seq2)
+                };
+                string-join(local:f() ! name(), ',')
+                """;
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("x,y,z", rs.getResource(0).getContent());
+    }
+
+    @Test
+    public void persistentExceptAgainstElementReturnType() throws XMLDBException {
+        // Sanity: same fix path should keep except working
+        final String query = """
+                declare function local:f() as element() {
+                    let $root := doc('/db/issue4255.xml')/root
+                    let $seq1 := ($root/x, $root/y)
+                    let $seq2 := ($root/y, $root/z)
+                    return ($seq1 except $seq2)
+                };
+                local:f()
+                """;
+        final ResourceSet rs = embedded.executeQuery(query);
+        assertEquals("<x/>", rs.getResource(0).getContent());
+    }
+}


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

**Closes #4255**

## Summary

A user-defined function declared `as element()` returning the result of a persistent `intersect` failed with `err:XPTY0004 expected type: element(); got: node()` even when every item in the result was in fact an element. The bug also affected `except` (same code path; never reported separately). `union` was unaffected because it goes through a different result-set implementation that already tracks item types.

## Root cause

| `NodeSet` operation | Result type | Tracks `itemType`? |
|---|---|---|
| `union()`     | `NewArrayNodeSet` (extends `AbstractArrayNodeSet`) | **yes** — `checkItemType()` on every `add()` |
| `intersection()` | `AVLTreeNodeSet` (extends `AbstractNodeSet`) | **no** — inherited `getItemType()` returns `Type.NODE` unconditionally |
| `except()`    | `AVLTreeNodeSet`                                  | **no** — same as `intersection()` |

`FunctionCall.eval` (line 216) performs a sequence-level return-type check via `SequenceType.checkType(result.getItemType())`. For an `AVLTreeNodeSet` result, `getItemType()` returned the supertype `Type.NODE = 56`, which is *not* a sub-type of the declared `Type.ELEMENT = 60`, so the check threw `XPTY0004`.

## Fix

Give `AVLTreeNodeSet` per-add item-type tracking, mirroring `AbstractArrayNodeSet.checkItemType`:

- New `itemType` field starts at `Type.ANY_TYPE`
- `add(NodeProxy)` calls `checkItemType(proxy.getType())`:
  - `ANY_TYPE` → first item's type
  - same type → no-op
  - different type → fall back to `Type.NODE`
- New `getItemType()` override returns the tracked type (or `Type.NODE` when nothing has been added)

This is the same shape `AbstractArrayNodeSet` already uses, so the behavior aligns across all `NodeSet` implementations.

## What changed

- `exist-core/src/main/java/org/exist/dom/persistent/AVLTreeNodeSet.java`
  - +1 import (`Type`)
  - +1 field (`itemType`)
  - +1 call in `add()`
  - +1 private helper `checkItemType`
  - +1 `@Override getItemType()`
- `exist-core/src/test/java/org/exist/xquery/IntersectElementReturnTypeTest.java` (new)
  - 4 tests: persistent + in-memory intersect, persistent union (sanity), persistent except (regression for the latent twin bug)

## Test plan

- [x] `mvn test -pl exist-core -Dtest=IntersectElementReturnTypeTest` — 4/4 pass
- [x] `mvn test -pl exist-core -Dtest='XQuery3Tests,XPathQueryTest,IntersectElementReturnTypeTest'` — 1184/1184 pass, 5 skipped (pre-existing), 0 regressions

## Spec reference

- [W3C XPath 3.1 §3.16 — Combining Node Sequences](https://www.w3.org/TR/xpath-31/#combining_seq) — `intersect` returns nodes from both operand sequences; the result's *item type* must be the type common to the operand sequences.
