### PR TITLE
[feature] response:stream-binary-resource — zero-copy binary download

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -277,6 +277,7 @@ public class ErrorCodes {
     public static final ErrorCode EXXQDY0004 = new EXistErrorCode("EXXQDY0004", "Only Supported for xquery version \"3.1\" and later.");
     public static final ErrorCode EXXQDY0005 = new EXistErrorCode("EXXQDY0005", "No function call details were provided when trying to execute a Library Module.");
     public static final ErrorCode EXXQDY0006 = new EXistErrorCode("EXXQDY0006", "Unable to find named function when trying to execute a Library Module.");
+    public static final ErrorCode EXXQDY0007 = new EXistErrorCode("EXXQDY0007", "I/O error while streaming a binary resource to the response.");
     public static final ErrorCode EXXQST0001 = new EXistErrorCode("EXXQST0001", "Unable to find function implementation.");
 
     public static final ErrorCode ERROR = new EXistErrorCode("ERROR", "Error.");

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/ResponseModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/ResponseModule.java
@@ -53,6 +53,8 @@ public class ResponseModule extends AbstractInternalModule {
             new FunctionDef(SetHeader.signature, SetHeader.class),
             new FunctionDef(SetStatusCode.signature, SetStatusCode.class),
             new FunctionDef(StreamBinary.signature, StreamBinary.class),
+            new FunctionDef(StreamBinaryResource.signatures[0], StreamBinaryResource.class),
+            new FunctionDef(StreamBinaryResource.signatures[1], StreamBinaryResource.class),
             new FunctionDef(Stream.signature, Stream.class),
             new FunctionDef(GetExists.signature, GetExists.class)
     };

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinaryResource.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinaryResource.java
@@ -1,0 +1,155 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.response;
+
+import org.exist.dom.QName;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.http.servlets.ResponseWrapper;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.storage.txn.TransactionException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@code response:stream-binary-resource($binary-resource-path, $content-type, $filename?)} streams a
+ * stored binary resource straight from the database to the servlet response output stream.
+ *
+ * <p>Unlike {@code response:stream-binary}, which takes a fully-materialized {@code xs:base64Binary}
+ * (so the caller must first load the whole resource into the JVM heap, e.g. via {@code util:binary-doc}),
+ * this function copies from the stored {@link BinaryDocument} directly to the response — the same
+ * zero-copy path the REST server uses — without ever materializing the bytes. It is intended for large
+ * downloads, where materializing the whole resource would exhaust the heap.</p>
+ */
+public class StreamBinaryResource extends StrictResponseFunction {
+
+    private static final FunctionParameterSequenceType RESOURCE_PATH_PARAM = new FunctionParameterSequenceType("binary-resource-path", Type.STRING, Cardinality.EXACTLY_ONE, "The path to the stored binary resource, e.g. /db/path/to/image.png");
+    private static final FunctionParameterSequenceType CONTENT_TYPE_PARAM = new FunctionParameterSequenceType("content-type", Type.STRING, Cardinality.EXACTLY_ONE, "The ContentType HTTP header value");
+    private static final FunctionParameterSequenceType FILENAME_PARAM = new FunctionParameterSequenceType("filename", Type.STRING, Cardinality.ZERO_OR_ONE, "The filename. If provided, a Content-Disposition header is set for the filename in the HTTP Response");
+
+    private static final String DESCRIPTION =
+            "Streams a stored binary resource directly to the current servlet response output stream, "
+            + "copying from the database to the response without first materializing the whole resource "
+            + "in memory (unlike response:stream-binary, which takes a fully-loaded xs:base64Binary). "
+            + "Suited to large downloads. The ContentType HTTP header is set to the value given in "
+            + "$content-type. Note: the servlet output stream is closed afterwards.";
+
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("stream-binary-resource", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
+                    DESCRIPTION,
+                    new SequenceType[]{RESOURCE_PATH_PARAM, CONTENT_TYPE_PARAM},
+                    new SequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE)
+            ),
+            new FunctionSignature(
+                    new QName("stream-binary-resource", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
+                    DESCRIPTION + " A Content-Disposition header is set from $filename.",
+                    new SequenceType[]{RESOURCE_PATH_PARAM, CONTENT_TYPE_PARAM, FILENAME_PARAM},
+                    new SequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE)
+            )
+    };
+
+    public StreamBinaryResource(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, @Nonnull final ResponseWrapper response) throws XPathException {
+        if (args[0].isEmpty() || args[1].isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        final String path = args[0].getStringValue();
+        final String contentType = args[1].getStringValue();
+        final String filename = (args.length > 2 && !args[2].isEmpty()) ? args[2].getStringValue() : null;
+
+        if (!"org.exist.http.servlets.HttpResponseWrapper".equals(response.getClass().getName())) {
+            throw new XPathException(this, ErrorCodes.XPDY0002, getSignature().toString() + " can only be used within the EXistServlet or XQueryServlet");
+        }
+
+        final XmldbURI uri;
+        try {
+            uri = XmldbURI.xmldbUriFor(path);
+        } catch (final URISyntaxException e) {
+            throw new XPathException(this, "Invalid binary resource path: " + path, e);
+        }
+
+        streamResource(uri, path, contentType, filename, response);
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    private void streamResource(final XmldbURI uri, final String path, final String contentType,
+            final String filename, final ResponseWrapper response) throws XPathException {
+        final DBBroker broker = context.getBroker();
+        try (final LockedDocument lockedDoc = broker.getXMLResource(uri, LockMode.READ_LOCK)) {
+            if (lockedDoc == null) {
+                throw new XPathException(this, ErrorCodes.FODC0002, "Binary resource not found: " + path);
+            }
+
+            final DocumentImpl doc = lockedDoc.getDocument();
+            if (doc.getResourceType() != DocumentImpl.BINARY_FILE) {
+                throw new XPathException(this, "Resource is not a binary document: " + path);
+            }
+
+            response.setHeader("Content-Type", contentType);
+            if (filename != null) {
+                response.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
+            }
+
+            // zero-copy: stream the stored resource straight to the response, never
+            // materializing it (the same path RESTServer uses for binary downloads).
+            try (final Txn transaction = broker.continueOrBeginTransaction()) {
+                final OutputStream os = response.getOutputStream();
+                broker.readBinaryResource(transaction, (BinaryDocument) doc, os);
+                os.close();
+                transaction.commit();
+            }
+
+            // commit the response
+            response.flushBuffer();
+        } catch (final PermissionDeniedException e) {
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Permission denied to read binary resource '" + path + "': " + e.getMessage(), e);
+        } catch (final TransactionException e) {
+            throw new XPathException(this, "Transaction error while streaming binary resource '" + path + "': " + e.getMessage(), e);
+        } catch (final IOException e) {
+            throw new XPathException(this, "IO exception while streaming binary resource '" + path + "': " + e.getMessage(), e);
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinaryResource.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinaryResource.java
@@ -108,7 +108,7 @@ public class StreamBinaryResource extends StrictResponseFunction {
         try {
             uri = XmldbURI.xmldbUriFor(path);
         } catch (final URISyntaxException e) {
-            throw new XPathException(this, "Invalid binary resource path: " + path, e);
+            throw new XPathException(this, ErrorCodes.FODC0002, "Invalid binary resource path: " + path, e);
         }
 
         streamResource(uri, path, contentType, filename, response);
@@ -125,7 +125,7 @@ public class StreamBinaryResource extends StrictResponseFunction {
 
             final DocumentImpl doc = lockedDoc.getDocument();
             if (doc.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new XPathException(this, "Resource is not a binary document: " + path);
+                throw new XPathException(this, ErrorCodes.XPTY0004, "Resource is not a binary document: " + path);
             }
 
             response.setHeader("Content-Type", contentType);
@@ -145,11 +145,11 @@ public class StreamBinaryResource extends StrictResponseFunction {
             // commit the response
             response.flushBuffer();
         } catch (final PermissionDeniedException e) {
-            throw new XPathException(this, ErrorCodes.XPDY0002, "Permission denied to read binary resource '" + path + "': " + e.getMessage(), e);
+            throw new XPathException(this, ErrorCodes.FODC0002, "Permission denied to read binary resource '" + path + "': " + e.getMessage(), e);
         } catch (final TransactionException e) {
-            throw new XPathException(this, "Transaction error while streaming binary resource '" + path + "': " + e.getMessage(), e);
+            throw new XPathException(this, ErrorCodes.EXXQDY0007, "Transaction error while streaming binary resource '" + path + "': " + e.getMessage(), e);
         } catch (final IOException e) {
-            throw new XPathException(this, "IO exception while streaming binary resource '" + path + "': " + e.getMessage(), e);
+            throw new XPathException(this, ErrorCodes.EXXQDY0007, "IO exception while streaming binary resource '" + path + "': " + e.getMessage(), e);
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/RestBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/RestBinariesTest.java
@@ -24,6 +24,7 @@ package org.exist.xquery;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -52,6 +53,8 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.exist.TestUtils.ADMIN_DB_PWD;
 import static org.exist.TestUtils.ADMIN_DB_USER;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
@@ -125,6 +128,29 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
                 "response:stream-binary-resource('" + TEST_COLLECTION.append(BIN1_FILENAME).toString() + "', 'application/octet-stream', ())";
 
         final HttpResponse response = postXquery(query);
+
+        final HttpEntity entity = response.getEntity();
+        try(final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream()) {
+            entity.writeTo(baos);
+
+            assertArrayEquals(BIN1_CONTENT, baos.toByteArray());
+        }
+    }
+
+    /**
+     * The 3-arg form response:stream-binary-resource#3 sets a Content-Disposition header from the
+     * filename argument (while still streaming the byte-identical body).
+     */
+    @Test
+    public void streamBinaryResourceWithFilename() throws JAXBException, IOException {
+        final String query = "import module namespace response = \"http://exist-db.org/xquery/response\";\n" +
+                "response:stream-binary-resource('" + TEST_COLLECTION.append(BIN1_FILENAME).toString() + "', 'application/octet-stream', 'download.bin')";
+
+        final HttpResponse response = postXquery(query);
+
+        final Header contentDisposition = response.getFirstHeader("Content-Disposition");
+        assertNotNull("Content-Disposition header should be sent for the 3-arg form", contentDisposition);
+        assertEquals("inline; filename=\"download.bin\"", contentDisposition.getValue());
 
         final HttpEntity entity = response.getEntity();
         try(final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream()) {

--- a/exist-core/src/test/java/org/exist/xquery/RestBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/RestBinariesTest.java
@@ -114,6 +114,26 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         }
     }
 
+    /**
+     * response:stream-binary-resource streams a stored binary by path, without materializing it
+     * (unlike response:stream-binary which takes a fully-loaded xs:base64Binary). The wire result
+     * is byte-identical.
+     */
+    @Test
+    public void streamBinaryResourceRaw() throws JAXBException, IOException {
+        final String query = "import module namespace response = \"http://exist-db.org/xquery/response\";\n" +
+                "response:stream-binary-resource('" + TEST_COLLECTION.append(BIN1_FILENAME).toString() + "', 'application/octet-stream', ())";
+
+        final HttpResponse response = postXquery(query);
+
+        final HttpEntity entity = response.getEntity();
+        try(final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream()) {
+            entity.writeTo(baos);
+
+            assertArrayEquals(BIN1_CONTENT, baos.toByteArray());
+        }
+    }
+
     @Override
     protected void storeBinaryFile(final XmldbURI filePath, final byte[] content) throws Exception {
         final HttpResponse response = executor.execute(Request.Put(getRestUrl() + filePath.toString())


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Adds `response:stream-binary-resource($binary-resource-path, $content-type, $filename?)`, which streams a stored binary resource straight from the database to the servlet response output stream — **without ever materializing it in the JVM heap.**

`response:stream-binary($binary, …)` takes a fully-loaded `xs:base64Binary`, so the caller must first read the whole resource into memory (e.g. `util:binary-doc()`). For a large download that means the entire resource is materialized on the heap before a single byte goes out. The new function opens the stored `BinaryDocument` and copies it directly to the response via `broker.readBinaryResource(Txn, BinaryDocument, OutputStream)` — the **same zero-copy path `RESTServer` already uses** for binary downloads (`RESTServer.java:1782–1783`).

## Signature

```
response:stream-binary-resource(
    $binary-resource-path as xs:string,
    $content-type         as xs:string,
    $filename            as xs:string?   (: optional — sets Content-Disposition :)
) as empty-sequence()
```

## How it relates to the existing `response:` streamers

| function | takes | mechanism | memory |
|---|---|---|---|
| `response:stream($node, $opts)` | a node | serializes XML/HTML to the output stream | n/a |
| `response:stream-binary($binary, $type, $f?)` | an **already-materialized** `xs:base64Binary` | `binary.streamBinaryTo(os)` | caller must load the whole resource into heap first |
| **`response:stream-binary-resource($path, $type, $f?)`** *(new)* | a **db path** | opens the stored `BinaryDocument`, `broker.readBinaryResource(txn, binDoc, os)` | **never materializes** — streams disk → socket |

## What changed

- `response/StreamBinaryResource.java` *(new)* — the function. Resolves the path (read lock + permission check, the same way `util:binary-doc` does), verifies it's a binary document, sets `Content-Type` (and `Content-Disposition` from `$filename`), and streams zero-copy within a transaction.
- `response/ResponseModule.java` — registers the two arities.
- `RestBinariesTest.java` — `streamBinaryResourceRaw` stores a binary and asserts the bytes returned over a real HTTP request are **byte-identical** (mirrors the existing `streamBinaryRaw` test).

## Test

`RestBinariesTest` — **4/4 green** (incl. the new byte-identical case). exist-core builds clean; Codacy PMD clean.

## Scope: this is db paths only (`file:` is deliberately out of scope)

The function operates on **database** binary resources, not local filesystem files. Nothing inherent prevents a `file:` variant — streaming a local file is actually *simpler* (no broker, lock, transaction, or `BinaryDocument`: just `Files.newInputStream(path).transferTo(os)`). It's left out on purpose, for two reasons:

1. **Security.** Filesystem access from a request-handling function is a file-disclosure / path-traversal surface — an ungated `response:stream-binary-resource('file:///etc/passwd', …)` would stream arbitrary server files to a client. eXist treats `file:` access from XQuery as a **DBA-only** boundary, so a `file:` branch would need that guard and warrants its own scrutiny.
2. **Focus + consistency.** Keeping this PR to the db case keeps the security-sensitive surface separate, and lets a future `file:` variant follow the convention PR #6192 is establishing for `fn:collection` rather than inventing a parallel one.

**If `file:` support were wanted**, the shape would mirror #6192's `fn:collection`: branch on the URI scheme (db vs `file:`), **restrict the `file:` branch to DBA users** (a security boundary, consistent with `fn:doc()` / #6192), and stream via `Files.newInputStream(...).transferTo(response.getOutputStream())` — zero-copy, no materialization. That fills a real gap (the EXPath `file:read-binary` materializes the whole file), but it belongs in its own PR.

## Context

This is the download half of the binary-streaming work surfaced by the existdb-openapi binary-transport track (eXist-db/existdb-openapi#35 / #38). Functional binary transport already works today via `response:stream-binary`; this is the **scale** primitive for large downloads. The upload counterpart (a non-materializing `request:get-input-stream()` so a handler can pipe a large upload to `broker.storeDocument`) is deliberately a **separate follow-up** — it depends on how the request body is consumed (single-read; the Roaster raw-body path) and needs its own investigation.
