### PR TITLE
[bugfix] repo:remove: throw with diagnostic info instead of swallowing exceptions

### DIFF
--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/EXPathErrorCode.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/EXPathErrorCode.java
@@ -49,7 +49,7 @@ public class EXPathErrorCode extends ErrorCode {
     public final static ErrorCode EXPDY005 = new EXPathErrorCode("EXPATH005", "Invalid repo URI");
     public final static ErrorCode EXPDY006 = new EXPathErrorCode("EXPATH006", "Failed to connect to public repo");
     // other error thrown from expath library
-    public final static ErrorCode EXPDY007 = new EXPathErrorCode("EXPATH00", null);
+    public final static ErrorCode EXPDY007 = new EXPathErrorCode("EXPATH007", "Generic error from the expath repository library.");
     
     public final static String EXPATH_ERROR_NS = "http://expath.org/ns/error";
     public final static String EXPATH_ERROR_PREFIX = "experr";

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/RemoveFunction.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/RemoveFunction.java
@@ -47,42 +47,45 @@ import org.expath.pkg.repo.tui.BatchUserInteraction;
  * @author ljo
  */
 public class RemoveFunction extends BasicFunction {
-    @SuppressWarnings("unused")
-	private final static Logger logger = LogManager.getLogger(RemoveFunction.class);
+    private final static Logger LOG = LogManager.getLogger(RemoveFunction.class);
 
     public final static FunctionSignature signature =
-		new FunctionSignature(
-			new QName("remove", ExpathPackageModule.NAMESPACE_URI, ExpathPackageModule.PREFIX),
-			"Remove package, pkgName, from repository.",
-			new SequenceType[] { new FunctionParameterSequenceType("pkgName", Type.STRING, Cardinality.EXACTLY_ONE, "package name")},
-			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if successful, false otherwise"));
+            new FunctionSignature(
+                    new QName("remove", ExpathPackageModule.NAMESPACE_URI, ExpathPackageModule.PREFIX),
+                    "Remove package, pkgName, from repository. Throws EXPATH007 with the underlying cause on failure (e.g. package not found, dependent packages still installed, filesystem permission error).",
+                    new SequenceType[]{new FunctionParameterSequenceType("pkgName", Type.STRING, Cardinality.EXACTLY_ONE, "package name")},
+                    new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the package was removed"));
 
-	public RemoveFunction(XQueryContext context) {
-		super(context, signature);
- 	}
+    public RemoveFunction(final XQueryContext context) {
+        super(context, signature);
+    }
 
-	public Sequence eval(Sequence[] args, Sequence contextSequence)
-		throws XPathException {
-	    Sequence removed = BooleanValue.TRUE;
-	    boolean force = false;
-	    UserInteractionStrategy interact = new BatchUserInteraction();
-	    String pkg = args[0].getStringValue();
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final boolean force = false;
+        final UserInteractionStrategy interact = new BatchUserInteraction();
+        final String pkg = args[0].getStringValue();
 
-	    try {
-		Optional<ExistRepository> repo = getContext().getRepository();
-		if (repo.isPresent()) {
-		    Repository parent_repo = repo.get().getParentRepo();
-		    parent_repo.removePackage(pkg, force, interact);
-		    repo.get().reportAction(ExistRepository.Action.UNINSTALL, pkg);
-		    context.getBroker().getBrokerPool().getXQueryPool().clear();
-		} else {
-		    throw new XPathException(this, "expath repository not available");
-		}
-	    } catch (PackageException | XPathException pe) {
-		return BooleanValue.FALSE;
-		// /TODO: _repo.removePackage seems to throw PackageException
-		// throw new XPathException("Problem removing package " + pkg + " in expath repository, check that eXist-db has access permissions to expath repository file directory  ", pe);
-	    }
-        return removed;
-	}
+        final Optional<ExistRepository> repo = getContext().getRepository();
+        if (repo.isEmpty()) {
+            throw new XPathException(this, EXPathErrorCode.EXPDY007, "expath repository not available");
+        }
+
+        try {
+            final Repository parentRepo = repo.get().getParentRepo();
+            parentRepo.removePackage(pkg, force, interact);
+            repo.get().reportAction(ExistRepository.Action.UNINSTALL, pkg);
+            context.getBroker().getBrokerPool().getXQueryPool().clear();
+        } catch (final PackageException pe) {
+            // Previously this catch returned BooleanValue.FALSE and swallowed the exception
+            // (with a TODO from the previous author noting this should throw with the
+            // underlying cause). The silent false offered no diagnostic, and downstream
+            // tooling had no way to surface the actual failure to the user. Now we log and
+            // rethrow so both the eXist log and the caller see the original cause.
+            LOG.warn("Failed to remove package {}: {}", pkg, pe.getMessage(), pe);
+            throw new XPathException(this, EXPathErrorCode.EXPDY007,
+                    "Failed to remove package " + pkg + ": " + pe.getMessage(), pe);
+        }
+        return BooleanValue.TRUE;
+    }
 }

--- a/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/deployment.xql
+++ b/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/deployment.xql
@@ -180,8 +180,15 @@ function deploy:install-uninstall-library() {
         $inList,
         $avail1,
         $avail2,
-        $undeploy/@result/string(), 
+        $undeploy/@result/string(),
         $remove,
         $avail3
     )
+};
+
+declare
+    %test:name("repo:remove on unknown package throws EXPATH007 rather than silently returning false")
+    %test:assertError("EXPATH007")
+function deploy:remove-unknown-throws() {
+    repo:remove("http://exist-db.org/apps/this-package-does-not-exist-and-never-did")
 };


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

`RemoveFunction.eval` silently caught all `PackageException` / `XPathException` and returned `xs:boolean false` with no logging and no exception propagation. Users had no way to see why a removal failed, and downstream tooling (Dashboard, xst) showed misleading "OK" / "✔︎" messages because they had no error signal to consume. This PR throws an `XPathException(EXPATH007, ..., cause)` with the original cause attached, plus logs at WARN level so the server log captures it too.

## Reproduction (before)

```xquery
xquery version "3.1";
repo:remove("http://exist-db.org/apps/this-package-does-not-exist")
(: → xs:boolean false, with no log entry, no error info :)
```

## Reproduction (after)

```
err:EXPATH007: Failed to remove package http://exist-db.org/apps/this-package-does-not-exist:
  The package does not exist: http://exist-db.org/apps/this-package-does-not-exist
```

Server log:

```
WARN  (RemoveFunction.java:81) - Failed to remove package http://exist-db.org/apps/...:
  The package does not exist: http://exist-db.org/apps/...
  org.expath.pkg.repo.PackageException: The package does not exist: ...
      at org.expath.pkg.repo.Repository.removePackage(Repository.java:468)
      ...
```

## What changed

`extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/`:

- **`RemoveFunction.java`** — rewrite the catch to log + rethrow as `XPathException(EXPDY007, cause)`. Minor cleanups: consistent `final` + `@Override`, drop the `@SuppressWarnings("unused")` logger (now actually used), unify the `Optional.isPresent()` / `Optional.isEmpty()` style.
- **`EXPathErrorCode.java`** — drive-by typo fix. `EXPDY007` was declared with the literal `"EXPATH00"` (missing the `7`) and a `null` description. Now `"EXPATH007"` with a description. The PR's regression test depends on the error code working correctly. The change is technically public-facing (callers `catch`ing on `err:EXPATH00` would break), but `EXPATH00` looks like nothing anyone caught deliberately.

`extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/`:

- **`deployment.xql`** — new `%test:assertError("EXPATH007")` regression test: `repo:remove` on a non-existent package now throws rather than silently returning false.

## Why a separate PR (vs. bundling with the install-and-deploy fix)

The two bugs surface together for users (Craig Berry on Slack ran into both in sequence) but they live in unrelated files and have unrelated fix shapes. Splitting keeps each PR small and reviewable. The companion PR (`Deployment.installAndDeploy` ignoring explicit version) is filed separately.

## Test plan

- [x] `mvn test -pl extensions/modules/expathrepo -Dtest=ExpathRepoTests` — 9/9 pass (including new regression)
- [x] Codacy/PMD clean on all touched files
- [x] US-English sweep clean
- [ ] CI green

## Related items not in scope

- `repo:remove` hard-codes `force = false`. The EXPath repo refuses to remove packages with reverse dependencies under that flag. Worth exposing a `force` overload (`repo:remove($name, $force as xs:boolean)`), but that's a behavior addition rather than a bugfix and belongs in its own PR.
- xst's `commands/package/uninstall.js` has a separate inversion bug at line 21 (`success = Boolean(result.error)`) that contributes to the misleading "✔︎ uninstalled" output. Tracked separately in eXist-db/xst.
