### PR TITLE
[feature] Expose eXist serializer extensions through the standard output: namespace

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -48,6 +48,7 @@ import javax.xml.transform.OutputKeys;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -87,12 +88,9 @@ public class SerializerUtils {
      * in the standard W3C serialization namespace and as plain map keys, mirroring BaseX,
      * so that eXist extensions can be set uniformly alongside the W3C parameters.
      */
-    private static final Set<String> ExistParameterConventionLocalNames = new HashSet<>();
-    static {
-        for (final ExistParameterConvention existParameterConvention : ExistParameterConvention.values()) {
-            ExistParameterConventionLocalNames.add(existParameterConvention.getLocalParameterName());
-        }
-    }
+    private static final Set<String> EXIST_PARAMETER_CONVENTION_LOCAL_NAMES = Arrays.stream(ExistParameterConvention.values())
+            .map(ExistParameterConvention::getLocalParameterName)
+            .collect(Collectors.toUnmodifiableSet());
 
     public interface ParameterConvention<T> {
 
@@ -316,7 +314,7 @@ public class SerializerUtils {
         // the standard namespace, mirroring BaseX, so they can be set uniformly with the W3C ones.
         if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(nsURI)
                 && !W3CParameterConventionKeys.contains(local)
-                && !ExistParameterConventionLocalNames.contains(local)) {
+                && !EXIST_PARAMETER_CONVENTION_LOCAL_NAMES.contains(local)) {
             throw new XPathException(ErrorCodes.SEPM0017, "serialization parameter not recognized: " + key);
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -81,6 +81,19 @@ public class SerializerUtils {
         }
     }
 
+    /**
+     * The local names of eXist's implementation-specific serialization parameters
+     * (e.g. {@code expand-xincludes}, {@code highlight-matches}). These are accepted
+     * in the standard W3C serialization namespace and as plain map keys, mirroring BaseX,
+     * so that eXist extensions can be set uniformly alongside the W3C parameters.
+     */
+    private static final Set<String> ExistParameterConventionLocalNames = new HashSet<>();
+    static {
+        for (final ExistParameterConvention existParameterConvention : ExistParameterConvention.values()) {
+            ExistParameterConventionLocalNames.add(existParameterConvention.getLocalParameterName());
+        }
+    }
+
     public interface ParameterConvention<T> {
 
         /**
@@ -298,7 +311,12 @@ public class SerializerUtils {
         if (properties.containsKey(local)) {
             throw new XPathException(parent, FnModule.SEPM0019, "serialization parameter specified twice: " + key);
         }
-        if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(nsURI) && !W3CParameterConventionKeys.contains(local)) {
+        // A parameter in the W3C serialization namespace must be either a known W3C parameter or
+        // a known eXist extension (e.g. output:expand-xincludes). eXist extensions are accepted in
+        // the standard namespace, mirroring BaseX, so they can be set uniformly with the W3C ones.
+        if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(nsURI)
+                && !W3CParameterConventionKeys.contains(local)
+                && !ExistParameterConventionLocalNames.contains(local)) {
             throw new XPathException(ErrorCodes.SEPM0017, "serialization parameter not recognized: " + key);
         }
 
@@ -308,8 +326,10 @@ public class SerializerUtils {
                     "serialization parameter element must be in a namespace: " + local);
         }
 
-        // Accept eXist-specific parameters from the exist: namespace (issue #3446)
-        // These include expand-xincludes, highlight-matches, process-xsl-pi, add-exist-id, jsonp, etc.
+        // Accept eXist-specific parameters from the legacy exist: namespace (issue #3446).
+        // Deprecated: the recommended form is the standard W3C serialization namespace
+        // (e.g. output:expand-xincludes). The exist: namespace is kept for backward
+        // compatibility and may be removed in a future major release.
         if (Namespaces.EXIST_NS.equals(nsURI)) {
             readSerializationProperty(reader, local, properties);
             return;
@@ -471,8 +491,8 @@ public class SerializerUtils {
             }
 
             for (final ExistParameterConvention existParameterConvention : ExistParameterConvention.values()) {
-                final Sequence parameterValue = getParameterValue(parent, entries, existParameterConvention,
-                        new QNameValue(null, existParameterConvention.getParameterName()));
+                final AtomicValue entryKey = chooseExistParameterMapKey(entries, existParameterConvention);
+                final Sequence parameterValue = getParameterValue(parent, entries, existParameterConvention, entryKey);
                 setPropertyForMap(properties, existParameterConvention, parameterValue);
             }
 
@@ -480,6 +500,46 @@ public class SerializerUtils {
         } catch (final UnsupportedOperationException e) {
             throw new XPathException(parent, FnModule.SENR0001, e.getMessage());
         }
+    }
+
+    /**
+     * Determines which map key supplies an eXist implementation-specific serialization parameter.
+     *
+     * eXist extensions may be given in a serialization options map under any of three key forms,
+     * checked here in order of preference:
+     * <ol>
+     *   <li>the standard W3C serialization namespace, e.g.
+     *       {@code Q{http://www.w3.org/2010/xslt-xquery-serialization}expand-xincludes}
+     *       (the recommended, BaseX-compatible form);</li>
+     *   <li>a plain string key, e.g. {@code "expand-xincludes"} (also recommended, and the form
+     *       used when standard and extension parameters are set together in one string-keyed map);</li>
+     *   <li>the legacy eXist namespace, e.g.
+     *       {@code Q{http://exist.sourceforge.net/NS/exist}expand-xincludes} (deprecated, retained
+     *       for backward compatibility).</li>
+     * </ol>
+     *
+     * @param entries the serialization options map
+     * @param convention the eXist parameter convention to look up
+     * @return the key actually present in the map, preferring forms (1) then (2) then (3); if none
+     *     is present, the legacy key is returned so that the caller applies the parameter's default value
+     */
+    private static AtomicValue chooseExistParameterMapKey(final AbstractMapType entries, final ExistParameterConvention convention) {
+        final String local = convention.getLocalParameterName();
+
+        final AtomicValue outputNsKey = new QNameValue(null,
+                new QName(local, Namespaces.XSLT_XQUERY_SERIALIZATION_NS, OUTPUT_NAMESPACE));
+        if (entries.contains(outputNsKey)) {
+            return outputNsKey;
+        }
+
+        final AtomicValue stringKey = new StringValue(local);
+        if (entries.contains(stringKey)) {
+            return stringKey;
+        }
+
+        // legacy exist: namespace (deprecated); also the fallback when no key is present, so that
+        // getParameterValue() supplies the parameter's default value
+        return new QNameValue(null, convention.getParameterName());
     }
 
     private static Sequence getParameterValue(final Expression parent, final AbstractMapType entries, final ParameterConvention<?> parameterConvention, final AtomicValue parameterConventionEntryKey)
@@ -555,9 +615,14 @@ public class SerializerUtils {
                 final Item item = iterator.nextItem();
                 // Use subtype check: xs:integer is a valid xs:decimal, xs:string subtypes are valid xs:string, etc.
                 // Also accept xs:untypedAtomic — the W3C spec allows untypedAtomic values to be cast
-                // to the required type for serialization parameters
+                // to the required type for serialization parameters.
+                // For eXist extension parameters (e.g. expand-xincludes), additionally accept an
+                // xs:string value (e.g. "no") so they can be supplied alongside standard parameters in
+                // a string-keyed options map; their string form is normalized in setPropertyForMap.
                 if (!Type.subTypeOf(item.getType(), parameterConvention.getType())
-                        && item.getType() != Type.UNTYPED_ATOMIC) {
+                        && item.getType() != Type.UNTYPED_ATOMIC
+                        && !(parameterConvention instanceof ExistParameterConvention
+                                && Type.subTypeOf(item.getType(), Type.STRING))) {
                     return false;
                 }
             }
@@ -583,8 +648,12 @@ public class SerializerUtils {
                 if (boolItem instanceof BooleanValue bv) {
                     value = bv.getValue() ? "yes" : "no";
                 } else {
+                    // Accept the same case-insensitive true-set as BaseX (1/true/yes/on); any other
+                    // value (including false/no/off/0) maps to "no", preserving eXist's lenient,
+                    // non-throwing handling of this shared boolean branch.
                     final String boolStr = boolItem.getStringValue().trim();
-                    value = ("true".equals(boolStr) || "1".equals(boolStr)) ? "yes" : "no";
+                    value = (boolStr.equalsIgnoreCase("true") || boolStr.equalsIgnoreCase("yes")
+                            || boolStr.equalsIgnoreCase("on") || "1".equals(boolStr)) ? "yes" : "no";
                 }
                 properties.setProperty(localParameterName, value);
             }

--- a/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class SerializationTest {
@@ -103,6 +104,17 @@ public class SerializationTest {
 			"""
             <?xml version="1.1" encoding="ISO-8859-1" standalone="yes"?>
             <bookmap id="bookmap-2"/>""";
+
+	private static final XmldbURI TEST_XINCLUDE_TARGET_URI = XmldbURI.create("xi-target.xml");
+
+	private static final String XINCLUDE_TARGET = "<p>INCLUDED</p>";
+
+	private static final XmldbURI TEST_XINCLUDE_MAIN_URI = XmldbURI.create("xi-main.xml");
+
+	private static final String XINCLUDE_MAIN =
+			"<doc xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
+					+ "<xi:include href=\"/db/" + TEST_COLLECTION_NAME + "/xi-target.xml\"/>"
+					+ "</doc>";
 
 	@Parameterized.Parameters(name = "{0}")
 	public static java.util.Collection<Object[]> data() {
@@ -244,6 +256,38 @@ public class SerializationTest {
 		}
 	}
 
+	/**
+	 * The eXist serializer extension expand-xincludes is settable through the standard
+	 * W3C output: namespace as a prolog option, applied to the query result serialization.
+	 */
+	@Test
+	public void prologOutputExpandXincludesNo() throws XMLDBException {
+		final XQueryService service = testCollection.getService(XQueryService.class);
+		final ResourceSet result = service.query(
+				"declare namespace output=\"http://www.w3.org/2010/xslt-xquery-serialization\";\n"
+						+ "declare option output:expand-xincludes \"no\";\n"
+						+ "doc(\"/db/" + TEST_COLLECTION_NAME + "/xi-main.xml\")");
+		final String serialized = result.getResource(0).getContent().toString();
+		assertTrue("xi:include should be preserved when expand-xincludes=no, was: " + serialized,
+				serialized.contains("xi:include"));
+		assertFalse("target content should not be expanded, was: " + serialized,
+				serialized.contains("INCLUDED"));
+	}
+
+	@Test
+	public void prologOutputExpandXincludesYes() throws XMLDBException {
+		final XQueryService service = testCollection.getService(XQueryService.class);
+		final ResourceSet result = service.query(
+				"declare namespace output=\"http://www.w3.org/2010/xslt-xquery-serialization\";\n"
+						+ "declare option output:expand-xincludes \"yes\";\n"
+						+ "doc(\"/db/" + TEST_COLLECTION_NAME + "/xi-main.xml\")");
+		final String serialized = result.getResource(0).getContent().toString();
+		assertTrue("target content should be expanded when expand-xincludes=yes, was: " + serialized,
+				serialized.contains("INCLUDED"));
+		assertFalse("xi:include should be replaced when expanded, was: " + serialized,
+				serialized.contains("xi:include"));
+	}
+
 	private static void assertXMLEquals(final String expected, final Resource actual) throws XMLDBException {
 		final Source srcExpected = Input.fromString(expected).build();
 		final Source srcActual = Input.fromString(actual.getContent().toString()).build();
@@ -273,6 +317,14 @@ public class SerializationTest {
 		final XMLResource res2 = testCollection.createResource(TEST_XML_DOC_WITH_XMLDECL_URI.lastSegmentString(), XMLResource.class);
 		res2.setContent(XML_WITH_XMLDECL);
 		testCollection.storeResource(res2);
+
+		final XMLResource res3 = testCollection.createResource(TEST_XINCLUDE_TARGET_URI.lastSegmentString(), XMLResource.class);
+		res3.setContent(XINCLUDE_TARGET);
+		testCollection.storeResource(res3);
+
+		final XMLResource res4 = testCollection.createResource(TEST_XINCLUDE_MAIN_URI.lastSegmentString(), XMLResource.class);
+		res4.setContent(XINCLUDE_MAIN);
+		testCollection.storeResource(res4);
     }
 
     @After

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -785,6 +785,95 @@ function ser:exist-process-xsl-pi-string($value as xs:boolean) {
         map { "exist:process-xsl-pi": $value })
 };
 
+(: ======================================================================= :)
+(: eXist serializer extensions through the standard W3C output: namespace.  :)
+(: Mirrors BaseX: the EXistOutputKeys extensions are settable uniformly via  :)
+(: the output: namespace and as plain map keys, alongside the W3C            :)
+(: parameters. The legacy exist:-namespace forms above remain supported      :)
+(: (deprecated, retained for backward compatibility).                        :)
+(: ======================================================================= :)
+
+(: default (no params) expands XIncludes, preserving eXist's existing behavior :)
+declare
+    %test:assertXPath("contains($result, 'comment')")
+function ser:output-expand-xinclude-default-expands() {
+    serialize($ser:xi-doc)
+};
+
+(: output:-namespaced map key (xs:QName) :)
+declare
+    %test:args("true")
+    %test:assertXPath("contains($result, 'comment')")
+    %test:args("false")
+    %test:assertXPath("contains($result, 'include')")
+function ser:output-expand-xinclude-QName($value as xs:boolean) {
+    serialize($ser:xi-doc,
+        map { xs:QName("output:expand-xincludes"): $value })
+};
+
+(: plain (un-prefixed) map key, boolean value :)
+declare
+    %test:args("true")
+    %test:assertXPath("contains($result, 'comment')")
+    %test:args("false")
+    %test:assertXPath("contains($result, 'include')")
+function ser:output-expand-xinclude-plain-key-boolean($value as xs:boolean) {
+    serialize($ser:xi-doc,
+        map { "expand-xincludes": $value })
+};
+
+(: plain map key, string value ("yes"/"no") :)
+declare
+    %test:args("yes")
+    %test:assertXPath("contains($result, 'comment')")
+    %test:args("no")
+    %test:assertXPath("contains($result, 'include')")
+function ser:output-expand-xinclude-plain-key-string($value as xs:string) {
+    serialize($ser:xi-doc,
+        map { "expand-xincludes": $value })
+};
+
+(: output: serialization-parameters element child :)
+declare
+    %test:args("yes")
+    %test:assertXPath("contains($result, 'comment')")
+    %test:args("no")
+    %test:assertXPath("contains($result, 'include')")
+function ser:output-expand-xinclude-element($value as xs:string) {
+    serialize($ser:xi-doc,
+        <output:serialization-parameters>
+            <output:expand-xincludes value="{$value}"/>
+        </output:serialization-parameters>)
+};
+
+(: Mixed standard + eXist-extension parameters in ONE string-keyed map.       :)
+(: The exact expected output proves all four took effect simultaneously:      :)
+(: method=xml, indent=no (no pretty-print whitespace), omit-xml-declaration=   :)
+(: yes (no XML declaration), and expand-xincludes=no (xi:include preserved).   :)
+declare
+    %test:assertEquals('&lt;article xmlns:xi="http://www.w3.org/2001/XInclude"&gt;&lt;title&gt;My Title&lt;/title&gt;&lt;xi:include href="/db/serialization-test/test.xml"/&gt;&lt;/article&gt;')
+function ser:output-mixed-standard-and-extension() {
+    serialize($ser:xi-doc,
+        map {
+            "method": "xml",
+            "indent": false(),
+            "omit-xml-declaration": true(),
+            "expand-xincludes": "no"
+        })
+};
+
+(: another extension (add-exist-id) through a plain map key, proving it is    :)
+(: the whole EXistOutputKeys family, not just expand-xincludes :)
+declare
+    %test:args("none")
+    %test:assertXPath("not(contains($result, 'exist:id'))")
+    %test:args("all")
+    %test:assertXPath("contains($result, 'exist:id')")
+function ser:output-add-exist-id-plain-key($value as xs:string) {
+    serialize(doc($ser:collection || "/test.xml"),
+        map { "add-exist-id": $value })
+};
+
 declare
     %test:args("text")
     %test:assertEquals("1--2")

--- a/extensions/modules/file/src/test/xquery/modules/file/serialize.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/serialize.xqm
@@ -127,6 +127,30 @@ function serialize:xml-final-newline() {
         "</root>" || $fixtures:NL
 };
 
+(: eXist extension (insert-final-newline) supplied through the standard W3C output:    :)
+(: namespace rather than the legacy exist: namespace; same result as xml-final-newline :)
+declare
+    %test:assertTrue
+function serialize:xml-final-newline-output-ns() {
+    let $directory := helper:get-test-directory($serialize:suite)
+    let $_ := file:mkdirs($directory)
+
+    let $path := $directory || "/xml-final-newline-output-ns.xml"
+    let $_ := file:serialize($serialize:xml, $path,
+    <output:serialization-parameters
+            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+          <output:insert-final-newline value="yes" />
+        </output:serialization-parameters>)
+
+    return file:read($path) eq
+        "<root>" || $fixtures:NL ||
+        "    <unary attribute=""value""/>" || $fixtures:NL ||
+        "    <nested>" || $fixtures:NL ||
+        "        text" || $fixtures:NL ||
+        "    </nested>" || $fixtures:NL ||
+        "</root>" || $fixtures:NL
+};
+
 declare
     %test:assertTrue
 function serialize:xml-minified() {


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Makes eXist's implementation-specific serialization parameters (`EXistOutputKeys` — `expand-xincludes`, `highlight-matches`, `add-exist-id`, `process-xsl-pi`, `jsonp`, `insert-final-newline`, etc.) settable **uniformly through the standard W3C serialization namespace** (`http://www.w3.org/2010/xslt-xquery-serialization`, prefix `output`) and as plain map keys, mirroring BaseX — across `fn:serialize` (both the options `map(*)` and the `output:serialization-parameters` element forms), `file:serialize`, and the `declare option output:…` prolog.

Until now these extensions could only be set through eXist's own `exist:` namespace (or the legacy `declare option exist:serialize`). The most important one, `expand-xincludes`, was therefore unreachable through the `output:` mechanisms clients actually use — so an open → edit → save round-trip via `fn:serialize` would silently expand and **destroy `<xi:include>` elements**. This unblocks safe XInclude-preserving reads in existdb-openapi (`/api/db/resource`'s JSON-envelope path) and the same latent data-loss exposure in eXide.

This is the first of three PRs; a follow-up covers the REST interface (`?_expand-xincludes=…`) and a third covers RESTXQ `%output:…` annotations.

## What changed

`exist-core/.../xquery/util/SerializerUtils.java`:

- **`fn:serialize` map form** — eXist extension parameters are now resolved from a serialization options map under three key forms, in order of preference: the standard `output:` namespace (`Q{…xslt-xquery-serialization}expand-xincludes`), a plain string key (`"expand-xincludes"`), then the legacy `exist:` namespace (deprecated). Standard and extension parameters can therefore be mixed in a single string-keyed map without special-casing.
- **`output:serialization-parameters` element form** — a child in the `output:` namespace whose local name is a known eXist extension is now accepted (previously rejected with `SEPM0017`).
- The map type-check is relaxed so an `xs:string` value (e.g. `"no"`) is accepted for an extension parameter, and boolean string parsing is aligned with BaseX (`1`/`true`/`yes`/`on`, case-insensitive).

The `declare option output:…` prolog path already threaded any `output:`-namespaced option through to the result serializer, so it needed **no code change** — it is now covered by tests.

## Backward compatibility

- The legacy `exist:` namespace forms (map `QName` keys, `exist:`-namespaced element children) and `declare option exist:serialize` remain fully supported, now marked **deprecated** in favor of the uniform `output:` form (in preparation for a future major-version removal).
- With **no** serialization parameters supplied, output is **byte-identical** to before across every facility — the `conf.xml` `<serializer>` defaults are unchanged. Verified: a no-parameter `fn:serialize` still expands XIncludes by default, exactly as today.

## Namespace policy (following BaseX)

The W3C spec asks implementations to define non-official parameters in a non-null namespace. BaseX deliberately waives this and accepts its extensions in the standard `output:` namespace for convenience across the many ways parameters are supplied; this PR follows BaseX. eXist's own `exist:` namespace remains accepted (deprecated), so nothing that relied on it breaks.

## Test plan

- [x] `serialize.xql` (XQSuite) — 12 new cases: `output:` map `QName` key, plain string key (boolean and string value), `output:serialization-parameters` element child, a **mixed standard + extension** map asserted against exact expected output (proving `method` + `indent` + `omit-xml-declaration` + `expand-xincludes` all take effect together), `add-exist-id` via a plain key, and a default-expands guard. All existing cases still pass (131 total).
- [x] `SerializationTest` (JUnit, local + remote XML:DB) — `declare option output:expand-xincludes` `yes`/`no` on a stored XInclude document. Full class green (22).
- [x] `file` module `serialize.xqm` — an eXist extension (`insert-final-newline`) supplied through the `output:` namespace in `file:serialize`. Full `FileTests` green (54).
- [x] Confirmed on clean `develop` that none of the new forms worked (the element form even errored with `SEPM0017`); with this change all are honored and the default is unchanged.

## Spec references

- W3C XSLT and XQuery Serialization 3.1 — implementation-defined serialization parameters
- BaseX serialization docs: https://docs.basex.org/13/Serialization

## Downstream (unblocked by this PR)

- **existdb-openapi**: add `expand-xincludes` to the `/api/db/resource` JSON-envelope read (held in PR #48 pending this).
- **eXide**: fix the latent XInclude data-loss exposure on its "open with expand off" path.
- **All clients** (Oxygen plugin, vscode-existdb, notebook kernel): safe XInclude editing and uniform serialization control.
