### PR TITLE
[bugfix] macOS .app: accept Java 21+ for JVM discovery

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1078,7 +1078,7 @@
                                     <identifier>org.exist.start.Main</identifier>
                                     <mainClassName>org.exist.start.Main</mainClassName>
                                     <executableName>eXist-JavaAppLauncher</executableName>
-                                    <jvmRequired>21</jvmRequired>
+                                    <jvmRequired>21+</jvmRequired>
                                     <minimumSystemVersion>11.0</minimumSystemVersion>
                                     <!-- Populate LSArchitecturePriority so macOS LaunchServices
                                          will launch the .app. The plugin emits an empty


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

The macOS `.app` bundle's `Info.plist` `JVMVersion` key currently reads `21` (literal). Apple's `JavaAppLauncher` interprets that as a strict match: hosts that only have Java 22 / 23 / 24 installed would be rejected even though eXist runs fine on those. Switch to `21+` — the established Apple-convention "this major or later" form (`1.6+`, `1.7+`, `1.8+`, …) — so the launcher picks up any JDK ≥ 21.

Follow-up to @duncdrum's review on PR #6434 (https://github.com/eXist-db/exist/pull/6434#discussion_r3344318178), where he flagged the same JVM-discoverability concern.

## What changed

`exist-distribution/pom.xml`, line 926: `<jvmRequired>21</jvmRequired>` → `<jvmRequired>21+</jvmRequired>`.

The `appbundler-maven-plugin` propagates this value into `Info.plist` verbatim as a string, so the `+` reaches the launcher with no further plumbing.

## Verification

```bash
mvn -pl exist-distribution com.evolvedbinary.appbundler:appbundler-maven-plugin:3.3.0:bundle@exist-db-mac-app -DskipTests
/usr/libexec/PlistBuddy -c "Print :JVMVersion" exist-distribution/target/exist-distribution-*.app/Contents/Info.plist
# 21+
```

End-to-end JVM-discovery testing against the various JDK distributions @duncdrum mentioned (Zulu / Temurin / system-default) needs the full signed-and-notarized DMG pipeline, which happens on a release cut — so the "would Zulu have been discovered before this change?" question is best answered against the next beta DMG.

## Related

- PR #6434 — three other beta3 macOS launch fixes (this is the smallest follow-up split out per @duncdrum's "not a blocker" note on the strict-version concern)
- Apple `JavaAppLauncher` convention for `JVMVersion`: trailing `+` denotes "this version or later"
