### PR TITLE
[bugfix] eliminate port-binding TOCTOU race in test servers

### DIFF
--- a/exist-core/src/main/java/org/exist/test/ExistWebServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistWebServer.java
@@ -37,7 +37,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import static org.exist.util.IPUtil.nextFreePort;
 import static org.junit.Assert.fail;
 import static org.exist.repo.AutoDeploymentTrigger.AUTODEPLOY_PROPERTY;
 
@@ -62,10 +61,16 @@ import static org.exist.repo.AutoDeploymentTrigger.AUTODEPLOY_PROPERTY;
  * <ul>
  *   <li>{@code exist.jetty.standalone.webapp.dir} — exploded standalone test webapp root</li>
  *   <li>{@code exist.jetty.portal.dir} — portal webapp for distribution-mode tests</li>
- *   <li>{@code jetty.port}, {@code jetty.secure.port}, {@code jetty.ssl.port} — set automatically when
- *       {@code useRandomPort} is {@code true}</li>
+ *   <li>{@code jetty.port}, {@code jetty.secure.port}, {@code jetty.ssl.port} — set to {@code 0} when
+ *       {@code useRandomPort} is {@code true}, causing the OS to assign ephemeral ports at bind time.
+ *       Call {@link #getPort()} after startup to obtain the actual bound port.</li>
  *   <li>{@code jetty.home} — Jetty configuration directory ({@code exist-jetty-config/target/classes/...})</li>
  * </ul>
+ * <p>
+ * <strong>Note on naming:</strong> {@code useRandomPort} (and the corresponding builder method) are named
+ * for historical compatibility. The underlying mechanism is OS ephemeral port allocation (port {@code 0}),
+ * not random selection from a range — which eliminates the TOCTOU bind-failure race that affected
+ * concurrent {@code forkCount &gt; 1} test runs.
  * Startup failures throw {@link IllegalStateException} with detail from {@link org.exist.jetty.JettyStart}
  * ({@code webAppStartupFailureDetail} is included in the exception message).
  * <p>
@@ -81,10 +86,6 @@ public class ExistWebServer extends ExternalResource {
     private static final String PROP_JETTY_PORT = "jetty.port";
     private static final String PROP_JETTY_SECURE_PORT = "jetty.secure.port";
     private static final String PROP_JETTY_SSL_PORT = "jetty.ssl.port";
-
-    private static final int MIN_RANDOM_PORT = 49152;
-    private static final int MAX_RANDOM_PORT = 65535;
-    private static final int MAX_RANDOM_PORT_ATTEMPTS = 10;
 
     private JettyStart server = null;
     private String prevAutoDeploy = "off";
@@ -216,33 +217,26 @@ public class ExistWebServer extends ExternalResource {
                 LOG.info("Using temporary storage location: {}", absTemporaryStorage);
             }
 
-            if(useRandomPort) {
-                synchronized(ExistWebServer.class) {
-                    startJettyServer();
-                }
-            } else {
-                startJettyServer();
-            }
+            startJettyServer();
         } else {
             throw new IllegalStateException("ExistWebServer already running");
         }
         super.before();
     }
 
