### PR TITLE
[ci] Fix missing Windows installer JAR in release artifacts (runner.temp path)

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -328,18 +328,28 @@ jobs:
 
       - name: Collect installer artifacts
         shell: bash
+        env:
+          # Use the runner-provided temp dir rather than `/tmp` directly: on
+          # Windows runners Git Bash resolves `/tmp` to MSYS2's mount point,
+          # but actions/upload-artifact (a Node.js action) resolves the same
+          # `/tmp` to the root of the C drive. Those are different physical
+          # paths, so files staged into Git Bash's `/tmp/release-assets`
+          # were invisible to the upload step and beta3 shipped without the
+          # signed Windows installer JAR.
+          RELEASE_ASSETS: ${{ runner.temp }}/release-assets
         run: |
-          mkdir -p /tmp/release-assets
+          mkdir -p "$RELEASE_ASSETS"
           find exist-installer/target \
             -name "*.jar" -not -name "*sources*" -not -name "*javadoc*" \
-            -exec cp {} /tmp/release-assets/ \;
+            -exec cp {} "$RELEASE_ASSETS/" \;
           find exist-installer/target -name "*.exe" \
-            -exec cp {} /tmp/release-assets/ \; 2>/dev/null || true
+            -exec cp {} "$RELEASE_ASSETS/" \; 2>/dev/null || true
+          ls -lh "$RELEASE_ASSETS/"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-windows
-          path: /tmp/release-assets/
+          path: ${{ runner.temp }}/release-assets/
           retention-days: 3
 
   # ── Job 4: Publish GitHub Release ───────────────────────────────────────────

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -329,13 +329,7 @@ jobs:
       - name: Collect installer artifacts
         shell: bash
         env:
-          # Use the runner-provided temp dir rather than `/tmp` directly: on
-          # Windows runners Git Bash resolves `/tmp` to MSYS2's mount point,
-          # but actions/upload-artifact (a Node.js action) resolves the same
-          # `/tmp` to the root of the C drive. Those are different physical
-          # paths, so files staged into Git Bash's `/tmp/release-assets`
-          # were invisible to the upload step and beta3 shipped without the
-          # signed Windows installer JAR.
+          # Use the runner-provided temp dir; Git Bash and Node actions disagree on /tmp.
           RELEASE_ASSETS: ${{ runner.temp }}/release-assets
         run: |
           mkdir -p "$RELEASE_ASSETS"


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

The 7.0.0-beta3 GitHub release is missing the signed Windows installer JAR. 6.4.1 shipped `exist-installer-6.4.1.jar` (the IzPack self-extracting installer) as a release asset; the beta3 release has only `*.dmg`, `*-unix.tar.bz2`, and `*-win.zip` — no installer JAR. The IzPack installer is what users (and tools like Oxygen) on Windows have historically run, so it being absent is what Lars and @duncdrum hit when they reported the Windows installer was broken.

The build is fine. The signing is fine. The artifact-staging path is broken.

## Root cause

The `Build Windows installer` job in `ci-release.yml` builds the IzPack installer, signs it via Azure Key Vault JCA, and verifies the signature — the run log for beta3 (run `26822492422`) shows `jar signed.` / `jar verified.`. The very next step ("Collect installer artifacts") then runs:

```bash
mkdir -p /tmp/release-assets
find exist-installer/target -name "*.jar" ... -exec cp {} /tmp/release-assets/ \;
```

… and `actions/upload-artifact@v7` reports:

```
##[warning]No files were found with the provided path: /tmp/release-assets/. No artifacts will be uploaded.
```

The `cp` succeeds. The upload sees nothing. Different physical paths under the same string:

- **Git Bash on Windows** resolves `/tmp/release-assets` to MSYS2's tmp mount.
- **`actions/upload-artifact`** is a Node.js action; on Windows, Node resolves `/tmp/release-assets/` to `C:\tmp\release-assets\` (the root of the C drive, which does not exist).

Because the publish job downloads `release-*` artifacts via `actions/download-artifact` and merges them, the empty `release-windows` artifact silently drops the installer JAR before `softprops/action-gh-release` runs its upload step. macOS and Linux are unaffected because `/tmp` resolves to the same physical path for both the shell and the actions runtime on those runners.

## What changed

`.github/workflows/ci-release.yml` — `Build Windows installer` job, "Collect installer artifacts" step + the `actions/upload-artifact@v7` `path:` immediately below it:

- Stage the JAR under `${{ runner.temp }}/release-assets/` instead of `/tmp/release-assets/`. `runner.temp` is a path Actions sets for the runner that both Git Bash and Node-side actions see identically.
- Add a final `ls -lh` in the collect step so a future regression is visible in the log alongside the existing `List release assets` step in `publish-github-release`.

The Linux and macOS jobs continue to use `/tmp/release-assets` — those runners don't have the path-mismatch and changing them would be churn for no benefit.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-release.yml'))"` — YAML valid
- [x] Diff is scoped to one job (only the Windows collect+upload steps)
- [ ] End-to-end verification needs a tagged release; can be confirmed on the next beta cut by checking the GitHub release has `exist-installer-*.jar` listed alongside `*.dmg`, `*-unix.tar.bz2`, `*-win.zip`. The job-level signal to watch for in the log is `ls -lh` listing the JAR, where today the log shows only the `No files were found` warning.

## Related

- 7.0.0-beta3 release: https://github.com/eXist-db/exist/releases/tag/eXist-7.0.0-beta3 (missing installer JAR)
- 6.4.1 release for comparison: https://github.com/eXist-db/exist/releases/tag/eXist-6.4.1 (has installer JAR)
- macOS launch fixes (separate PR): https://github.com/eXist-db/exist/pull/6434

## Out of scope

- Producing a code-signed Windows `.exe` installer wrapper (launch4j / IzPack-native / similar). The workflow already has an `AzureSignTool sign` step scaffolded for this, but the current beta3 build produces no `.exe` (`No .exe produced on this runner; skipping Authenticode signing`). That's the design conversation @duncdrum opened in Slack with @reinhapa — separate change.
