### PR TITLE
[ci] fixes to the release pipeline

### DIFF
--- a/.github/workflows/ci-oidc-smoke.yml
+++ b/.github/workflows/ci-oidc-smoke.yml
@@ -1,0 +1,96 @@
+name: Release signing smoke (Azure OIDC + Key Vault JAR sign)
+
+# Exercises the Azure federated credential AND the Key Vault JCA jarsigner
+# path without dispatching a full release. Triggered by tags matching
+# `eXist-*-oidc-smoke` — a pattern that ci-release.yml does NOT match, so
+# the full release pipeline never starts.
+#
+# Validates:
+#   1. Federated credential's matching expression accepts eXist-* tag subject
+#      (Azure OIDC login succeeds).
+#   2. Key Vault Crypto User RBAC propagated to the App Registration
+#      (jarsigner can read the cert metadata).
+#   3. Cert is usable for signing (no DigiCert HSM non-exportable key issue
+#      — Azure SDK #44085 — would surface here).
+#   4. TSA timestamping reachable (Sectigo URL responds).
+#
+# Usage:
+#   git tag -a eXist-99.0.0-oidc-smoke -m "release signing smoke"
+#   git push origin eXist-99.0.0-oidc-smoke
+#   # watch Actions → Release signing smoke (~2-3 min)
+#   git push origin :eXist-99.0.0-oidc-smoke   # cleanup
+#
+# Mirrors ci-release.yml build-windows signing commands. Runs on
+# ubuntu-latest because jarsigner + the Azure JCA library are platform-
+# independent; this catches the same cert/RBAC failures the real Windows
+# job would. Authenticode .exe signing (AzureSignTool) is Windows-only
+# and not exercised here.
+
+on:
+  push:
+    tags:
+      - 'eXist-*-oidc-smoke'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  smoke:
+    name: OIDC login + Key Vault JAR sign
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Azure login (OIDC)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Confirm token + tenant
+        run: |
+          az account show --query "{tenantId:tenantId,user:user.name}" -o table
+          echo "OIDC login succeeded — federated credential expression matches eXist-* tag subject."
+
+      - name: Build throwaway JAR to sign
+        run: |
+          mkdir -p /tmp/smoke && cd /tmp/smoke
+          echo "smoke canary" > canary.txt
+          jar cf smoke.jar canary.txt
+          ls -la smoke.jar
+
+      - name: Sign smoke JAR with Azure Key Vault JCA
+        env:
+          AZURE_KEYVAULT_URI: ${{ vars.AZURE_KEYVAULT_URI }}
+          AZURE_KEYVAULT_CERT_NAME: ${{ vars.AZURE_KEYVAULT_CERT_NAME }}
+        run: |
+          # Mirrors ci-release.yml:223-247 (Sign installer JAR step)
+          KV_JCA_JAR="$HOME/.m2/azure-keyvault-jca.jar"
+          if [ ! -f "$KV_JCA_JAR" ]; then
+            mvn -q dependency:get \
+              -Dartifact=com.azure:azure-security-keyvault-jca:2.10.0:jar \
+              -Ddest="$KV_JCA_JAR"
+          fi
+          ls -la "$KV_JCA_JAR"
+          jarsigner \
+            -keystore NONE \
+            -storetype AzureKeyVault \
+            -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
+            -providerArg "-J-Dazure.keyvault.uri=${AZURE_KEYVAULT_URI}" \
+            -J-cp "$KV_JCA_JAR" \
+            -tsa http://timestamp.sectigo.com/ \
+            /tmp/smoke/smoke.jar "$AZURE_KEYVAULT_CERT_NAME"
+
+      - name: Verify smoke JAR signature
+        run: |
+          jarsigner -verify -strict -verbose /tmp/smoke/smoke.jar | tail -20
+          echo "Key Vault JCA signing succeeded — Crypto User RBAC + cert + TSA all working."

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1035,6 +1035,26 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <!--
+                                    Signs the lz4-java native binaries (Apple notarization #4000 cause)
+                                -->
+                                <id>mac-codesign-lz4-native</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <useMavenLogger>true</useMavenLogger>
+                                    <executable>${project.basedir}/src/main/scripts/codesign-lz4-mac.sh</executable>
+                                    <arguments>
+                                        <argument>${mac.bundle.java.dir}</argument>
+                                        <argument>1.11.0</argument>
+                                        <argument>${project.build.directory}/lz4-native</argument>
+                                        <argument>${mac.codesign.identity}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>mac-codesign-app</id>
                                 <phase>package</phase>
                                 <goals>

--- a/exist-distribution/src/main/scripts/codesign-lz4-mac.sh
+++ b/exist-distribution/src/main/scripts/codesign-lz4-mac.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# eXist-db Open Source Native XML Database
+# Copyright (C) 2001 The eXist-db Authors
+#
+# info@exist-db.org
+# http://www.exist-db.org
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+
+# $1 is .app/Contents/Java dir
+# $2 is the lz4-java version
+# $3 is temp work directory
+# $4 is the mac codesign identity
+
+
+set -e
+#set -x  ## enable to help debug
+
+jar="${1}/lz4-java-${2}.jar"
+
+# ensure a clean temp work directory
+if [ -d "${3}/net" ]
+then
+  rm -rf "${3}/net"
+fi
+
+# lz4-java's darwin natives live under net/jpountz/util/darwin/<arch>/liblz4-java.dylib
+archs=('aarch64' 'x86_64')
+for arch in "${archs[@]}"
+do
+  mkdir -p "${3}/net/jpountz/util/darwin/${arch}"
+
+  pushd "${3}"
+
+  # extract the native file
+  jar -xf "${jar}" "net/jpountz/util/darwin/${arch}/liblz4-java.dylib"
+
+  # test if signed; sign if not (mirrors codesign-jansi-mac.sh pattern)
+  /usr/bin/codesign --verbose --test-requirement="=anchor trusted" \
+                    --verify "net/jpountz/util/darwin/${arch}/liblz4-java.dylib" || \
+                    /usr/bin/codesign --verbose --force --timestamp --sign "${4}" \
+                    "net/jpountz/util/darwin/${arch}/liblz4-java.dylib"
+
+  # overwrite the file in the jar
+  jar -uf "${jar}" "net/jpountz/util/darwin/${arch}/liblz4-java.dylib"
+
+  popd
+done


### PR DESCRIPTION
Mac notarisation errors are straight forward. This should fix all reported errors from the last attempt.

Azure is not hence a smoke test to run from CI, to test the modification in the cloud before the next release attempt