### PR TITLE
[bugfix] Roll IzPack back from 5.2.5 to 5.2.4 (console-mode regression)

### DIFF
--- a/exist-installer/pom.xml
+++ b/exist-installer/pom.xml
@@ -214,47 +214,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!--
-          Diagnostic profile: roll IzPack back to 5.2.4 to verify it fixes the
-          console-mode regression in the assembled installer JAR.
-
-          Symptom on develop (IzPack 5.2.5): `java -jar exist-installer-*.jar -console`
-          crashes on the first HTMLInfoPanel with `NoClassDefFoundError: org.jsoup.nodes.Node`.
-
-          Cause: IzPack 5.2.5 rewrote `AbstractTextConsolePanel`'s HTML extraction to use
-          jsoup (`Jsoup.parse` / `Document.selectFirst` / `Element.text` / `Document.body`)
-          and `izpack-installer-5.2.5.pom` declares `org.jsoup:jsoup:1.18.3` as a dependency,
-          but the izpack-maven-plugin's installer-jar assembly does not pull jsoup into the
-          output. Only one stray multi-release shadow class (`META-INF/versions/9/org/jsoup/
-          helper/RequestAuthHandler.class`) ends up in the JAR; nothing at the standard
-          classpath root.
-
-          Disassembly of `com.izforge.izpack.installer.console.AbstractTextConsolePanel`:
-          - 5.2.4: no jsoup bytecode references at all.
-          - 5.2.5: invokestatic `org/jsoup/Jsoup.parse` and four other jsoup calls.
-
-          IzPack 5.2.4 is the last release without the jsoup-on-installer-classpath
-          requirement, so pinning back to 5.2.4 sidesteps the regression entirely until
-          upstream izpack-maven-plugin learns to bundle jsoup in the assembled installer.
-
-          To A/B locally:
-            mvn -Prelease-build clean package -pl exist-installer -am  # broken in console mode
-            mvn -Prelease-build,izpack-rollback-5.2.4 clean package -pl exist-installer -am  # works
-
-          Try the resulting JAR with `java -jar exist-installer/target/exist-installer-*.jar -console`.
-
-          Note: an explicit `<dependency>org.jsoup:jsoup</dependency>` on exist-installer is
-          NOT sufficient to fix the 5.2.5 build; the dep gets resolved to ~/.m2 but the
-          izpack-maven-plugin doesn't include it in the assembled JAR, and the plugin has no
-          public parameter for injecting extra runtime jars. Confirmed locally.
-        -->
-        <profile>
-            <id>izpack-rollback-5.2.4</id>
-            <properties>
-                <izpack.version>5.2.4</izpack.version>
-            </properties>
-        </profile>
     </profiles>
 
 </project>

--- a/exist-installer/pom.xml
+++ b/exist-installer/pom.xml
@@ -214,6 +214,47 @@
                 </plugins>
             </build>
         </profile>
+
+        <!--
+          Diagnostic profile: roll IzPack back to 5.2.4 to verify it fixes the
+          console-mode regression in the assembled installer JAR.
+
+          Symptom on develop (IzPack 5.2.5): `java -jar exist-installer-*.jar -console`
+          crashes on the first HTMLInfoPanel with `NoClassDefFoundError: org.jsoup.nodes.Node`.
+
+          Cause: IzPack 5.2.5 rewrote `AbstractTextConsolePanel`'s HTML extraction to use
+          jsoup (`Jsoup.parse` / `Document.selectFirst` / `Element.text` / `Document.body`)
+          and `izpack-installer-5.2.5.pom` declares `org.jsoup:jsoup:1.18.3` as a dependency,
+          but the izpack-maven-plugin's installer-jar assembly does not pull jsoup into the
+          output. Only one stray multi-release shadow class (`META-INF/versions/9/org/jsoup/
+          helper/RequestAuthHandler.class`) ends up in the JAR; nothing at the standard
+          classpath root.
+
+          Disassembly of `com.izforge.izpack.installer.console.AbstractTextConsolePanel`:
+          - 5.2.4: no jsoup bytecode references at all.
+          - 5.2.5: invokestatic `org/jsoup/Jsoup.parse` and four other jsoup calls.
+
+          IzPack 5.2.4 is the last release without the jsoup-on-installer-classpath
+          requirement, so pinning back to 5.2.4 sidesteps the regression entirely until
+          upstream izpack-maven-plugin learns to bundle jsoup in the assembled installer.
+
+          To A/B locally:
+            mvn -Prelease-build clean package -pl exist-installer -am  # broken in console mode
+            mvn -Prelease-build,izpack-rollback-5.2.4 clean package -pl exist-installer -am  # works
+
+          Try the resulting JAR with `java -jar exist-installer/target/exist-installer-*.jar -console`.
+
+          Note: an explicit `<dependency>org.jsoup:jsoup</dependency>` on exist-installer is
+          NOT sufficient to fix the 5.2.5 build; the dep gets resolved to ~/.m2 but the
+          izpack-maven-plugin doesn't include it in the assembled JAR, and the plugin has no
+          public parameter for injecting extra runtime jars. Confirmed locally.
+        -->
+        <profile>
+            <id>izpack-rollback-5.2.4</id>
+            <properties>
+                <izpack.version>5.2.4</izpack.version>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -127,7 +127,7 @@
         <aspectj.version>1.9.25.1</aspectj.version>
         <exquery.distribution.version>0.2.1</exquery.distribution.version>
         <icu.version>76.1</icu.version>
