### PR TITLE
[feature] Add REST _expand-xincludes serialization parameter

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -404,6 +404,11 @@ public class RESTServer {
             final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION, "no");
             outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
         }
+        if ((option = getParameter(request, Expand_Xincludes)) != null) {
+            // take user query-string specified expand-xincludes setting; when absent the
+            // serializer default (expand) applies, so existing requests are unchanged
+            outputProperties.setProperty(EXistOutputKeys.EXPAND_XINCLUDES, option);
+        }
         if ((option = getParameter(request, Source)) != null && !safeMode) {
             source = "yes".equals(option);
         }

--- a/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
@@ -379,7 +379,19 @@ enum RESTServerParameter {
      *
      * The value of the parameter should be either "yes" or "no".
      */
-    Omit_Original_Xml_Declaration;
+    Omit_Original_Xml_Declaration,
+
+    /**
+     * Can be used in the Query String of a GET request to control whether
+     * XInclude elements are expanded during serialization. When set to "no",
+     * {@code <xi:include>} elements are preserved verbatim rather than expanded,
+     * which is required for a non-destructive open/edit/save round-trip.
+     *
+     * Contexts: GET
+     *
+     * The value of the parameter should be either "yes" or "no".
+     */
+    Expand_Xincludes;
 
     /**
      * Get the parameter key that is

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -220,6 +220,15 @@ public class RESTServiceTest {
     private static final XmldbURI TEST_XMLDECL_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("rest-test-xmldecl");
     private static final XmldbURI TEST_XML_DOC_WITH_XMLDECL_URI = XmldbURI.create("test-with-xmldecl.xml");
 
+    private static final XmldbURI TEST_XINCLUDE_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("rest-test-xinclude");
+    private static final XmldbURI TEST_XINCLUDE_TARGET_URI = XmldbURI.create("xi-target.xml");
+    private static final String XINCLUDE_TARGET = "<p>INCLUDED</p>";
+    private static final XmldbURI TEST_XINCLUDE_MAIN_URI = XmldbURI.create("xi-main.xml");
+    private static final String XINCLUDE_MAIN =
+            "<doc xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
+                    + "<xi:include href=\"" + TEST_XINCLUDE_COLLECTION_URI.append("xi-target.xml") + "\"/>"
+                    + "</doc>";
+
     private static String credentials;
     private static String badCredentials;
 
@@ -352,6 +361,12 @@ public class RESTServiceTest {
 
             try (final Collection col = broker.getOrCreateCollection(transaction, TEST_XMLDECL_COLLECTION_URI)) {
                 broker.storeDocument(transaction, TEST_XML_DOC_WITH_XMLDECL_URI, new StringInputSource(XML_WITH_XMLDECL), MimeType.XML_TYPE, col);
+                broker.saveCollection(transaction, col);
+            }
+
+            try (final Collection col = broker.getOrCreateCollection(transaction, TEST_XINCLUDE_COLLECTION_URI)) {
+                broker.storeDocument(transaction, TEST_XINCLUDE_TARGET_URI, new StringInputSource(XINCLUDE_TARGET), MimeType.XML_TYPE, col);
+                broker.storeDocument(transaction, TEST_XINCLUDE_MAIN_URI, new StringInputSource(XINCLUDE_MAIN), MimeType.XML_TYPE, col);
                 broker.saveCollection(transaction, col);
             }
 
@@ -714,6 +729,55 @@ try {
         } finally {
             connect.disconnect();
         }
+    }
+
+    private String getXIncludeMain(final String queryString) throws IOException {
+        final String uri = getServerUri() + TEST_XINCLUDE_COLLECTION_URI.append(TEST_XINCLUDE_MAIN_URI) + queryString;
+        final HttpURLConnection connect = getConnection(uri);
+        try {
+            connect.setRequestProperty("Authorization", "Basic " + credentials);
+            connect.setRequestMethod("GET");
+            connect.connect();
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+            return readResponse(connect.getInputStream());
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    @Test
+    public void getExpandXincludesDefault() throws IOException {
+        // default: XIncludes are expanded (unchanged behavior)
+        final String response = getXIncludeMain("");
+        assertTrue("default GET should expand XIncludes, was: " + response, response.contains("INCLUDED"));
+        assertFalse("default GET should not retain xi:include, was: " + response, response.contains("xi:include"));
+    }
+
+    @Test
+    public void getExpandXincludesNo() throws IOException {
+        // _expand-xincludes=no preserves xi:include for a non-destructive round-trip
+        final String response = getXIncludeMain("?_expand-xincludes=no");
+        assertTrue("xi:include should be preserved, was: " + response, response.contains("xi:include"));
+        assertFalse("target content should not be expanded, was: " + response, response.contains("INCLUDED"));
+    }
+
+    @Test
+    public void getExpandXincludesYes() throws IOException {
+        final String response = getXIncludeMain("?_expand-xincludes=yes");
+        assertTrue("target content should be expanded, was: " + response, response.contains("INCLUDED"));
+        assertFalse("xi:include should be replaced, was: " + response, response.contains("xi:include"));
+    }
+
+    @Test
+    public void getMixedStandardAndExpandXincludes() throws IOException {
+        // standard params (indent, omit-xml-declaration) and the extension (expand-xincludes)
+        // are honored together in a single request without disturbing one another
+        final String response = getXIncludeMain("?_indent=no&_omit-xml-declaration=yes&_expand-xincludes=no");
+        assertTrue("xi:include should be preserved, was: " + response, response.contains("xi:include"));
+        assertFalse("target content should not be expanded, was: " + response, response.contains("INCLUDED"));
+        assertFalse("omit-xml-declaration=yes should suppress the XML declaration, was: " + response,
+                response.contains("<?xml"));
     }
 
     @Test


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Adds an `_expand-xincludes` serialization parameter to eXist's REST interface. A GET of a stored XML document previously always expanded `<xi:include>` elements during serialization, with no way to turn that off — so an open → edit → save round-trip through REST would silently expand and **destroy the include**. The REST interface already exposes the other serialization controls as `_`-prefixed query-string parameters (`_indent`, `_omit-xml-declaration`, `_output-doctype`, `_encoding`, …); `expand-xincludes` was simply missing.

This is PR 2 of 3 for uniform serialization-extension control (core #6447 → REST → RESTXQ). It unblocks existdb-openapi's REST binary-streaming read path; the companion core PR (#6447) covers `fn:serialize`, `file:serialize`, and the `output:` prolog.

## What changed

- `RESTServerParameter`: new `Expand_Xincludes` enum constant → query-string key `_expand-xincludes` (the existing `xmlKey()`/`queryStringKey()` derivation produces this automatically).
- `RESTServer.doGet`: when `_expand-xincludes` is present, set `EXistOutputKeys.EXPAND_XINCLUDES` on the output properties used to serialize the resource. When the parameter is absent, the serializer's existing default (expand) applies — so existing requests are byte-for-byte unchanged.

It composes with the other serialization parameters; for example `?_indent=no&_omit-xml-declaration=yes&_expand-xincludes=no` honors all three together.

## Backward compatibility

No behavior change unless the new parameter is supplied. With no `_expand-xincludes`, output is identical to before (XIncludes expand by default), verified by a default-behavior test.

## Test plan

- [x] `RESTServiceTest` against a stored XInclude document (embedded server):
  - default GET expands the include (unchanged behavior);
  - `?_expand-xincludes=no` preserves `<xi:include>` and does not expand;
  - `?_expand-xincludes=yes` expands;
  - `?_indent=no&_omit-xml-declaration=yes&_expand-xincludes=no` honors all three (include preserved, no XML declaration).
- [x] PMD/Codacy clean on the changed lines (the file's other PMD findings are pre-existing in unrelated methods).

## Spec references

- W3C XSLT and XQuery Serialization 3.1 — implementation-defined serialization parameters
- BaseX serialization (REST query parameters): https://docs.basex.org/13/Serialization
