### PR TITLE
[bugfix] Compile statically-named arrow operator to a direct function call (closes #3887, #3336, #3885)

### DIFF
--- a/exist-core-jmh/src/main/java/org/exist/xquery/ArrowOperatorBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/xquery/ArrowOperatorBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.xmldb.api.base.XMLDBException;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the overhead of the XQuery 3.1 arrow operator against the equivalent direct call.
+ *
+ * <p>{@code EXPR => f(args)} is, per spec, exactly the call {@code f(EXPR, args)}. Each
+ * {@code arrow*} benchmark below has a matching {@code direct*} benchmark over an identical workload;
+ * comparing the pair quantifies what the arrow costs over a plain call. The loop applies a named
+ * function {@link #ITERATIONS} times so per-application dispatch overhead dominates the measurement.</p>
+ *
+ * <p>This is the companion guard for the change that compiles a statically-named arrow to a direct
+ * {@code FunctionCall} (instead of routing through a dynamic {@code FunctionReference} that allocated
+ * and re-analyzed a function reference per evaluation): {@code arrow*} should be at parity with
+ * {@code direct*}, and must not regress.</p>
+ *
+ * <p>Run via the unshaded jar plus the runtime classpath; the shaded benchmark jar trips a log4j2
+ * caller-class assertion when booting a {@code BrokerPool} (see {@code AxisBenchmark}):</p>
+ * <pre>{@code
+ *   mvn -pl exist-core-jmh dependency:build-classpath \
+ *       -Dmdep.outputFile=$PWD/exist-core-jmh/target/classpath.txt
+ *   CP="$PWD/exist-core-jmh/target/classes:\
+ *   $PWD/exist-core-jmh/target/exist-core-jmh-*-SNAPSHOT.jar:\
+ *   $(cat $PWD/exist-core-jmh/target/classpath.txt)"
+ *   java -cp "$CP" org.openjdk.jmh.Main ArrowOperatorBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class ArrowOperatorBenchmark {
+
+    @Param({"100000"})
+    public int iterations;
+
+    private LifecycleEmbeddedServer server;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Throwable {
+        server = new LifecycleEmbeddedServer();
+        server.before();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (server != null) {
+            server.after();
+            server = null;
+        }
+    }
+
+    // --- single named call: concat($i, "-x") ---
+
+    @Benchmark
+    public void directSingleCall(final Blackhole bh) throws XMLDBException {
+        bh.consume(server.executeQuery(
+                "count(for $i in 1 to " + iterations + " return concat($i, \"-x\"))"));
+    }
+
+    @Benchmark
+    public void arrowSingleCall(final Blackhole bh) throws XMLDBException {
+        bh.consume(server.executeQuery(
+                "count(for $i in 1 to " + iterations + " return $i => concat(\"-x\"))"));
+    }
+
+    // --- chained calls: upper-case + string-length, the idiom arrows are written for ---
+
+    @Benchmark
+    public void directChain(final Blackhole bh) throws XMLDBException {
+        bh.consume(server.executeQuery(
+                "count(for $i in 1 to " + iterations + " return string-length(upper-case(concat($i, \"-x\"))))"));
+    }
+
+    @Benchmark
+    public void arrowChain(final Blackhole bh) throws XMLDBException {
+        bh.consume(server.executeQuery(
+                "count(for $i in 1 to " + iterations + " return $i => concat(\"-x\") => upper-case() => string-length())"));
+    }
+
+    /**
+     * Widens {@link ExistXmldbEmbeddedServer#before()} / {@code after()} from protected to public so
+     * JMH's {@code @Setup} / {@code @TearDown} can drive the lifecycle directly (same pattern as
+     * {@code AxisBenchmark}).
+     */
+    private static final class LifecycleEmbeddedServer extends ExistXmldbEmbeddedServer {
+        LifecycleEmbeddedServer() {
+            super(false, true, true);
+        }
+
+        @Override
+        public void before() throws Throwable {
+            super.before();
+        }
+
+        @Override
+        public void after() {
+            super.after();
+        }
+    }
+}

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -4056,6 +4056,8 @@ throws PermissionDeniedException, EXistException, XPathException
         )
         { List<Expression> params = new ArrayList<Expression>(5); }
         (
+            QUESTION { params.add(new Function.Placeholder(context)); }
+            |
             {
                 PathExpr pathExpr = new PathExpr(context);
                 pathExpr.setASTNode(arrowOp_AST_in);

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -23,6 +23,7 @@ package org.exist.xquery;
 
 import org.exist.dom.QName;
 import org.exist.dom.QName.IllegalQNameException;
+import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.FunctionReference;
 import org.exist.xquery.value.Item;
@@ -41,7 +42,7 @@ public class ArrowOperator extends AbstractExpression {
 
     private QName qname = null;
     private Expression leftExpr;
-    private FunctionCall fcall = null;
+    private Expression namedCall = null;
     private Expression funcSpec = null;
     private List<Expression> parameters;
     private AnalyzeContextInfo cachedContextInfo;
@@ -74,45 +75,91 @@ public class ArrowOperator extends AbstractExpression {
                 ErrorCodes.EXXQDY0003,
                 "arrow operator is not available before XQuery 3.1");
         }
-        if (qname != null) {
-            fcall = NamedFunctionReference.lookupFunction(this, context, qname, parameters.size() + 1);
-        }
         this.cachedContextInfo = contextInfo;
-        leftExpr.analyze(contextInfo);
-        if (fcall != null) {
-            fcall.analyze(contextInfo);
-        }
-        if (funcSpec != null) {
+        if (qname != null) {
+            // Statically-named function: compile the arrow to the equivalent call
+            // f(leftExpr, parameters...), exactly as the parser builds a normal function call (the
+            // functionCall rule in XQueryTree.g). The left-hand side becomes a real argument
+            // expression — so it keeps its static context (fixing the lost-variable-scope bug, e.g.
+            // EXPR => util:eval()) — and a '?' placeholder yields a partial function application
+            // (fixing the placeholder arity bug). This replaces the previous dynamic FunctionReference
+            // dispatch, which pre-evaluated the left-hand side and modelled it as a placeholder.
+            final XQueryAST ast = new XQueryAST();
+            ast.setLine(getLine());
+            ast.setColumn(getColumn());
+            final List<Expression> callArgs = new ArrayList<>(parameters.size() + 1);
+            callArgs.add(toArgument(leftExpr));
+            boolean partial = false;
+            for (final Expression param : parameters) {
+                if (param instanceof Function.Placeholder) {
+                    partial = true;
+                    callArgs.add(param);
+                } else {
+                    callArgs.add(toArgument(param));
+                }
+            }
+            Expression call = FunctionFactory.createFunction(context, qname, ast, null, callArgs);
+            if (partial) {
+                // mirror the functionCall rule: a '?' placeholder turns the call into a partial
+                // function application yielding a function item of the remaining arity.
+                if (!(call instanceof FunctionCall)) {
+                    if (call instanceof CastExpression) {
+                        call = ((CastExpression) call).toFunction();
+                    }
+                    call = FunctionFactory.wrap(context, (Function) call);
+                }
+                call = new PartialFunctionApplication(context, (FunctionCall) call);
+            }
+            namedCall = call;
+            namedCall.analyze(contextInfo);
+        } else {
+            leftExpr.analyze(contextInfo);
             funcSpec.analyze(contextInfo);
         }
     }
 
+    /**
+     * Wraps an argument expression in a {@link PathExpr} when it is not already one, matching how the
+     * parser supplies function-call arguments (so {@link FunctionFactory#createFunction} optimizations
+     * that expect {@code PathExpr} arguments behave identically to a normal call). Placeholders are
+     * passed through unchanged by the caller.
+     */
+    private Expression toArgument(final Expression expr) {
+        if (expr instanceof PathExpr) {
+            return expr;
+        }
+        final PathExpr wrapped = new PathExpr(context);
+        wrapped.add(expr);
+        return wrapped;
+    }
+
     @Override
     public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
-        if (contextItem != null) {
-            contextSequence = contextItem.toSequence();
+        if (namedCall != null) {
+            // Statically-named arrow, compiled to f(leftExpr, parameters...): evaluate it directly,
+            // so the left-hand side is evaluated as an ordinary argument in this call's context.
+            return namedCall.eval(contextSequence, contextItem);
         }
-        contextSequence = leftExpr.eval(contextSequence, null);
 
-        final FunctionReference fref;
-        if (fcall != null) {
-            fref = new FunctionReference(this, fcall);
-        } else {
-            final Sequence funcSeq = funcSpec.eval(contextSequence, contextItem);
-            if (funcSeq.getCardinality() != Cardinality.EXACTLY_ONE)
-            {throw new XPathException(this, ErrorCodes.XPTY0004,
-                    "Expected exactly one item for the function to be called, got " + funcSeq.getItemCount() +
-                            ". Expression: " + ExpressionDumper.dump(funcSpec));}
-            final Item item0 = funcSeq.itemAt(0);
-            if (!Type.subTypeOf(item0.getType(), Type.FUNCTION)) {
-                throw new XPathException(this, ErrorCodes.XPTY0004,
-                    "Type error: expected function, got " + Type.getTypeName(item0.getType()));
-            }
-            fref = (FunctionReference)item0;
+        // Dynamic (higher-order) right-hand side: the function to call is obtained by evaluating
+        // funcSpec, so the left-hand side value is captured and supplied as the first argument.
+        final Sequence focus = contextItem != null ? contextItem.toSequence() : contextSequence;
+        final Sequence leftValue = leftExpr.eval(focus, null);
+
+        final Sequence funcSeq = funcSpec.eval(leftValue, contextItem);
+        if (funcSeq.getCardinality() != Cardinality.EXACTLY_ONE)
+        {throw new XPathException(this, ErrorCodes.XPTY0004,
+                "Expected exactly one item for the function to be called, got " + funcSeq.getItemCount() +
+                        ". Expression: " + ExpressionDumper.dump(funcSpec));}
+        final Item item0 = funcSeq.itemAt(0);
+        if (!Type.subTypeOf(item0.getType(), Type.FUNCTION)) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                "Type error: expected function, got " + Type.getTypeName(item0.getType()));
         }
+        final FunctionReference fref = (FunctionReference) item0;
         try {
             final List<Expression> fparams = new ArrayList<>(parameters.size() + 1);
-            fparams.add(new ContextParam(context, contextSequence));
+            fparams.add(new ContextParam(context, leftValue));
             fparams.addAll(parameters);
 
             fref.setArguments(fparams);
@@ -128,28 +175,29 @@ public class ArrowOperator extends AbstractExpression {
 
     @Override
     public int returnsType() {
-        return fcall == null ? Type.ITEM : fcall.returnsType();
+        return namedCall == null ? Type.ITEM : namedCall.returnsType();
     }
 
     @Override
     public Cardinality getCardinality() {
-        return fcall == null ? super.getCardinality() : fcall.getCardinality();
+        return namedCall == null ? super.getCardinality() : namedCall.getCardinality();
     }
 
     @Override
     public void dump(final ExpressionDumper dumper) {
         leftExpr.dump(dumper);
         dumper.display(" => ");
-        if (fcall != null) {
-            dumper.display(fcall.getFunction().getName()).display('(');
+        if (qname != null) {
+            dumper.display(qname.getStringValue());
         } else {
             funcSpec.dump(dumper);
         }
+        dumper.display('(');
         for (int i = 0; i < parameters.size(); i++) {
             if (i > 0) {
                 dumper.display(", ");
-                parameters.get(i).dump(dumper);
             }
+            parameters.get(i).dump(dumper);
         }
         dumper.display(')');
     }
@@ -157,15 +205,17 @@ public class ArrowOperator extends AbstractExpression {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
-        leftExpr.resetState(postOptimization);
-        if (fcall != null) {
-            fcall.resetState(postOptimization);
-        }
-        if (funcSpec != null) {
-            funcSpec.resetState(postOptimization);
-        }
-        for (Expression param: parameters) {
-            param.resetState(postOptimization);
+        if (namedCall != null) {
+            // namedCall owns leftExpr and parameters as its arguments.
+            namedCall.resetState(postOptimization);
+        } else {
+            leftExpr.resetState(postOptimization);
+            if (funcSpec != null) {
+                funcSpec.resetState(postOptimization);
+            }
+            for (Expression param : parameters) {
+                param.resetState(postOptimization);
+            }
         }
     }
 
@@ -180,6 +230,7 @@ public class ArrowOperator extends AbstractExpression {
 
         @Override
         public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+            // nothing to analyze: the captured left-hand-side value is already evaluated
         }
 
         @Override
@@ -194,7 +245,7 @@ public class ArrowOperator extends AbstractExpression {
 
         @Override
         public void dump(ExpressionDumper dumper) {
-
+            // the captured value has no source representation to display
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -76,46 +76,49 @@ public class ArrowOperator extends AbstractExpression {
                 "arrow operator is not available before XQuery 3.1");
         }
         this.cachedContextInfo = contextInfo;
-        if (qname != null) {
-            // Statically-named function: compile the arrow to the equivalent call
-            // f(leftExpr, parameters...), exactly as the parser builds a normal function call (the
-            // functionCall rule in XQueryTree.g). The left-hand side becomes a real argument
-            // expression — so it keeps its static context (fixing the lost-variable-scope bug, e.g.
-            // EXPR => util:eval()) — and a '?' placeholder yields a partial function application
-            // (fixing the placeholder arity bug). This replaces the previous dynamic FunctionReference
-            // dispatch, which pre-evaluated the left-hand side and modelled it as a placeholder.
-            final XQueryAST ast = new XQueryAST();
-            ast.setLine(getLine());
-            ast.setColumn(getColumn());
-            final List<Expression> callArgs = new ArrayList<>(parameters.size() + 1);
-            callArgs.add(toArgument(leftExpr));
-            boolean partial = false;
-            for (final Expression param : parameters) {
-                if (param instanceof Function.Placeholder) {
-                    partial = true;
-                    callArgs.add(param);
-                } else {
-                    callArgs.add(toArgument(param));
-                }
-            }
-            Expression call = FunctionFactory.createFunction(context, qname, ast, null, callArgs);
-            if (partial) {
-                // mirror the functionCall rule: a '?' placeholder turns the call into a partial
-                // function application yielding a function item of the remaining arity.
-                if (!(call instanceof FunctionCall)) {
-                    if (call instanceof CastExpression) {
-                        call = ((CastExpression) call).toFunction();
-                    }
-                    call = FunctionFactory.wrap(context, (Function) call);
-                }
-                call = new PartialFunctionApplication(context, (FunctionCall) call);
-            }
-            namedCall = call;
-            namedCall.analyze(contextInfo);
-        } else {
+        if (qname == null) {
+            // Dynamic (higher-order) right-hand side: analyze the operands as they are. The function
+            // to call is resolved at evaluation time by evaluating funcSpec.
             leftExpr.analyze(contextInfo);
             funcSpec.analyze(contextInfo);
+            return;
         }
+
+        // Statically-named function: compile the arrow to the equivalent call
+        // f(leftExpr, parameters...), exactly as the parser builds a normal function call (the
+        // functionCall rule in XQueryTree.g). The left-hand side becomes a real argument
+        // expression — so it keeps its static context (fixing the lost-variable-scope bug, e.g.
+        // EXPR => util:eval()) — and a '?' placeholder yields a partial function application
+        // (fixing the placeholder arity bug). This replaces the previous dynamic FunctionReference
+        // dispatch, which pre-evaluated the left-hand side and modelled it as a placeholder.
+        final XQueryAST ast = new XQueryAST();
+        ast.setLine(getLine());
+        ast.setColumn(getColumn());
+        final List<Expression> callArgs = new ArrayList<>(parameters.size() + 1);
+        callArgs.add(toArgument(leftExpr));
+        boolean partial = false;
+        for (final Expression param : parameters) {
+            if (param instanceof Function.Placeholder) {
+                partial = true;
+                callArgs.add(param);
+            } else {
+                callArgs.add(toArgument(param));
+            }
+        }
+        Expression call = FunctionFactory.createFunction(context, qname, ast, null, callArgs);
+        if (partial) {
+            // mirror the functionCall rule: a '?' placeholder turns the call into a partial
+            // function application yielding a function item of the remaining arity.
+            if (!(call instanceof FunctionCall)) {
+                if (call instanceof CastExpression) {
+                    call = ((CastExpression) call).toFunction();
+                }
+                call = FunctionFactory.wrap(context, (Function) call);
+            }
+            call = new PartialFunctionApplication(context, (FunctionCall) call);
+        }
+        namedCall = call;
+        namedCall.analyze(contextInfo);
     }
 
     /**
@@ -147,10 +150,11 @@ public class ArrowOperator extends AbstractExpression {
         final Sequence leftValue = leftExpr.eval(focus, null);
 
         final Sequence funcSeq = funcSpec.eval(leftValue, contextItem);
-        if (funcSeq.getCardinality() != Cardinality.EXACTLY_ONE)
-        {throw new XPathException(this, ErrorCodes.XPTY0004,
-                "Expected exactly one item for the function to be called, got " + funcSeq.getItemCount() +
-                        ". Expression: " + ExpressionDumper.dump(funcSpec));}
+        if (funcSeq.getCardinality() != Cardinality.EXACTLY_ONE) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Expected exactly one item for the function to be called, got " + funcSeq.getItemCount() +
+                            ". Expression: " + ExpressionDumper.dump(funcSpec));
+        }
         final Item item0 = funcSeq.itemAt(0);
         if (!Type.subTypeOf(item0.getType(), Type.FUNCTION)) {
             throw new XPathException(this, ErrorCodes.XPTY0004,
@@ -208,14 +212,14 @@ public class ArrowOperator extends AbstractExpression {
         if (namedCall != null) {
             // namedCall owns leftExpr and parameters as its arguments.
             namedCall.resetState(postOptimization);
-        } else {
-            leftExpr.resetState(postOptimization);
-            if (funcSpec != null) {
-                funcSpec.resetState(postOptimization);
-            }
-            for (Expression param : parameters) {
-                param.resetState(postOptimization);
-            }
+            return;
+        }
+        leftExpr.resetState(postOptimization);
+        if (funcSpec != null) {
+            funcSpec.resetState(postOptimization);
+        }
+        for (Expression param : parameters) {
+            param.resetState(postOptimization);
         }
     }
 

--- a/exist-core/src/test/xquery/xquery3/arrowop.xql
+++ b/exist-core/src/test/xquery/xquery3/arrowop.xql
@@ -25,6 +25,8 @@ module namespace ao="http://exist-db.org/xquery/test/arrowop";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
+import module namespace util="http://exist-db.org/xquery/util";
+
 declare
     %test:assertEquals("Hello world")
 function ao:func-by-name1() {
@@ -149,8 +151,13 @@ declare %private function ao:string-join($s as xs:string*, $sep as xs:string) {
     string-join($s, $sep)
 };
 
+(: EXPR => f(args) is exactly the call f(EXPR, args) and applies the same function conversion
+   rules: xs:integer items do not convert to a declared xs:string* parameter, so this raises
+   XPTY0004 — identical to the direct call ao:string-join((1,2,3), "-") and to Saxon. (Before the
+   arrow was compiled to a direct call, the dynamic FunctionReference path was wrongly lenient here
+   and returned "1-2-3", which a normal call never would.) :)
 declare
-    %test:assertEquals("1-2-3")
+    %test:assertError("XPTY0004")
 function ao:type-checks-user-func() {
     (1, 2, 3) => ao:string-join("-")
 };
@@ -276,4 +283,47 @@ function ao:for-each-pair-with-contextitem () {
     (<a/>,<b/>,<a/>,<b/>)
         => for-each-pair((<a/>,<b/>,<a/>,<b/>), function ($a, $b) { node-name($a) || node-name($b) })
         => string-join()
+};
+
+(:~
+    closes https://github.com/eXist-db/exist/issues/3336
+    EXPR => f(?) is f(EXPR, ?): the left-hand side fills the first argument and the placeholder
+    leaves the second open, yielding an arity-1 partial application. Previously the LHS was modelled
+    as a placeholder too, so both slots were left open and applying one argument raised XPST0017.
+ ~:)
+declare
+    %test:assertEquals("ello")
+function ao:placeholder-partial-application() {
+    ("hello" => substring(?))(2)
+};
+
+(:~
+    closes https://github.com/eXist-db/exist/issues/3887
+    The arrow left-hand side is passed as a real argument expression, so a context-sensitive callee
+    (here util:eval) sees the in-scope variables exactly as the direct call util:eval(concat(...))
+    does. Previously the LHS was pre-evaluated and injected via a dynamic FunctionReference, and the
+    variable $v was not visible, raising XPST0008.
+ ~:)
+declare
+    %test:assertEquals(2)
+function ao:context-sensitive-callee-sees-scope() {
+    let $v := 1
+    return concat("$v", "+1") => util:eval()
+};
+
+declare %private function ao:npe-map2($a) { $a };
+
+declare %private function ao:npe-map1($a as xs:string) {
+    tokenize($a, "\|") => for-each(ao:npe-map2(?))
+};
+
+(:~
+    closes https://github.com/eXist-db/exist/issues/3885
+    A named arrow function whose argument is itself a partial application (a '?' placeholder nested
+    inside a call after the arrow) no longer raises a NullPointerException.
+ ~:)
+declare
+    %test:assertEquals("a", "b", "c", "d", "e")
+function ao:nested-partial-after-arrow() {
+    ("a|b", "c", "d|e") => for-each(ao:npe-map1(?))
 };

--- a/exist-core/src/test/xquery/xquery3/arrowop.xql
+++ b/exist-core/src/test/xquery/xquery3/arrowop.xql
@@ -162,6 +162,27 @@ function ao:type-checks-user-func() {
     (1, 2, 3) => ao:string-join("-")
 };
 
+(: companion to ao:type-checks-user-func: when the left-hand operand already matches the declared
+   xs:string* parameter, the same arrow succeeds — confirming the XPTY0004 above is a type mismatch,
+   not a defect in the arrow itself. Identical to the direct call ao:string-join(("1","2","3"), "-"). :)
+declare
+    %test:assertEquals("1-2-3")
+function ao:type-checks-user-func-strings() {
+    ("1", "2", "3") => ao:string-join("-")
+};
+
+(: the other way to make it type-check: keep integer input but cast to string inside the RHS
+   function, whose parameter then accepts xs:anyAtomicType*. EXPR => f(args) still equals f(EXPR, args). :)
+declare %private function ao:string-join-atomic($s as xs:anyAtomicType*, $sep as xs:string) {
+    string-join($s ! string(.), $sep)
+};
+
+declare
+    %test:assertEquals("1-2-3")
+function ao:type-checks-user-func-cast-inside() {
+    (1, 2, 3) => ao:string-join-atomic("-")
+};
+
 declare function ao:A($x) { 
     let $y := $x || $x 
     return 


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

The XQuery 3.1 arrow operator `EXPR => f(args)` is, per spec, exactly the call `f(EXPR, args)`. eXist instead evaluated **every** arrow — including the statically-named case — by building a dynamic `FunctionReference`: it pre-evaluated the left-hand side, injected it as a placeholder (`ContextParam extends Function.Placeholder`), then re-analyzed and dynamically dispatched on each evaluation. That caused three bugs, a conformance gap, and a 2–3× per-call performance penalty.

This compiles the statically-named arrow to a real `FunctionCall` — the same thing the parser builds for an ordinary call — which fixes all of the above. A genuine higher-order right-hand side (a variable or parenthesized expression yielding a function) still uses the dynamic path.

## What changed

- **`exist-core/.../ArrowOperator.java`** — `analyze()` now compiles the named arrow via `FunctionFactory.createFunction(qname, [leftExpr, parameters…])`, wrapping in `PartialFunctionApplication` when a `?` placeholder is present (mirroring the parser's `functionCall` rule). `eval()` for the named case simply delegates to that call, so the left-hand side is evaluated as an ordinary argument in the call's own context. The higher-order (`funcSpec`) path is preserved.
- **`exist-core/.../parser/XQueryTree.g`** — the `arrowOp` tree-walker rule had **no `QUESTION → Function.Placeholder` branch** (unlike `functionCall`), so a `?` in an arrow argument list was never turned into a placeholder. Added the branch (the grammar half of #3336).
- **`exist-core/.../xquery3/arrowop.xql`** — three new regression tests (#3887, #3336, #3885) and one updated assertion (see *Conformance* below).
- **`exist-core-jmh/.../ArrowOperatorBenchmark.java`** *(separate `[test]` commit)* — a JMH benchmark comparing arrow vs. the equivalent direct call.

## Bugs fixed

Because the left-hand side is now a genuine argument expression instead of a pre-evaluated placeholder:

- **Closes #3887** — a context-sensitive callee sees in-scope variables, like the direct call. `let $v := 1 return concat("$v","+1") => util:eval()` returned `XPST0008 Variable '$v' is not declared`; now returns `2`, matching `util:eval(concat("$v","+1"))`.
- **Closes #3336** — `EXPR => f(?)` is a partial application of the remaining arity. `('hello' => substring(?))(2)` returned `XPST0017` (wrong arity); now returns `"ello"`.
- **Closes #3885** — no `NullPointerException` for a nested partial application after the arrow (`… => for-each(f(?))`).

## Conformance — one existing test assertion changed (please review)

The fix also makes the arrow apply **function-conversion rules** like the equivalent direct call. On `develop`, the arrow was *more lenient* than a direct call:

```xquery
declare function local:sj($s as xs:string*, $sep as xs:string) { string-join($s, $sep) };
local:sj((1,2,3), "-")        (: develop: XPTY0004 — integers are not xs:string :)
(1,2,3) => local:sj("-")      (: develop: wrongly returned "1-2-3" :)
```

Saxon raises `XPTY0004` for both forms; so does eXist's direct call. After this change the arrow agrees. The existing `ao:type-checks-user-func` test asserted the old lenient `"1-2-3"`; it now asserts `XPTY0004` (with a comment explaining why). This is the only behavior change beyond the three bug fixes, and it brings the arrow into line with the spec, the direct call, and Saxon.

## Spec references

- XQuery 3.1 — [3.1.5 Arrow Operator](https://www.w3.org/TR/xquery-31/#id-arrow-operator): *"An ArrowExpr … is equivalent to … a function call."*
- XPath/XQuery 3.1 — [3.1.5.1 Evaluating Static and Dynamic Function Calls](https://www.w3.org/TR/xquery-31/#id-function-calls) / the function conversion rules; `XPTY0004` for an argument that does not match the required type.

## Reference implementations

Both lower the named arrow to a static call and agree on the behavior:

- **Saxon 12.5** (observed): `('hello' => substring(?))(2)` → `ello`; `(1 to 5) => reverse()` → `5 4 3 2 1`; `(1,2,3) => local:sj("-")` (into `xs:string*`) → `XPTY0004`.
- **BaseX** (source, `QueryParser.arrow()`): a named function becomes a static `Functions.get(name, [LHS, args…])` with the LHS as a real argument expression; the dynamic path is reserved for a function-valued RHS.

## Performance (JMH, 100k iterations, 5 measurement iterations)

| Benchmark | Before | After | |
|---|---|---|---|
| arrow single call | 55.4 ± 4.1 ms | 25.0 ± 1.7 ms | **2.2× faster** |
| arrow 3-arrow chain | 110.2 ± 7.5 ms | 34.1 ± 4.4 ms | **3.2× faster** |
| direct single *(control)* | 24.3 ± 0.4 ms | 24.3 ± 0.4 ms | flat |
| direct chain *(control)* | 34.7 ± 4.6 ms | 34.8 ± 3.2 ms | flat |

After the fix the arrow is at parity with the equivalent direct call; the direct-call controls are unchanged, confirming the change touches only the arrow path.

## W3C XQTS (HEAD) — before/after on the affected test sets

Run via the same in-repo `exist-xqts` job this PR's CI runs.

| test set | before (develop) | after |
|---|---|---|
| **`prod-ArrowPostfix`** | 41/42 (1 fail) | **42/42** |
| `prod-SequenceType` | 21/21 | 21/21 |
| `misc-HigherOrderFunctions`, `prod-FunctionCall`, `prod-NamedFunctionRef`, `prod-InlineFunctionExpr`, `fn-function-*` | (pre-existing fails) | **identical** |

`ArrowPostfix-108` (a placeholder-after-arrow `=> concat(?, …)` case) failed on `develop` with `XPST0017 fn:concat requires at least two arguments` and now passes. Every other set's failure/error/skip counts are byte-identical before and after — no collateral movement.

## Test plan

- [x] New regression tests in `arrowop.xql` for #3887, #3336, #3885; updated type-conversion assertion.
- [x] `xquery.xquery3.XQuery3Tests` (includes `arrowop.xql`) green: 1,059 tests.
- [x] 2,610 XQSuite tests green across maps / arrays / xquery3 / core / inspect / util / optimizer / numbers.
- [x] W3C XQTS HEAD: `prod-ArrowPostfix` 41→42, no regression in the function/HoF/sequence-type sets.
- [x] JMH benchmark: arrow now at parity with the direct call (2.2–3.2× faster than before).
- [x] Codacy PMD clean on the changed Java.
