### PR TITLE
[bugfix] Surface %test:tearDown errors in xqsuite output

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -113,30 +113,50 @@ declare function test:suite(
                     namespace-uri-from-QName(function-name($func)) = $module
                 })
             let $setup := test:call-func-with-annotation($modFunctions, "setUp", $test-error-function)
-            let $result :=
-                if (empty($setup) or $setup/self::ok) then
-                    let $startTime := util:system-time()
-                    let $results := test:function-by-annotation($modFunctions, "assert", $runner)
-                    let $elapsed :=
-                        util:system-time() - $startTime
-                    return
-                        <testsuite package="{$module}" timestamp="{util:system-dateTime()}"
-                            tests="{count($results)}"
-                            failures="{count($results/failure)}"
-                            errors="{count($results/error)}"
-                            pending="{count($results/pending)}"
-                            time="{$elapsed}">
-                            { $results }
-                        </testsuite>
+            let $setupOk := empty($setup) or exists($setup/self::ok)
+            let $startTime := util:system-time()
+            let $results :=
+                if ($setupOk) then
+                    test:function-by-annotation($modFunctions, "assert", $runner)
+                else ()
+            let $elapsed := util:system-time() - $startTime
+            (:
+             : tearDown always runs, regardless of whether setUp or any test
+             : threw. Prior to https://github.com/eXist-db/exist/issues/6422
+             : a tearDown error was caught in test:call-func-with-annotation
+             : and the resulting <system-err/> was then discarded by the
+             : outer ($result, $tearDown)[1] selector, leaving the bug
+             : invisible to any consumer of the suite XML (CI, IDE, reports).
+             : Surface it as a <system-err> child on the <testsuite>, and
+             : count it as one additional error.
+             :)
+            let $tearDown := test:call-func-with-annotation($modFunctions, "tearDown", $test-error-function)
+            let $tearDownErr := $tearDown/self::system-err
+            return
+                if ($setupOk) then
+                    <testsuite package="{$module}" timestamp="{util:system-dateTime()}"
+                        tests="{count($results)}"
+                        failures="{count($results/failure)}"
+                        errors="{count($results/error) + count($tearDownErr)}"
+                        pending="{count($results/pending)}"
+                        time="{$elapsed}">
+                        { $results }
+                        {
+                            if ($tearDownErr) then
+                                <system-err>{ "tearDown error: " || $tearDownErr/string() }</system-err>
+                            else ()
+                        }
+                    </testsuite>
                 else
                     <testsuite package="{$module}" timestamp="{util:system-dateTime()}"
-                        errors="{count($functions)}">
-                        {$setup/string()}
+                        errors="{count($functions) + count($tearDownErr)}">
+                        {
+                            if ($tearDownErr) then
+                                $setup/string() || "&#10;tearDown error: " || $tearDownErr/string()
+                            else
+                                $setup/string()
+                        }
                     </testsuite>
-            return (
-                $result,
-                test:call-func-with-annotation($modFunctions, "tearDown", $test-error-function)
-            )[1]
         }
         </testsuites>
 };