-        <izpack.version>5.2.5</izpack.version>
+        <izpack.version>5.2.4</izpack.version>
         <jansi.version>4.1.3</jansi.version>
         <jline.classifier>jdk11</jline.classifier>
         <jaxb.api.version>4.0.5</jaxb.api.version>


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

Pin `izpack.version` from 5.2.5 → 5.2.4 in `exist-parent/pom.xml` to fix the assembled installer JAR's console-mode regression Lars reported on Windows. Confirmed locally on macOS via A/B; per @reinhapa in [Slack](https://exist-db.slack.com/archives/C0824H3C76J/p1780512413684899?thread_ts=1780416133.977389), a proper upstream fix needs a new IzPack release (5.2.6+) that updates the izpack-maven-plugin's assembly to bundle jsoup. Until that ships, this PR is the unblocking change for 7.0.0 (which @duncdrum endorsed in the same thread).

## Background

`java -jar exist-installer/target/exist-installer-*.jar -console` against `develop`'s build crashes immediately:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/jsoup/nodes/Node
    at com.izforge.izpack.installer.console.ConsolePanelView.createView(ConsolePanelView.java:96)
    at com.izforge.izpack.installer.console.ConsolePanels.initialise(ConsolePanels.java:71)
    ...
```

This fires on the first panel declared in `install.xml` (`<panel classname="HTMLInfoPanel" id="start"/>`). GUI mode tolerates it for first-paint but presumably hits the same wall later. Console mode is the clean repro.

## Root cause

Disassembly of `com.izforge.izpack.installer.console.AbstractTextConsolePanel` across the two IzPack versions:

- **5.2.4**: zero jsoup bytecode references.
- **5.2.5**: `invokestatic org/jsoup/Jsoup.parse`, `Document.selectFirst`, `Element.text`, `Document.body`, plus a `processNode(Node, ...)` private method.

So 5.2.5 rewrote the HTML→text extraction to use jsoup. `izpack-installer-5.2.5.pom` declares `org.jsoup:jsoup:1.18.3` as a dependency, but the izpack-maven-plugin's installer-jar assembly does NOT pull jsoup into the output. Inspecting the assembled JAR:

```bash
unzip -l exist-installer-*.jar | grep -E 'org/jsoup/' | wc -l
# 1   (just a stray META-INF/versions/9/org/jsoup/helper/RequestAuthHandler.class)
unzip -l exist-installer-*.jar | grep -E 'org/jsoup/' | grep -v 'META-INF/'
# (no entries — nothing at the standard classpath root)
```

So jsoup is effectively missing. `HTMLInfoConsolePanel`'s constructor fails on class load.

This matches @reinhapa's "incomplete backport" hunch from the Slack thread: 5.2.5 added the jsoup runtime dep at the panel level, but the matching izpack-maven-plugin change to bundle it in the assembled installer didn't come along.

## Did I try the explicit-jsoup-dependency route?

Yes — adding `<dependency>org.jsoup:jsoup:1.18.3</dependency>` (runtime scope) to `exist-installer/pom.xml` resolves the jsoup JAR to `~/.m2` but does NOT inject it into the assembled installer JAR. The izpack-maven-plugin's `bundle` assembly walks IzPack's own component poms and does not pull in arbitrary runtime deps declared on the consuming project. The plugin has no public parameter for injecting extra runtime jars either (confirmed by reading the plugin's `plugin.xml`). So an explicit-dep workaround without an upstream izpack-maven-plugin fix is not viable.

## What changed

`exist-parent/pom.xml`, line 130: `<izpack.version>5.2.5</izpack.version>` → `<izpack.version>5.2.4</izpack.version>`.

That's the entire net diff vs. develop. The first commit on this branch added a profile-gated `izpack-rollback-5.2.4` knob for A/B; the second commit drops the profile and applies the rollback directly. Squash-merging produces a one-line net change.

## Test plan

Local verification on macOS (Zulu 21):

- [x] `mvn -Prelease-build clean install -pl exist-installer ...` at develop → builds 5.2.5 → `java -jar … -console` crashes with `NoClassDefFoundError: org.jsoup.nodes.Node`.
- [x] Same command on this branch → builds 5.2.4 → `java -jar … -console` renders the "Information / Welcome to the eXist-db Installer!" panel and waits for input. GUI mode also launches cleanly.
- [ ] Windows verification (@duncdrum) — confirm the rollback fixes the same symptom on a real Windows host (in time for the preconference talk).

## Forward path

Tracking upstream IzPack: a 5.2.6 release that updates `izpack-maven-plugin` to bundle jsoup in the assembled installer is the durable fix. When that's available, we bump `izpack.version` back forward (and add jsoup to whatever metadata the plugin then needs).

## Related

- Slack #core thread on the 7.0.0-beta3 macOS launch + Windows installer regressions: <https://exist-db.slack.com/archives/C0824H3C76J/p1780416133977389>
- @reinhapa's "incomplete backport" note + commitment to a 5.2.6: <https://exist-db.slack.com/archives/C0824H3C76J/p1780512413684899?thread_ts=1780416133.977389>
- @duncdrum's "in favor of downgrading and waiting for 5.2.6" endorsement: <https://exist-db.slack.com/archives/C0824H3C76J/p1780516203608579?thread_ts=1780416133.977389>
- Sibling PR #6435 — Windows installer JAR upload (the artifact was missing entirely from beta3 due to a runner-temp path issue; this PR is about the JAR's *contents* once it ships)
