### PR TITLE
[bugfix] InteractiveClient/GUI: when connection to database fails, allow user to reconnect easily.

### DIFF
--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2059,7 +2059,7 @@ public class InteractiveClient {
      * Ask user for login data using gui.
      *
      * @param props Client properties
-     * @return FALSE when pressed cancel, TRUE is sucessfull.
+     * @return FALSE when the login dialog was dismissed, TRUE if login data was provided.
      */
     private boolean getGuiLoginData(final Properties props) {
         return getGuiLoginData(props, ClientFrame::getLoginData);
@@ -2165,7 +2165,7 @@ public class InteractiveClient {
                         ClientFrame.showErrorMessage("Connection to database failed: " + message, cnf);
                         final boolean haveLoginData = getGuiLoginData(properties);
                         if (!haveLoginData) {
-                            // user pressed Cancel
+                            // user dismissed the login dialog; abort startup
                             return false;
                         }
                     } else {
@@ -2278,7 +2278,7 @@ public class InteractiveClient {
 
                     final boolean haveLoginData = getGuiLoginData(properties);
                     if (!haveLoginData) {
-                        // pressed cancel
+                        // user dismissed the login dialog; abort startup
                         return true;
                     }
 

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2084,26 +2084,28 @@ public class InteractiveClient {
     private void connectToDatabase() throws XMLDBException {
         try {
             connect();
+        } catch (final XMLDBException ex) {
+            handleConnectException(ex, ex);
         } catch (final Exception ex) {
-            final String message = ex.getMessage() != null ? ex.getMessage() : ex.getClass().getName();
-            if (options.startGUI && isRetryableError(message)) {
-                if (frame != null) {
-                    frame.setStatus("Connection to database failed; message: " + message);
-                }
-                if (ex instanceof XMLDBException xe) {
-                    throw xe;
-                } else {
-                    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, message, ex);
-                }
-
-            }
-            if (options.startGUI && frame != null) {
-                frame.setStatus("Connection to database failed; message: " + message);
-            } else {
-                consoleErr("Connection to database failed; message: " + message, ex);
-            }
-            System.exit(SystemExitCodes.CATCH_ALL_GENERAL_ERROR_EXIT_CODE);
+            handleConnectException(new XMLDBException(ErrorCodes.VENDOR_ERROR, ex.getMessage(), ex), ex);
         }
+    }
+
+    private void handleConnectException(final XMLDBException toThrow, final Exception original) throws XMLDBException {
+        final String message = original.getMessage() != null ? original.getMessage() : original.getClass().getName();
+        if (options.startGUI && isRetryableError(message)) {
+            if (frame != null) {
+                frame.setStatus("Connection to database failed; message: " + message);
+            }
+            throw toThrow;
+        }
+
+        if (options.startGUI && frame != null) {
+            frame.setStatus("Connection to database failed; message: " + message);
+        } else {
+            consoleErr("Connection to database failed; message: " + message, original);
+        }
+        System.exit(SystemExitCodes.CATCH_ALL_GENERAL_ERROR_EXIT_CODE);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2084,19 +2084,23 @@ public class InteractiveClient {
     private void connectToDatabase() throws XMLDBException {
         try {
             connect();
-        } catch (final Exception cnf) {
-            final String message = cnf.getMessage() != null ? cnf.getMessage() : cnf.getClass().getName();
+        } catch (final Exception ex) {
+            final String message = ex.getMessage() != null ? ex.getMessage() : ex.getClass().getName();
             if (options.startGUI && isRetryableError(message)) {
                 if (frame != null) {
                     frame.setStatus("Connection to database failed; message: " + message);
                 }
-                throw cnf instanceof XMLDBException xe ? xe
-                        : new XMLDBException(ErrorCodes.VENDOR_ERROR, message, cnf);
+                if (ex instanceof XMLDBException xe) {
+                    throw xe;
+                } else {
+                    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, message, ex);
+                }
+
             }
             if (options.startGUI && frame != null) {
                 frame.setStatus("Connection to database failed; message: " + message);
             } else {
-                consoleErr("Connection to database failed; message: " + message, cnf);
+                consoleErr("Connection to database failed; message: " + message, ex);
             }
             System.exit(SystemExitCodes.CATCH_ALL_GENERAL_ERROR_EXIT_CODE);
         }

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2078,15 +2078,25 @@ public class InteractiveClient {
 
     /**
      * Reusable method for connecting to database. Exits process on failure.
+     * In GUI mode, retryable errors (e.g. wrong credentials) are rethrown as
+     * XMLDBException so the caller can prompt the user and retry.
      */
-    private void connectToDatabase() {
+    private void connectToDatabase() throws XMLDBException {
         try {
             connect();
         } catch (final Exception cnf) {
+            final String message = cnf.getMessage() != null ? cnf.getMessage() : cnf.getClass().getName();
+            if (options.startGUI && isRetryableError(message)) {
+                if (frame != null) {
+                    frame.setStatus("Connection to database failed; message: " + message);
+                }
+                throw cnf instanceof XMLDBException xe ? xe
+                        : new XMLDBException(ErrorCodes.VENDOR_ERROR, message, cnf);
+            }
             if (options.startGUI && frame != null) {
-                frame.setStatus("Connection to database failed; message: " + cnf.getMessage());
+                frame.setStatus("Connection to database failed; message: " + message);
             } else {
-                consoleErr("Connection to database failed; message: " + cnf.getMessage(), cnf);
+                consoleErr("Connection to database failed; message: " + message, cnf);
             }
             System.exit(SystemExitCodes.CATCH_ALL_GENERAL_ERROR_EXIT_CODE);
         }
@@ -2142,8 +2152,30 @@ public class InteractiveClient {
                     .build();
         }
 
-        // connect to the db
-        connectToDatabase();
+        // connect to the db; in GUI mode retry on bad credentials
+        if (interactive && options.startGUI) {
+            boolean connected = false;
+            while (!connected) {
+                try {
+                    connectToDatabase();
+                    connected = true;
+                } catch (final XMLDBException cnf) {
+                    final String message = cnf.getMessage() != null ? cnf.getMessage() : cnf.getClass().getName();
+                    if (isRetryableError(message)) {
+                        final boolean haveLoginData = getGuiLoginData(properties);
+                        if (!haveLoginData) {
+                            // user pressed Cancel
+                            return false;
+                        }
+                    } else {
+                        consoleErr("Connection to database failed; message: " + message, cnf);
+                        System.exit(SystemExitCodes.CATCH_ALL_GENERAL_ERROR_EXIT_CODE);
+                    }
+                }
+            }
+        } else {
+            connectToDatabase();
+        }
 
         if (current == null) {
             if (options.startGUI && frame != null) {
@@ -2253,7 +2285,12 @@ public class InteractiveClient {
                     shutdown(false);
 
                     // connect to the db
-                    connectToDatabase();
+                    try {
+                        connectToDatabase();
+                    } catch (final XMLDBException e) {
+                        // connection failed again; loop will re-prompt for credentials
+                        errorMessageReference.set(getExceptionMessage(e));
+                    }
 
                 } else if (!errorMessage.isEmpty()) {
                     // No pattern match, but we have an error. stop here
@@ -2281,6 +2318,7 @@ public class InteractiveClient {
     boolean isRetryableError(String errorMessage) {
         return errorMessage.contains("Invalid password for user") ||
                 errorMessage.contains("Connection refused: connect") ||
+                errorMessage.contains("Unauthorized") ||
                 UNKNOWN_USER_PATTERN.matcher(errorMessage).find();
     }
 

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2162,6 +2162,7 @@ public class InteractiveClient {
                 } catch (final XMLDBException cnf) {
                     final String message = cnf.getMessage() != null ? cnf.getMessage() : cnf.getClass().getName();
                     if (isRetryableError(message)) {
+                        ClientFrame.showErrorMessage("Connection to database failed: " + message, cnf);
                         final boolean haveLoginData = getGuiLoginData(properties);
                         if (!haveLoginData) {
                             // user pressed Cancel

--- a/exist-core/src/test/java/org/exist/client/InteractiveClientTest.java
+++ b/exist-core/src/test/java/org/exist/client/InteractiveClientTest.java
@@ -268,7 +268,7 @@ class InteractiveClientTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"xxxxInvalid password for userXXXX", "YYYYYConnection refused: connectXXXXX", "XXXUser AAAA unknownXXXX"})
+    @ValueSource(strings = {"xxxxInvalid password for userXXXX", "YYYYYConnection refused: connectXXXXX", "XXXUser AAAA unknownXXXX", "HTTP server returned unexpected status: Unauthorized"})
     void isRetryableError(String errorMessage) {
         assertThat(client.isRetryableError(errorMessage)).isTrue();
     }


### PR DESCRIPTION
InteractiveClient/GUI: when connection to database fails, allow user to reconnect easily.

Right now the GUI stops and a stack trace is written. Now it loops back to the start, and an error message is added.

<img width="804" height="557" alt="image" src="https://github.com/user-attachments/assets/53bae36a-c2a5-44fe-995b-9de547e16a91" />
