### PR TITLE
[test] Pin preceding/following axis after not() filter for #3684

### DIFF
--- a/exist-core/src/test/xquery/xquery3/precedingFollowingAfterNot.xqm
+++ b/exist-core/src/test/xquery/xquery3/precedingFollowingAfterNot.xqm
@@ -1,0 +1,126 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Regression test for https://github.com/eXist-db/exist/issues/3684.
+ :
+ : A FLWOR whose `for` clause filtered with a `not(@attr)` predicate, then
+ : traversed the `preceding::` or `following::` axis, returned wrong results
+ : when the source was a persistent (stored) document but worked correctly
+ : in-memory. The bug no longer reproduces on develop; this XQSuite pins
+ : the reproducer so the in-mem / persistent asymmetry cannot return
+ : silently.
+ :
+ : Adapted verbatim from the report by @joewiz (#3684, 2021).
+ :)
+module namespace t="http://exist-db.org/xquery/test/preceding-following-after-not";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $t:XML :=
+    document {
+        <root>
+            <foo/>
+            <bar>
+                <bar/>
+            </bar>
+            <foo/>
+        </root>
+    };
+
+declare
+    %test:setUp
+function t:setup() {
+    xmldb:create-collection("/db", "test-3684"),
+    xmldb:store("/db/test-3684", "test.xml", $t:XML)
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    xmldb:remove("/db/test-3684")
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:preceding-with-predicate-db() {
+    for $bar in doc("/db/test-3684/test.xml")//bar[not(@baz)]
+    return
+        exists($bar/preceding::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:preceding-without-predicate-db() {
+    for $bar in doc("/db/test-3684/test.xml")//bar
+    return
+        exists($bar/preceding::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:preceding-with-predicate-in-mem() {
+    for $bar in $t:XML//bar[not(@baz)]
+    return
+        exists($bar/preceding::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:preceding-without-predicate-in-mem() {
+    for $bar in $t:XML//bar
+    return
+        exists($bar/preceding::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:following-with-predicate-db() {
+    for $bar in doc("/db/test-3684/test.xml")//bar[not(@baz)]
+    return
+        exists($bar/following::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:following-without-predicate-db() {
+    for $bar in doc("/db/test-3684/test.xml")//bar
+    return
+        exists($bar/following::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:following-with-predicate-in-mem() {
+    for $bar in $t:XML//bar[not(@baz)]
+    return
+        exists($bar/following::foo)
+};
+
+declare
+    %test:assertEquals("true", "true")
+function t:following-without-predicate-in-mem() {
+    for $bar in $t:XML//bar
+    return
+        exists($bar/following::foo)
+};


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

**Closes #3684**

## Summary

A FLWOR whose `for` clause filtered with a `not(@attr)` predicate, then traversed the `preceding::` or `following::` axis, returned wrong results when the source was a persistent (stored) document but worked correctly in-memory. The bug no longer reproduces on develop — verified 2026-05-30 against HEAD `b990cd6f7c`; downstream work on the persistent-axis evaluator or `not()`-predicate handling appears to have incidentally fixed it.

Per @duncdrum's review prompt on the issue (favouring regression tests even when no fix commit is paired), this PR pins the reproducer so the in-mem/persistent asymmetry cannot return silently.

## What's tested

The XQSuite (`exist-core/src/test/xquery/xquery3/precedingFollowingAfterNot.xqm`) is adapted verbatim from the report on the issue and covers the cross-product:

- `preceding::` + `following::`
- with-predicate (`bar[not(@baz)]`) + without-predicate (`bar`)
- persistent (`doc()`) + in-memory (`document{}`)

= 8 functions, all asserting `"true,true"` (both `<bar>` elements have a preceding and a following `<foo/>`).

With the original bug present, only the persistent + with-predicate variants returned the wrong value. With the bug fixed, all eight return `"true,true"`.

## What changed

- `exist-core/src/test/xquery/xquery3/precedingFollowingAfterNot.xqm` (new)

The XQSuite is auto-discovered by `xquery.xquery3.XQuery3Tests` (no Java glue needed).

## Test plan

- [x] `mvn test -pl exist-core -Dtest='XQuery3Tests#precedingFollowingAfterNot'` — 8 functions pass
- [x] Broader: `mvn test -pl exist-core -Dtest=XQuery3Tests` — 1038/1038 pass, 0 regressions