+    /**
+     * Shuts down and restarts the embedded Jetty server.
+     * <p>
+     * When {@code useRandomPort} is {@code true}, the restarted server binds to a new OS-assigned
+     * ephemeral port. Callers that cached the value of {@link #getPort()} before the restart must
+     * re-read it afterwards.
+     */
     public void restart() {
         if(server != null) {
             try {
-                if (useRandomPort) {
-                    synchronized (ExistWebServer.class) {
-                        server.shutdown();
-                        server.run(jettyStandaloneMode);
-                        awaitJettyReadyAfterRun();
-                    }
-                } else {
-                    server.shutdown();
-                    server.run(jettyStandaloneMode);
-                    awaitJettyReadyAfterRun();
-                }
+                server.shutdown();
+                server.run(jettyStandaloneMode);
+                awaitJettyReadyAfterRun();
             } catch (final Exception e) {
                 throw new IllegalStateException("Failed to restart ExistWebServer", e);
             }
@@ -254,15 +248,8 @@ public class ExistWebServer extends ExternalResource {
     @Override
     protected void after() {
         if(server != null) {
-            if (useRandomPort) {
-                synchronized (ExistWebServer.class) {
-                    shutdownJettyServer();
-                    disposeTemporaryStorage();
-                }
-            } else {
-                shutdownJettyServer();
-                disposeTemporaryStorage();
-            }
+            shutdownJettyServer();
+            disposeTemporaryStorage();
         } else {
             throw new IllegalStateException("ExistWebServer already stopped");
         }
@@ -277,9 +264,9 @@ public class ExistWebServer extends ExternalResource {
 
     private void startJettyServer() {
         if (useRandomPort) {
-            System.setProperty(PROP_JETTY_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
-            System.setProperty(PROP_JETTY_SECURE_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
-            System.setProperty(PROP_JETTY_SSL_PORT, Integer.toString(nextFreePort(MIN_RANDOM_PORT, MAX_RANDOM_PORT, MAX_RANDOM_PORT_ATTEMPTS)));
+            System.setProperty(PROP_JETTY_PORT, "0");
+            System.setProperty(PROP_JETTY_SECURE_PORT, "0");
+            System.setProperty(PROP_JETTY_SSL_PORT, "0");
         }
         server = new JettyStart();
         server.run(jettyStandaloneMode);

--- a/exist-core/src/main/java/org/exist/util/IPUtil.java
+++ b/exist-core/src/main/java/org/exist/util/IPUtil.java
@@ -51,15 +51,26 @@ public class IPUtil {
     /**
      * Attempts to get the next random free IP port in the range {@code from} and {@code to}.
      *
+     * <p><strong>Deprecated — TOCTOU race:</strong> this method probes a port by opening and
+     * immediately closing a {@link ServerSocket}.  The port is free at the moment of the probe but
+     * can be claimed by another process before the caller binds to it.  Under concurrent test
+     * execution (e.g. {@code forkCount &gt; 1}) this race reliably causes "Failed to bind" failures.
+     *
+     * <p>Prefer passing port {@code 0} directly to the server being started (Jetty, GreenMail, …)
+     * so that the OS allocates an ephemeral port atomically at bind time, then read back the
+     * actual port from the bound socket after startup.
+     *
      * @param from start of the port range
      * @param to end of the port range
      * @param maxAttempts the number of attempts to make to find a free port
      *
-     * @return a potentially free IP port. This is done on a best effort basis! It is possible that the port returned
-     *     is free, but by time you come to use it, it is then in-use; if so, just try calling this again.
+     * @return a potentially free IP port. This is done on a best effort basis — the port may be
+     *     taken by the time the caller tries to bind.
      *
      * @throws IllegalStateException if maxAttempts is exceeded
+     * @deprecated use port {@code 0} and read the bound port from the server after startup
      */
+    @Deprecated
     public static int nextFreePort(final int from, final int to, final int maxAttempts) {
         for (int attempts = 0; attempts < maxAttempts; attempts++) {
             final int port = random(from, to);
@@ -76,8 +87,7 @@ public class IPUtil {
     }
 
     private static boolean isLocalPortFree(final int port) {
-        try {
-            new ServerSocket(port).close();
+        try (final ServerSocket ignored = new ServerSocket(port)) {
             return true;
         } catch (final IOException e) {
             return false;

--- a/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/SendEmailIT.java
+++ b/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/SendEmailIT.java
@@ -73,7 +73,6 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.exist.util.IPUtil.nextFreePort;
 import static org.exist.xquery.modules.mail.Util.executeQuery;
 import static org.exist.xquery.modules.mail.Util.withCompiledQuery;
 import static org.junit.Assert.*;
@@ -123,10 +122,8 @@ public class SendEmailIT {
     private static final String EMAIL_UID = "emailuid";
     private static final String EMAIL_PWD = "emailpwd";
 
-    private final int smtpPort = nextFreePort(2525, 2599, 10);
-
     @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup(smtpPort, "127.0.0.1", "smtp"));
+    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup(0, "127.0.0.1", "smtp"));
 
     @BeforeClass
     public static void setup() throws PermissionDeniedException, IOException, SAXException, EXistException, LockException {
@@ -576,7 +573,7 @@ public class SendEmailIT {
                         "return\n" +
                         "  mail:send-email(\n" +
                         "      <mail><from>" + from + "</from><to>" + to + "</to><subject>" + subject + "</subject><message>" + message + "</message>{$attachments}</mail>,\n" +
-                        "      '127.0.0.1:" + smtpPort + "',\n" +
+                        "      '127.0.0.1:" + greenMail.getSmtp().getPort() + "',\n" +
                         "      ()\n" +
                         "  )";
 
@@ -640,7 +637,7 @@ public class SendEmailIT {
                         "  let $session := mail:get-mail-session(\n" +
                         "      <properties>\n" +
                         "          <property name=\"mail.transport.protocol\" value=\"smtp\"/>\n" +
-                        "          <property name=\"mail.smtp.port\" value=\"" + smtpPort + "\"/>\n" +
+                        "          <property name=\"mail.smtp.port\" value=\"" + greenMail.getSmtp().getPort() + "\"/>\n" +
                         "          <property name=\"mail.smtp.host\" value=\"127.0.0.1\"/>\n";
 
         if (authenticationOption == AuthenticationOption.AUTHENTICATED) {


### PR DESCRIPTION
`ExistWebServer` probed for a free port by opening and immediately closing a ServerSocket, then passed that port number to Jetty. Between the probe and Jetty's `bind()` another fork JVM (forkCount=2C) could claim the same port, producing sporadic "Failed to bind" failures in the WebDAV test suite and anywhere else ExistWebServer is used.

Fix seems almost too simple just set port to `0` and let the OS handle it.
