### PR TITLE
[feature] Distinct error codes for sm: permission functions (let callers map 403 vs 400)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -279,6 +279,13 @@ public class ErrorCodes {
     public static final ErrorCode EXXQDY0006 = new EXistErrorCode("EXXQDY0006", "Unable to find named function when trying to execute a Library Module.");
     public static final ErrorCode EXXQST0001 = new EXistErrorCode("EXXQST0001", "Unable to find function implementation.");
 
+    // --- Security / permission error codes ---
+    // Distinct codes so callers (e.g. HTTP API layers) can map a permission failure to
+    // 403 and an invalid-argument failure to 400 by branching on $err:code, instead of
+    // matching message text. Used by the sm: permission functions (PermissionsFunction).
+    public static final ErrorCode EXXQDY0007 = new EXistErrorCode("EXXQDY0007", "Permission denied.");
+    public static final ErrorCode EXXQDY0008 = new EXistErrorCode("EXXQDY0008", "Invalid argument.");
+
     public static final ErrorCode ERROR = new EXistErrorCode("ERROR", "Error.");
 
     public static class ErrorCode {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
@@ -35,6 +35,7 @@ import org.exist.util.SyntaxException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -289,8 +290,10 @@ public class PermissionsFunction extends BasicFunction {
                 
                 transaction.commit();
                 
-            } catch(final TransactionException | PermissionDeniedException e) {
-              throw new XPathException(this, e);
+            } catch(final PermissionDeniedException pde) {
+              throw new XPathException(this, ErrorCodes.EXXQDY0007, pde);
+            } catch(final TransactionException te) {
+              throw new XPathException(this, te);
             }
         }
 
@@ -301,7 +304,7 @@ public class PermissionsFunction extends BasicFunction {
         try {
             return permissionsToXml(getPermissions(pathUri));
         } catch(final PermissionDeniedException pde) {
-            throw new XPathException(this, "Permission to retrieve permissions is denied for user '" + context.getSubject().getName() + "' on '" + pathUri.toString() + "': " + pde.getMessage(), pde);
+            throw new XPathException(this, ErrorCodes.EXXQDY0007, "Permission to retrieve permissions is denied for user '" + context.getSubject().getName() + "' on '" + pathUri.toString() + "': " + pde.getMessage(), pde);
         }
     }
 
@@ -367,7 +370,7 @@ public class PermissionsFunction extends BasicFunction {
     
     private Sequence functionHasAccess(final XmldbURI pathUri, final String modeStr) throws XPathException {
         if(modeStr == null || modeStr.isEmpty() || modeStr.length() > 3) {
-            throw new XPathException(this, "Mode string must be partial i.e. rwx not rwxrwxrwx");
+            throw new XPathException(this, ErrorCodes.EXXQDY0008, "Mode string must be partial i.e. rwx not rwxrwxrwx");
         }
         
         int mode = 0;
@@ -399,7 +402,7 @@ public class PermissionsFunction extends BasicFunction {
             final String octal = mode == 0 ? "0" : "0" + Integer.toOctalString(mode);
             return new StringValue(this, octal);
         } catch(final SyntaxException se) {
-            throw new XPathException(this, se.getMessage(), se);
+            throw new XPathException(this, ErrorCodes.EXXQDY0008, se.getMessage(), se);
         }
     }
     

--- a/exist-core/src/test/xquery/securitymanager/permission-error-codes.xqm
+++ b/exist-core/src/test/xquery/securitymanager/permission-error-codes.xqm
@@ -1,0 +1,73 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : The sm: permission functions assign distinct error codes so callers can tell a
+ : permission failure (EXXQDY0007) from an invalid-argument failure (EXXQDY0008)
+ : by branching on $err:code rather than matching message text -- e.g. an HTTP API
+ : mapping the former to 403 and the latter to 400.
+ :)
+module namespace pec = "http://exist-db.org/test/securitymanager/permission-error-codes";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace sm = "http://exist-db.org/xquery/securitymanager";
+
+declare variable $pec:col := "/db/permission-error-codes-test";
+declare variable $pec:resource := $pec:col || "/locked.xml";
+
+(: a resource owned by admin with no group/other access, so a non-owner non-dba
+   (guest) is denied any chmod on it :)
+declare
+    %test:setUp
+function pec:setup() {
+    xmldb:create-collection("/db", "permission-error-codes-test"),
+    xmldb:store($pec:col, "locked.xml", <locked/>),
+    sm:chmod(xs:anyURI($pec:resource), "rwx------")
+};
+
+declare
+    %test:tearDown
+function pec:teardown() {
+    if (xmldb:collection-available($pec:col)) then xmldb:remove($pec:col) else ()
+};
+
+(: invalid argument -> EXXQDY0008: sm:has-access requires a partial (<=3 char) mode :)
+declare
+    %test:assertError("EXXQDY0008")
+function pec:has-access-overlong-mode() {
+    sm:has-access(xs:anyURI("/db"), "rwxrwxrwx")
+};
+
+(: invalid argument -> EXXQDY0008: sm:mode-to-octal rejects a malformed symbolic mode :)
+declare
+    %test:assertError("EXXQDY0008")
+function pec:mode-to-octal-bad-syntax() {
+    sm:mode-to-octal("not-a-valid-mode")
+};
+
+(: permission denied -> EXXQDY0007: guest is neither owner nor dba of the locked resource :)
+declare
+    %test:assertError("EXXQDY0007")
+function pec:guest-chmod-denied() {
+    system:as-user("guest", "guest", sm:chmod(xs:anyURI($pec:resource), "rwxr-xr-x"))
+};


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Problem

The `sm:` permission functions (`sm:chmod` / `sm:chown` / `sm:chgrp`, and the mode validators behind `sm:has-access` / `sm:mode-to-octal`) throw the **same generic `ErrorCodes.ERROR`** for unrelated failures — permission-denied, a malformed mode string, and a mode syntax error are distinguishable only by message text:

- permission denied — `catch (PermissionDeniedException) { throw new XPathException(this, e); }`
- bad mode string — `throw new XPathException(this, "Mode string must be partial …")`
- mode syntax error — `catch (SyntaxException se) { throw new XPathException(this, se.getMessage(), se); }`

`XPathException`'s default error code is `ErrorCodes.ERROR`, and none of these sites override it (the throwable-carrying constructor only adopts a code when the cause is an `XPathErrorProvider`, which `PermissionDeniedException` is not). So all three surface as `ERROR`.

An HTTP API layer wants to map a permission failure to **403 Forbidden** and an invalid argument to **400 Bad Request**, but with one generic code the only discriminator is the message string — brittle (wording can change; no contract). existdb-openapi currently works around it by classifying *per operation* (a `chmod`/`chown`/`chgrp` failure ⇒ 403, a `set-mime-type` failure ⇒ 400) rather than inspecting the error. (Surfaced by the existdb-openapi/db-core work.)

## Change

Assign two distinct, stable codes — following the documented eXist `EXXQDY` scheme — so callers can branch on `$err:code`:

| code | meaning | thrown for |
|---|---|---|
| `EXXQDY0007` | Permission denied | `PermissionDeniedException` (chmod/chown/chgrp/ACL, get-permissions) |
| `EXXQDY0008` | Invalid argument | malformed mode string / mode syntax error |

The `TransactionException \| PermissionDeniedException` multi-catch in the main dispatch is **split**, so a transaction failure keeps the generic code (it's a server error → 500, not a 403).

Now an API layer maps cleanly:
```xquery
try { sm:chmod($uri, $mode) }
catch err:EXXQDY0007 { (: 403 :) }
catch err:EXXQDY0008 { (: 400 :) }
```
and existdb-openapi's `db-core:set-permissions` can drop its per-operation heuristic.

## Files

- `ErrorCodes.java` — add `EXXQDY0007` / `EXXQDY0008` in a labeled Security/permission block.
- `PermissionsFunction.java` — thread the codes through the four throw sites; split the multi-catch.
- `permission-error-codes.xqm` (new XQSuite test, auto-discovered by `SecurityManagerTests`) — asserts both codes fire: invalid-argument via `sm:has-access` (overlong mode) and `sm:mode-to-octal` (bad syntax); permission-denied via a guest `sm:chmod` of an admin-only `rwx------` resource.

## Test

`SecurityManagerTests` — **7/7 green**. exist-core builds clean; Codacy PMD clean on both changed Java files.

## Scope note

This covers the `PermissionsFunction` permission/mode failures — the ones an HTTP layer most needs to classify. The same generic-code pattern (`new XPathException(this, "message")` with no code) is pervasive across the rest of the `sm:` module (`AccountManagement`, `AccountStatus`, `FindGroup`, …); extending distinct codes there is a natural follow-up. If the team would prefer a dedicated security code family over reusing `EXXQDY`, that's an easy rename before merge.
