### PR TITLE
[bugfix] Windows startup.bat: use %BASEDIR% for exist.autodeploy.dir (closes #6456)

### DIFF
--- a/exist-distribution/src/main/templates/template.bat
+++ b/exist-distribution/src/main/templates/template.bat
@@ -104,7 +104,7 @@ set "CLASSPATH=%BASEDIR%\etc;%REPO%\*"
 if NOT "%CLASSPATH_PREFIX%" == "" set "CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%"
 
 %JAVACMD% %JAVA_OPTS% -Xms128m -XX:+UseNUMA -XX:+UseZGC -XX:+UseStringDeduplication ^
-    -Dexist.autodeploy.dir="$BASEDIR\autodeploy" ^
+    -Dexist.autodeploy.dir="%BASEDIR%\autodeploy" ^
     -Dexist.configurationFile="%BASEDIR%\etc\conf.xml" ^
     -Dexist.home="%BASEDIR%" ^
     -Dexist.jetty.config="%BASEDIR%\etc\jetty\standard.enabled-jetty-configs" ^


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

On Windows, no autodeploy packages are installed at startup — the apps collection is empty and the dashboard and eXide return 404. `startup.bat` (from `template.bat`) sets the autodeploy directory with Unix-style variable syntax:

```bat
-Dexist.autodeploy.dir="$BASEDIR\autodeploy" ^
```

In a `.bat` script `$BASEDIR` is not a variable, so `exist.autodeploy.dir` is set to a literal `$BASEDIR\autodeploy` path that does not exist; eXist finds no autodeploy directory and installs nothing. Every other system property in the template already uses Windows-style `%BASEDIR%` — this was the only Unix-style reference, introduced when the `autodeploy.dir` property was added in PR #6267.

## Fix

`exist-distribution/src/main/templates/template.bat` — one line:

```diff
-    -Dexist.autodeploy.dir="$BASEDIR\autodeploy" ^
+    -Dexist.autodeploy.dir="%BASEDIR%\autodeploy" ^
```

## Test plan

- [x] Verified by inspection: line 107 was the only `$BASEDIR` in the template; the 8 other `BASEDIR` references (including the adjacent `-Dexist.configurationFile`, `-Dexist.home`, `-Dexist.jetty.config`, `-Dlog4j.configurationFile`) all already use `%BASEDIR%`.
- [ ] Windows smoke test: build `exist-distribution-*-win.zip`, extract, run `startup.bat`, confirm the dashboard loads and `data\expathrepo` is populated. (Best run on Windows / a Windows CI runner — see the discussion about adding a Windows autodeploy smoke test to CI.)

## Credit

Diagnosed by @wylovan in #6456, including the exact root cause and the fix. Closes #6456.
