### PR TITLE
[bugfix] repo:install-and-deploy respect explicitly-requested version

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -375,124 +375,185 @@ public class Deployment {
         }
         try {
             // if there's a <setup> element, run the query it points to
-            final Optional<ElementImpl> setup = findElement(repoXML, SETUP_ELEMENT);
-            final Optional<String> setupPath = setup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
-
+            final Optional<String> setupPath = findElementValue(repoXML, SETUP_ELEMENT);
             if (setupPath.isPresent()) {
                 runQuery(broker, null, packageDir, setupPath.get(), pkgName, QueryPurpose.SETUP);
                 return Optional.empty();
-            } else {
-                // otherwise create the target collection
-                XmldbURI targetCollection = null;
-                if (userTarget != null) {
-                    try {
-                        targetCollection = XmldbURI.create(userTarget);
-                    } catch (final IllegalArgumentException e) {
-                        throw new PackageException("Bad collection URI: " + userTarget, e);
-                    }
-                } else {
-                    final Optional<ElementImpl> target = findElement(repoXML, TARGET_COLL_ELEMENT);
-                    final Optional<String> targetPath = target.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
-
-                    if (targetPath.isPresent()) {
-                        // determine target collection
-                        try {
-                            targetCollection = XmldbURI.create(getTargetCollection(broker, targetPath.get()));
-                        } catch (final IllegalArgumentException e) {
-                            throw new PackageException("Bad collection URI for <target> element: " + targetPath.get(), e);
-                        }
-                    } else {
-                        LOG.warn("EXPath Package '{}' does not contain a <target> in its repo.xml, no files will be deployed to /apps", pkgName);
-                    }
-                }
-                if (targetCollection == null) {
-                    // no target means: package does not need to be deployed into database
-                    // however, we need to preserve a copy for backup purposes.
-                    // Use targetPkg's abbrev+version directly rather than re-resolving
-                    // packages.latest() — when install-and-deploy was called with an
-                    // explicit older version, the registry's latest may be a different
-                    // (higher) version, and re-resolving would point this status target
-                    // at the wrong version's collection.
-                    final String pkgColl = targetPkg.getAbbrev() + "-" + targetPkg.getVersion();
-                    targetCollection = XmldbURI.SYSTEM.append("repo/" + pkgColl);
-                }
-
-                // extract the permissions (if any)
-                final Optional<ElementImpl> permissions = findElement(repoXML, PERMISSIONS_ELEMENT);
-                final Optional<RequestedPerms> requestedPerms = permissions.flatMap(elem -> {
-                    final Optional<Either<Integer, String>> perms = Optional.of(elem.getAttribute("mode")).flatMap(mode -> {
-                        try {
-                            return Optional.of(Either.Left(Integer.parseInt(mode, 8)));
-                        } catch (final NumberFormatException e) {
-                            if (mode.matches("^[rwx-]{9}")) {
-                                return Optional.of(Either.Right(mode));
-                            } else {
-                                return Optional.empty();
-                            }
-                        }
-                    });
-
-                    return perms.map(p -> new RequestedPerms(
-                            elem.getAttribute("user"),
-                            elem.getAttribute("password"),
-                            Optional.of(elem.getAttribute("group")),
-                            p
-                    ));
-                });
-
-                //check that if there were permissions then we were able to parse them, a failure would be related to the mode string
-                if (permissions.isPresent() && requestedPerms.isEmpty()) {
-                    final String mode = permissions.map(elem -> elem.getAttribute("mode")).orElse(null);
-                    throw new PackageException("Bad format for mode attribute in <permissions>: " + mode);
-                }
-
-                // run the pre-setup query if present
-                final Optional<ElementImpl> preSetup = findElement(repoXML, PRE_SETUP_ELEMENT);
-                final Optional<String> preSetupPath = preSetup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
-
-                if (preSetupPath.isPresent()) {
-                    runQuery(broker, targetCollection, packageDir, preSetupPath.get(), pkgName, QueryPurpose.PREINSTALL);
-                }
-
-                // create the group specified in the permissions element if needed
-                // create the user specified in the permissions element if needed; assign it to the specified group
-                // TODO: if the user already exists, check and ensure the user is assigned to the specified group
-                if (requestedPerms.isPresent()) {
-                    checkUserSettings(broker, requestedPerms.get());
-                }
-
-                final InMemoryNodeSet resources = findElements(repoXML, RESOURCES_ELEMENT);
-
-                // store all package contents into database, using the user/group/mode in the permissions element. however:
-                // 1. repo.xml is excluded for now, since it may contain the default user's password in the clear
-                // 2. contents of directories identified in the path attribute of any <resource path=""/> element are stored as binary
-                final List<String> errors = scanDirectory(broker, transaction, packageDir, targetCollection, resources, true, false,
-                        requestedPerms);
-
-                // store repo.xml, filtering out the default user's password
-                storeRepoXML(broker, transaction, repoXML, targetCollection, requestedPerms);
-
-                // run the post-setup query if present
-                final Optional<ElementImpl> postSetup = findElement(repoXML, POST_SETUP_ELEMENT);
-                final Optional<String> postSetupPath = postSetup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
-
-                if (postSetupPath.isPresent()) {
-                    runQuery(broker, targetCollection, packageDir, postSetupPath.get(), pkgName, QueryPurpose.POSTINSTALL);
-                }
-
-                // TODO: it should be safe to clean up the file system after a package
-                // has been deployed. Might be enabled after 2.0
-                //cleanup(pkgName, repo);
-
-                if (!errors.isEmpty()) {
-                    throw new PackageException("Deployment incomplete, " + errors.size() + " issues found: " +
-                            String.join("; ", errors));
-                }
-                return Optional.ofNullable(targetCollection.getCollectionPath());
             }
+
+            // otherwise create the target collection
+            final XmldbURI targetCollection = resolveTargetCollection(broker, repoXML, targetPkg, userTarget);
+
+            // extract the permissions (if any)
+            final Optional<RequestedPerms> requestedPerms = findRequestedPerms(repoXML);
+
+            // run the pre-setup query if present
+            runOptionalQuery(broker, targetCollection, packageDir, repoXML, PRE_SETUP_ELEMENT, pkgName, QueryPurpose.PREINSTALL);
+
+            // create the group specified in the permissions element if needed
+            // create the user specified in the permissions element if needed; assign it to the specified group
+            // TODO: if the user already exists, check and ensure the user is assigned to the specified group
+            if (requestedPerms.isPresent()) {
+                checkUserSettings(broker, requestedPerms.get());
+            }
+
+            final InMemoryNodeSet resources = findElements(repoXML, RESOURCES_ELEMENT);
+
+            // store all package contents into database, using the user/group/mode in the permissions element. however:
+            // 1. repo.xml is excluded for now, since it may contain the default user's password in the clear
+            // 2. contents of directories identified in the path attribute of any <resource path=""/> element are stored as binary
+            final List<String> errors = scanDirectory(broker, transaction, packageDir, targetCollection, resources, true, false,
+                    requestedPerms);
+
+            // store repo.xml, filtering out the default user's password
+            storeRepoXML(broker, transaction, repoXML, targetCollection, requestedPerms);
+
+            // run the post-setup query if present
+            runOptionalQuery(broker, targetCollection, packageDir, repoXML, POST_SETUP_ELEMENT, pkgName, QueryPurpose.POSTINSTALL);
+
+            // TODO: it should be safe to clean up the file system after a package
+            // has been deployed. Might be enabled after 2.0
+            //cleanup(pkgName, repo);
+
+            if (!errors.isEmpty()) {
+                throw new PackageException("Deployment incomplete, " + errors.size() + " issues found: " +
+                        String.join("; ", errors));
+            }
+            return Optional.ofNullable(targetCollection.getCollectionPath());
         } catch (final XPathException e) {
             throw new PackageException("Error found while processing repo.xml: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Returns the non-empty string value of the first descendant element with the given name.
+     *
+     * @param repoXML the parsed repo.xml descriptor
+     * @param elementName the name of the element to look for
+     *
+     * @return the element's string value, or {@link Optional#empty()} if the element is absent or empty
+     *
+     * @throws XPathException if the descriptor cannot be traversed
+     */
+    private Optional<String> findElementValue(final DocumentImpl repoXML, final QName elementName) throws XPathException {
+        return findElement(repoXML, elementName).map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
+    }
+
+    /**
+     * Runs the setup query pointed to by the given repo.xml element, if that element is present
+     * and names a non-empty path.
+     *
+     * @param broker the database broker
+     * @param targetCollection the collection the package is deployed into
+     * @param packageDir the unpacked package directory
+     * @param repoXML the parsed repo.xml descriptor
+     * @param elementName the repo.xml element holding the query path
+     * @param pkgName the package name, for error reporting
+     * @param purpose the purpose of the query, for error reporting
+     *
+     * @throws PackageException if the query fails
+     * @throws IOException if the query resource cannot be read
+     * @throws XPathException if the descriptor cannot be traversed
+     */
+    private void runOptionalQuery(final DBBroker broker, final XmldbURI targetCollection, final Path packageDir,
+                                  final DocumentImpl repoXML, final QName elementName, final String pkgName,
+                                  final QueryPurpose purpose) throws PackageException, IOException, XPathException {
+        final Optional<String> queryPath = findElementValue(repoXML, elementName);
+        if (queryPath.isPresent()) {
+            runQuery(broker, targetCollection, packageDir, queryPath.get(), pkgName, purpose);
+        }
+    }
+
+    /**
+     * Determines the collection a package should be deployed into: an explicitly requested
+     * target takes precedence, then the {@code <target>} element of repo.xml. If neither is
+     * given the package does not need to be deployed into the database, and a copy is
+     * preserved under {@code /db/system/repo} for backup purposes instead.
+     *
+     * @param broker the database broker
+     * @param repoXML the parsed repo.xml descriptor
+     * @param targetPkg the package being deployed
+     * @param userTarget an explicitly requested target collection, or null
+     *
+     * @return the target collection URI, never null
+     *
+     * @throws PackageException if a target collection URI is malformed
+     * @throws XPathException if the descriptor cannot be traversed
+     */
+    private XmldbURI resolveTargetCollection(final DBBroker broker, final DocumentImpl repoXML, final Package targetPkg,
+                                             final String userTarget) throws PackageException, XPathException {
+        if (userTarget != null) {
+            try {
+                return XmldbURI.create(userTarget);
+            } catch (final IllegalArgumentException e) {
+                throw new PackageException("Bad collection URI: " + userTarget, e);
+            }
+        }
+
+        final Optional<String> targetPath = findElementValue(repoXML, TARGET_COLL_ELEMENT);
+        if (targetPath.isPresent()) {
+            // determine target collection
+            try {
+                return XmldbURI.create(getTargetCollection(broker, targetPath.get()));
+            } catch (final IllegalArgumentException e) {
+                throw new PackageException("Bad collection URI for <target> element: " + targetPath.get(), e);
+            }
+        }
+
+        LOG.warn("EXPath Package '{}' does not contain a <target> in its repo.xml, no files will be deployed to /apps", targetPkg.getName());
+
+        // no target means: package does not need to be deployed into database
+        // however, we need to preserve a copy for backup purposes.
+        // Use targetPkg's abbrev+version directly rather than re-resolving
+        // packages.latest() — when install-and-deploy was called with an
+        // explicit older version, the registry's latest may be a different
+        // (higher) version, and re-resolving would point this status target
+        // at the wrong version's collection.
+        final String pkgColl = targetPkg.getAbbrev() + "-" + targetPkg.getVersion();
+        return XmldbURI.SYSTEM.append("repo/" + pkgColl);
+    }
+
+    /**
+     * Extracts the user, group and mode requested by the {@code <permissions>} element of repo.xml.
+     *
+     * @param repoXML the parsed repo.xml descriptor
+     *
+     * @return the requested permissions, or {@link Optional#empty()} if there is no
+     *     {@code <permissions>} element
+     *
+     * @throws PackageException if a {@code <permissions>} element is present but its mode
+     *     attribute cannot be parsed
+     * @throws XPathException if the descriptor cannot be traversed
+     */
+    private Optional<RequestedPerms> findRequestedPerms(final DocumentImpl repoXML) throws PackageException, XPathException {
+        final Optional<ElementImpl> permissions = findElement(repoXML, PERMISSIONS_ELEMENT);
+        final Optional<RequestedPerms> requestedPerms = permissions.flatMap(elem -> {
+            final Optional<Either<Integer, String>> perms = Optional.of(elem.getAttribute("mode")).flatMap(mode -> {
+                try {
+                    return Optional.of(Either.Left(Integer.parseInt(mode, 8)));
+                } catch (final NumberFormatException e) {
+                    if (mode.matches("^[rwx-]{9}")) {
+                        return Optional.of(Either.Right(mode));
+                    } else {
+                        return Optional.empty();
+                    }
+                }
+            });
+
+            return perms.map(p -> new RequestedPerms(
+                    elem.getAttribute("user"),
+                    elem.getAttribute("password"),
+                    Optional.of(elem.getAttribute("group")),
+                    p
+            ));
+        });
+
+        //check that if there were permissions then we were able to parse them, a failure would be related to the mode string
+        if (permissions.isPresent() && requestedPerms.isEmpty()) {
+            final String mode = permissions.map(elem -> elem.getAttribute("mode")).orElse(null);
+            throw new PackageException("Bad format for mode attribute in <permissions>: " + mode);
+        }
+        return requestedPerms;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -255,8 +255,16 @@ public class Deployment {
             broker.getBrokerPool().reportStatus("Installing app: " + pkg.getAbbrev());
             repo.get().reportAction(ExistRepository.Action.INSTALL, pkg.getName());
 
-            LOG.info("Deploying package {}", pkgName);
-            return deploy(broker, transaction, pkgName, repo, null);
+            // installPackage may return packages.latest() (the highest-version
+            // entry by semver) rather than the just-installed package when the
+            // registry already had a higher version with the same name. Deploy
+            // the freshly-installed package specifically (looked up by the
+            // version we extracted from the XAR descriptor above) so an explicit
+            // repo:install-and-deploy(name, "<older>", url) is not silently
+            // upgraded to packages.latest().
+            final Package deployTarget = resolveInstalledVersion(repo.get(), pkg, pkgVersion);
+            LOG.info("Deploying package {} (version {})", pkgName, deployTarget.getVersion());
+            return deploy(broker, transaction, deployTarget, null);
         }
 
         // Totally unnecessary to do the above if repo is unavailable.
@@ -271,6 +279,18 @@ public class Deployment {
             throw new PackageException("Package requires eXist-db version " + version + ". " +
                     "Installed version is " + procVersion);
         }
+    }
+
+    private Package resolveInstalledVersion(final ExistRepository repo, final Package installed, final String requestedVersion) {
+        if (requestedVersion == null) {
+            return installed;
+        }
+        final Packages allVersions = repo.getParentRepo().getPackages(installed.getName());
+        if (allVersions == null) {
+            return installed;
+        }
+        final Package match = allVersions.version(requestedVersion);
+        return match != null ? match : installed;
     }
 
     public Optional<String> undeploy(final DBBroker broker, final Txn transaction, final String pkgName, final Optional<ExistRepository> repo) throws PackageException {
@@ -317,14 +337,38 @@ public class Deployment {
         return Optional.empty();
     }
 
+    /**
+     * Deploy a package by name. Resolves the package via {@code packages.latest()} for
+     * that name (see {@link #getPackage(String, Optional)}), which is appropriate for
+     * callers that explicitly want "the latest installed version of this package" —
+     * e.g., the user invoking {@code repo:deploy(name)} directly.
+     *
+     * NOT appropriate for the install-and-deploy flow when a specific version has just
+     * been installed alongside an existing higher version; that path should call
+     * {@link #deploy(DBBroker, Txn, Package, String)} with the
+     * freshly-installed package itself.
+     */
     public Optional<String> deploy(final DBBroker broker, final Txn transaction, final String pkgName, final Optional<ExistRepository> repo, final String userTarget) throws PackageException, IOException {
-        final Optional<Path> maybePackageDir = getPackageDir(pkgName, repo);
-        if (maybePackageDir.isEmpty()) {
+        final Optional<Package> pkg = getPackage(pkgName, repo);
+        if (pkg.isEmpty()) {
             throw new PackageException("Package not found: " + pkgName);
         }
+        return deploy(broker, transaction, pkg.get(), userTarget);
+    }
 
-        final Path packageDir = maybePackageDir.get();
-
+    /**
+     * Deploy a specific {@link Package}. Use this overload when the caller knows exactly
+     * which package version to deploy (e.g., the one it just installed) rather than
+     * wanting the {@code packages.latest()} for the given name.
+     *
+     * Introduced to fix the bug where {@code repo:install-and-deploy} with an explicit
+     * version argument would correctly install the requested version but then deploy the
+     * existing higher version instead, because the name-based lookup always returned
+     * {@code packages.latest()}.
+     */
+    public Optional<String> deploy(final DBBroker broker, final Txn transaction, final Package targetPkg, final String userTarget) throws PackageException, IOException {
+        final Path packageDir = getPackageDir(targetPkg);
+        final String pkgName = targetPkg.getName();
         final DocumentImpl repoXML = getRepoXML(broker, packageDir);
         if (repoXML == null) {
             return Optional.empty();
@@ -363,10 +407,13 @@ public class Deployment {
                 }
                 if (targetCollection == null) {
                     // no target means: package does not need to be deployed into database
-                    // however, we need to preserve a copy for backup purposes
-                    final Optional<Package> pkg = getPackage(pkgName, repo);
-                    pkg.orElseThrow(() -> new XPathException((Expression) null, "expath repository is not available so the package was not stored."));
-                    final String pkgColl = pkg.get().getAbbrev() + "-" + pkg.get().getVersion();
+                    // however, we need to preserve a copy for backup purposes.
+                    // Use targetPkg's abbrev+version directly rather than re-resolving
+                    // packages.latest() — when install-and-deploy was called with an
+                    // explicit older version, the registry's latest may be a different
+                    // (higher) version, and re-resolving would point this status target
+                    // at the wrong version's collection.
+                    final String pkgColl = targetPkg.getAbbrev() + "-" + targetPkg.getVersion();
                     targetCollection = XmldbURI.SYSTEM.append("repo/" + pkgColl);
                 }
 

--- a/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/deployment.xql
+++ b/extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/deployment.xql
@@ -70,6 +70,39 @@ declare variable $deploy:entries-library := (
     <entry name="test.xml" type="xml"><test><foo/></test></entry>
 );
 
+(: Separate fixture for the version-routing regression test — uses a distinct
+   package name so leftover state doesn't pollute the dtest tests above. :)
+declare variable $deploy:expathxml-vtest-high :=
+    <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/dtest-versioning" abbrev="dtest-versioning" version="1.0.0" spec="1.0">
+        <title>Deployment Test (versioning)</title>
+        <dependency package="http://exist-db.org/html-templating" semver-min="1.0.2"/>
+    </package>;
+
+declare variable $deploy:expathxml-vtest-low :=
+    <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/dtest-versioning" abbrev="dtest-versioning" version="0.5.0" spec="1.0">
+        <title>Deployment Test (versioning, older)</title>
+        <dependency package="http://exist-db.org/html-templating" semver-min="1.0.2"/>
+    </package>;
+
+declare variable $deploy:repoxml-vtest :=
+    <meta xmlns="http://exist-db.org/xquery/repo">
+        <description>Deployment Test (versioning)</description>
+        <type>application</type>
+        <target>dtest-versioning</target>
+    </meta>;
+
+declare variable $deploy:entries-vtest-high := (
+    <entry name="expath-pkg.xml" type="xml">{$deploy:expathxml-vtest-high}</entry>,
+    <entry name="repo.xml" type="xml">{$deploy:repoxml-vtest}</entry>,
+    <entry name="test-high.xml" type="xml"><test><foo/></test></entry>
+);
+
+declare variable $deploy:entries-vtest-low := (
+    <entry name="expath-pkg.xml" type="xml">{$deploy:expathxml-vtest-low}</entry>,
+    <entry name="repo.xml" type="xml">{$deploy:repoxml-vtest}</entry>,
+    <entry name="test-low.xml" type="xml"><test><foo/></test></entry>
+);
+
 declare
     %test:setUp
 function deploy:setup() {
@@ -191,4 +224,57 @@ declare
     %test:assertError("EXPATH007")
 function deploy:remove-unknown-throws() {
     repo:remove("http://exist-db.org/apps/this-package-does-not-exist-and-never-did")
+};
+
+declare
+    %test:name("install-and-deploy respects the freshly installed package version (regression for Deployment.installAndDeploy deploying packages.latest() instead of the version just installed)")
+    %test:assertEquals("ok", "ok", "0.5.0", "true")
+function deploy:install-lower-version-after-higher() {
+    (: Use a distinct package name from the other tests (`dtest-versioning`,
+       not `dtest`) so leftover state doesn't pollute the rest of the suite. :)
+    let $pkg-name := "http://exist-db.org/apps/dtest-versioning"
+    let $target-coll := "/db/apps/dtest-versioning"
+
+    (: Install version 1.0.0 first. :)
+    let $zip-high := compression:zip($deploy:entries-vtest-high, false())
+    let $stored-high := xmldb:store("/db/deployment-test", "dtest-versioning-high", $zip-high)
+    let $deployed-high := repo:install-and-deploy-from-db($stored-high)
+
+    (: Then install version 0.5.0 (lower) while 1.0.0 is still present.
+       Before the fix, Deployment.installAndDeploy correctly fetched 0.5.0
+       but the subsequent deploy() step ran against packages.latest() (1.0.0)
+       and the user-visible deployed version stayed at 1.0.0. :)
+    let $zip-low := compression:zip($deploy:entries-vtest-low, false())
+    let $stored-low := xmldb:store("/db/deployment-test", "dtest-versioning-low", $zip-low)
+    let $deployed-low := repo:install-and-deploy-from-db($stored-low)
+
+    (: After the second install, the descriptor copied into the deployed target
+       collection should be 0.5.0's (the just-installed version), not 1.0.0's
+       (the existing higher version). Before the fix the second deploy step
+       used packages.latest() and copied 1.0.0's descriptor instead.
+       NOTE: we read /db/apps/<target>/expath-pkg.xml, NOT
+       repo:get-resource(name, "expath-pkg.xml") — the latter reads from
+       packages.latest()'s dir, not from the deployed target. :)
+    let $deployed-version := doc($target-coll || "/expath-pkg.xml")/*:package/@version/string()
+
+    (: Sanity check: the just-installed 0.5.0 XAR's distinctive resource
+       test-low.xml should be present in the deployed target collection.
+       (test-high.xml may also still be there from the prior 1.0.0 deploy —
+       deploy does not clean up old files — so its presence is not
+       informative either way.) :)
+    let $low-resource-deployed := exists(doc($target-coll || "/test-low.xml"))
+
+    (: Cleanup — best effort; loop until repo:list no longer contains the package
+       (both versions are now in the registry, so a single remove may not suffice). :)
+    let $_cleanup :=
+        for $attempt in 1 to 5
+        where exists(repo:list()[. = $pkg-name])
+        return (repo:undeploy($pkg-name), try { repo:remove($pkg-name) } catch * { () })
+
+    return (
+        $deployed-high/@result/string(),
+        $deployed-low/@result/string(),
+        $deployed-version,
+        string($low-resource-deployed)
+    )
 };


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

When a higher version of a package is already installed in the EXPath registry, calling `repo:install-and-deploy($name, $version, $url)` with an explicit *lower* `$version` reports success but silently deploys the existing higher version instead of the one the user asked for. This PR makes the deploy step use the freshly-installed package directly, so the explicit version request is honored.

This was surfaced by Craig Berry on Slack while attempting to downgrade `tei-publisher-lib` from 6.1.0 to 6.0.2. A companion fix for the related silent-failure on `repo:remove` is in #6432.

## What changed

**`exist-core/src/main/java/org/exist/repo/Deployment.java`**

- Added a `Package`-based overload `deploy(DBBroker, Txn, Package, String)`. The body is the prior `deploy(... String pkgName, Optional<ExistRepository> repo, ...)` lifted to take a `Package` directly, so the package-dir / abbrev / version lookups all flow from one consistent source instead of re-resolving by name halfway through.
- The original by-name overload is kept (for `repo:deploy(name)` callers) and delegates to the new one via `getPackage(pkgName, repo)`.
- `installAndDeploy(...)` now resolves the just-installed package by the version extracted from the XAR descriptor (`Packages.version(requestedVersion)`) rather than relying on what `installPackage()` returns — which, for the higher-version-already-present case, was `packages.latest()`. The lookup is in a small `resolveInstalledVersion()` helper to keep `installAndDeploy`'s NPath complexity at its prior level.

**`extensions/modules/expathrepo/src/test/xquery/modules/expathrepo/deployment.xql`**

- New regression test `deploy:install-lower-version-after-higher`: installs version 1.0.0, then installs version 0.5.0 (using fresh fixtures with name `http://exist-db.org/apps/dtest-versioning` to avoid polluting other tests), and asserts that the `expath-pkg.xml` written to the deployed target collection `/db/apps/dtest-versioning/` reports version 0.5.0. Before the fix this returned 1.0.0.
- The assertion reads `doc("/db/apps/<target>/expath-pkg.xml")` rather than `repo:get-resource(name, "expath-pkg.xml")` — the latter returns from `packages.latest()`'s repo dir and so reports 1.0.0 even after a correct deploy of 0.5.0; only the deployed target collection shows what was actually delivered to the user.

## Root cause

In `Deployment.installAndDeploy`:

1. `repo.getParentRepo().installPackage(xar, ...)` is called, which installs the XAR into the registry and returns *some* `Package` — but for an EXPath name with multiple versions present, it returns `packages.latest()`, not necessarily the just-installed one.
2. The follow-up `deploy(pkgName, ...)` then calls `getPackage(pkgName, repo)`, which also returns `packages.latest()`, and deploys from *that* package's dir.

So even though the right XAR was unpacked into `data/expathrepo/<abbrev>-<requested>/`, the deploy step copies files out of `data/expathrepo/<abbrev>-<latest>/` into `/db/apps/<target>/`. Result: install OK, but deploy installs the wrong version, with no error.

## Test plan

- [x] `mvn test -pl extensions/modules/expathrepo -Dtest='ExpathRepoTests'` — 9/9 pass (8 prior + new regression)
- [x] Codacy / PMD on changed Java file — no new warnings introduced (NPath, `cleanup()` unused, parameter reassignment warnings are pre-existing on this file)
- [x] Manually reproduced Craig's scenario (install 1.0.0, then `repo:install-and-deploy(name, "0.5.0", url)` against local copy of the XAR) — before this commit, deployed `expath-pkg.xml` reports 1.0.0; after, 0.5.0.

## Related

- https://github.com/eXist-db/exist/pull/6432 — sibling fix for `repo:remove` returning `false` with no diagnostic
- https://github.com/eXist-db/xst/pull/376 — client-side fix so xst surfaces the underlying failure instead of printing `✔︎ uninstalled`
- Slack thread: https://exist-db.slack.com/archives/CG2MRUZ35/p1780415385757139
