### PR TITLE
[refactor] Modernize Maven 3 build pipeline and release automation

### DIFF
--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'The version of the Maven Daemon to install'
     required: true
-    default: '1.0.3'
+    default: '1.0.6'
   file-version-suffix:
     description: 'A suffix to append to the version of the download file of Maven Daemon to install'
     required: false

--- a/.github/actions/maven-github-settings/action.yml
+++ b/.github/actions/maven-github-settings/action.yml
@@ -1,19 +1,43 @@
-# Creates Maven settings.xml with auth for the eXist-db org's GitHub Packages repos.
+# Creates Maven settings.xml with auth for the eXist-db org's GitHub Packages repos
+# and optionally for Sonatype Central Portal publishing.
 # Required for resolving artifacts from maven.pkg.github.com/eXist-db/{exist, exist-xqts-runner, jackrabbit-webdav-jakarta}.
 name: Maven GitHub Packages settings
-description: Create settings.xml with github, github-xqts-runner, and github-jackrabbit-webdav-jakarta servers
+description: Create settings.xml with GitHub Packages and (optionally) Sonatype Central Portal servers
 inputs:
   token:
     description: 'GitHub token for package authentication'
     required: true
+  central-token-username:
+    description: 'Sonatype Central Portal user token username (release jobs only)'
+    required: false
+    default: ''
+  central-token-password:
+    description: 'Sonatype Central Portal user token password (release jobs only)'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
     - name: Create Maven settings for GitHub Packages
       shell: bash
+      env:
+        CENTRAL_TOKEN_USERNAME: ${{ inputs.central-token-username }}
+        CENTRAL_TOKEN_PASSWORD: ${{ inputs.central-token-password }}
       run: |
         mkdir -p ~/.m2
         OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+        # Build optional Central Portal server block
+        CENTRAL_SERVER=""
+        if [ -n "$CENTRAL_TOKEN_USERNAME" ]; then
+          CENTRAL_SERVER="
+            <server>
+              <id>central</id>
+              <username>${CENTRAL_TOKEN_USERNAME}</username>
+              <password>${CENTRAL_TOKEN_PASSWORD}</password>
+            </server>"
+        fi
+
         cat > ~/.m2/settings.xml << EOF
         <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
           <servers>
@@ -31,7 +55,7 @@ runs:
               <id>github-jackrabbit-webdav-jakarta</id>
               <username>${OWNER}</username>
               <password>${{ inputs.token }}</password>
-            </server>
+            </server>${CENTRAL_SERVER}
           </servers>
         </settings>
         EOF

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -1,6 +1,11 @@
 name: Publish Container
 on:
   push:
+    branches:
+      - develop
+      - master
+    tags:
+      - 'eXist-*'
   pull_request:
   schedule:
       - cron: "0 6 * * *"
@@ -11,8 +16,13 @@ jobs:
     name: Test and Publish Container Images
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # NOTE (DP): Publish on develop and master, test on PRs against these
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.base_ref ==  'develop' || github.base_ref ==  'master'
+    # Publish on develop (latest) and eXist-* tags (versioned + release); test on PRs against these branches.
+    if: >
+      github.ref == 'refs/heads/develop' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/eXist-') ||
+      github.base_ref == 'develop' ||
+      github.base_ref == 'master'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,7 +53,17 @@ jobs:
         timeout-minutes: 35
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -V -B --no-transfer-progress -q -Pdocker -DskipTests -Ddependency-check.skip=true -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives clean package
+        run: |
+          REVISION_ARG=""
+          if [[ "${{ github.ref }}" == refs/tags/eXist-* ]]; then
+            VERSION="${{ github.ref_name }}"
+            REVISION_ARG="-Drevision=${VERSION#eXist-}"
+          fi
+          mvn -V -B --no-transfer-progress -q \
+            -Pdocker -DskipTests -Ddependency-check.skip=true \
+            -P '!mac-dmg-on-unix,skip-build-dist-archives' \
+            $REVISION_ARG \
+            clean package
       - name: Check local images
         run: docker image ls
       - name: Check license headers
@@ -73,8 +93,6 @@ jobs:
           name: exist-core-failed-log
           path: exist.log
 
-      # NOTE (DP): When on master push release, when on develop push latest: Version is included automatically
-      # TODO (DP): Confirm that releases triggered from maven publish images with the non SNAPSHOT version
       - name: Publish latest images
         if: github.repository == 'eXist-db/exist' && github.ref == 'refs/heads/develop'
         env:
@@ -83,14 +101,24 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: mvn --no-transfer-progress -q -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
-      - name: Publish release images
-        if: github.repository == 'eXist-db/exist' && github.ref == 'refs/heads/master'
+
+      - name: Publish versioned release images
+        if: github.repository == 'eXist-db/exist' && startsWith(github.ref, 'refs/tags/eXist-')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: mvn --no-transfer-progress -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#eXist-}"
+          mvn --no-transfer-progress -q \
+            -Drevision="$VERSION" \
+            -Ddocker.tag=release \
+            -Ddocker.username=$DOCKER_USERNAME \
+            -Ddocker.password=$DOCKER_PASSWORD \
+            docker:build docker:push
         working-directory: ./exist-docker
+
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
       # - name: Publish experimental images
       #   if: github.base_ref == 'develop'

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -60,8 +60,8 @@ jobs:
             REVISION_ARG="-Drevision=${VERSION#eXist-}"
           fi
           mvn -V -B --no-transfer-progress -q \
-            -Pdocker -DskipTests -Ddependency-check.skip=true \
-            -P '!mac-dmg-on-unix,skip-build-dist-archives' \
+            -Pdocker,skip-build-dist-archives \
+            -DskipTests -Ddependency-check.skip=true \
             $REVISION_ARG \
             clean package
       - name: Check local images

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -33,11 +33,11 @@ jobs:
           distribution: temurin
           java-version: '21'
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4
         with:
           platforms: linux/amd64,linux/arm64
       - name: Make buildkit default
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
         id: buildx
       - uses: ./.github/actions/maven-cache
       - uses: ./.github/actions/maven-github-settings