--- a/exist-core/src/test/java/org/exist/xquery/xqsuite/XQSuiteTearDownErrorTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/xqsuite/XQSuiteTearDownErrorTest.java
@@ -1,0 +1,177 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.xqsuite;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for issue #6422: XQSuite must surface errors thrown
+ * from {@code %test:tearDown} functions in the suite output, not silently
+ * swallow them.
+ *
+ * <p>Each test stores a small XQuery module to the database, calls
+ * {@code test:suite(inspect:module-functions(...))} on the module, and
+ * inspects the resulting {@code <testsuites>} element. A clean tearDown
+ * must produce no tearDown marker; a throwing tearDown must produce a
+ * {@code <system-err>} child on the {@code <testsuite>} naming the
+ * error, and the {@code errors} count must be bumped by one.</p>
+ */
+public class XQSuiteTearDownErrorTest {
+
+    private static final String COLLECTION = "/db/test-6422";
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer embedded =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    @BeforeClass
+    public static void createCollection() throws XMLDBException {
+        embedded.executeQuery("xmldb:create-collection('/db', 'test-6422')");
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        try {
+            embedded.executeQuery("xmldb:remove('" + COLLECTION + "')");
+        } catch (final XMLDBException ignored) {
+        }
+    }
+
+    @Test
+    public void cleanTearDownProducesNoMarker() throws XMLDBException {
+        final String module = """
+                xquery version "3.1";
+                module namespace t = "http://exist-db.org/xquery/test/6422-clean";
+                declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+                declare %test:tearDown function t:cleanup() { () };
+                declare %test:assertEquals(1) function t:passes() { 1 };
+                """;
+        final String suiteXml = runSuiteAgainstStoredModule("clean.xqm",
+                module, "http://exist-db.org/xquery/test/6422-clean");
+        assertFalse("clean tearDown should not emit a system-err marker: " + suiteXml,
+                suiteXml.contains("tearDown error"));
+        assertTrue("testsuite errors=\"0\" expected for clean tearDown: " + suiteXml,
+                suiteXml.contains("errors=\"0\""));
+    }
+
+    @Test
+    public void throwingTearDownIsSurfaced() throws XMLDBException {
+        final String module = """
+                xquery version "3.1";
+                module namespace t = "http://exist-db.org/xquery/test/6422-throw";
+                declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+                declare %test:tearDown function t:cleanup() {
+                    error(xs:QName("t:teardown-boom"), "tearDown blew up here")
+                };
+                declare %test:assertEquals(1) function t:passes() { 1 };
+                """;
+        final String suiteXml = runSuiteAgainstStoredModule("throw.xqm",
+                module, "http://exist-db.org/xquery/test/6422-throw");
+
+        // The bug was that suiteXml had no mention of the tearDown failure
+        // at all — neither a marker element nor a bumped errors count.
+        assertTrue("throwing tearDown must produce a <system-err>tearDown error: ...</system-err> on the testsuite, got: "
+                        + suiteXml,
+                suiteXml.contains("tearDown error: ")
+                        && suiteXml.contains("tearDown blew up here"));
+
+        // Test itself passed → tests="1", failures="0". The tearDown failure
+        // counts as one additional error.
+        assertTrue("testsuite must count the tearDown failure as one error: " + suiteXml,
+                suiteXml.contains("errors=\"1\""));
+        assertTrue("the passing test should still be present: " + suiteXml,
+                suiteXml.contains("tests=\"1\"") && suiteXml.contains("failures=\"0\""));
+    }
+
+    @Test
+    public void throwingSetUpAndTearDownBothSurfaced() throws XMLDBException {
+        // Both setUp and tearDown throw. The original behaviour reported
+        // setUp's error and dropped tearDown's; now both must appear.
+        final String module = """
+                xquery version "3.1";
+                module namespace t = "http://exist-db.org/xquery/test/6422-both";
+                declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+                declare %test:setUp function t:setup() {
+                    error(xs:QName("t:setup-boom"), "setUp blew up")
+                };
+                declare %test:tearDown function t:cleanup() {
+                    error(xs:QName("t:teardown-boom"), "tearDown also blew up")
+                };
+                declare %test:assertEquals(1) function t:wouldHavePassed() { 1 };
+                """;
+        final String suiteXml = runSuiteAgainstStoredModule("both.xqm",
+                module, "http://exist-db.org/xquery/test/6422-both");
+        assertTrue("setUp error must still be surfaced: " + suiteXml,
+                suiteXml.contains("setUp blew up"));
+        assertTrue("tearDown error must now be surfaced even when setUp also failed: "
+                        + suiteXml,
+                suiteXml.contains("tearDown error: ")
+                        && suiteXml.contains("tearDown also blew up"));
+    }
+
+    /**
+     * Store the given module text at {@code /db/test-6422/<filename>}, then
+     * execute {@code test:suite(inspect:module-functions(...))} against its
+     * URI. Returns the suite XML as a string.
+     */
+    private static String runSuiteAgainstStoredModule(final String filename,
+                                                      final String moduleText,
+                                                      final String moduleNs) throws XMLDBException {
+        final String storeQuery = "xmldb:store('" + COLLECTION + "', '" + filename + "', "
+                + "$moduleText, 'application/xquery')";
+        // xmldb:store takes a node or string; pass moduleText through a let.
+        embedded.executeQuery(
+                "let $moduleText := \"" + escapeXQueryStringLiteral(moduleText) + "\" "
+                        + "return " + storeQuery);
+
+        final String suiteQuery = ""
+                + "import module namespace test='http://exist-db.org/xquery/xqsuite';\n"
+                + "import module namespace t='" + moduleNs + "' "
+                + "    at 'xmldb:exist:///" + COLLECTION + "/" + filename + "';\n"
+                + "serialize(\n"
+                + "    test:suite(inspect:module-functions(xs:anyURI('xmldb:exist:///"
+                + COLLECTION + "/" + filename + "'))),\n"
+                + "    map { 'method': 'xml' }\n"
+                + ")";
+        final ResourceSet rs = embedded.executeQuery(suiteQuery);
+        assertEquals(1, rs.getSize());
+        return (String) rs.getResource(0).getContent();
+    }
+
+    /** Escape a string for inclusion in an XQuery double-quoted string literal. */
+    private static String escapeXQueryStringLiteral(final String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\"\"");
+    }
+}


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

