### PR TITLE
bugfix: Add missing class path entry

### DIFF
--- a/exist-installer/src/main/izpack/jobs.xml
+++ b/exist-installer/src/main/izpack/jobs.xml
@@ -38,7 +38,7 @@
         <os family="windows"/>
         <executefile name="java">
             <arg>-cp</arg>
-            <arg>$INSTALL_PATH\lib\Saxon-HE-${saxon.version}.jar</arg>
+            <arg>$INSTALL_PATH\lib\Saxon-HE-${saxon.version}.jar;$INSTALL_PATH/lib/xmlresolver-${xmlresolver.version}.jar</arg>
             <arg>net.sf.saxon.Transform</arg>
             <arg>-s:$INSTALL_PATH\etc\conf.xml</arg>
             <arg>-xsl:$tmpdir\conf.xslt</arg>
@@ -51,7 +51,7 @@
         <os family="unix"/>
         <executefile name="java">
             <arg>-cp</arg>
-            <arg>$INSTALL_PATH/lib/Saxon-HE-${saxon.version}.jar</arg>
+            <arg>$INSTALL_PATH/lib/Saxon-HE-${saxon.version}.jar:$INSTALL_PATH/lib/xmlresolver-${xmlresolver.version}.jar</arg>
             <arg>net.sf.saxon.Transform</arg>
             <arg>-s:$INSTALL_PATH/etc/conf.xml</arg>
             <arg>-xsl:$tmpdir/conf.xslt</arg>


### PR DESCRIPTION
### Description:
Fixes a NoClassDefFoundError during post installation with IzPack installer:

```
[ Starting processing ]
Starting process Setting data dir... (1/2)
Exception in thread "main" java.lang.NoClassDefFoundError: org/xmlresolver/Resolver
	at net.sf.saxon.lib.CatalogResourceResolver.<init>(CatalogResourceResolver.java:46)
	at net.sf.saxon.Configuration.init(Configuration.java:387)
	at net.sf.saxon.Configuration.<init>(Configuration.java:234)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:79)
	at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:189)
	at java.base/java.lang.Class.newInstance(Class.java:715)
	at net.sf.saxon.Configuration.newConfiguration(Configuration.java:250)
	at net.sf.saxon.s9api.Processor.<init>(Processor.java:83)
	at net.sf.saxon.Transform.doTransform(Transform.java:326)
	at net.sf.saxon.Transform.main(Transform.java:84)
Caused by: java.lang.ClassNotFoundException: org.xmlresolver.Resolver
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 12 more
```