--- a/.github/workflows/ci-release-prepare.yml
+++ b/.github/workflows/ci-release-prepare.yml
@@ -1,0 +1,63 @@
+name: Prepare Release
+
+# Replaces mvn release:prepare. Updates CITATION.cff, commits, creates the
+# annotated tag, and pushes — which then triggers ci-release.yml.
+#
+# Requires a fine-grained PAT (RELEASE_PAT) with contents:write on this repo.
+# GITHUB_TOKEN pushes do not trigger downstream tag workflows.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 7.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare eXist-${{ inputs.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # PAT required so the tag push triggers ci-release.yml.
+          # GITHUB_TOKEN pushes are intentionally blocked from triggering workflows.
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: ./.github/actions/maven-cache
+
+      - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update CITATION.cff
+        run: |
+          mvn -B --no-transfer-progress \
+            -Pcitation-release-metadata \
+            -DupdateCff=true \
+            -Drevision=${{ inputs.version }} \
+            validate
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CITATION.cff
+          # Only commit if CITATION.cff actually changed
+          git diff --staged --quiet || \
+            git commit -m "[release] Prepare eXist-${{ inputs.version }}"
+          git tag -a "eXist-${{ inputs.version }}" \
+            -m "eXist-db ${{ inputs.version }}"
+          git push origin HEAD
+          git push origin "eXist-${{ inputs.version }}"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,309 @@
+name: Release
+
+# Triggered by an eXist-* tag (created by ci-release-prepare.yml).
+# Four jobs run in parallel then converge on a single GitHub Release:
+#   build-linux   — Maven Central deploy + zip/tar archives (Ubuntu)
+#   build-mac     — signed + notarized DMG (macOS)
+#   build-windows — signed installer JAR + Authenticode .exe (Windows)
+#   publish-github-release — collects all artifacts, creates the GitHub Release
+
+on:
+  push:
+    tags:
+      - 'eXist-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to re-release (e.g. eXist-7.0.0)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  JAVA_VERSION: '21'
+
+# ─── Shared helper ────────────────────────────────────────────────────────────
+# Extract the semantic version from the tag name (strips the "eXist-" prefix).
+# Usage in run steps:  TAG="${{ github.event.inputs.tag || github.ref_name }}"
+#                      REVISION="${TAG#eXist-}"
+
+jobs:
+
+  # ── Job 1: Build and publish to Maven Central ────────────────────────────────
+  build-linux:
+    name: Build and publish to Maven Central
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+      CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: ./.github/actions/maven-cache
+
+      - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          central-token-username: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          central-token-password: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+
+      - name: Import GPG key
+        env:
+          EXISTDB_RELEASE_KEY: ${{ secrets.EXISTDB_RELEASE_KEY }}
+        run: echo "$EXISTDB_RELEASE_KEY" | base64 --decode | gpg --batch --import
+
+      - name: Deploy to Maven Central
+        env:
+          EXISTDB_RELEASE_KEY_ID: ${{ secrets.EXISTDB_RELEASE_KEY_ID }}
+          EXISTDB_RELEASE_KEY_PASSPHRASE: ${{ secrets.EXISTDB_RELEASE_KEY_PASSPHRASE }}
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          REVISION="${TAG#eXist-}"
+          mvn -V -B --no-transfer-progress \
+            -Prelease-build \
+            -Drevision="$REVISION" \
+            -Drelease.preflight=true \
+            -DskipTests \
+            -Ddependency-check.skip=true \
+            -Dlicense.skip=true \
+            -Dexistdb.release.key="$EXISTDB_RELEASE_KEY_ID" \
+            -Dexistdb.release.key.passphrase="$EXISTDB_RELEASE_KEY_PASSPHRASE" \
+            clean deploy
+
+      - name: Collect distribution archives
+        run: |
+          mkdir -p /tmp/release-assets
+          cp exist-distribution/target/*.zip     /tmp/release-assets/ 2>/dev/null || true
+          cp exist-distribution/target/*.tar.bz2 /tmp/release-assets/ 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-linux
+          path: /tmp/release-assets/
+          retention-days: 1
+
+  # ── Job 2: Build signed + notarized macOS DMG ────────────────────────────────
+  build-mac:
+    name: Build macOS DMG
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: ./.github/actions/maven-cache
+
+      - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Import Developer ID certificate
+        env:
+          EXISTDB_MAC_CERTIFICATE: ${{ secrets.EXISTDB_MAC_CERTIFICATE }}
+          EXISTDB_MAC_CERTIFICATE_PASSWORD: ${{ secrets.EXISTDB_MAC_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASS=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASS" release.keychain
+          security default-keychain -s release.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASS" release.keychain
+          security set-keychain-settings -lut 21600 release.keychain
+          echo "$EXISTDB_MAC_CERTIFICATE" | base64 --decode > /tmp/cert.p12
+          security import /tmp/cert.p12 -k release.keychain \
+            -P "$EXISTDB_MAC_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" release.keychain
+          rm /tmp/cert.p12
+
+      - name: Build, sign, notarize and staple DMG
+        env:
+          EXISTDB_APPLE_ID: ${{ secrets.EXISTDB_APPLE_ID }}
+          EXISTDB_APPLE_APP_PASSWORD: ${{ secrets.EXISTDB_APPLE_APP_PASSWORD }}
+          EXISTDB_APPLE_TEAM_ID: ${{ secrets.EXISTDB_APPLE_TEAM_ID }}
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          REVISION="${TAG#eXist-}"
+          mvn -V -B --no-transfer-progress \
+            -Prelease-build \
+            -Dmac-signing=true \
+            -Drevision="$REVISION" \
+            -DskipTests \
+            -Ddependency-check.skip=true \
+            -Dlicense.skip=true \
+            -Dmac.codesign.identity="${{ vars.EXISTDB_MAC_CODESIGN_IDENTITY }}" \
+            -Dexistdb.release.notarize.apple-id="$EXISTDB_APPLE_ID" \
+            -Dexistdb.release.notarize.password="$EXISTDB_APPLE_APP_PASSWORD" \
+            -Dexistdb.release.notarize.team-id="$EXISTDB_APPLE_TEAM_ID" \
+            clean package
+
+      - name: Verify DMG notarization
+        run: |
+          DMG=$(find exist-distribution/target -name "*.dmg" | head -1)
+          xcrun stapler validate "$DMG"
+
+      - name: Collect DMG
+        run: |
+          mkdir -p /tmp/release-assets
+          cp exist-distribution/target/*.dmg /tmp/release-assets/ 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-mac
+          path: /tmp/release-assets/
+          retention-days: 1
+
+  # ── Job 3: Build signed Windows installer ───────────────────────────────────
+  build-windows:
+    name: Build Windows installer
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: ./.github/actions/maven-cache
+
+      - uses: ./.github/actions/maven-github-settings
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build installer
+        shell: bash
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          REVISION="${TAG#eXist-}"
+          mvn -V -B --no-transfer-progress \
+            -Prelease-build \
+            -Drevision="$REVISION" \
+            -DskipTests \
+            -Ddependency-check.skip=true \
+            -Dlicense.skip=true \
+            clean package
+
+      - name: Sign installer JAR (Azure Key Vault JCA)
+        shell: bash
+        env:
+          AZURE_KEYVAULT_URI: ${{ vars.AZURE_KEYVAULT_URI }}
+        run: |
+          JAR=$(find exist-installer/target -name "*.jar" \
+            -not -name "*sources*" -not -name "*javadoc*" | head -1)
+          [ -n "$JAR" ] || { echo "No installer JAR found in exist-installer/target"; exit 1; }
+          # Download Azure Key Vault JCA provider to classpath
+          KV_JCA_JAR="$HOME/.m2/azure-keyvault-jca.jar"
+          if [ ! -f "$KV_JCA_JAR" ]; then
+            mvn -q dependency:get \
+              -Dartifact=com.azure:azure-security-keyvault-jca:2.10.0:jar \
+              -Ddest="$KV_JCA_JAR"
+          fi
+          VAULT_NAME="${AZURE_KEYVAULT_URI##https://}"
+          VAULT_NAME="${VAULT_NAME%%.*}"
+          CERT_NAME=$(az keyvault certificate list \
+            --vault-name "$VAULT_NAME" --query "[0].name" -o tsv)
+          ACCESS_TOKEN=$(az account get-access-token \
+            --resource "https://vault.azure.net" --query accessToken -o tsv)
+          jarsigner \
+            -keystore NONE \
+            -storetype AzureKeyVault \
+            -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
+            -providerArg "-J-Dazure.keyvault.uri=${AZURE_KEYVAULT_URI}" \
+            -J-Dazure.keyvault.accessToken="$ACCESS_TOKEN" \
+            -J-cp "$KV_JCA_JAR" \
+            -tsa http://timestamp.sectigo.com/ \
+            "$JAR" "$CERT_NAME"
+          jarsigner -verify -strict "$JAR"
+
+      - name: Sign .exe with Authenticode (AzureSignTool)
+        shell: pwsh
+        env:
+          AZURE_KEYVAULT_URI: ${{ vars.AZURE_KEYVAULT_URI }}
+        run: |
+          $exe = Get-ChildItem -Path exist-installer/target -Filter "*.exe" |
+            Select-Object -First 1
+          if (-not $exe) {
+            Write-Host "No .exe produced on this runner; skipping Authenticode signing"
+            exit 0
+          }
+          dotnet tool install --global AzureSignTool --version 5.0.0
+          $vaultName = ($env:AZURE_KEYVAULT_URI -replace 'https://|\.vault\.azure\.net/?', '')
+          $certName  = az keyvault certificate list `
+            --vault-name $vaultName --query "[0].name" -o tsv
+          $token = az account get-access-token `
+            --resource "https://vault.azure.net" --query accessToken -o tsv
+          AzureSignTool sign `
+            --azure-key-vault-url      $env:AZURE_KEYVAULT_URI `
+            --azure-key-vault-certificate $certName `
+            --azure-key-vault-accesstoken $token `
+            --timestamp-rfc3161        http://timestamp.sectigo.com/ `
+            --description              "eXist-db Installer" `
+            $exe.FullName
+          $sig = Get-AuthenticodeSignature $exe.FullName
+          if ($sig.Status -ne 'Valid') {
+            Write-Error "Authenticode signature invalid: $($sig.Status)"
+            exit 1
+          }
+
+      - name: Collect installer artifacts
+        shell: bash
+        run: |
+          mkdir -p /tmp/release-assets
+          find exist-installer/target \
+            -name "*.jar" -not -name "*sources*" -not -name "*javadoc*" \
+            -exec cp {} /tmp/release-assets/ \;
+          find exist-installer/target -name "*.exe" \
+            -exec cp {} /tmp/release-assets/ \; 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-windows
+          path: /tmp/release-assets/
+          retention-days: 1
+
+  # ── Job 4: Publish GitHub Release ───────────────────────────────────────────
+  publish-github-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build-linux, build-mac, build-windows]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: /tmp/release-assets
+
+      - name: List release assets
+        run: ls -lh /tmp/release-assets/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: /tmp/release-assets/*
+          generate_release_notes: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -130,11 +130,17 @@ jobs:
             -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" release.keychain
           rm /tmp/cert.p12
 
+      - name: Write Apple API key
+        env:
+          EXISTDB_APPLE_API_KEY: ${{ secrets.EXISTDB_APPLE_API_KEY }}
+        run: |
+          echo "$EXISTDB_APPLE_API_KEY" | base64 --decode > /tmp/notarytool.p8
+          chmod 600 /tmp/notarytool.p8
+
       - name: Build, sign, notarize and staple DMG
         env:
-          EXISTDB_APPLE_ID: ${{ secrets.EXISTDB_APPLE_ID }}
-          EXISTDB_APPLE_APP_PASSWORD: ${{ secrets.EXISTDB_APPLE_APP_PASSWORD }}
-          EXISTDB_APPLE_TEAM_ID: ${{ secrets.EXISTDB_APPLE_TEAM_ID }}
+          EXISTDB_APPLE_API_KEY_ID: ${{ secrets.EXISTDB_APPLE_API_KEY_ID }}
+          EXISTDB_APPLE_API_ISSUER_ID: ${{ secrets.EXISTDB_APPLE_API_ISSUER_ID }}
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           REVISION="${TAG#eXist-}"
@@ -146,10 +152,14 @@ jobs:
             -Ddependency-check.skip=true \
             -Dlicense.skip=true \
             -Dmac.codesign.identity="${{ vars.EXISTDB_MAC_CODESIGN_IDENTITY }}" \
-            -Dexistdb.release.notarize.apple-id="$EXISTDB_APPLE_ID" \
-            -Dexistdb.release.notarize.password="$EXISTDB_APPLE_APP_PASSWORD" \
-            -Dexistdb.release.notarize.team-id="$EXISTDB_APPLE_TEAM_ID" \
+            -Dexistdb.release.notarize.key-path=/tmp/notarytool.p8 \
+            -Dexistdb.release.notarize.key-id="$EXISTDB_APPLE_API_KEY_ID" \
+            -Dexistdb.release.notarize.issuer-id="$EXISTDB_APPLE_API_ISSUER_ID" \
             clean package
+
+      - name: Remove Apple API key
+        if: always()
+        run: rm -f /tmp/notarytool.p8
 
       - name: Verify DMG notarization
         run: |
@@ -251,7 +261,7 @@ jobs:
             Write-Host "No .exe produced on this runner; skipping Authenticode signing"
             exit 0
           }
-          dotnet tool install --global AzureSignTool --version 5.0.0
+          dotnet tool install --global AzureSignTool --version 7.0.1
           $vaultName = ($env:AZURE_KEYVAULT_URI -replace 'https://|\.vault\.azure\.net/?', '')
           $certName  = az keyvault certificate list `
             --vault-name $vaultName --query "[0].name" -o tsv

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read  # default; jobs that need more declare it explicitly
 
 env:
   JAVA_VERSION: '21'
@@ -77,7 +77,6 @@ jobs:
             -Ddependency-check.skip=true \
             -Dlicense.skip=true \
             -Dexistdb.release.key="$EXISTDB_RELEASE_KEY_ID" \
-            -Dexistdb.release.key.passphrase="$EXISTDB_RELEASE_KEY_PASSPHRASE" \
             clean deploy
 
       - name: Collect distribution archives
@@ -90,13 +89,13 @@ jobs:
         with:
           name: release-linux
           path: /tmp/release-assets/
-          retention-days: 1
+          retention-days: 3
 
   # ── Job 2: Build signed + notarized macOS DMG ────────────────────────────────
   build-mac:
     name: Build macOS DMG
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
@@ -175,13 +174,16 @@ jobs:
         with:
           name: release-mac
           path: /tmp/release-assets/
-          retention-days: 1
+          retention-days: 3
 
   # ── Job 3: Build signed Windows installer ───────────────────────────────────
   build-windows:
     name: Build Windows installer
     runs-on: windows-latest
     timeout-minutes: 60
+    permissions:
+      id-token: write  # OIDC for Azure Key Vault signing
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -199,7 +201,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -233,18 +235,12 @@ jobs:
               -Dartifact=com.azure:azure-security-keyvault-jca:2.10.0:jar \
               -Ddest="$KV_JCA_JAR"
           fi
-          VAULT_NAME="${AZURE_KEYVAULT_URI##https://}"
-          VAULT_NAME="${VAULT_NAME%%.*}"
-          CERT_NAME=$(az keyvault certificate list \
-            --vault-name "$VAULT_NAME" --query "[0].name" -o tsv)
-          ACCESS_TOKEN=$(az account get-access-token \
-            --resource "https://vault.azure.net" --query accessToken -o tsv)
+          CERT_NAME="${{ vars.AZURE_KEYVAULT_CERT_NAME }}"
           jarsigner \
             -keystore NONE \
             -storetype AzureKeyVault \
             -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
             -providerArg "-J-Dazure.keyvault.uri=${AZURE_KEYVAULT_URI}" \
-            -J-Dazure.keyvault.accessToken="$ACCESS_TOKEN" \
             -J-cp "$KV_JCA_JAR" \
             -tsa http://timestamp.sectigo.com/ \
             "$JAR" "$CERT_NAME"
@@ -262,17 +258,13 @@ jobs:
             exit 0
           }
           dotnet tool install --global AzureSignTool --version 7.0.1
-          $vaultName = ($env:AZURE_KEYVAULT_URI -replace 'https://|\.vault\.azure\.net/?', '')
-          $certName  = az keyvault certificate list `
-            --vault-name $vaultName --query "[0].name" -o tsv
-          $token = az account get-access-token `
-            --resource "https://vault.azure.net" --query accessToken -o tsv
+          $certName = '${{ vars.AZURE_KEYVAULT_CERT_NAME }}'
           AzureSignTool sign `
-            --azure-key-vault-url      $env:AZURE_KEYVAULT_URI `
-            --azure-key-vault-certificate $certName `
-            --azure-key-vault-accesstoken $token `
-            --timestamp-rfc3161        http://timestamp.sectigo.com/ `
-            --description              "eXist-db Installer" `
+            --azure-key-vault-url          $env:AZURE_KEYVAULT_URI `
+            --azure-key-vault-certificate  $certName `
+            --azure-key-vault-managed-identity `
+            --timestamp-rfc3161            http://timestamp.sectigo.com/ `
+            --description                  "eXist-db Installer" `
             $exe.FullName
           $sig = Get-AuthenticodeSignature $exe.FullName
           if ($sig.Status -ne 'Valid') {
@@ -294,7 +286,7 @@ jobs:
         with:
           name: release-windows
           path: /tmp/release-assets/
-          retention-days: 1
+          retention-days: 3
 
   # ── Job 4: Publish GitHub Release ───────────────────────────────────────────
   publish-github-release:
@@ -302,8 +294,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-linux, build-mac, build-windows]
+    permissions:
+      contents: write  # create GitHub Release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: release-*
           merge-multiple: true
@@ -312,7 +306,7 @@ jobs:
       - name: List release assets
         run: ls -lh /tmp/release-assets/
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: /tmp/release-assets/*

--- a/.github/workflows/ci-snapshots.yml
+++ b/.github/workflows/ci-snapshots.yml
@@ -31,5 +31,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -V -B --no-transfer-progress -q -DskipTests -Ddependency-check.skip=true \
-          -P !mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,skip-build-dist-archives \
+          -P skip-build-dist-archives \
           clean deploy

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -86,7 +86,7 @@ jobs:
         id: install-mvnd
         uses: ./.github/actions/install-mvnd
         with:
-          version: '1.0.3'
+          version: '1.0.6'
           file-version-suffix: ''
           cache: 'true'
       - name: Maven Build

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_OPTS: ${{ env.MAVEN_OPTS }} -D'aether.connector.basic.connectTimeout=10000' -D'aether.connector.basic.requestTimeout=30000'
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -T 1C compile test-compile -Ponnx-model -D'dependency-check.skip' -D'license.skip' --projects '!exist-installer'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -T 1C compile test-compile -Ponnx-model -D'dependency-check.skip' -D'license.skip'
       - name: Maven Unit Tests
         id: unit-tests
         if: matrix.test-type == 'unit'
@@ -109,10 +109,10 @@ jobs:
       - name: Maven Integration Tests
         if: matrix.test-type == 'integration'
         timeout-minutes: 45
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress verify -Ponnx-model -DskipUnitTests=true -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress verify "-Ponnx-model,!mac-dmg-on-mac" -DskipUnitTests=true -D'dependency-check.skip' -D'license.skip' -D'mvnd.maxLostKeepAlive=6000'
       - name: Javadoc (ubuntu unit only)
         if: matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit'
-        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B --no-transfer-progress -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution' --also-make
       - name: Maven Code Coverage (Develop branch, ubuntu unit only)
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest' && matrix.test-type == 'unit'
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -V -B --no-transfer-progress -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -V -B --no-transfer-progress -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -Pskip-build-dist-archives verify site org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dependency-reduced-pom.xml
 
 # Maven generated
 effective-pom.xml
+.flattened-pom.xml
 
 # XQTS test artefacts
 work/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,10 @@ eXist-db is an open-source native XML database with full XQuery support. The mai
 ```bash
 JAVA_HOME=$(/usr/libexec/java_home -v 21) \
   mvn -T1.5C clean install -DskipTests -Ddependency-check.skip=true -Ddocker=false \
-  -P 'skip-build-dist-archives,!build-dist-archives,!mac-dmg-on-mac,!codesign-mac-dmg,!mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,!appassembler-booter'
+  -Pskip-build-dist-archives
 ```
+
+On macOS this still produces an unsigned DMG (`mac-dmg-on-mac` is active by default on Mac runners). Add `-P '!mac-dmg-on-mac'` to skip it.
 
 ### Build a single module
 
@@ -61,12 +63,10 @@ The DMG is unsigned. For the fully signed and notarized DMG used in releases, se
 ### IzPack installer JAR
 
 Produces the cross-platform installer JAR in `exist-installer/target/`.
-Maven will warn "could not be activated because it does not exist" for the `installer` profile — this is a Maven 3 multi-module quirk; the build is correct.
 
 ```bash
 JAVA_HOME=$(/usr/libexec/java_home -v 21) \
   mvn -T1.5C clean package \
-  -Pinstaller \
   -pl exist-installer -am \
   -DskipTests \
   -Ddependency-check.skip=true \
@@ -81,7 +81,7 @@ Run the installer: `java -jar exist-installer/target/exist-installer-7.0.0-SNAPS
 ```bash
 # Build the Docker image
 mvn -T1.5C clean package -DskipTests -Ddependency-check.skip=true -Ddocker=true \
-  -P 'skip-build-dist-archives,!build-dist-archives,!mac-dmg-on-mac,!codesign-mac-dmg,!mac-dmg-on-unix,!installer,!concurrency-stress-tests,!micro-benchmarks,!appassembler-booter' \
+  -Pskip-build-dist-archives \
   -pl exist-docker -am
 
 cp exist-docker/target/classes/Dockerfile exist-docker/target/exist-docker-*-docker-dir/Dockerfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,41 @@ mvn test -pl exist-core -Ddependency-check.skip=true -Ddocker=false
 mvn test -pl exist-core -Dtest="org.exist.xquery.XPathQueryTest" -Ddependency-check.skip=true -Ddocker=false
 ```
 
+### Distribution artifacts (zip, tar.bz2, DMG)
+
+Produces release archives and, on macOS, an unsigned DMG suitable for local testing.
+Output lands in `exist-distribution/target/`.
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+  mvn -T1.5C clean package \
+  -pl exist-distribution -am \
+  -DskipTests \
+  -Ddependency-check.skip=true \
+  -Ddocker=false \
+  -Drevision=7.0.0-SNAPSHOT
+```
+
+The DMG is unsigned. For the fully signed and notarized DMG used in releases, see `exist-versioning-release.md`.
+
+### IzPack installer JAR
+
+Produces the cross-platform installer JAR in `exist-installer/target/`.
+Maven will warn "could not be activated because it does not exist" for the `installer` profile — this is a Maven 3 multi-module quirk; the build is correct.
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+  mvn -T1.5C clean package \
+  -Pinstaller \
+  -pl exist-installer -am \
+  -DskipTests \
+  -Ddependency-check.skip=true \
+  -Ddocker=false \
+  -Drevision=7.0.0-SNAPSHOT
+```
+
+Run the installer: `java -jar exist-installer/target/exist-installer-7.0.0-SNAPSHOT.jar`
+
 ### Docker image
 
 ```bash

--- a/exist-ant/pom.xml
+++ b/exist-ant/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -222,7 +222,7 @@
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
             <version>4.1.3</version>
-            <classifier>jdk11</classifier>
+            <classifier>${jline.classifier}</classifier>
         </dependency>
 
         <dependency>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -54,7 +54,7 @@
         <mac.bundle.resources.dir>${mac.bundle.dir}/Contents/Resources</mac.bundle.resources.dir>
         <mac.bundle.java.dir>${mac.bundle.dir}/Contents/Java</mac.bundle.java.dir>
         <mac.dmg>${project.build.directory}/eXist-db-${project.version}.dmg</mac.dmg>
-        <mac.codesign.identity>Developer ID Application: Evolved Binary Ltd</mac.codesign.identity>
+        <mac.codesign.identity></mac.codesign.identity>
     </properties>
 
     <dependencies>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -1063,10 +1063,10 @@
                 <os>
                     <family>mac</family>
                 </os>
-                <!-- Note: Travis Mac doesn't support the hdiutil attach required by create-dmg-mac.sh -->
+                <!-- Opt-in: only when mac-signing=true so local dev builds and CI test runs don't attempt DMG creation -->
                 <property>
-                    <name>env.CI</name>
-                    <value>!true</value>
+                    <name>mac-signing</name>
+                    <value>true</value>
                 </property>
             </activation>
             <build>
@@ -1187,16 +1187,31 @@
                                     <useMavenLogger>true</useMavenLogger>
                                     <executable>/usr/bin/xcrun</executable>
                                     <arguments>
-                                        <argument>altool</argument>
-                                        <argument>--notarize-app</argument>
-                                        <argument>--verbose</argument>
-                                        <argument>--primary-bundle-id</argument>
-                                        <argument>org.exist-db</argument>
-                                        <argument>--username</argument>
-                                        <argument>${existdb.release.notarize.username}</argument>
+                                        <argument>notarytool</argument>
+                                        <argument>submit</argument>
+                                        <argument>${mac.dmg}</argument>
+                                        <argument>--apple-id</argument>
+                                        <argument>${existdb.release.notarize.apple-id}</argument>
                                         <argument>--password</argument>
                                         <argument>${existdb.release.notarize.password}</argument>
-                                        <argument>--file</argument>
+                                        <argument>--team-id</argument>
+                                        <argument>${existdb.release.notarize.team-id}</argument>
+                                        <argument>--wait</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>mac-staple-dmg</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <useMavenLogger>true</useMavenLogger>
+                                    <executable>/usr/bin/xcrun</executable>
+                                    <arguments>
+                                        <argument>stapler</argument>
+                                        <argument>staple</argument>
                                         <argument>${mac.dmg}</argument>
                                     </arguments>
                                 </configuration>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1191,12 +1191,12 @@
                                         <argument>notarytool</argument>
                                         <argument>submit</argument>
                                         <argument>${mac.dmg}</argument>
-                                        <argument>--apple-id</argument>
-                                        <argument>${existdb.release.notarize.apple-id}</argument>
-                                        <argument>--password</argument>
-                                        <argument>${existdb.release.notarize.password}</argument>
-                                        <argument>--team-id</argument>
-                                        <argument>${existdb.release.notarize.team-id}</argument>
+                                        <argument>--key</argument>
+                                        <argument>${existdb.release.notarize.key-path}</argument>
+                                        <argument>--key-id</argument>
+                                        <argument>${existdb.release.notarize.key-id}</argument>
+                                        <argument>--issuer</argument>
+                                        <argument>${existdb.release.notarize.issuer-id}</argument>
                                         <argument>--wait</argument>
                                     </arguments>
                                 </configuration>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1027,6 +1027,7 @@
                                         <argument>${jansi.version}</argument>
                                         <argument>${project.build.directory}/jansi-native</argument>
                                         <argument>${mac.codesign.identity}</argument>
+                                        <argument>${jline.classifier}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1064,11 +1064,8 @@
                 <os>
                     <family>mac</family>
                 </os>
-                <!-- Opt-in: only when mac-signing=true so local dev builds and CI test runs don't attempt DMG creation -->
-                <property>
-                    <name>mac-signing</name>
-                    <value>true</value>
-                </property>
+                <!-- Active on any macOS build. Negate with !mac-dmg-on-mac for quick builds.
+                     Signing and notarization are gated separately by codesign-mac-dmg (mac-signing=true). -->
             </activation>
             <build>
                 <plugins>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -968,6 +968,9 @@
 
     <profiles>
         <profile>
+            <!-- Shares the `onnx-model` id with exist-parent's profile so that a single
+                 `-Ponnx-model` activates the model download (in parent) AND adds the
+                 exist-vector runtime dependency (here). Keep ids in sync. -->
             <id>onnx-model</id>
             <dependencies>
                 <dependency>

--- a/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
+++ b/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
@@ -37,37 +37,45 @@
 # $2 is the jansi version
 # $3 is temp work directory
 # $4 the mac codesign identity
+# $5 is the jline classifier (e.g. jdk11)
 
 
 set -e
 #set -x  ## enable to help debug
 
-# ensure a clean temp work directory
-if [ -d "${3}/org" ]
-then
-  rm -rf "${3}/org"
-fi
-
-# for each native arch
-archs=('arm64' 'x86' 'x86_64')
-for arch in ${archs[@]}
+# for each jar file
+for jar in "${1}/jansi-${2}.jar" "${1}/jline-${2}-${5}.jar"
 do
-  # create the temp output dirs
-  mkdir -p "${3}/org/jline/nativ/Mac/${arch}"
+  # ensure a clean temp work directory for each jar
+  if [ -d "${3}/org" ]
+  then
+    rm -rf "${3}/org"
+  fi
 
-  # switch to temp output dir
-  pushd "${3}"
+  # for each native arch
+  archs=('arm64' 'x86' 'x86_64')
+  for arch in "${archs[@]}"
+  do
+    # create the temp output dirs
+    mkdir -p "${3}/org/jline/nativ/Mac/${arch}"
 
-  # extract the native files
-  jar -xf "${1}/jansi-${2}.jar" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # switch to temp output dir
+    pushd "${3}"
 
-  # test if the file is unsigned, and sign if needed
-  /usr/bin/codesign --verbose --test-requirement="=anchor trusted" --verify "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib" || /usr/bin/codesign --verbose --force --timestamp --sign "${4}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # extract the native files
+    jar -xf "${jar}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
-  # overwrite the file in the jar
-  jar -uf "${1}/jansi-${2}.jar" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
+    # test if the file is unsigned, and sign if needed
+    /usr/bin/codesign --verbose --test-requirement="=anchor trusted" \
+                      --verify "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib" || \
+                      /usr/bin/codesign --verbose --force --timestamp --sign "${4}" \
+                      "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
-  # switch back from temp output dir
-  popd
+    # overwrite the file in the jar
+    jar -uf "${jar}" "org/jline/nativ/Mac/${arch}/libjlinenative.jnilib"
 
+    # switch back from temp output dir
+    popd
+
+  done
 done

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-indexes-jmh/pom.xml
+++ b/exist-indexes-jmh/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-installer/pom.xml
+++ b/exist-installer/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-jetty-config/pom.xml
+++ b/exist-jetty-config/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1227,7 +1227,7 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendlyVersions</flattenMode>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.exist-db</groupId>
     <artifactId>exist-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>eXist-db Parent</name>
@@ -97,14 +97,18 @@
             <name>GitHub Registry for Snapshots</name>
             <url>https://maven.pkg.github.com/eXist-db/exist</url>
         </snapshotRepository>
-        <repository>
+        <!-- Release publishing is handled by central-publishing-maven-plugin in the
+             release-build profile; this legacy Nexus staging entry is superseded. -->
+        <!-- repository>
             <id>sonatype-nexus-staging</id>
             <name>Nexus Release Repository</name>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
+        </repository -->
     </distributionManagement>
 
     <properties>
+        <revision>7.0.0-SNAPSHOT</revision>
+
         <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
@@ -832,6 +836,16 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
+                </plugin>
+                <plugin>
                     <groupId>software.xdev</groupId>
                     <artifactId>find-and-replace-maven-plugin</artifactId>
                     <version>1.0.5</version>
@@ -1207,6 +1221,31 @@
 
         <plugins>
             <plugin>
+                <!-- Resolves ${revision} in deployed/installed POMs (Maven 3 CI-friendly versions) -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendlyVersions</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.6.3</version>
@@ -1446,6 +1485,100 @@
     </reporting>
 
     <profiles>
+
+        <!-- === Release pipeline === -->
+        <profile>
+            <id>release-build</id>
+            <properties>
+                <exist.release>true</exist.release>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <keyname>${existdb.release.key}</keyname>
+                                    <passphrase>${existdb.release.key.passphrase}</passphrase>
+                                    <gpgArguments>
+                                        <arg>--batch</arg>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <!-- uploaded: bundle accepted, sync to Central mirrors is async.
+                                 Avoids blocking CI for the 15-30 min full publication sync. -->
+                            <waitUntil>uploaded</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release-preflight</id>
+            <activation>
+                <property>
+                    <name>release.preflight</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>release-preflight-checks</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireEnvironmentVariable>
+                                            <variableName>CENTRAL_TOKEN_USERNAME</variableName>
+                                            <message>CENTRAL_TOKEN_USERNAME env var is required for release publishing.</message>
+                                        </requireEnvironmentVariable>
+                                        <requireEnvironmentVariable>
+                                            <variableName>CENTRAL_TOKEN_PASSWORD</variableName>
+                                            <message>CENTRAL_TOKEN_PASSWORD env var is required for release publishing.</message>
+                                        </requireEnvironmentVariable>
+                                        <requireProperty>
+                                            <property>existdb.release.key</property>
+                                            <message>existdb.release.key is required for GPG artifact signing.</message>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <property>existdb.release.key.passphrase</property>
+                                            <message>existdb.release.key.passphrase is required for GPG artifact signing.</message>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- === End Release pipeline === -->
 
         <profile>
             <!-- NOTE: this is used from the maven-release-plugin -->

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -112,7 +112,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
-        <maven.minimum.version>3.9.9</maven.minimum.version>
+        <maven.minimum.version>3.9.16</maven.minimum.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <project.copyright.name>The eXist-db Authors</project.copyright.name>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -129,6 +129,7 @@
         <icu.version>76.1</icu.version>
         <izpack.version>5.2.5</izpack.version>
         <jansi.version>4.1.3</jansi.version>
+        <jline.classifier>jdk11</jline.classifier>
         <jaxb.api.version>4.0.5</jaxb.api.version>
         <jaxb.impl.version>4.0.2</jaxb.impl.version>
         <eclipse.angus-activation.version>2.0.3</eclipse.angus-activation.version>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1507,13 +1507,29 @@
                                 </goals>
                                 <configuration>
                                     <keyname>${existdb.release.key}</keyname>
-                                    <passphrase>${existdb.release.key.passphrase}</passphrase>
-                                    <gpgArguments>
-                                        <arg>--batch</arg>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
+                                    <passphraseEnvName>EXISTDB_RELEASE_KEY_PASSPHRASE</passphraseEnvName>
+                                    <signer>bc</signer>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals><goal>jar-no-fork</goal></goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals><goal>jar</goal></goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -1567,10 +1583,10 @@
                                             <property>existdb.release.key</property>
                                             <message>existdb.release.key is required for GPG artifact signing.</message>
                                         </requireProperty>
-                                        <requireProperty>
-                                            <property>existdb.release.key.passphrase</property>
-                                            <message>existdb.release.key.passphrase is required for GPG artifact signing.</message>
-                                        </requireProperty>
+                                        <requireEnvironmentVariable>
+                                            <variableName>EXISTDB_RELEASE_KEY_PASSPHRASE</variableName>
+                                            <message>EXISTDB_RELEASE_KEY_PASSPHRASE env var is required for GPG artifact signing.</message>
+                                        </requireEnvironmentVariable>
                                     </rules>
                                 </configuration>
                             </execution>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -839,12 +839,12 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <version>1.7.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.7.0</version>
+                    <version>0.10.0</version>
                 </plugin>
                 <plugin>
                     <groupId>software.xdev</groupId>

--- a/exist-samples/pom.xml
+++ b/exist-samples/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-service/pom.xml
+++ b/exist-service/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-start/pom.xml
+++ b/exist-start/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -115,9 +115,11 @@ The `ci-release.yml` workflow runs four jobs in parallel then converges:
 | `build-windows` | windows-latest | signed installer JAR + Authenticode `.exe` |
 | `publish-github-release` | ubuntu-latest | GitHub Release with all assets attached |
 
-### Prerequisites: required GitHub secrets
+### Prerequisites: required GitHub secrets and repository rules
 
 All secrets must be in place under **Settings → Secrets and variables → Actions** before running a release. See `plans/internal-release-runbook.template.md` for the full table and rotation guidance.
+
+A **tag ruleset** restricts creation and deletion of `eXist-*` tags to users with the Maintain or Admin role (Settings → Rules → Rulesets). The `RELEASE_PAT` owner must hold one of those roles; all other automation only reads tags and is unaffected.
 
 | Secret | Used by |
 |--------|---------|
@@ -136,7 +138,7 @@ All secrets must be in place under **Settings → Secrets and variables → Acti
 | `AZURE_TENANT_ID` | `build-windows` — Azure tenant |
 | `AZURE_SUBSCRIPTION_ID` | `build-windows` — Azure subscription |
 
-Repository variable (not a secret): `AZURE_KEYVAULT_URI` (e.g. `https://exist-db-signing.vault.azure.net/`) and `EXISTDB_MAC_CODESIGN_IDENTITY`.
+Repository variables (not secrets): `AZURE_KEYVAULT_URI` (e.g. `https://exist-db-signing.vault.azure.net/`), `AZURE_KEYVAULT_CERT_NAME` (the certificate name as it appears in Key Vault, e.g. `existdb-code-signing`), and `EXISTDB_MAC_CODESIGN_IDENTITY`.
 
 ### Preparing a Product Release
 

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -127,11 +127,11 @@ All secrets must be in place under **Settings → Secrets and variables → Acti
 | `EXISTDB_RELEASE_KEY_PASSPHRASE` | `build-linux` — GPG passphrase |
 | `CENTRAL_TOKEN_USERNAME` | `build-linux` — Sonatype Central Portal user token username |
 | `CENTRAL_TOKEN_PASSWORD` | `build-linux` — Sonatype Central Portal user token password |
-| `EXISTDB_MAC_CERTIFICATE` | `build-mac` — Developer ID Application cert (base64 PKCS12) |
+| `EXISTDB_MAC_CERTIFICATE` | `build-mac` — Developer ID Application cert (base64 PKCS12) for codesigning |
 | `EXISTDB_MAC_CERTIFICATE_PASSWORD` | `build-mac` — Certificate password |
-| `EXISTDB_APPLE_ID` | `build-mac` — Apple ID for `notarytool` |
-| `EXISTDB_APPLE_APP_PASSWORD` | `build-mac` — App-specific password for `notarytool` |
-| `EXISTDB_APPLE_TEAM_ID` | `build-mac` — Apple Developer Team ID |
+| `EXISTDB_APPLE_API_KEY` | `build-mac` — App Store Connect API private key (base64-encoded `.p8`) for notarytool |
+| `EXISTDB_APPLE_API_KEY_ID` | `build-mac` — API Key ID (10-char alphanumeric) |
+| `EXISTDB_APPLE_API_ISSUER_ID` | `build-mac` — App Store Connect Issuer ID (UUID) |
 | `AZURE_CLIENT_ID` | `build-windows` — OIDC app registration client ID |
 | `AZURE_TENANT_ID` | `build-windows` — Azure tenant |
 | `AZURE_SUBSCRIPTION_ID` | `build-windows` — Azure subscription |

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -117,7 +117,7 @@ The `ci-release.yml` workflow runs four jobs in parallel then converges:
 
 ### Prerequisites: required GitHub secrets and repository rules
 
-All secrets must be in place under **Settings → Secrets and variables → Actions** before running a release. See `plans/internal-release-runbook.template.md` for the full table and rotation guidance.
+All secrets must be in place under **Settings → Secrets and variables → Actions** before running a release. See `internal-release-runbook.template.md` for the full table and rotation guidance.
 
 A **tag ruleset** restricts creation and deletion of `eXist-*` tags to users with the Maintain or Admin role (Settings → Rules → Rulesets). The `RELEASE_PAT` owner must hold one of those roles; all other automation only reads tags and is unaffected.
 

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -84,150 +84,87 @@ It is trivial for a developer to relate a timestamp back to a Git hash (by using
 
 ### Where the version number is stored
 
-The version number is stored in the `exist-parent/pom.xml` file, in a single property, `<version>`. The Semantic Versioning number `3.2.0-SNAPSHOT` would be stored as follows:
+The version number is stored in `exist-parent/pom.xml` as the `<revision>` CI-friendly property:
+```xml
+<properties>
+    <revision>7.0.0-SNAPSHOT</revision>
+</properties>
 ```
-<version>3.2.0-SNAPSHOT</version>
-```
+
+All module `<parent>` blocks reference `<version>${revision}</version>`. The `flatten-maven-plugin` resolves `${revision}` to a literal version in every installed or deployed POM so that downstream consumers see a concrete version, not the placeholder.
 
 That version number is also copied into the `META-INF/MANIFEST.MF` file of any Jar packages that are built, using the standard manifest attributes: `Specification-Version` and `Implementation-Version`.
 
 ## Release Process
 
-This section details concrete steps for creating and publishing product releases. Each section here assumes you are starting with a clean Git checkout of the `develop` branch from [https://github.com/eXist-db/exist.git](https://github.com/eXist-db/exist.git).
+This section details concrete steps for creating and publishing product releases. Releases are fully automated via two GitHub Actions workflows — no local Maven invocation is required for normal releases.
 
-### Initiating Semantic Versioning
+### Overview: two-workflow release pattern
 
-Version 3.0.0 was released before Semantic Versioning. The following steps will initiate Semantic Versioning for the remainder of the development phase of the next release, a new minor version to be called version 3.1.0:
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `ci-release-prepare.yml` | `workflow_dispatch` | Updates `CITATION.cff`, commits, creates annotated tag `eXist-X.Y.Z`, pushes |
+| `ci-release.yml` | `push.tags: eXist-*` | Parallel platform builds → GitHub Release |
 
-1.  Modify `$EXIST_HOME/build.properties` to read:
+The `ci-release.yml` workflow runs four jobs in parallel then converges:
 
-    ```
-    project.version = 3.1.0-SNAPSHOT
-    ```
+| Job | Runner | Output |
+|-----|--------|--------|
+| `build-linux` | ubuntu-latest | zip + tar.bz2 archives; deploy to Maven Central |
+| `build-mac` | macos-latest | signed + notarized DMG |
+| `build-windows` | windows-latest | signed installer JAR + Authenticode `.exe` |
+| `publish-github-release` | ubuntu-latest | GitHub Release with all assets attached |
 
-2.  Commit the changes and push to `origin` (or `upstream` if you are on a fork).
+### Prerequisites: required GitHub secrets
+
+All secrets must be in place under **Settings → Secrets and variables → Actions** before running a release. See `plans/internal-release-runbook.template.md` for the full table and rotation guidance.
+
+| Secret | Used by |
+|--------|---------|
+| `RELEASE_PAT` | `ci-release-prepare` — PAT with `contents:write`; required because `GITHUB_TOKEN` pushes do not trigger downstream tag workflows |
+| `EXISTDB_RELEASE_KEY` | `build-linux` — GPG private key (armored, base64-encoded); imported via `gpg --import` |
+| `EXISTDB_RELEASE_KEY_ID` | `build-linux` — GPG key ID passed to `-Dexistdb.release.key=` (e.g. `ABC1234`) |
+| `EXISTDB_RELEASE_KEY_PASSPHRASE` | `build-linux` — GPG passphrase |
+| `CENTRAL_TOKEN_USERNAME` | `build-linux` — Sonatype Central Portal user token username |
+| `CENTRAL_TOKEN_PASSWORD` | `build-linux` — Sonatype Central Portal user token password |
+| `EXISTDB_MAC_CERTIFICATE` | `build-mac` — Developer ID Application cert (base64 PKCS12) |
+| `EXISTDB_MAC_CERTIFICATE_PASSWORD` | `build-mac` — Certificate password |
+| `EXISTDB_APPLE_ID` | `build-mac` — Apple ID for `notarytool` |
+| `EXISTDB_APPLE_APP_PASSWORD` | `build-mac` — App-specific password for `notarytool` |
+| `EXISTDB_APPLE_TEAM_ID` | `build-mac` — Apple Developer Team ID |
+| `AZURE_CLIENT_ID` | `build-windows` — OIDC app registration client ID |
+| `AZURE_TENANT_ID` | `build-windows` — Azure tenant |
+| `AZURE_SUBSCRIPTION_ID` | `build-windows` — Azure subscription |
+
+Repository variable (not a secret): `AZURE_KEYVAULT_URI` (e.g. `https://exist-db-signing.vault.azure.net/`) and `EXISTDB_MAC_CODESIGN_IDENTITY`.
 
 ### Preparing a Product Release
 
-Once development on a new stable version is complete, the following steps will prepare the version for release. For purposes of illustration, we will assume we are preparing the stable release of version 5.3.0.
-You will require a system with:
-* macOS
-* JDK 8
-* Maven 3.6.0+
-* Docker
-* GnuPG
-* A GPG key (for signing release artifacts)
-* A Java KeyStore with key (for signing IzPack Installer)
-* A valid Apple Developer Certificate (for signing Mac DMG)
-* A Github account and username / password or Github Personal access tokens (https://github.com/settings/tokens) with permission to publish Github releases to the eXist-db .org
+For purposes of illustration, we will assume we are preparing the stable release of version 7.0.0.
 
-1. You will need login credentials for the eXist-db organisation on:
-    1. Sonatype OSS staging for Maven Central - https://oss.sonatype.org/
-    2. DockerHub - https://cloud.docker.com/orgs/existdb/
-    
-    Your credentials for these should be stored securely in the `<servers`> section on your machine in your local `~/.m2/settings.xml` file, e.g.:
-    ```xml
-    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+1.  Merge any outstanding PRs that have been reviewed and accepted for the milestone eXist-7.0.0.
 
-        <servers>
-        
-            <!-- Sonatype OSS staging for Maven Central -->
-            <server>
-                <id>sonatype-nexus-staging</id>
-                <username>YOUR-USERNAME</username>
-                <password>YOUR-PASSWORD</password>
-            </server>
-            
-            <!-- eXist-db DockerHub -->
-            <server>
-                <id>docker.io</id>
-                <username>YOUR-USERNAME</username>
-                <password>YOUR-PASSWORD</password>
-            </server>
+2.  Confirm that CI is green on `develop` (or your release branch).
 
-            <!-- eXist-db Github Release -->
-            <server>
-                <id>github</id>
-                <privateKey>[Github Personal access tokens]</privateKey>
-            </server>
-        </servers>
-    </settings>
-    ```
+3.  Go to **Actions → Prepare Release** and click **Run workflow**. Enter the version number (e.g. `7.0.0`). Click **Run workflow**.
 
-2. You will need your GPG Key, Java KeyStore, and Apple Notarization API credentials for signing the release artifacts in the `<activeProfiles`> section on your machine in your local `~/.m2/settings.xml` file, e.g.:
-    ```xml
-    <profiles>
-   
-       <profile>
-           <id>existdb-release-signing</id>
-           <properties>
-               <existdb.release.key>ABC1234</existdb.release.key>
-               <existdb.release.public-keyfile>${user.home}/.gnupg/pubring.gpg</existdb.release.public-keyfile>
-               <existdb.release.private-keyfile>${user.home}/.gnupg/secring.gpg</existdb.release.private-keyfile>
-               <existdb.release.key.passphrase>your-password</existdb.release.key.passphrase>
-   
-               <existdb.release.keystore>${user.home}/your.store</existdb.release.keystore>
-               <existdb.release.keystore.pass>your-keystore-password</existdb.release.keystore.pass>
-               <existdb.release.keystore.key.alias>your-alias</existdb.release.keystore.key.alias>
-               <existdb.release.keystore.key.pass>your-key-password</existdb.release.keystore.key.pass>
-   
-                <existdb.release.notarize.username>your-apple-developer-email@your-dom.ain</existdb.release.notarize.username>
-                <existdb.release.notarize.password>your-apple-notarize-api-password</existdb.release.notarize.password>
-           </properties>
-       </profile>
-   
-    </profiles>
+    The workflow will:
+    - Run `mvn -Pcitation-release-metadata -DupdateCff=true -Drevision=7.0.0 validate` to update `CITATION.cff`.
+    - Commit the change if `CITATION.cff` was modified (`[release] Prepare eXist-7.0.0`).
+    - Create an annotated tag `eXist-7.0.0`.
+    - Push the commit and the tag.
 
+4.  The tag push automatically triggers **Actions → Release**. Monitor the four parallel jobs. Total runtime is approximately 45–90 minutes (macOS notarization and Windows Authenticode signing dominate).
 
-    <activeProfiles>
-   
-           <activeProfile>existdb-release-signing</activeProfile>
-   
-    </activeProfiles>
-    ```
-
-3.  Merge any outstanding PRs that have been reviewed and accepted for the milestone eXist-5.3.0.
-
-4.  Make sure that you have the HEAD of `origin/develop` (or `upstream` if you are on a fork).
-
-5.  Prepare the release, if you wish you can do a dry-run first by specifiying `-DdryRun=true`:
-    ```
-    $ mvn -Ddocker=true -Dmac-signing=true -P installer -Dizpack-signing=true -Darguments="-Ddocker=true -Dmac-signing=true -P installer -Dizpack-signing=true" release:prepare
-    ```
-    
-    Maven will start the release process and prompt you for any information that it requires, for example:
-    
-    ```
-    [INFO] --- maven-release-plugin:2.1:prepare (default-cli) @ exist ---
-    [INFO] Verifying that there are no local modifications...
-    [INFO]   ignoring changes on: pom.xml.next, pom.xml.releaseBackup, pom.xml.tag, pom.xml.backup, pom.xml.branch, release.properties
-    [INFO] Executing: /bin/sh -c cd /Users/aretter/code/exist.maven && git status
-    [INFO] Working directory: /Users/aretter/code/exist.maven
-    [INFO] Checking dependencies and plugins for snapshots ...
-    What is the release version for "eXist-db"? (org.exist-db:exist) 5.3.0: :
-    What is SCM release tag or label for "eXist-db"? (org.exist-db:exist) eXist-5.3.0: :
-    What is the new development version for "eXist-db"? (org.exist-db:exist) 5.4.0-SNAPSHOT: :
-    ```
-
-6.  Once the prepare process completes you can perform the release. This will upload Maven Artifacts to Maven
-Central (staging), Docker images to Docker Hub, and eXist-db distributions and installer to Github releases:
-    ```
-    $ mvn -Ddocker=true -Dmac-signing=true -P installer -Dizpack-signing=true -Djarsigner.skip=false -Darguments="-Ddocker=true -Dmac-signing=true -P installer -Dizpack-signing=true -Djarsigner.skip=false" release:perform
-    ```
-
-7.  Update the stable branch (`master`) of eXist-db to reflect the latest release:
-    ```
-    $ git push origin eXist-5.3.0:master
-    ```
+5.  When all four jobs pass, the **Publish GitHub Release** job creates the GitHub Release and attaches all artifacts automatically.
 
 #### Publishing/Promoting the Product Release
+
 1.  Check that the new versions are visible on [Github](https://github.com/eXist-db/exist/releases).
 
 2.  Check that the new versions are visible on [DockerHub](https://hub.docker.com/r/existdb/existdb).
 
-3.  Login to https://oss.sonatype.org and release the Maven artifacts to Maven central as described [here](https://central.sonatype.org/pages/releasing-the-deployment.html).
+3.  Maven Central: the `build-linux` job deploys via `central-publishing-maven-plugin` with `autoPublish=true`. Artifacts are queued for sync immediately after upload. Check [central.sonatype.com](https://central.sonatype.com) for the `org.exist-db` namespace to confirm propagation (typically 15–30 min after job completion).
 
 4.  Update the Mac HomeBrew for eXist-db, see: [Releasing to Homebrew](https://github.com/eXist-db/exist/blob/develop/exist-versioning-release.md#releasing-to-homebrew).
 
@@ -297,6 +234,12 @@ Central (staging), Docker images to Docker Hub, and eXist-db distributions and i
 
 13. Go to GitHub and move all issues and PRs which are still open for the release milestone to the next release milestone. Close the release milestone.
 
+
+### Manual fallback (CI unavailable)
+
+If the CI release workflow is unavailable, the `exist-release` Maven profile (backed by `maven-release-plugin`) remains usable for emergency releases. This path requires a local macOS machine with valid Apple credentials, GnuPG, and all signing keys available in `~/.m2/settings.xml`. See `plans/internal-release-runbook.template.md` §9 for the full procedure and required properties.
+
+Tag naming must still follow the `eXist-X.Y.Z` convention. After a manual tag push, re-run **Actions → Release** via `workflow_dispatch` with the tag name to produce platform artifacts that were skipped locally.
 
 ### Releasing to Homebrew
 [Homebrew](http://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, applications like eXist can be installed via a simple command. eXist's presence on Homebrew is found in the Caskroom project, as a "cask", at [https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb).

--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/extensions/contentextraction/pom.xml
+++ b/extensions/contentextraction/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/exiftool/pom.xml
+++ b/extensions/exiftool/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/expath/pom.xml
+++ b/extensions/expath/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/exquery/modules/pom.xml
+++ b/extensions/exquery/modules/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/exquery/modules/request/pom.xml
+++ b/extensions/exquery/modules/request/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/exquery/pom.xml
+++ b/extensions/exquery/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/exquery/restxq/pom.xml
+++ b/extensions/exquery/restxq/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/indexes/indexes-integration-tests/pom.xml
+++ b/extensions/indexes/indexes-integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     

--- a/extensions/indexes/ngram/pom.xml
+++ b/extensions/indexes/ngram/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/indexes/pom.xml
+++ b/extensions/indexes/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/indexes/range/pom.xml
+++ b/extensions/indexes/range/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/indexes/sort/pom.xml
+++ b/extensions/indexes/sort/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     

--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     

--- a/extensions/indexes/vector-it/pom.xml
+++ b/extensions/indexes/vector-it/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/cache/pom.xml
+++ b/extensions/modules/cache/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/counter/pom.xml
+++ b/extensions/modules/counter/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/cqlparser/pom.xml
+++ b/extensions/modules/cqlparser/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/example/pom.xml
+++ b/extensions/modules/example/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/exi/pom.xml
+++ b/extensions/modules/exi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/expathrepo/expathrepo-trigger-test/pom.xml
+++ b/extensions/modules/expathrepo/expathrepo-trigger-test/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/expathrepo/pom.xml
+++ b/extensions/modules/expathrepo/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/image/pom.xml
+++ b/extensions/modules/image/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/jndi/pom.xml
+++ b/extensions/modules/jndi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/mail/pom.xml
+++ b/extensions/modules/mail/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/persistentlogin/pom.xml
+++ b/extensions/modules/persistentlogin/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/pom.xml
+++ b/extensions/modules/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/process/pom.xml
+++ b/extensions/modules/process/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/scheduler/pom.xml
+++ b/extensions/modules/scheduler/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/simpleql/pom.xml
+++ b/extensions/modules/simpleql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/sql-oracle/pom.xml
+++ b/extensions/modules/sql-oracle/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/xmldiff/pom.xml
+++ b/extensions/modules/xmldiff/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/modules/xslfo/pom.xml
+++ b/extensions/modules/xslfo/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/extensions/security/activedirectory/pom.xml
+++ b/extensions/security/activedirectory/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     

--- a/extensions/security/iprange/pom.xml
+++ b/extensions/security/iprange/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/security/ldap/pom.xml
+++ b/extensions/security/ldap/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/security/pom.xml
+++ b/extensions/security/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/vector/pom.xml
+++ b/extensions/vector/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/extensions/xqdoc/pom.xml
+++ b/extensions/xqdoc/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>exist-parent</relativePath>
     </parent>
 
@@ -71,11 +71,28 @@
     </build>
 
     <profiles>
+        <!-- === Build umbrella profiles === -->
         <profile>
-            <id>installer</id>
+            <!-- Default contributor build: compiles, tests, produces a runnable distribution dir.
+                 Does NOT build installer, stress tests, or micro-benchmarks. -->
+            <id>local-build</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+        </profile>
+
+        <profile>
+            <!-- Full release build: adds exist-installer to the reactor and sets exist.release=true
+                 to enable dist archive assembly in exist-distribution. Use with -Prelease-build. -->
+            <id>release-build</id>
+            <modules>
+                <module>exist-installer</module>
+            </modules>
+        </profile>
+        <!-- === End Build umbrella profiles === -->
+
+        <profile>
+            <id>installer</id>
             <modules>
                 <module>exist-installer</module>
             </modules>
@@ -95,10 +112,17 @@
         </profile>
 
         <profile>
+            <!-- Activates both stress tests and micro-benchmarks in one shot: -Pperf-tests -->
+            <id>perf-tests</id>
+            <modules>
+                <module>exist-core-jcstress</module>
+                <module>exist-core-jmh</module>
+                <module>exist-indexes-jmh</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>concurrency-stress-tests</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <modules>
                 <module>exist-core-jcstress</module>
             </modules>
@@ -106,9 +130,6 @@
 
         <profile>
             <id>micro-benchmarks</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <modules>
                 <module>exist-core-jmh</module>
                 <module>exist-indexes-jmh</module>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <!-- === Build umbrella profiles === -->
         <profile>
             <!-- Default contributor build: compiles, tests, produces a runnable distribution dir.
-                 Does NOT build installer, stress tests, or micro-benchmarks. -->
+                 Does NOT build installer or perf modules. -->
             <id>local-build</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -82,21 +82,14 @@
         </profile>
 
         <profile>
-            <!-- Full release build: adds exist-installer to the reactor and sets exist.release=true
-                 to enable dist archive assembly in exist-distribution. Use with -Prelease-build. -->
+            <!-- Full release build: adds exist-installer to the reactor and (via exist-parent's
+                 release-build profile) enables GPG signing + Central publishing. -->
             <id>release-build</id>
             <modules>
                 <module>exist-installer</module>
             </modules>
         </profile>
         <!-- === End Build umbrella profiles === -->
-
-        <profile>
-            <id>installer</id>
-            <modules>
-                <module>exist-installer</module>
-            </modules>
-        </profile>
 
         <profile>
             <id>docker</id>
@@ -112,25 +105,10 @@
         </profile>
 
         <profile>
-            <!-- Activates both stress tests and micro-benchmarks in one shot: -Pperf-tests -->
+            <!-- Stress tests + JMH micro-benchmarks. -->
             <id>perf-tests</id>
             <modules>
                 <module>exist-core-jcstress</module>
-                <module>exist-core-jmh</module>
-                <module>exist-indexes-jmh</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>concurrency-stress-tests</id>
-            <modules>
-                <module>exist-core-jcstress</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>micro-benchmarks</id>
-            <modules>
                 <module>exist-core-jmh</module>
                 <module>exist-indexes-jmh</module>
             </modules>


### PR DESCRIPTION
## Summary

Ports the lessons from the deferred Maven 4 experiment (#6276) into a
production-ready Maven 3 pipeline. Replaces `maven-release-plugin` with a
two-workflow GitHub Actions pattern, simplifies the profile graph, modernizes
macOS notarization (notarytool + API key auth), and adds Windows Authenticode
signing via Azure Key Vault. Maven Central publishing migrated from legacy
OSSRH to the new Central Portal (`central-publishing-maven-plugin`).

## What changed

### POM modernization
- All 59 POMs switched to `${revision}` (CI-friendly versions). `<revision>7.0.0-SNAPSHOT>` set as default in `exist-parent`.
- `flatten-maven-plugin 1.7.3` added — `flattenMode=resolveCiFriendliesOnly` — so deployed POMs resolve `${revision}` to a literal version. `flatten.clean` execution bound to `clean` phase so `mvn package` is idempotent.
- Minimum Maven version bumped to 3.9.16.

### Profile simplification
- Removed `activeByDefault` from `installer` / `concurrency-stress-tests` / `micro-benchmarks` — they no longer leak into contributor builds.
- New umbrella profiles: `local-build` (default), `release-build` (adds installer + GPG signing + Central publishing), `perf-tests` (stress + benchmarks).
- Removed redundant `installer`, `concurrency-stress-tests`, `micro-benumbrella restructure.

### Release pipeline (CI)
- New `ci-release-prepare.yml` (workflow_dispatch): updates `CITATION.cff`, commits, creates annotated `eXist-X.Y.Z` tag, pushes via `RELEASE_PAT`.
- New `ci-release.yml` (tag-triggered): parallel `build-linux` (Maven Cbuild-mac` (signed + notarized DMG), `build-windows` (signed installerJAR + Authenticode `.exe`), converging on `publish-github-release`.
- `release-preflight` enforcer profile validates required secrets befor
- Workflows hardened: least-privilege permissions, tokens out of CLI args, third-party actions SHA-pinned.

### macOS signing
- Migrated from deprecated `altool --notarize-app` to `notarytool submitaple` with App Store Connect API Key auth (no Apple ID, no 2FA).
- Decoupled `mac-dmg-on-mac` activation from `mac-signing` — contributors get an unsigned DMG automatically on macOS without extra flags.
- Removed default `mac.codesign.identity`.
- Jansi native code now signed in both jarfiles.

### Windows signing
- Azure OIDC federated identity via `azure/login@v2` (no long-lived sec
- JAR signing via `azure-security-keyvault-jca`; `.exe` Authenticode via `AzureSignTool`.

### Documentation
- `exist-versioning-release.md` rewritten for the two-workflow pattern


## Closes

- Closes #3394 — Maven profiles for specific use-cases
- Closes #3411 — distribution archives not built by default
- Closes #4117 — wrong Docker tags during release
- Closes #4217 — improve GitHub-release plugin usage
- Closes #4519 — revise POM versioning
- Closes #5597 — move installer generation to CI
- Closes #5641 — dependency-check only in exist-distribution
- Closes #6177 — staple notarization ticket to DMG
- Closes #6411 — cannot `mvn package` twice
- Closes #6414 — default `mac.codesign.identity` causes contributor bui

see  #6176