**Closes #6422** (verified independently with a before/after JUnit run on develop HEAD `b990cd6f7c`)

## Summary

XQSuite caught errors thrown from `%test:tearDown` functions in `test:call-func-with-annotation` and emitted a `<system-err>` element — but the outer `($result, $tearDown)[1]` selector at the end of `test:suite` then discarded that element. Consumers of the suite XML (CI, IDE Run-as-test panels, JUnit-shaped reporters) saw no trace of the tearDown failure. The `%test:setUp` counterpart was already surfaced via the testsuite text content, but the tearDown path was a silent dead end.

@dizzzz +1'd the issue, so opening this PR. Reviewers — see the note at the bottom on the chosen output shape; the issue discussion left the wire format open and I'm happy to adjust based on review.

## Root cause

In `xqsuite.xql`, around line 137 of develop:

```xquery
return (
    $result,
    test:call-func-with-annotation($modFunctions, "tearDown", $test-error-function)
)[1]
```

`call-func-with-annotation` returns `<ok/>` on success and `<system-err>{$err:description}</system-err>` on failure. For setUp the `<system-err>` was already flowing into the testsuite's text content. For tearDown the same `<system-err>` was discarded by `[1]`.

## Fix

`exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql`:

- Compute the tearDown result before constructing `<testsuite>`, so its `<system-err/>` can be folded in alongside the test results.
- When tearDown threw, append a `<system-err>tearDown error: …</system-err>` child to the `<testsuite>` and bump the `errors` count by one. Element name matches the JUnit convention so existing consumers handle it naturally.
- On the setUp-failure path (which already short-circuits the test run), append the same `"tearDown error: …"` text to the existing error message and count the tearDown error toward `errors` too.
- Clean tearDowns continue to produce no marker — output is byte-identical to before the fix, so passing test files are unchanged.

## What's tested

New `exist-core/src/test/java/org/exist/xquery/xqsuite/XQSuiteTearDownErrorTest.java` with three cases:

- `cleanTearDownProducesNoMarker` — backwards-compatible: clean tearDowns emit no marker, `errors="0"`
- `throwingTearDownIsSurfaced` — passing test + throwing tearDown → `errors="1"` plus a `<system-err>tearDown error: …</system-err>` element under the testsuite
- `throwingSetUpAndTearDownBothSurfaced` — both setUp and tearDown throw → both messages appear in the testsuite text

Each test stores a small module to `/db/test-6422`, runs `test:suite(inspect:module-functions(...))` against it, serializes the result, and asserts on the XML.

## Before / after

Verified the assertions actually exercise the change by temporarily reverting `xqsuite.xql` to develop, rebuilding, and running the same tests — 2 of 3 fail with the bug's signature (`errors="0"`, no system-err element). Restoring the fix → 3/3 pass.

```
(without fix, develop)
[ERROR] throwingTearDownIsSurfaced -- expected <system-err>tearDown error: ...</system-err>,
        got: <testsuites><testsuite ... tests="1" failures="0" errors="0" pending="0"
                                        time="PT0.1S">
               <testcase name="passes" ... /></testsuite></testsuites>

(with fix)
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

## Test plan

- [x] `mvn test -pl exist-core -Dtest=XQSuiteTearDownErrorTest` — 3/3 pass
- [x] `mvn test -pl exist-core -Dtest='XQSuiteTests,XQuery3Tests,XQSuiteTearDownErrorTest'` — 1124/1124 pass, 1 skipped (pre-existing), 0 regressions
- [x] Confirmed the regression test fails on develop without the fix (see Before/after above)
- [x] Codacy PMD on the new JUnit — clean

## A note on shape — open to feedback

I considered three output shapes for the tearDown failure:

1. **`<system-err>tearDown error: …</system-err>`** child of the `<testsuite>` (this PR). JUnit-idiomatic, no test-count inflation, no new element name to teach consumers.
2. A synthetic `<testcase name="tearDown">` with an `<error/>` child. Cleanest for JUnit consumers that show per-test panels, but adds a "test" that wasn't in the source and bumps `tests`.
3. A custom `<tearDownError/>` element. Clear intent but a new element name for every consumer.

I picked (1) for the smallest surface. If reviewers prefer (2) or (3), or want the `errors` attribute counted differently, I'll happily reshape — let me know.

cc @duncdrum @line-o @reinhapa @dizzzz (per the issue discussion).
