### PR TITLE
[bugfix] asterisk and dot in element()-typed args in field @expression

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
@@ -122,11 +122,9 @@ public abstract class AbstractFieldConfig {
                 processResult(result, luceneDoc);
             }
         } catch (PermissionDeniedException | XPathException e) {
-            isValid = false;
             throw e;
         } finally {
-            compiled.reset();
-            compiled.getContext().reset();
+            try { compiled.reset(); } finally { compiled.getContext().reset(); }
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
@@ -29,7 +29,6 @@ import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
-import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.xmldb.XmldbURI;
@@ -100,9 +99,9 @@ public abstract class AbstractFieldConfig {
 
     protected abstract void processText(CharSequence text, Document luceneDoc);
 
-    protected abstract void build(DBBroker broker, DocumentImpl document, NodeId nodeId, Document luceneDoc, CharSequence text);
+    protected abstract void build(DBBroker broker, NodeProxy contextNode, Document luceneDoc, CharSequence text);
 
-    protected void doBuild(DBBroker broker, DocumentImpl document, NodeId nodeId, Document luceneDoc, CharSequence text)
+    protected void doBuild(DBBroker broker, NodeProxy contextNode, Document luceneDoc, CharSequence text)
             throws PermissionDeniedException, XPathException {
         if (expression.isEmpty()) {
             processText(text, luceneDoc);
@@ -116,9 +115,8 @@ public abstract class AbstractFieldConfig {
         }
 
         final XQuery xquery = broker.getBrokerPool().getXQueryService();
-        final NodeProxy currentNode = new NodeProxy(null, document, nodeId);
         try {
-            Sequence result = xquery.execute(broker, compiled, currentNode);
+            Sequence result = xquery.execute(broker, compiled, contextNode);
 
             if (!result.isEmpty()) {
                 processResult(result, luceneDoc);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFacetConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFacetConfig.java
@@ -23,8 +23,7 @@ package org.exist.indexing.lucene;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.FacetField;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.numbering.NodeId;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.util.Configuration;
@@ -117,9 +116,9 @@ public class LuceneFacetConfig extends AbstractFieldConfig {
         }
     }
 
-    public void build(DBBroker broker, DocumentImpl document, NodeId nodeId, Document luceneDoc, CharSequence text) {
+    public void build(DBBroker broker, NodeProxy contextNode, Document luceneDoc, CharSequence text) {
         try {
-            doBuild(broker, document, nodeId, luceneDoc, text);
+            doBuild(broker, contextNode, luceneDoc, text);
         } catch (PermissionDeniedException e) {
             LOG.warn("Permission denied while evaluating expression for facet '{}': {}", dimension, expression, e);
         } catch (XPathException e) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -150,11 +150,9 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
             Sequence result = xquery.execute(broker, compiledCondition, contextNode);
             return result != null && result.effectiveBooleanValue();
         } catch (PermissionDeniedException | XPathException e) {
-            isValid = false;
             throw e;
         } finally {
-            compiledCondition.reset();
-            compiledCondition.getContext().reset();
+            try { compiledCondition.reset(); } finally { compiledCondition.getContext().reset(); }
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -24,9 +24,7 @@ package org.exist.indexing.lucene;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.*;
 import org.apache.lucene.util.BytesRef;
-import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
-import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.util.Configuration;
@@ -123,10 +121,10 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     }
 
     @Override
-    protected void build(DBBroker broker, DocumentImpl document, NodeId nodeId, Document luceneDoc, CharSequence text) {
+    protected void build(DBBroker broker, NodeProxy contextNode, Document luceneDoc, CharSequence text) {
         try {
-            if (checkCondition(broker, document, nodeId)) {
-                doBuild(broker, document, nodeId, luceneDoc, text);
+            if (checkCondition(broker, contextNode)) {
+                doBuild(broker, contextNode, luceneDoc, text);
             }
         } catch (XPathException e) {
             LOG.warn("XPath error while evaluating expression for field named '{}': {}: {}", fieldName, expression, e.getMessage(), e);
@@ -135,7 +133,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         }
     }
 
-    private boolean checkCondition(DBBroker broker, DocumentImpl document, NodeId nodeId) throws PermissionDeniedException, XPathException {
+    private boolean checkCondition(DBBroker broker, NodeProxy contextNode) throws PermissionDeniedException, XPathException {
         if (condition.isEmpty()) {
             return true;
         }
@@ -148,9 +146,8 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         }
 
         final XQuery xquery = broker.getBrokerPool().getXQueryService();
-        final NodeProxy currentNode = new NodeProxy(null, document, nodeId);
         try {
-            Sequence result = xquery.execute(broker, compiledCondition, currentNode);
+            Sequence result = xquery.execute(broker, compiledCondition, contextNode);
             return result != null && result.effectiveBooleanValue();
         } catch (PermissionDeniedException | XPathException e) {
             isValid = false;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -2070,14 +2070,16 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             for (final PendingDoc pending : nodesToWrite) {
                 final Document doc = new Document();
 
-
+                final short nodeType = pending.qname.getNameType() == ElementValue.ATTRIBUTE
+                        ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE;
+                final NodeProxy contextNode = new NodeProxy(null, currentDoc, pending.nodeId, nodeType);
                 List<AbstractFieldConfig> facetConfigs = pending.idxConf.getFacetsAndFields();
                 final ReindexScope scope = broker.getIndexController().getReindexScope();
                 facetConfigs.forEach(config -> {
                     if (scope == ReindexScope.VECTOR && !(config instanceof LuceneVectorFieldConfig)) {
                         return; // Vector-only: skip fulltext fields and facets
                     }
-                    config.build(broker, currentDoc, pending.nodeId, doc, pending.text);
+                    config.build(broker, contextNode, doc, pending.text);
                 });
                 // register field analyzers so indexing uses the same analyzer as querying
                 final LuceneConfig luceneConfig = pending.idxConf.getParent();

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneVectorFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneVectorFieldConfig.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.indexing.ReindexScope;
 import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
@@ -356,8 +357,10 @@ public class LuceneVectorFieldConfig extends AbstractFieldConfig {
     }
 
     @Override
-    protected void build(final DBBroker broker, final DocumentImpl document, final NodeId nodeId,
+    protected void build(final DBBroker broker, final NodeProxy contextNode,
             final Document luceneDoc, final CharSequence text) {
+        final DocumentImpl document = contextNode.getOwnerDocument();
+        final NodeId nodeId = contextNode.getNodeId();
         final ReindexScope scope = broker.getIndexController().getReindexScope();
         try {
             if (scope == ReindexScope.FULLTEXT && VECTOR_STORE_DB.equals(luceneConfig.getVectorStore())) {
@@ -372,7 +375,7 @@ public class LuceneVectorFieldConfig extends AbstractFieldConfig {
                 STORE_CONTEXT.set(new StoreContext(broker, document, nodeId));
             }
             try {
-                doBuild(broker, document, nodeId, luceneDoc, text);
+                doBuild(broker, contextNode, luceneDoc, text);
             } finally {
                 if (embeddingLocal) {
                     STORE_CONTEXT.remove();
@@ -381,7 +384,7 @@ public class LuceneVectorFieldConfig extends AbstractFieldConfig {
         } catch (IOException e) {
             LOG.debug("vector.dbx read failed, falling back to XML: {}", e.getMessage());
             try {
-                doBuild(broker, document, nodeId, luceneDoc, text);
+                doBuild(broker, contextNode, luceneDoc, text);
             } catch (PermissionDeniedException | XPathException ex) {
                 LOG.warn("Error evaluating expression for vector field '{}': {}", fieldName, ex.getMessage());
             }

--- a/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneIndexingTests.java
+++ b/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneIndexingTests.java
@@ -33,7 +33,8 @@ import org.junit.runner.RunWith;
 @RunWith(XSuite.class)
 @XSuite.XSuiteFiles({
     "src/test/xquery/lucene/ft-query-field.xqm",
-    "src/test/xquery/lucene/self-axis-index.xqm"
+    "src/test/xquery/lucene/self-axis-index.xqm",
+    "src/test/xquery/lucene/field-expression-context.xqm"
 })
 public class LuceneIndexingTests {
 }

--- a/extensions/indexes/lucene/src/test/xquery/lucene/field-expression-context.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/field-expression-context.xqm
@@ -1,0 +1,119 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Regression for #6446: field @expression using self::* or . silently produced no
+ : indexed content, or threw XPTY0004 when the expression was passed to a module
+ : function with an element()-typed parameter.  Root cause: the context NodeProxy was
+ : constructed without a node type (UNKNOWN_NODE_TYPE = -1), so NameTest.isOfType(-1)
+ : always returned false for wildcard element tests, and Type.NODE was not accepted as
+ : a subtype of element() in function-call argument checking.
+ :)
+module namespace t = "http://exist-db.org/xquery/lucene/field-expression-context";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+import module namespace ft = "http://exist-db.org/xquery/lucene";
+
+declare variable $t:COLL      := "/db/test-field-expr-ctx";
+declare variable $t:CONF_COLL := "/db/system/config/db/" || substring-after($t:COLL, "/db/");
+
+(:~ Strict element() parameter exposes the XPTY0004 failure path from #6446. :)
+declare variable $t:MODULE := ``[xquery version "3.1";
+module namespace idx = "http://exist-db.org/xquery/lucene/field-expr-ctx-lib";
+declare function idx:get-metadata($root as element(), $field as xs:string) as xs:string {
+    normalize-space($root)
+};
+]``;
+
+declare variable $t:XML := document { <entry><form><orth>hello</orth></form></entry> };
+
+declare variable $t:xconf :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index>
+            <lucene>
+                <module uri="http://exist-db.org/xquery/lucene/field-expr-ctx-lib"
+                        prefix="idx" at="field-expr-ctx-lib.xql"/>
+                <text qname="entry">
+                    <!-- baselines: worked before fix -->
+                    <field name="xdot"          expression="."/>
+                    <field name="xname"         expression="self::entry"/>
+                    <field name="xchildren"     expression="*"/>
+                    <field name="xdotchildren"  expression="./*"/>
+                    <!-- self::* regressions (#6446) -->
+                    <field name="xself"              expression="self::*"/>
+                    <field name="xdotself"           expression="./self::*"/>
+                    <field name="xdotselfchild"      expression="./self::*/form"/>
+                    <!-- element()-typed module call regressions (#6446) -->
+                    <field name="mdot"               expression="idx:get-metadata(., 'x')"/>
+                    <field name="mname"              expression="idx:get-metadata(self::entry, 'x')"/>
+                    <field name="mself"              expression="idx:get-metadata(self::*, 'x')"/>
+                    <field name="mdotself"           expression="idx:get-metadata(./self::*, 'x')"/>
+                    <field name="mdotselfchild"      expression="idx:get-metadata(./self::*/form, 'x')"/>
+                    <field name="mchildren"          expression="idx:get-metadata(*, 'x')"/>
+                    <field name="mdotchildren"       expression="idx:get-metadata(./*, 'x')"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare %test:setUp function t:setup() {
+    let $_ := (xmldb:create-collection("/db/system", "config"),
+               xmldb:create-collection("/db/system/config", "db"))
+    let $_ := (xmldb:create-collection("/db", substring-after($t:COLL, "/db/")),
+               xmldb:create-collection("/db/system/config/db", substring-after($t:COLL, "/db/")))
+    return (
+        xmldb:store($t:COLL, "field-expr-ctx-lib.xql", $t:MODULE, "application/xquery"),
+        xmldb:store($t:CONF_COLL, "collection.xconf", $t:xconf),
+        xmldb:store($t:COLL, "test.xml", $t:XML),
+        xmldb:reindex($t:COLL)
+    )
+};
+
+declare %test:tearDown function t:tearDown() {
+    if (xmldb:collection-available($t:COLL)) then xmldb:remove($t:COLL) else (),
+    if (xmldb:collection-available($t:CONF_COLL)) then xmldb:remove($t:CONF_COLL) else ()
+};
+
+declare function t:indexed($field as xs:string) as xs:boolean {
+    exists(collection($t:COLL)//entry[ft:query(., $field || ":(hello)")])
+};
+
+(:~ --- baselines --- :)
+declare %test:assertTrue function t:xdot()         { t:indexed("xdot") };
+declare %test:assertTrue function t:xname()        { t:indexed("xname") };
+declare %test:assertTrue function t:xchildren()    { t:indexed("xchildren") };
+declare %test:assertTrue function t:xdotchildren() { t:indexed("xdotchildren") };
+
+(:~ --- self::* expression regressions (#6446) --- :)
+declare %test:assertTrue function t:xself()         { t:indexed("xself") };
+declare %test:assertTrue function t:xdotself()      { t:indexed("xdotself") };
+declare %test:assertTrue function t:xdotselfchild() { t:indexed("xdotselfchild") };
+
+(:~ --- element()-typed module call regressions (#6446) --- :)
+declare %test:assertTrue function t:mdot()          { t:indexed("mdot") };
+declare %test:assertTrue function t:mname()         { t:indexed("mname") };
+declare %test:assertTrue function t:mself()         { t:indexed("mself") };
+declare %test:assertTrue function t:mdotself()      { t:indexed("mdotself") };
+declare %test:assertTrue function t:mdotselfchild() { t:indexed("mdotselfchild") };
+declare %test:assertTrue function t:mchildren()     { t:indexed("mchildren") };
+declare %test:assertTrue function t:mdotchildren()  { t:indexed("mdotchildren") };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/field-expression-context.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/field-expression-context.xqm
@@ -45,7 +45,13 @@ declare function idx:get-metadata($root as element(), $field as xs:string) as xs
 };
 ]``;
 
-declare variable $t:XML := document { <entry><form><orth>hello</orth></form></entry> };
+(:~
+ : vec attribute carries a dim=4 text-encoded float vector on the entry element.
+ : Using an attribute rather than a child element means XPath axes * and ./* still
+ : return only <form>, so module-call fields (mchildren, mdotchildren) are unaffected,
+ : and string(<entry>) remains "hello" so all text-field query assertions still hold.
+ :)
+declare variable $t:XML := document { <entry vec="1.0 0.0 0.0 0.0"><form><orth>hello</orth></form></entry> };
 
 declare variable $t:xconf :=
     <collection xmlns="http://exist-db.org/collection-config/1.0">
@@ -71,6 +77,13 @@ declare variable $t:xconf :=
                     <field name="mdotselfchild"      expression="idx:get-metadata(./self::*/form, 'x')"/>
                     <field name="mchildren"          expression="idx:get-metadata(*, 'x')"/>
                     <field name="mdotchildren"       expression="idx:get-metadata(./*, 'x')"/>
+                    <!-- vector-field expression context regressions (#6446) -->
+                    <!-- @vec is a dim=4 float attribute; self::*/@vec exercises the element-type
+                         check that was broken: if the context NodeProxy had UNKNOWN_NODE_TYPE,
+                         self::* returned empty, the attribute step had no context, and no vector
+                         was indexed. -->
+                    <vector-field name="v_baseline" expression="@vec"        dimension="4" similarity="cosine" encoding="text"/>
+                    <vector-field name="v_self"     expression="self::*/@vec" dimension="4" similarity="cosine" encoding="text"/>
                 </text>
             </lucene>
         </index>
@@ -117,3 +130,11 @@ declare %test:assertTrue function t:mdotself()      { t:indexed("mdotself") };
 declare %test:assertTrue function t:mdotselfchild() { t:indexed("mdotselfchild") };
 declare %test:assertTrue function t:mchildren()     { t:indexed("mchildren") };
 declare %test:assertTrue function t:mdotchildren()  { t:indexed("mdotchildren") };
+
+(:~ --- vector-field expression context regressions (#6446) --- :)
+declare function t:vector-indexed($field as xs:string) as xs:boolean {
+    exists(collection($t:COLL)//entry[ft:query-field-vector($field, [1.0, 0.0, 0.0, 0.0], 1)])
+};
+
+declare %test:assertTrue function t:vector-baseline() { t:vector-indexed("v_baseline") };
+declare %test:assertTrue function t:vector-xself()    { t:vector-indexed("v_self") };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/vector-search.xqm
@@ -360,6 +360,36 @@ declare variable $vs:COLLECTION_ORDER_SINGLE := "/db/" || $vs:COLLECTION_ORDER_S
 declare variable $vs:COLLECTION_ORDER_MULTI_NAME := "lucene-test-vector-order-multi";
 declare variable $vs:COLLECTION_ORDER_MULTI := "/db/" || $vs:COLLECTION_ORDER_MULTI_NAME;
 
+(:~
+ : Data for runtime-expression-error test.
+ : Valid1 (before) and Valid2 (after) should both get vectors; BadExpr triggers error() in the
+ : expression, which before the isValid fix would permanently disable the field for all
+ : subsequent documents in the same indexing run.
+ :)
+declare variable $vs:DATA_EXPR_ERROR :=
+    <articles>
+        <article><title>Valid1</title><embedding>{$vs:EMB_TEXT_A}</embedding></article>
+        <article><title>BadExpr</title><embedding>{$vs:EMB_TEXT_B}</embedding></article>
+        <article><title>Valid2</title><embedding>{$vs:EMB_TEXT_C}</embedding></article>
+    </articles>;
+
+declare variable $vs:XCONF_EXPR_ERROR :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="article">
+                    <field name="title" expression="title"/>
+                    <vector-field name="embedding"
+                        expression="if (title = 'BadExpr') then error() else embedding"
+                        dimension="4" similarity="cosine" encoding="text"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $vs:COLLECTION_EXPR_ERROR_NAME := "lucene-test-vector-expr-error";
+declare variable $vs:COLLECTION_EXPR_ERROR := "/db/" || $vs:COLLECTION_EXPR_ERROR_NAME;
+
 (:~ Lucene fulltext only — no vector-field (profiler NONE tests). :)
 declare variable $vs:DATA_NO_VECTOR :=
     <articles>
@@ -484,7 +514,13 @@ function vs:setup() {
       xmldb:store($vs:COLLECTION_ORDER_MULTI, "b.xml", $vs:DATA_ORDER_B),
       xmldb:store($vs:COLLECTION_ORDER_MULTI, "c.xml", $vs:DATA_ORDER_C),
       xmldb:store("/db/system/config/db/" || $vs:COLLECTION_ORDER_MULTI_NAME, "collection.xconf", $vs:XCONF_ORDER),
-      xmldb:reindex($vs:COLLECTION_ORDER_MULTI) )
+      xmldb:reindex($vs:COLLECTION_ORDER_MULTI),
+      (: Runtime expression error: field must survive for subsequent docs. :)
+      xmldb:create-collection("/db/system/config/db", $vs:COLLECTION_EXPR_ERROR_NAME),
+      xmldb:create-collection("/db", $vs:COLLECTION_EXPR_ERROR_NAME),
+      xmldb:store($vs:COLLECTION_EXPR_ERROR, "test.xml", $vs:DATA_EXPR_ERROR),
+      xmldb:store("/db/system/config/db/" || $vs:COLLECTION_EXPR_ERROR_NAME, "collection.xconf", $vs:XCONF_EXPR_ERROR),
+      xmldb:reindex($vs:COLLECTION_EXPR_ERROR) )
 };
 
 (:~
@@ -528,7 +564,9 @@ function vs:tearDown() {
     xmldb:remove($vs:COLLECTION_ORDER_SINGLE),
     xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_ORDER_SINGLE_NAME),
     xmldb:remove($vs:COLLECTION_ORDER_MULTI),
-    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_ORDER_MULTI_NAME)
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_ORDER_MULTI_NAME),
+    xmldb:remove($vs:COLLECTION_EXPR_ERROR),
+    xmldb:remove("/db/system/config/db/" || $vs:COLLECTION_EXPR_ERROR_NAME)
 };
 
 (:~
@@ -672,6 +710,18 @@ declare
     %test:assertEquals(1)
 function vs:non-finite-doc-still-text-searchable() {
     count(collection($vs:COLLECTION_NON_FINITE)//article[ft:query(., "NonFinite")])
+};
+
+(:~
+ : (8f) runtime expression error does not permanently disable the vector field.
+ : DATA_EXPR_ERROR: Valid1, BadExpr (throws error()), Valid2 — all in one document.
+ : Before the isValid fix, BadExpr's XPathException set isValid=false, silently dropping
+ : Valid2's vector. After the fix both Valid1 and Valid2 are indexed; count must be 2.
+ :)
+declare
+    %test:assertEquals(2)
+function vs:runtime-expr-error-does-not-disable-subsequent-docs() {
+    count(collection($vs:COLLECTION_EXPR_ERROR)//article[ft:query-vector(., [1.0, 0.0, 0.0, 0.0], 5)])
 };
 
 (:~


### PR DESCRIPTION
build the `NodeProxy` once in `LuceneIndexWorker.write()`, where the PendingDoc qname is in scope to determine element vs. attribute, then pass it through `build()/doBuild()/checkCondition()` as the evaluation context. This removes `DocumentImpl/NodeId/short` from those signatures and
makes the abstraction explicit: callers supply the context node, field configs evaluate against it.

close #6446