### PR TITLE
[test] Add cross-surface resource-naming conformance ratchet

### DIFF
--- a/exist-core/src/test/java/org/exist/backup/BackupRestoreNamingConformanceTest.java
+++ b/exist-core/src/test/java/org/exist/backup/BackupRestoreNamingConformanceTest.java
@@ -1,0 +1,271 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.backup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import org.exist.TestUtils;
+import org.exist.backup.restore.listener.LogRestoreListener;
+import org.exist.backup.restore.listener.RestoreListener;
+import org.exist.collections.Collection;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.serializers.Serializer;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.util.io.InputStreamUtil;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.util.URIUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Backup &rarr; restore round-trip conformance for awkward resource names.
+ *
+ * <p>Extends the resource-naming conformance net (see {@code ResourceNamingConformanceTest} in the webdav
+ * module, and issue #6463) to the backup/restore path @line-o asked about on PR #6508: for a corpus of
+ * awkward leaf names (spaces, sub-delimiters, non-ASCII, CJK, Cyrillic, and the literal-{@code %} cases
+ * Decision 2 flags), it stores each resource, snapshots the exact stored key and content, exports a full
+ * backup, wipes the collection, restores, and asserts the snapshot is reproduced <em>byte-for-byte</em> —
+ * no resource lost, renamed, or collided by the round-trip. That is the guard against "even theoretical
+ * data loss" through backup/restore.</p>
+ *
+ * <p><b>Scope.</b> This guards the <em>restore</em> path. Resources are stored under the same leaf keys a
+ * WebDAV/REST store lands them under (verified in the printed mapping: {@code café.xml -> caf%C3%A9.xml},
+ * {@code a+b.xml -> a%2Bb.xml}, {@code with space.xml -> with%20space.xml}, …), via eXist's own
+ * {@code encodeXmldbUriFor}. Two distinct names collapsing onto one key <em>on the way in</em> — the
+ * Decision 2 store-time collision — rides a different store path (the persistent layer's non-escaping
+ * encoding) and is out of scope here; this encoder escapes a literal {@code %} to {@code %25}, so the
+ * corpus stores injectively and the {@code before}-snapshot size check is a setup-integrity guard, not a
+ * claim about that other path.</p>
+ *
+ * <p>Parameterized over {@link SystemExport}'s direct / non-direct modes and plain / zip, mirroring
+ * {@link SystemExportImportTest}.</p>
+ */
+@RunWith(Parameterized.class)
+public class BackupRestoreNamingConformanceTest {
+
+    @ClassRule
+    public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/backup-naming-conformance");
+    private static final String MARKER = "backup-naming-probe";
+
+    /** Awkward human-intended leaf names. {@code /} is excluded (path separator); the literal-{@code %} cases are included. */
+    private static final List<String> XML_NAMES = List.of(
+            "plain.xml",            // control: must always survive
+            "with space.xml",
+            "a+b.xml",
+            "a%b.xml",              // literal percent (not a valid %XX escape)
+            "a%20b.xml",            // the literal text "%20", not a space
+            "a@b.xml",
+            "a&b.xml",
+            "report(2024).xml",
+            "o'brien.xml",
+            "café.xml",
+            "Привет.xml",
+            "文書.xml");
+
+    private static final String BINARY_NAME = "résumé.bin";
+    private static final byte[] BINARY_CONTENT = "binary résumé payload".getBytes(UTF_8);
+
+    @Parameter
+    public String apiName;
+
+    @Parameter(value = 1)
+    public boolean direct;
+
+    @Parameter(value = 2)
+    public boolean zip;
+
+    @Parameters(name = "{0} zip:{2}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"direct", true, false},
+                {"non-direct", false, false},
+                {"direct", true, true},
+                {"non-direct", false, true}
+        });
+    }
+
+    /** Unique XML content per resource, so the byte-for-byte comparison is meaningful and any collision shows. */
+    private static String contentFor(final String humanName) {
+        final String escaped = humanName
+                .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+        return "<probe name=\"" + escaped + "\">" + MARKER + "</probe>";
+    }
+
+    private static XmldbURI storedKeyFor(final String humanName) throws Exception {
+        // eXist's own encoder: the leaf key a WebDAV/REST store would land this name under.
+        return URIUtils.encodeXmldbUriFor(TEST_COLLECTION.toString() + "/" + humanName).lastSegment();
+    }
+
+    @Before
+    public void storeCorpus() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = pool.getTransactionManager().beginTransaction()) {
+
+            final Collection existing = broker.getCollection(TEST_COLLECTION);
+            if (existing != null) {
+                broker.removeCollection(txn, existing);
+            }
+            final Collection test = broker.getOrCreateCollection(txn, TEST_COLLECTION);
+            broker.saveCollection(txn, test);
+
+            for (final String name : XML_NAMES) {
+                broker.storeDocument(txn, storedKeyFor(name), new StringInputSource(contentFor(name)), MimeType.XML_TYPE, test);
+            }
+            broker.storeDocument(txn, storedKeyFor(BINARY_NAME), new StringInputSource(BINARY_CONTENT), MimeType.BINARY_TYPE, test);
+
+            txn.commit();
+        }
+    }
+
+    @After
+    public void removeCorpus() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = pool.getTransactionManager().beginTransaction()) {
+            final Collection test = broker.getCollection(TEST_COLLECTION);
+            if (test != null) {
+                broker.removeCollection(txn, test);
+            }
+            txn.commit();
+        }
+    }
+
+    @Test
+    public void awkwardNamesSurviveBackupRestore() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+
+        // snapshot the stored (key -> content) state BEFORE the round-trip
+        final Map<String, String> before = snapshot(pool);
+        printMapping("before backup", before);
+
+        // setup-integrity: every corpus name must have stored as its own distinct key in this path, so the
+        // round-trip below genuinely exercises all of them (not fewer after an accidental store-time clash).
+        assertEquals("setup stored fewer resources than the corpus — a name clashed on the way in; see the "
+                        + "printed mapping", XML_NAMES.size() + 1, before.size());
+
+        // export a full backup
+        final Path backup;
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = pool.getTransactionManager().beginTransaction()) {
+            final SystemExport export = new SystemExport(broker, txn, null, null, direct);
+            backup = export.export(temporaryFolder.newFolder().getAbsolutePath(), false, zip, null);
+            txn.commit();
+        }
+
+        // wipe the collection
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = pool.getTransactionManager().beginTransaction()) {
+            final Collection test = broker.getCollection(TEST_COLLECTION);
+            assertNotNull(test);
+            broker.removeCollection(txn, test);
+            txn.commit();
+        }
+
+        // restore from the backup
+        final RestoreListener listener = new LogRestoreListener();
+        new SystemImport(pool).restore(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD, null, backup, listener);
+
+        // snapshot AFTER the round-trip
+        final Map<String, String> after = snapshot(pool);
+        printMapping("after restore", after);
+
+        // the round-trip must be faithful: the same stored keys, each with byte-for-byte identical content,
+        // none dropped, renamed, or collided.
+        assertEquals("backup -> restore changed the set of stored resource names", before.keySet(), after.keySet());
+        assertEquals("backup -> restore did not reproduce every resource's content byte-for-byte", before, after);
+    }
+
+    /** stored-key -&gt; content for every document under the test collection (XML serialized; binary as a UTF-8 string). */
+    private Map<String, String> snapshot(final BrokerPool pool) throws Exception {
+        final Map<String, String> out = new TreeMap<>();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn txn = pool.getTransactionManager().beginTransaction()) {
+            final Collection test = broker.getCollection(TEST_COLLECTION);
+            assertNotNull("test collection missing", test);
+            for (final Iterator<DocumentImpl> it = test.iterator(broker); it.hasNext(); ) {
+                final DocumentImpl doc = it.next();
+                final String key = doc.getFileURI().toString();       // the exact stored key
+                final String content;
+                if (doc instanceof BinaryDocument bin) {
+                    try (final InputStream is = broker.getBinaryResource(txn, bin)) {
+                        content = "binary:" + InputStreamUtil.readString(is, UTF_8);
+                    }
+                } else {
+                    content = serialize(broker, doc);
+                }
+                out.put(key, content);
+            }
+            txn.commit();
+        }
+        return out;
+    }
+
+    private String serialize(final DBBroker broker, final DocumentImpl doc) throws Exception {
+        final Serializer serializer = broker.borrowSerializer();
+        try {
+            serializer.setUser(broker.getCurrentSubject());
+            return serializer.serialize(doc);
+        } finally {
+            broker.returnSerializer(serializer);
+        }
+    }
+
+    private void printMapping(final String phase, final Map<String, String> snapshot) {
+        final StringBuilder sb = new StringBuilder("\n=== Backup/restore naming conformance (")
+                .append(apiName).append(", zip:").append(zip).append(") — ").append(phase).append(" ===\n");
+        for (final String key : snapshot.keySet()) {
+            sb.append("    ").append(key).append('\n');
+        }
+        sb.append("  ").append(snapshot.size()).append(" stored resource(s)\n");
+        System.out.println(sb);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xmldb/XQueryNamingConformanceTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/XQueryNamingConformanceTest.java
@@ -1,0 +1,220 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmldb;
+
+import static org.junit.Assert.fail;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * XQuery-accessor resource-naming conformance — the XQuery-side companion to the cross-surface HTTP harness
+ * ({@code org.exist.webdav.ResourceNamingConformanceTest}) and the backup/restore round-trip
+ * ({@code org.exist.backup.BackupRestoreNamingConformanceTest}). Same awkward-name corpus, same ratchet
+ * discipline; see issue #6463.
+ *
+ * <p>For every corpus name it stores/creates via {@code xmldb:store} / {@code xmldb:create-collection} in
+ * two modes and reads back <b>by the requested name</b> via the XQuery accessors:</p>
+ * <ul>
+ *   <li><b>resources</b> — read via {@code doc()}, {@code collection()}, {@code xmldb:get-child-resources()};</li>
+ *   <li><b>collections</b> — read via {@code xmldb:get-child-collections()}.</li>
+ * </ul>
+ * <p>and in two <b>modes</b>: <b>raw</b> (the naive {@code xmldb:store($col, $name, …)}) and <b>encode</b>
+ * (the eXide/TEI {@code xmldb:encode-uri($name)} workaround applied on both the store and the read).</p>
+ *
+ * <p>Characterized behavior, pinned by {@link #KNOWN_FAILURES} exactly (same ratchet as the sibling tests):
+ * {@code doc()}, {@code collection()} and {@code xmldb:get-child-resources()} agree in every case — they are
+ * one behavior, not three. Naive {@code xmldb:store}/{@code create-collection} reject a space, a literal
+ * {@code %} and a {@code #} outright (FORG0001) and, for non-ASCII names, store an encoded key that a
+ * read-by-requested-name then misses (the store&harr;doc disagreement). The {@code encode-uri} workaround,
+ * applied consistently on store and read, makes every name round-trip. Entries drop out of the allowlist as
+ * the naming contract lands.</p>
+ */
+public class XQueryNamingConformanceTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer server = new ExistEmbeddedServer(true, true);
+
+    private static final String RES_COLL = "/db/naming-xq-res";
+    private static final String COLL_PARENT = "/db/naming-xq-coll";
+
+    /** Awkward human-intended names. {@code /} is excluded (path separator); the literal-{@code %} cases are included. */
+    private static final List<String> CORPUS = List.of(
+            "plain.xml",            // control: must always work
+            "with space.xml",
+            "a+b.xml",
+            "a%b.xml",              // literal percent
+            "a%20b.xml",            // literal "%20"
+            "a#b.xml",              // hash
+            "a@b.xml",
+            "a&b.xml",
+            "report(2024).xml",
+            "o'brien.xml",
+            "café.xml",
+            "Привет.xml",
+            "文書.xml");
+
+    /**
+     * Ratchet allowlist: the {@code kind:mode:name:reader} cells that do NOT round-trip by the requested name.
+     * The set of failing cells must equal this exactly. Documented current behavior; entries drop out as fixes land.
+     * All failures are in <b>raw</b> mode — the {@code encode} workaround round-trips every name — and every reader
+     * of a given (kind, name) fails together, confirming the accessors agree.
+     */
+    private static final Set<String> KNOWN_FAILURES = Set.of(
+            // All failures are in RAW mode, and the same six names fail across every accessor — confirming
+            // doc()/collection()/get-child-resources() agree, and that get-child-collections mirrors them for
+            // collections. The encode-uri workaround round-trips every name (no encode-mode entries here).
+            // 'with space', a%b and a#b are rejected on create (FORG0001); the three non-ASCII names store an
+            // encoded key that a read-by-requested-name then misses (the store<->doc disagreement).
+
+            // resources — xmldb:store, read by requested name via doc() / collection() / get-child-resources():
+            "res:raw:with space.xml:doc", "res:raw:with space.xml:collection", "res:raw:with space.xml:get-child-resources",
+            "res:raw:a%b.xml:doc", "res:raw:a%b.xml:collection", "res:raw:a%b.xml:get-child-resources",
+            "res:raw:a#b.xml:doc", "res:raw:a#b.xml:collection", "res:raw:a#b.xml:get-child-resources",
+            "res:raw:café.xml:doc", "res:raw:café.xml:collection", "res:raw:café.xml:get-child-resources",
+            "res:raw:Привет.xml:doc", "res:raw:Привет.xml:collection", "res:raw:Привет.xml:get-child-resources",
+            "res:raw:文書.xml:doc", "res:raw:文書.xml:collection", "res:raw:文書.xml:get-child-resources",
+
+            // collections — xmldb:create-collection, read by requested name via get-child-collections():
+            "coll:raw:with space.xml:get-child-collections",
+            "coll:raw:a%b.xml:get-child-collections",
+            "coll:raw:a#b.xml:get-child-collections",
+            "coll:raw:café.xml:get-child-collections",
+            "coll:raw:Привет.xml:get-child-collections",
+            "coll:raw:文書.xml:get-child-collections"
+    );
+
+    @Test
+    public void xqueryAccessorNamingConformance() {
+        final StringBuilder matrix = new StringBuilder("\n=== XQuery-accessor resource-naming matrix (read back by requested name) ===\n");
+        final Set<String> failing = new LinkedHashSet<>();
+
+        for (final String mode : List.of("raw", "encode")) {
+            matrix.append("\n-- resources, xmldb:store (").append(mode).append(") --\n");
+            matrix.append(String.format("%-16s %-8s %-26s %-8s %-8s %-18s%n",
+                    "requested", "created", "stored-key", "doc()", "coll()", "get-child-res"));
+            for (final String name : CORPUS) {
+                freshResources();
+                final String nameExpr = "encode".equals(mode) ? "xmldb:encode-uri(" + lit(name) + ")" : lit(name);
+                final boolean created = xqStr("xmldb:store(" + lit(RES_COLL) + ", " + nameExpr + ", <probe>M</probe>)").startsWith("/db/");
+                final String stored = created ? xqStr("string-join(xmldb:get-child-resources(" + lit(RES_COLL) + "), ',')") : "-";
+                final boolean doc = created && xqBool("exists(doc(concat(" + lit(RES_COLL + "/") + ", " + nameExpr + ")))");
+                final boolean coll = created && xqBool("exists(collection(" + lit(RES_COLL) + ")[ends-with(document-uri(.), concat('/', " + nameExpr + "))])");
+                final boolean gcr = created && xqBool("xmldb:get-child-resources(" + lit(RES_COLL) + ") = " + nameExpr);
+
+                record(failing, "res", mode, name, "doc", doc);
+                record(failing, "res", mode, name, "collection", coll);
+                record(failing, "res", mode, name, "get-child-resources", gcr);
+                matrix.append(String.format("%-16s %-8s %-26s %-8s %-8s %-18s%n",
+                        name, created ? "ok" : "FAIL", stored,
+                        doc ? "PASS" : "FAIL", coll ? "PASS" : "FAIL", gcr ? "PASS" : "FAIL"));
+            }
+
+            matrix.append("\n-- collections, xmldb:create-collection (").append(mode).append(") --\n");
+            matrix.append(String.format("%-16s %-8s %-26s %-18s%n", "requested", "created", "stored-key", "get-child-coll"));
+            for (final String name : CORPUS) {
+                freshCollections();
+                final String nameExpr = "encode".equals(mode) ? "xmldb:encode-uri(" + lit(name) + ")" : lit(name);
+                final boolean created = xqStr("xmldb:create-collection(" + lit(COLL_PARENT) + ", " + nameExpr + ")").startsWith("/db/");
+                final String stored = created ? xqStr("string-join(xmldb:get-child-collections(" + lit(COLL_PARENT) + "), ',')") : "-";
+                final boolean gcc = created && xqBool("xmldb:get-child-collections(" + lit(COLL_PARENT) + ") = " + nameExpr);
+
+                record(failing, "coll", mode, name, "get-child-collections", gcc);
+                matrix.append(String.format("%-16s %-8s %-26s %-18s%n", name, created ? "ok" : "FAIL", stored, gcc ? "PASS" : "FAIL"));
+            }
+        }
+        System.out.println(matrix);
+
+        final Set<String> regressions = new LinkedHashSet<>(failing);
+        regressions.removeAll(KNOWN_FAILURES);
+        final Set<String> nowFixed = new LinkedHashSet<>(KNOWN_FAILURES);
+        nowFixed.removeAll(failing);
+
+        final StringBuilder msg = new StringBuilder();
+        if (!regressions.isEmpty()) {
+            msg.append(regressions.size()).append(" accessor cell(s) regressed (kind:mode:name:reader):\n    ")
+                    .append(String.join("\n    ", regressions)).append('\n');
+        }
+        if (!nowFixed.isEmpty()) {
+            msg.append(nowFixed.size()).append(" cell(s) now round-trip but are still listed as known failures.\n")
+                    .append("Remove them from KNOWN_FAILURES so they become regression-guarded:\n    ")
+                    .append(String.join("\n    ", nowFixed)).append('\n');
+        }
+        if (msg.length() > 0) {
+            fail(msg.append("--- current matrix ---").append(matrix).toString());
+        }
+    }
+
+    private static void record(final Set<String> failing, final String kind, final String mode, final String name, final String reader, final boolean ok) {
+        if (!ok) {
+            failing.add(kind + ":" + mode + ":" + name + ":" + reader);
+        }
+    }
+
+    /** An XQuery string literal (double-quoted) for an arbitrary name; only {@code &} and {@code <} need escaping. */
+    private static String lit(final String s) {
+        return '"' + s.replace("&", "&amp;").replace("<", "&lt;") + '"';
+    }
+
+    private void freshResources() {
+        xqStr("if (xmldb:collection-available(" + lit(RES_COLL) + ")) then xmldb:remove(" + lit(RES_COLL) + ") else (), "
+                + "xmldb:create-collection('/db', 'naming-xq-res')");
+    }
+
+    private void freshCollections() {
+        xqStr("if (xmldb:collection-available(" + lit(COLL_PARENT) + ")) then xmldb:remove(" + lit(COLL_PARENT) + ") else (), "
+                + "xmldb:create-collection('/db', 'naming-xq-coll')");
+    }
+
+    private boolean xqBool(final String query) {
+        return "true".equals(xqStr(query));
+    }
+
+    private String xqStr(final String query) {
+        final BrokerPool pool = server.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            final StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < result.getItemCount(); i++) {
+                if (i > 0) {
+                    sb.append('|');
+                }
+                sb.append(result.itemAt(i).getStringValue());
+            }
+            return sb.toString();
+        } catch (final Exception e) {
+            // a create that the naming layer rejects (e.g. FORG0001) surfaces here; treated as "not created".
+            return "ERR:" + e.getClass().getSimpleName();
+        }
+    }
+}

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -89,6 +89,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- XML-RPC client for the cross-surface resource-naming harness -->
+        <dependency>
+            <groupId>com.evolvedbinary.thirdparty.org.apache.xmlrpc</groupId>
+            <artifactId>xmlrpc-client</artifactId>
+            <version>${apache.xmlrpc.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- needed for starting up a jetty server -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -28,12 +28,11 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -59,17 +58,19 @@ import static org.junit.Assert.fail;
  *
  * Surfaces covered in this first increment:
  * <ul>
- *   <li><b>WebDAV</b> (Apache Jackrabbit server since PR #6364) — probed via raw HTTP PUT/GET so the
- *       on-the-wire encoding is explicit.</li>
- *   <li><b>REST</b> — via {@link HttpURLConnection}.</li>
+ *   <li><b>WebDAV</b> (Apache Jackrabbit server since PR #6364) — probed via {@link HttpClient}.</li>
+ *   <li><b>REST</b> — via {@link HttpClient}.</li>
  *   <li>an <b>oracle</b> for the stored name — eXist's native REST collection listing (no XQuery module
  *       needed; the WebDAV module's test conf.xml registers no XQuery builtin-modules), reporting what
  *       name actually got stored under the test collection.</li>
  * </ul>
  *
  * <p>The harness is module- and WebDAV-client-independent: the test collection is created by a REST PUT
- * (which auto-creates it), and all probes are raw HTTP. Probe content is valid XML because the corpus
- * names end in {@code .xml} and eXist parses {@code .xml} resources on store.</p>
+ * (which auto-creates it), and all probes go over {@link HttpClient}. Request URLs are built with the
+ * multi-argument {@link URI} constructor, which percent-encodes the path; note this leaves RFC 3986
+ * sub-delimiters ({@code + @ & ( ) '}) literal on the wire, which is itself part of the encoding
+ * behavior this harness characterizes. Probe content is valid XML because the corpus names end in
+ * {@code .xml} and eXist parses {@code .xml} resources on store.</p>
  *
  * TODO (follow-up increments, see the resource-naming tasking):
  * <ul>
@@ -87,6 +88,8 @@ public class ResourceNamingConformanceTest {
     // valid XML, because the corpus names end in .xml and eXist parses .xml resources on store
     private static final String MARKER = "naming-probe-content";
     private static final String CONTENT = "<probe>" + MARKER + "</probe>";
+
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
 
     /**
      * The corpus of "awkward" leaf resource names. Each is the human-intended name the user
@@ -111,23 +114,26 @@ public class ResourceNamingConformanceTest {
     }
 
     /**
-     * The ratchet allowlist: corpus labels that do NOT yet round-trip cross-surface (stored via
-     * WebDAV, then read back by the requested name via both WebDAV and REST). This set must match
-     * the names that currently fail exactly.
+     * The ratchet allowlist: corpus labels that do NOT round-trip cross-surface (stored via WebDAV,
+     * then read back by the requested name via both WebDAV and REST). The set of names that currently
+     * fail must equal this set exactly.
      *
-     * <p>When a naming fix lands and one of these starts round-tripping, the test fails and tells you
-     * to <b>remove</b> it from this set — at which point that name becomes regression-guarded. If a
-     * name that is <em>not</em> listed here ever stops round-tripping, the test fails as a regression.
-     * So the matrix can neither silently drift nor silently regress. See the resource-naming tasking
+     * <p>It is <b>empty</b>: with request URLs built the standard way (the multi-argument
+     * {@link URI} constructor, which leaves RFC 3986 sub-delimiters such as {@code + @ & ( ) '} literal
+     * in the path, exactly as a browser or {@code curl} sends them), every corpus name — including
+     * those with sub-delimiters and non-ASCII characters — round-trips between WebDAV and REST. eXist
+     * may store a percent-encoded form (e.g. a space as {@code %20}; see the {@code (≠)} markers in the
+     * printed matrix), but both surfaces agree on read, so the content is reachable by the requested
+     * name. An earlier revision of this harness percent-encoded sub-delimiters in the request URL and
+     * saw five "failures" ({@code + @ & ( ) '}); those were artifacts of that encoding choice, not of
+     * eXist's storage, and disappear once the URL is encoded conventionally.</p>
+     *
+     * <p>The ratchet therefore guards the <em>good</em> state: if any corpus name ever stops
+     * round-tripping cross-surface, the test fails as a regression. If a future change makes a new,
+     * not-yet-covered name fail, add it here with a comment. See the resource-naming tasking
      * (issues #3795, #3665, #1824, #5299, #1612).</p>
      */
-    private static final Set<String> KNOWN_FAILURES = Set.of(
-            "plus",        // a+b.xml         — '+' stored as %2B; REST read by requested name misses
-            "at",          // a@b.xml
-            "ampersand",   // a&b.xml
-            "parens",      // report(2024).xml
-            "apostrophe"   // o'brien.xml
-    );
+    private static final Set<String> KNOWN_FAILURES = Set.of();
 
     @BeforeClass
     public static void createTestCollection() {
@@ -164,8 +170,7 @@ public class ResourceNamingConformanceTest {
             freshCollection();
 
             try {
-                // CREATE via WebDAV — raw HTTP PUT with RFC 3986 path-segment encoding, so the
-                // test controls exactly what is on the wire (no client library obscuring it)
+                // CREATE via WebDAV — HTTP PUT with the URI constructor encoding the path
                 final StringBuilder putBody = new StringBuilder();
                 final int putCode = webdavPut(TEST_COLLECTION + "/" + name, CONTENT, putBody);
                 row.created = putCode == 200 || putCode == 201 || putCode == 204;
@@ -176,7 +181,7 @@ public class ResourceNamingConformanceTest {
                 // ORACLE: what name actually landed in storage?
                 row.storedName = soleStoredName();
 
-                // READ-BACK via WebDAV (self round-trip, raw HTTP GET) — by the name the user PUT
+                // READ-BACK via WebDAV (self round-trip, HTTP GET) — by the name the user PUT
                 row.webdavReadBack = webdavGet(TEST_COLLECTION + "/" + name);
 
                 // READ via REST by the name the user PUT (cross-surface WebDAV -> REST): can a REST
@@ -237,27 +242,22 @@ public class ResourceNamingConformanceTest {
         return sb.toString();
     }
 
-    // ---- WebDAV helpers (raw HTTP, so the on-the-wire encoding is explicit) ----
+    // ---- WebDAV helpers (java.net.http.HttpClient; the multi-arg URI constructor encodes the path) ----
 
-    /** Raw HTTP PUT to the WebDAV endpoint; returns the HTTP status (or -1), appending any body. */
+    /** HTTP PUT to the WebDAV endpoint; returns the HTTP status (or -1), appending any body. */
     private static int webdavPut(final String dbPath, final String content, final StringBuilder bodyOut) {
         try {
-            final URL url = URI.create(webdavBase() + encodePathSegments(dbPath)).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("PUT");
-            conn.setRequestProperty("Content-Type", "application/xml");
-            conn.setDoOutput(true);
-            try (final OutputStream os = conn.getOutputStream()) {
-                os.write(content.getBytes(UTF_8));
-            }
-            final int code = conn.getResponseCode();
+            final HttpRequest req = authed(endpointUri("/webdav", dbPath))
+                    .header("Content-Type", "application/xml")
+                    .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
+                    .build();
+            final HttpResponse<String> resp = HTTP.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
             if (bodyOut != null) {
-                bodyOut.append(readBody(conn));
+                bodyOut.append(resp.body());
             }
-            conn.disconnect();
-            return code;
+            return resp.statusCode();
         } catch (final Exception e) {
+            restoreInterrupt(e);
             if (bodyOut != null) {
                 bodyOut.append(e);
             }
@@ -265,69 +265,28 @@ public class ResourceNamingConformanceTest {
         }
     }
 
-    /** Raw HTTP GET from the WebDAV endpoint; true if 200 and content matches. */
+    /** HTTP GET from the WebDAV endpoint; true if 200 and content matches. */
     private static Boolean webdavGet(final String dbPath) {
-        try {
-            final URL url = URI.create(webdavBase() + encodePathSegments(dbPath)).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("GET");
-            conn.connect();
-            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                conn.disconnect();
-                return false;
-            }
-            final String body = readBody(conn);
-            conn.disconnect();
-            return body.contains(MARKER);
-        } catch (final Exception e) {
-            return false;
-        }
-    }
-
-    private static String webdavBase() {
-        return "http://localhost:" + existWebServer.getPort() + "/webdav";
+        return getMatchesMarker(endpointUri("/webdav", dbPath));
     }
 
     // ---- REST helpers ----
 
     /** GET a db path via the REST interface; returns true if 200 and content matches. */
     private Boolean restGet(final String dbPath) {
-        try {
-            final String encoded = encodePathSegments(dbPath);
-            final URL url = URI.create(restBase() + encoded).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("GET");
-            conn.connect();
-            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                conn.disconnect();
-                return false;
-            }
-            final String body = readBody(conn);
-            conn.disconnect();
-            return body.contains(MARKER);
-        } catch (final Exception e) {
-            return false;
-        }
+        return getMatchesMarker(endpointUri("/rest", dbPath));
     }
 
-    /** Raw HTTP PUT to the REST endpoint (auto-creates parent collections); returns the HTTP status. */
+    /** HTTP PUT to the REST endpoint (auto-creates parent collections); returns the HTTP status. */
     private static int restPut(final String dbPath, final String content) {
         try {
-            final URL url = URI.create(restBase() + encodePathSegments(dbPath)).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("PUT");
-            conn.setRequestProperty("Content-Type", "application/xml");
-            conn.setDoOutput(true);
-            try (final OutputStream os = conn.getOutputStream()) {
-                os.write(content.getBytes(UTF_8));
-            }
-            final int code = conn.getResponseCode();
-            conn.disconnect();
-            return code;
+            final HttpRequest req = authed(endpointUri("/rest", dbPath))
+                    .header("Content-Type", "application/xml")
+                    .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
+                    .build();
+            return HTTP.send(req, HttpResponse.BodyHandlers.discarding()).statusCode();
         } catch (final Exception e) {
+            restoreInterrupt(e);
             return -1;
         }
     }
@@ -352,35 +311,63 @@ public class ResourceNamingConformanceTest {
     private List<String> restListChildResources(final String collection) {
         final List<String> names = new ArrayList<>();
         try {
-            final URL url = URI.create(restBase() + encodePathSegments(collection)).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("GET");
-            conn.connect();
-            final String body = readBody(conn);
-            conn.disconnect();
+            final HttpRequest req = authed(endpointUri("/rest", collection)).GET().build();
+            final String body = HTTP.send(req, HttpResponse.BodyHandlers.ofString(UTF_8)).body();
             final Matcher m = Pattern.compile("<exist:resource[^>]*\\sname=\"([^\"]*)\"").matcher(body);
             while (m.find()) {
                 names.add(unescapeXml(m.group(1)));
             }
-        } catch (final Exception ignored) {
+        } catch (final Exception e) {
+            restoreInterrupt(e);
             // treat as empty listing
         }
         return names;
     }
 
-    /** Raw HTTP DELETE against the REST endpoint (built-in; needs no XQuery module). */
+    /** HTTP DELETE against the REST endpoint (built-in; needs no XQuery module). */
     private static void restDelete(final String dbPath) {
         try {
-            final URL url = URI.create(restBase() + encodePathSegments(dbPath)).toURL();
-            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestProperty("Authorization", basicAuth());
-            conn.setRequestMethod("DELETE");
-            conn.connect();
-            conn.getResponseCode();
-            conn.disconnect();
-        } catch (final Exception ignored) {
+            final HttpRequest req = authed(endpointUri("/rest", dbPath)).DELETE().build();
+            HTTP.send(req, HttpResponse.BodyHandlers.discarding());
+        } catch (final Exception e) {
+            restoreInterrupt(e);
             // best-effort cleanup
+        }
+    }
+
+    /** Send a GET and report whether the response is 200 and its body contains the probe marker. */
+    private static Boolean getMatchesMarker(final URI uri) {
+        try {
+            final HttpResponse<String> resp = HTTP.send(authed(uri).GET().build(),
+                    HttpResponse.BodyHandlers.ofString(UTF_8));
+            return resp.statusCode() == 200 && resp.body().contains(MARKER);
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            return false;
+        }
+    }
+
+    /**
+     * Build the request URI for an endpoint and db path. The multi-argument {@link URI} constructor
+     * percent-encodes the path component (and, per RFC 3986, leaves sub-delimiters such as
+     * {@code + @ & ( ) '} literal — which is itself part of what this harness characterizes).
+     */
+    private static URI endpointUri(final String endpoint, final String dbPath) {
+        try {
+            return new URI("http", null, "localhost", existWebServer.getPort(), endpoint + dbPath, null, null);
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException("cannot build URI for " + endpoint + dbPath, e);
+        }
+    }
+
+    private static HttpRequest.Builder authed(final URI uri) {
+        return HttpRequest.newBuilder(uri).header("Authorization", basicAuth());
+    }
+
+    /** Re-assert the interrupt flag if a blocking HttpClient call was interrupted. */
+    private static void restoreInterrupt(final Exception e) {
+        if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -389,38 +376,9 @@ public class ResourceNamingConformanceTest {
                 .replace("&quot;", "\"").replace("&apos;", "'");
     }
 
-    private static String restBase() {
-        return "http://localhost:" + existWebServer.getPort() + "/rest";
-    }
-
     private static String basicAuth() {
         return "Basic " + java.util.Base64.getEncoder().encodeToString(
                 (TestUtils.ADMIN_DB_USER + ":" + TestUtils.ADMIN_DB_PWD).getBytes(UTF_8));
-    }
-
-    private static String readBody(final HttpURLConnection conn) throws IOException {
-        final java.io.InputStream is = conn.getResponseCode() < 400 ? conn.getInputStream() : conn.getErrorStream();
-        if (is == null) {
-            return "";
-        }
-        try (is; final OutputStream baos = new ByteArrayOutputStream()) {
-            is.transferTo(baos);
-            return baos.toString();
-        }
-    }
-
-    /** Percent-encode each path segment (between slashes) per RFC 3986, leaving '/' as separators. */
-    private static String encodePathSegments(final String path) {
-        final String[] segs = path.split("/", -1);
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < segs.length; i++) {
-            if (i > 0) {
-                sb.append('/');
-            }
-            // URLEncoder is form-encoding; convert '+' to %20 to get RFC 3986 path-segment encoding
-            sb.append(java.net.URLEncoder.encode(segs[i], UTF_8).replace("+", "%20"));
-        }
-        return sb.toString();
     }
 
     // ---- matrix rendering ----

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -21,6 +21,8 @@
  */
 package org.exist.webdav;
 
+import org.apache.xmlrpc.client.XmlRpcClient;
+import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import org.exist.TestUtils;
 import org.exist.test.ExistWebServer;
 import org.junit.AfterClass;
@@ -30,6 +32,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -56,28 +59,33 @@ import static org.junit.Assert.fail;
  * fixes land you remove entries from {@code KNOWN_FAILURES} to lock in each improvement — the test
  * tells you exactly which ones when they start passing.
  *
- * Surfaces covered in this first increment:
+ * Surfaces covered:
  * <ul>
  *   <li><b>WebDAV</b> (Apache Jackrabbit server since PR #6364) — probed via {@link HttpClient}.</li>
  *   <li><b>REST</b> — via {@link HttpClient}.</li>
+ *   <li><b>XML-RPC</b> — create ({@code parse}) and read ({@code getDocument}) via the
+ *       {@code org.apache.xmlrpc} client against {@code /xmlrpc}.</li>
  *   <li>an <b>oracle</b> for the stored name — eXist's native REST collection listing (no XQuery module
  *       needed; the WebDAV module's test conf.xml registers no XQuery builtin-modules), reporting what
  *       name actually got stored under the test collection.</li>
  * </ul>
  *
- * <p>The harness is module- and WebDAV-client-independent: the test collection is created by a REST PUT
- * (which auto-creates it), and all probes go over {@link HttpClient}. Request URLs are built with the
+ * <p>Two tests run over the same corpus. {@link #crossSurfaceNamingConformance()} is the original ratchet:
+ * store via WebDAV, read back by the requested name via WebDAV and REST. {@link #fullCrossSurfaceMatrix()}
+ * is the full N&times;N matrix: create via each surface, then read back — by the requested name — via every
+ * surface, ratcheted against {@link #KNOWN_MATRIX_FAILURES}. Together they show that WebDAV and REST agree
+ * on every corpus name, while XML-RPC diverges for names containing {@code %} or {@code #}.</p>
+ *
+ * <p>The HTTP harness is WebDAV-client-independent: the test collection is created by a REST PUT (which
+ * auto-creates it), and WebDAV/REST probes go over {@link HttpClient}. Request URLs are built with the
  * multi-argument {@link URI} constructor, which percent-encodes the path; note this leaves RFC 3986
  * sub-delimiters ({@code + @ & ( ) '}) literal on the wire, which is itself part of the encoding
  * behavior this harness characterizes. Probe content is valid XML because the corpus names end in
  * {@code .xml} and eXist parses {@code .xml} resources on store.</p>
  *
- * TODO (follow-up increments, see the resource-naming tasking):
- * <ul>
- *   <li>XML-RPC surface (create/read via {@code org.apache.xmlrpc} client against {@code /xmlrpc}).</li>
- *   <li>Full N×N cross-surface matrix (create-via-X then read-via-every-Y).</li>
- *   <li>existdb-openapi lives in a separate repo; its special-char suite is PR F there.</li>
- * </ul>
+ * <p>Related: {@code org.exist.backup.BackupRestoreNamingConformanceTest} (exist-core) extends the same
+ * corpus to the backup&rarr;restore round-trip. existdb-openapi's special-character suite lives in that
+ * repo (a separate PR). See issue #6463 and issues #3795, #3665, #1824, #5299, #1612.</p>
  */
 public class ResourceNamingConformanceTest {
 
@@ -134,6 +142,46 @@ public class ResourceNamingConformanceTest {
      * (issues #3795, #3665, #1824, #5299, #1612).</p>
      */
     private static final Set<String> KNOWN_FAILURES = Set.of();
+
+    /** The three remote surfaces the full N&times;N matrix drives. */
+    private enum Surface { WEBDAV, REST, XMLRPC }
+
+    /** Lazily-built XML-RPC client (against {@code /xmlrpc}); reused across probes. */
+    private static XmlRpcClient xmlrpcClient;
+
+    /**
+     * Ratchet allowlist for the full N&times;N matrix: the {@code create&gt;read:probe} cells that do NOT
+     * round-trip (a resource created via one surface, read back by the requested name via another). The set
+     * of failing cells must equal this exactly — same guard, at N&times;N scale, as {@link #KNOWN_FAILURES}.
+     * Populated from the characterized behavior; entries drop out as naming fixes land.
+     */
+    private static final Set<String> KNOWN_MATRIX_FAILURES = Set.of(
+            // XML-RPC is the divergent surface for names containing '%' or '#'. This is the documented current
+            // behavior; entries drop out of this allowlist as the naming contract (issue #6463) reaches the
+            // XML-RPC path. WebDAV and REST agree on every corpus name — no cross-surface failures between them.
+
+            // (a) a '%'- or '#'-name stored via HTTP (WebDAV/REST) cannot be read back via XML-RPC:
+            "WEBDAV>XMLRPC:literal-percent",   // a%b.xml
+            "WEBDAV>XMLRPC:encoded-space",     // a%20b.xml
+            "WEBDAV>XMLRPC:hash",              // a#b.xml
+            "REST>XMLRPC:literal-percent",
+            "REST>XMLRPC:encoded-space",
+            "REST>XMLRPC:hash",
+
+            // (b) XML-RPC create rejects a literal '%' (a%b.xml) outright, so no surface can read it:
+            "XMLRPC>WEBDAV:literal-percent",
+            "XMLRPC>REST:literal-percent",
+            "XMLRPC>XMLRPC:literal-percent",
+
+            // (c) XML-RPC stores 'a%20b.xml' under a form only XML-RPC itself reads back (HTTP surfaces miss it):
+            "XMLRPC>WEBDAV:encoded-space",
+            "XMLRPC>REST:encoded-space",
+
+            // (d) XML-RPC stores 'a#b.xml' but no surface — not even XML-RPC — reads it back by that name:
+            "XMLRPC>WEBDAV:hash",
+            "XMLRPC>REST:hash",
+            "XMLRPC>XMLRPC:hash"
+    );
 
     @BeforeClass
     public static void createTestCollection() {
@@ -382,6 +430,131 @@ public class ResourceNamingConformanceTest {
     private static String basicAuth() {
         return "Basic " + java.util.Base64.getEncoder().encodeToString(
                 (TestUtils.ADMIN_DB_USER + ":" + TestUtils.ADMIN_DB_PWD).getBytes(UTF_8));
+    }
+
+    // ==== full N×N cross-surface matrix (create-via-X, read-via-every-Y) ====
+
+    /**
+     * For every corpus name, create it via each surface and read it back — by the requested name — via
+     * every surface, producing the full create&times;read matrix across WebDAV, REST and XML-RPC. Prints
+     * the matrix (visible in CI) and enforces the same ratchet as {@link #crossSurfaceNamingConformance()}:
+     * the set of cells that fail to round-trip must equal {@link #KNOWN_MATRIX_FAILURES} exactly.
+     */
+    @Test
+    public void fullCrossSurfaceMatrix() {
+        final Surface[] surfaces = Surface.values();
+        final StringBuilder out = new StringBuilder(
+                "\n=== Resource-naming: full N×N cross-surface matrix (create-via-row, read-via-column) ===\n");
+        final Set<String> failing = new LinkedHashSet<>();
+
+        for (final Surface create : surfaces) {
+            out.append("\n-- created via ").append(create).append(" --\n");
+            out.append(String.format("%-16s %-18s %-8s", "probe", "requested", "created"));
+            for (final Surface read : surfaces) {
+                out.append(String.format(" %-9s", "read:" + read));
+            }
+            out.append('\n');
+
+            for (final Map.Entry<String, String> probe : CORPUS.entrySet()) {
+                final String label = probe.getKey();
+                final String name = probe.getValue();
+
+                freshCollection();
+                final boolean created = createVia(create, name);
+                out.append(String.format("%-16s %-18s %-8s", label, name, created ? "ok" : "FAIL"));
+
+                for (final Surface read : surfaces) {
+                    final boolean ok = created && readVia(read, name);
+                    out.append(String.format(" %-9s", ok ? "PASS" : "FAIL"));
+                    if (!ok) {
+                        // a cell fails when a resource created via `create` cannot be read back by the
+                        // requested name via `read` (create failing counts as every read-cell failing).
+                        failing.add(cell(create, read, label));
+                    }
+                }
+                out.append('\n');
+            }
+        }
+        System.out.println(out);
+
+        final Set<String> regressions = new LinkedHashSet<>(failing);
+        regressions.removeAll(KNOWN_MATRIX_FAILURES);           // failing but expected to pass -> regression
+        final Set<String> nowFixed = new LinkedHashSet<>(KNOWN_MATRIX_FAILURES);
+        nowFixed.removeAll(failing);                            // listed as broken but now passing -> tighten
+
+        final StringBuilder msg = new StringBuilder();
+        if (!regressions.isEmpty()) {
+            msg.append(regressions.size()).append(" cross-surface cell(s) regressed (create>read:probe):\n    ")
+                    .append(String.join("\n    ", regressions)).append('\n');
+        }
+        if (!nowFixed.isEmpty()) {
+            msg.append(nowFixed.size()).append(" cell(s) now round-trip but are still listed as known failures.\n")
+                    .append("Remove them from KNOWN_MATRIX_FAILURES so they become regression-guarded:\n    ")
+                    .append(String.join("\n    ", nowFixed)).append('\n');
+        }
+        if (msg.length() > 0) {
+            fail(msg.append("--- current matrix ---").append(out).toString());
+        }
+    }
+
+    private static String cell(final Surface create, final Surface read, final String label) {
+        return create + ">" + read + ":" + label;
+    }
+
+    /** Create {@code name} in the test collection via surface {@code s}; true if the surface reports success. */
+    private boolean createVia(final Surface s, final String name) {
+        final String dbPath = TEST_COLLECTION + "/" + name;
+        return switch (s) {
+            case WEBDAV -> {
+                final int code = webdavPut(dbPath, CONTENT, new StringBuilder());
+                yield code == 200 || code == 201 || code == 204;
+            }
+            case REST -> {
+                final int code = restPut(dbPath, CONTENT);
+                yield code == 200 || code == 201;
+            }
+            case XMLRPC -> {
+                try {
+                    final Object ok = xmlrpc().execute("parse", List.of(CONTENT.getBytes(UTF_8), dbPath, 1));
+                    yield Boolean.TRUE.equals(ok);
+                } catch (final Exception e) {
+                    restoreInterrupt(e);
+                    yield false;
+                }
+            }
+        };
+    }
+
+    /** Read {@code name} by the requested name via surface {@code s}; true if the content round-trips. */
+    private boolean readVia(final Surface s, final String name) {
+        final String dbPath = TEST_COLLECTION + "/" + name;
+        return switch (s) {
+            case WEBDAV -> Boolean.TRUE.equals(webdavGet(dbPath));
+            case REST -> Boolean.TRUE.equals(restGet(dbPath));
+            case XMLRPC -> {
+                try {
+                    final byte[] bytes = (byte[]) xmlrpc().execute("getDocument", List.of(dbPath, Map.of()));
+                    yield bytes != null && new String(bytes, UTF_8).contains(MARKER);
+                } catch (final Exception e) {
+                    restoreInterrupt(e);
+                    yield false;
+                }
+            }
+        };
+    }
+
+    private static XmlRpcClient xmlrpc() throws Exception {
+        if (xmlrpcClient == null) {
+            final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+            config.setServerURL(new URL("http", "localhost", existWebServer.getPort(), "/xmlrpc"));
+            config.setBasicUserName(TestUtils.ADMIN_DB_USER);
+            config.setBasicPassword(TestUtils.ADMIN_DB_PWD);
+            config.setEnabledForExtensions(true);
+            final XmlRpcClient client = new XmlRpcClient();
+            client.setConfig(config);
+            xmlrpcClient = client;
+        }
+        return xmlrpcClient;
     }
 
     // ---- matrix rendering ----

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -89,7 +89,7 @@ public class ResourceNamingConformanceTest {
     private static final String MARKER = "naming-probe-content";
     private static final String CONTENT = "<probe>" + MARKER + "</probe>";
 
-    private static final HttpClient HTTP = HttpClient.newHttpClient();
+    private static HttpClient http;
 
     /**
      * The corpus of "awkward" leaf resource names. Each is the human-intended name the user
@@ -137,12 +137,15 @@ public class ResourceNamingConformanceTest {
 
     @BeforeClass
     public static void createTestCollection() {
+        // HttpClient is AutoCloseable (Java 21); created here and closed in @AfterClass below.
+        http = HttpClient.newHttpClient();
         freshCollection();
     }
 
     @AfterClass
     public static void removeTestCollection() {
         restDelete(TEST_COLLECTION);
+        http.close();
     }
 
     /**
@@ -251,7 +254,7 @@ public class ResourceNamingConformanceTest {
                     .header("Content-Type", "application/xml")
                     .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
                     .build();
-            final HttpResponse<String> resp = HTTP.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
+            final HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
             if (bodyOut != null) {
                 bodyOut.append(resp.body());
             }
@@ -284,7 +287,7 @@ public class ResourceNamingConformanceTest {
                     .header("Content-Type", "application/xml")
                     .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
                     .build();
-            return HTTP.send(req, HttpResponse.BodyHandlers.discarding()).statusCode();
+            return http.send(req, HttpResponse.BodyHandlers.discarding()).statusCode();
         } catch (final Exception e) {
             restoreInterrupt(e);
             return -1;
@@ -312,7 +315,7 @@ public class ResourceNamingConformanceTest {
         final List<String> names = new ArrayList<>();
         try {
             final HttpRequest req = authed(endpointUri("/rest", collection)).GET().build();
-            final String body = HTTP.send(req, HttpResponse.BodyHandlers.ofString(UTF_8)).body();
+            final String body = http.send(req, HttpResponse.BodyHandlers.ofString(UTF_8)).body();
             final Matcher m = Pattern.compile("<exist:resource[^>]*\\sname=\"([^\"]*)\"").matcher(body);
             while (m.find()) {
                 names.add(unescapeXml(m.group(1)));
@@ -328,7 +331,7 @@ public class ResourceNamingConformanceTest {
     private static void restDelete(final String dbPath) {
         try {
             final HttpRequest req = authed(endpointUri("/rest", dbPath)).DELETE().build();
-            HTTP.send(req, HttpResponse.BodyHandlers.discarding());
+            http.send(req, HttpResponse.BodyHandlers.discarding());
         } catch (final Exception e) {
             restoreInterrupt(e);
             // best-effort cleanup
@@ -338,7 +341,7 @@ public class ResourceNamingConformanceTest {
     /** Send a GET and report whether the response is 200 and its body contains the probe marker. */
     private static Boolean getMatchesMarker(final URI uri) {
         try {
-            final HttpResponse<String> resp = HTTP.send(authed(uri).GET().build(),
+            final HttpResponse<String> resp = http.send(authed(uri).GET().build(),
                     HttpResponse.BodyHandlers.ofString(UTF_8));
             return resp.statusCode() == 200 && resp.body().contains(MARKER);
         } catch (final Exception e) {

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -1,0 +1,470 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.webdav;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.fail;
+
+/**
+ * Cross-surface resource-naming conformance harness (PR A).
+ *
+ * For a corpus of "awkward" resource names, this stores each name through one API surface and probes
+ * how it round-trips and what name actually lands in storage, across eXist's remote surfaces. It
+ * prints a matrix of the current behavior (visible in the CI log) and enforces a <b>ratchet</b>:
+ * the set of names that fail to round-trip cross-surface must exactly equal {@link #KNOWN_FAILURES}.
+ * So merging this guards every already-correct name against regression immediately, and as the naming
+ * fixes land you remove entries from {@code KNOWN_FAILURES} to lock in each improvement — the test
+ * tells you exactly which ones when they start passing.
+ *
+ * Surfaces covered in this first increment:
+ * <ul>
+ *   <li><b>WebDAV</b> (Apache Jackrabbit server since PR #6364) — probed via raw HTTP PUT/GET so the
+ *       on-the-wire encoding is explicit.</li>
+ *   <li><b>REST</b> — via {@link HttpURLConnection}.</li>
+ *   <li>an <b>oracle</b> for the stored name — eXist's native REST collection listing (no XQuery module
+ *       needed; the WebDAV module's test conf.xml registers no XQuery builtin-modules), reporting what
+ *       name actually got stored under the test collection.</li>
+ * </ul>
+ *
+ * <p>The harness is module- and WebDAV-client-independent: the test collection is created by a REST PUT
+ * (which auto-creates it), and all probes are raw HTTP. Probe content is valid XML because the corpus
+ * names end in {@code .xml} and eXist parses {@code .xml} resources on store.</p>
+ *
+ * TODO (follow-up increments, see the resource-naming tasking):
+ * <ul>
+ *   <li>XML-RPC surface (create/read via {@code org.apache.xmlrpc} client against {@code /xmlrpc}).</li>
+ *   <li>Full N×N cross-surface matrix (create-via-X then read-via-every-Y).</li>
+ *   <li>existdb-openapi lives in a separate repo; its special-char suite is PR F there.</li>
+ * </ul>
+ */
+public class ResourceNamingConformanceTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    private static final String TEST_COLLECTION = "/db/naming-conformance-test";
+    // valid XML, because the corpus names end in .xml and eXist parses .xml resources on store
+    private static final String MARKER = "naming-probe-content";
+    private static final String CONTENT = "<probe>" + MARKER + "</probe>";
+
+    /**
+     * The corpus of "awkward" leaf resource names. Each is the human-intended name the user
+     * believes they are creating. {@code /} is excluded (path separator); a {@code .xml}/{@code .bin}
+     * suffix is kept so MIME detection behaves normally.
+     */
+    private static final Map<String, String> CORPUS = new LinkedHashMap<>();
+    static {
+        CORPUS.put("ascii-control",   "plain.xml");        // control: must always work
+        CORPUS.put("space",           "with space.xml");
+        CORPUS.put("plus",            "a+b.xml");
+        CORPUS.put("literal-percent", "a%b.xml");
+        CORPUS.put("encoded-space",   "a%20b.xml");        // literal "%20" in the name
+        CORPUS.put("hash",            "a#b.xml");
+        CORPUS.put("at",              "a@b.xml");
+        CORPUS.put("ampersand",       "a&b.xml");
+        CORPUS.put("parens",          "report(2024).xml");
+        CORPUS.put("apostrophe",      "o'brien.xml");
+        CORPUS.put("non-ascii",       "café.xml");
+        CORPUS.put("cyrillic",        "Привет.xml");
+        CORPUS.put("cjk",             "文書.xml");
+    }
+
+    /**
+     * The ratchet allowlist: corpus labels that do NOT yet round-trip cross-surface (stored via
+     * WebDAV, then read back by the requested name via both WebDAV and REST). This set must match
+     * the names that currently fail exactly.
+     *
+     * <p>When a naming fix lands and one of these starts round-tripping, the test fails and tells you
+     * to <b>remove</b> it from this set — at which point that name becomes regression-guarded. If a
+     * name that is <em>not</em> listed here ever stops round-tripping, the test fails as a regression.
+     * So the matrix can neither silently drift nor silently regress. See the resource-naming tasking
+     * (issues #3795, #3665, #1824, #5299, #1612).</p>
+     */
+    private static final Set<String> KNOWN_FAILURES = Set.of(
+            "plus",        // a+b.xml         — '+' stored as %2B; REST read by requested name misses
+            "at",          // a@b.xml
+            "ampersand",   // a&b.xml
+            "parens",      // report(2024).xml
+            "apostrophe"   // o'brien.xml
+    );
+
+    @BeforeClass
+    public static void createTestCollection() {
+        freshCollection();
+    }
+
+    @AfterClass
+    public static void removeTestCollection() {
+        restDelete(TEST_COLLECTION);
+    }
+
+    /**
+     * Resets the test collection to empty: delete it, then recreate it by REST-PUTting a seed
+     * document (which auto-creates the collection) and removing the seed. Wiping the whole
+     * collection avoids depending on the stored name, which is what this test characterizes.
+     */
+    private static void freshCollection() {
+        restDelete(TEST_COLLECTION);
+        restPut(TEST_COLLECTION + "/__seed.xml", CONTENT);
+        restDelete(TEST_COLLECTION + "/__seed.xml");
+    }
+
+    @Test
+    public void crossSurfaceNamingConformance() throws Exception {
+        final List<Row> rows = new ArrayList<>();
+
+        for (final Map.Entry<String, String> probe : CORPUS.entrySet()) {
+            final String label = probe.getKey();
+            final String name = probe.getValue();
+            final Row row = new Row(label, name);
+
+            // start each probe from an empty collection (deleting by the requested name is unreliable,
+            // since the stored name may differ — which is exactly what this test characterizes)
+            freshCollection();
+
+            try {
+                // CREATE via WebDAV — raw HTTP PUT with RFC 3986 path-segment encoding, so the
+                // test controls exactly what is on the wire (no client library obscuring it)
+                final StringBuilder putBody = new StringBuilder();
+                final int putCode = webdavPut(TEST_COLLECTION + "/" + name, CONTENT, putBody);
+                row.created = putCode == 200 || putCode == 201 || putCode == 204;
+                if (!row.created) {
+                    row.error = "PUT " + putCode + ": " + putBody.toString().replaceAll("\\s+", " ").trim();
+                }
+
+                // ORACLE: what name actually landed in storage?
+                row.storedName = soleStoredName();
+
+                // READ-BACK via WebDAV (self round-trip, raw HTTP GET) — by the name the user PUT
+                row.webdavReadBack = webdavGet(TEST_COLLECTION + "/" + name);
+
+                // READ via REST by the name the user PUT (cross-surface WebDAV -> REST): can a REST
+                // client retrieve, by the requested name, what a WebDAV client just stored?
+                row.restReadBack = restGet(TEST_COLLECTION + "/" + name);
+            } catch (final Throwable t) {
+                row.error = t.getClass().getSimpleName() + ": " + String.valueOf(t.getMessage());
+            }
+            rows.add(row);
+        }
+
+        final String matrix = renderMatrix("WebDAV create -> {oracle, WebDAV read, REST read}", rows);
+        System.out.println(matrix);
+
+        // A name is "conformant" when it stores and its content round-trips by the requested name
+        // via BOTH WebDAV and REST.
+        final Set<String> failing = new LinkedHashSet<>();
+        for (final Row r : rows) {
+            final boolean conformant = r.created
+                    && Boolean.TRUE.equals(r.webdavReadBack)
+                    && Boolean.TRUE.equals(r.restReadBack);
+            if (!conformant) {
+                failing.add(r.label);
+            }
+        }
+
+        // Ratchet: the set of failing names must match KNOWN_FAILURES exactly.
+        final Set<String> regressions = new LinkedHashSet<>(failing);
+        regressions.removeAll(KNOWN_FAILURES);              // failing but expected to pass -> regression
+        final Set<String> nowFixed = new LinkedHashSet<>(KNOWN_FAILURES);
+        nowFixed.removeAll(failing);                        // listed as broken but now passing -> tighten the list
+
+        final StringBuilder msg = new StringBuilder();
+        if (!regressions.isEmpty()) {
+            msg.append(regressions.size())
+                    .append(" name(s) regressed — expected to round-trip cross-surface but failed:")
+                    .append(describe(regressions, rows)).append('\n');
+        }
+        if (!nowFixed.isEmpty()) {
+            msg.append(nowFixed.size())
+                    .append(" name(s) now round-trip cross-surface but are still listed as known failures.\n")
+                    .append("Remove them from KNOWN_FAILURES so they become regression-guarded:")
+                    .append(describe(nowFixed, rows)).append('\n');
+        }
+        if (msg.length() > 0) {
+            fail(msg.append("--- current matrix ---\n").append(matrix).toString());
+        }
+    }
+
+    /** Render a set of corpus labels as "    - label (requested-name)" lines for failure messages. */
+    private static String describe(final Set<String> labels, final List<Row> rows) {
+        final StringBuilder sb = new StringBuilder();
+        for (final Row r : rows) {
+            if (labels.contains(r.label)) {
+                sb.append("\n    - ").append(r.label).append(" (").append(r.requestedName).append(')');
+            }
+        }
+        return sb.toString();
+    }
+
+    // ---- WebDAV helpers (raw HTTP, so the on-the-wire encoding is explicit) ----
+
+    /** Raw HTTP PUT to the WebDAV endpoint; returns the HTTP status (or -1), appending any body. */
+    private static int webdavPut(final String dbPath, final String content, final StringBuilder bodyOut) {
+        try {
+            final URL url = URI.create(webdavBase() + encodePathSegments(dbPath)).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/xml");
+            conn.setDoOutput(true);
+            try (final OutputStream os = conn.getOutputStream()) {
+                os.write(content.getBytes(UTF_8));
+            }
+            final int code = conn.getResponseCode();
+            if (bodyOut != null) {
+                bodyOut.append(readBody(conn));
+            }
+            conn.disconnect();
+            return code;
+        } catch (final Exception e) {
+            if (bodyOut != null) {
+                bodyOut.append(e);
+            }
+            return -1;
+        }
+    }
+
+    /** Raw HTTP GET from the WebDAV endpoint; true if 200 and content matches. */
+    private static Boolean webdavGet(final String dbPath) {
+        try {
+            final URL url = URI.create(webdavBase() + encodePathSegments(dbPath)).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("GET");
+            conn.connect();
+            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                conn.disconnect();
+                return false;
+            }
+            final String body = readBody(conn);
+            conn.disconnect();
+            return body.contains(MARKER);
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    private static String webdavBase() {
+        return "http://localhost:" + existWebServer.getPort() + "/webdav";
+    }
+
+    // ---- REST helpers ----
+
+    /** GET a db path via the REST interface; returns true if 200 and content matches. */
+    private Boolean restGet(final String dbPath) {
+        try {
+            final String encoded = encodePathSegments(dbPath);
+            final URL url = URI.create(restBase() + encoded).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("GET");
+            conn.connect();
+            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                conn.disconnect();
+                return false;
+            }
+            final String body = readBody(conn);
+            conn.disconnect();
+            return body.contains(MARKER);
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    /** Raw HTTP PUT to the REST endpoint (auto-creates parent collections); returns the HTTP status. */
+    private static int restPut(final String dbPath, final String content) {
+        try {
+            final URL url = URI.create(restBase() + encodePathSegments(dbPath)).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/xml");
+            conn.setDoOutput(true);
+            try (final OutputStream os = conn.getOutputStream()) {
+                os.write(content.getBytes(UTF_8));
+            }
+            final int code = conn.getResponseCode();
+            conn.disconnect();
+            return code;
+        } catch (final Exception e) {
+            return -1;
+        }
+    }
+
+
+    /**
+     * The single stored child resource name under the test collection (null if zero, "?multiple:..." if >1).
+     *
+     * Uses eXist's native REST collection listing (a built-in of the REST servlet) rather than an
+     * {@code xmldb:*} query, because the WebDAV module's test {@code conf.xml} registers no XQuery
+     * builtin-modules — so this harness must not depend on any XQuery module.
+     */
+    private String soleStoredName() {
+        final List<String> names = restListChildResources(TEST_COLLECTION);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.size() == 1 ? names.get(0) : "?multiple:" + String.join(",", names);
+    }
+
+    /** GET a collection via REST and extract the child {@code <exist:resource name="..."/>} names. */
+    private List<String> restListChildResources(final String collection) {
+        final List<String> names = new ArrayList<>();
+        try {
+            final URL url = URI.create(restBase() + encodePathSegments(collection)).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("GET");
+            conn.connect();
+            final String body = readBody(conn);
+            conn.disconnect();
+            final Matcher m = Pattern.compile("<exist:resource[^>]*\\sname=\"([^\"]*)\"").matcher(body);
+            while (m.find()) {
+                names.add(unescapeXml(m.group(1)));
+            }
+        } catch (final Exception ignored) {
+            // treat as empty listing
+        }
+        return names;
+    }
+
+    /** Raw HTTP DELETE against the REST endpoint (built-in; needs no XQuery module). */
+    private static void restDelete(final String dbPath) {
+        try {
+            final URL url = URI.create(restBase() + encodePathSegments(dbPath)).toURL();
+            final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", basicAuth());
+            conn.setRequestMethod("DELETE");
+            conn.connect();
+            conn.getResponseCode();
+            conn.disconnect();
+        } catch (final Exception ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    private static String unescapeXml(final String s) {
+        return s.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+                .replace("&quot;", "\"").replace("&apos;", "'");
+    }
+
+    private static String restBase() {
+        return "http://localhost:" + existWebServer.getPort() + "/rest";
+    }
+
+    private static String basicAuth() {
+        return "Basic " + java.util.Base64.getEncoder().encodeToString(
+                (TestUtils.ADMIN_DB_USER + ":" + TestUtils.ADMIN_DB_PWD).getBytes(UTF_8));
+    }
+
+    private static String readBody(final HttpURLConnection conn) throws IOException {
+        final java.io.InputStream is = conn.getResponseCode() < 400 ? conn.getInputStream() : conn.getErrorStream();
+        if (is == null) {
+            return "";
+        }
+        try (is; final OutputStream baos = new ByteArrayOutputStream()) {
+            is.transferTo(baos);
+            return baos.toString();
+        }
+    }
+
+    /** Percent-encode each path segment (between slashes) per RFC 3986, leaving '/' as separators. */
+    private static String encodePathSegments(final String path) {
+        final String[] segs = path.split("/", -1);
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segs.length; i++) {
+            if (i > 0) {
+                sb.append('/');
+            }
+            // URLEncoder is form-encoding; convert '+' to %20 to get RFC 3986 path-segment encoding
+            sb.append(java.net.URLEncoder.encode(segs[i], UTF_8).replace("+", "%20"));
+        }
+        return sb.toString();
+    }
+
+    // ---- matrix rendering ----
+
+    private static final class Row {
+        final String label;
+        final String requestedName;
+        boolean created;
+        String storedName;
+        Boolean webdavReadBack;
+        Boolean restReadBack;
+        String error;
+
+        Row(final String label, final String requestedName) {
+            this.label = label;
+            this.requestedName = requestedName;
+        }
+    }
+
+    private static String renderMatrix(final String title, final List<Row> rows) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("\n=== Resource-naming conformance: ").append(title).append(" ===\n");
+        sb.append(String.format("%-16s %-18s %-8s %-22s %-10s %-9s %s%n",
+                "probe", "requested", "created", "stored-as", "dav-read", "rest-read", "error"));
+        for (final Row r : rows) {
+            final boolean stored = r.storedName != null && r.storedName.equals(r.requestedName);
+            sb.append(String.format("%-16s %-18s %-8s %-22s %-10s %-9s %s%n",
+                    r.label,
+                    r.requestedName,
+                    r.created ? "ok" : "FAIL",
+                    r.storedName == null ? "-" : (r.storedName + (stored ? "" : " (≠)")),
+                    cell(r.webdavReadBack),
+                    cell(r.restReadBack),
+                    r.error == null ? "" : r.error));
+        }
+        sb.append("Legend: stored-as '(≠)' = stored name differs from requested; ")
+                .append("dav-read/rest-read = content round-tripped via that surface.\n");
+        return sb.toString();
+    }
+
+    private static String cell(final Boolean b) {
+        if (b == null) {
+            return "-";
+        }
+        return b ? "PASS" : "FAIL";
+    }
+}

--- a/extensions/webdav/src/test/resources/standalone-webapp/WEB-INF/web.xml
+++ b/extensions/webdav/src/test/resources/standalone-webapp/WEB-INF/web.xml
@@ -87,6 +87,12 @@
         <url-pattern>/webdav/*</url-pattern>
     </servlet-mapping>
 
+    <!-- XML-RPC endpoint, so the cross-surface naming harness can drive XML-RPC alongside REST and WebDAV -->
+    <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc</url-pattern>
+    </servlet-mapping>
+
     <servlet-mapping>
         <servlet-name>XQueryURLRewrite</servlet-name>
         <url-pattern>/*</url-pattern>


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Adds a test that pins how eXist handles "awkward" resource names **across API surfaces** — the missing coverage for the resource-naming-stability work (issues #3795, #3665, #1824, #5299, #1612). It changes no behavior. It prints the current behavior as a matrix and enforces a **ratchet**: the set of names that fail to round-trip cross-surface must exactly equal a documented `KNOWN_FAILURES` allowlist.

The effect: **the moment this merges, every name that already works is guarded against regression**, and as each naming fix lands you remove an entry from the allowlist to lock the improvement in. The test can neither silently regress (an unlisted name that breaks fails the build) nor silently drift (a listed name that starts working fails the build and tells you to remove it).

There is no cross-surface special-character test in the suite today; this is the first.

## What it does

For a corpus of awkward leaf names (space, `+`, literal `%`, literal `%20`, `#`, `@`, `&`, parentheses, apostrophe, `café`, Cyrillic, CJK), per name it:

1. stores it **via WebDAV** (raw HTTP `PUT`, so the on-the-wire encoding is explicit);
2. reports **what name actually landed in storage**, via eXist's native REST collection listing;
3. reads the content back **by the requested name** via WebDAV and via REST;
4. prints the matrix, then asserts the ratchet (failing-set == `KNOWN_FAILURES`).

Design notes:
- **No XQuery-module dependency** — the WebDAV module's test `conf.xml` registers no builtin-modules, so the harness uses the REST collection listing rather than `xmldb:*`.
- **No WebDAV-client dependency** — the collection is created with a REST `PUT` (auto-create) and every probe is raw HTTP.
- Probe content is valid XML because the corpus names end in `.xml`, which eXist parses on store.

## What the matrix shows today

```
probe            requested          stored-as (oracle)        dav-read  rest-read
ascii-control    plain.xml          plain.xml                 PASS      PASS
space            with space.xml     with%20space.xml (≠)      PASS      PASS
plus             a+b.xml            a%2Bb.xml (≠)             PASS      FAIL
literal-percent  a%b.xml            a%25b.xml (≠)             PASS      PASS
encoded-space    a%20b.xml          a%2520b.xml (≠)           PASS      PASS
hash             a#b.xml            a%23b.xml (≠)             PASS      PASS
at               a@b.xml            a%40b.xml (≠)             PASS      FAIL
ampersand        a&b.xml            a%26b.xml (≠)             PASS      FAIL
parens           report(2024).xml   report%282024%29.xml (≠)  PASS      FAIL
apostrophe       o'brien.xml        o%27brien.xml (≠)         PASS      FAIL
non-ascii        café.xml           caf%C3%A9.xml (≠)         PASS      PASS
cyrillic         Привет.xml         %D0%9F…%82.xml (≠)        PASS      PASS
cjk              文書.xml           %E6%96%87%E6%9B%B8.xml (≠) PASS      PASS
```

So today: every name with a non-unreserved character is **stored percent-encoded**; WebDAV self-reads always round-trip; reading by the requested name via **REST fails specifically for sub-delim/reserved characters** (`+`, `@`, `&`, `(`/`)`, `'`). Those five are the current `KNOWN_FAILURES` allowlist.

## What devs see in CI

- **Normal (green):** the matrix prints into the build log; `Tests run: 1, Failures: 0`.
- **A naming fix lands** (a listed name now round-trips) → build fails with: *"N name(s) now round-trip cross-surface but are still listed as known failures. Remove them from KNOWN_FAILURES so they become regression-guarded: …"* + the matrix. You delete those lines from the allowlist and they become guarded.
- **A regression** (an unlisted name breaks) → build fails with: *"N name(s) regressed — expected to round-trip cross-surface but failed: …"* + the matrix.

## Scope / follow-ups (noted in the class Javadoc)

- XML-RPC surface (create/read against `/xmlrpc`).
- The full N×N cross-surface matrix (create-via-X then read-via-every-Y).
- existdb-openapi's special-character suite lives in that repo (a separate PR).
- This first increment treats "stored-as ≠ requested" as informational (the deeper, format-level concern handled later in the tasking); the ratchet enforces round-trip-by-requested-name.

## Where it lives

In the `extensions/webdav` test module — the only place that can drive REST **and** WebDAV **and** XML-RPC against one database in one test (module dependency direction means exist-core can't reach the WebDAV extension). A dedicated cross-surface integration-test module would be the alternative if preferred.

## Test plan

- [x] Runs green locally (`Tests run: 1, Failures: 0`); matrix prints to the build log.
- [x] Ratchet verified in both directions — a simulated regression and a simulated now-fixed entry each fail with the correct message + matrix.
- [x] Codacy/PMD clean on the new file.
- [x] No production code changed; no other test affected (the test log4j2 config used during diagnosis was reverted).

## Related

- Resource-naming-stability tasking (PR A) — this is the ratchet the rest of that plan tightens.
- Issues: #3795 (meta), #3665 (REST↔WebDAV), #1824 (`+` decode), #5299 (spaces), #1612 (non-ASCII).
