### PR TITLE
[bugfix] Log a deferred (tail-call) function's error once, not once per Sequence accessor

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
@@ -58,7 +58,23 @@ public abstract class DeferredFunctionCall implements Sequence {
             sequence = execute();
         }
     }
-    
+
+    /**
+     * Caches and logs an exception raised while realizing the deferred call, but only the first time.
+     * The non-throwing {@link Sequence} accessor methods catch the exception and return a default,
+     * and {@link #realize()} re-throws the cached exception on every later access; without this guard
+     * the same failure would be logged once per accessor the consumer calls (e.g. the serializer or
+     * the html-templating engine, which inspect a result sequence through several accessors).
+     *
+     * @param e the exception raised by {@link #execute()} (or re-thrown by {@link #realize()})
+     */
+    private void captureAndLogOnce(final XPathException e) {
+        if (caughtException == null) {
+            caughtException = e;
+            LOG.error("Exception in deferred function: {}", e.getMessage());
+        }
+    }
+
     protected FunctionSignature getSignature() {
         return signature;
     }
@@ -102,8 +118,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.getCardinality();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return Cardinality.EMPTY_SEQUENCE;
         }
     }
@@ -113,8 +128,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.getDocumentSet();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return null;
         }
     }
@@ -124,8 +138,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.getCollectionIterator();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return null;
         }
     }
@@ -135,8 +148,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.getItemType();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return Type.ANY_TYPE;
         }
     }
@@ -147,8 +159,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.getItemCountLong();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return 0;
         }
     }
@@ -169,8 +180,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.hasMany();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return false;
         }
     }
@@ -180,8 +190,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.hasOne();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return false;
         }
     }
@@ -191,7 +200,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.isCached();
         } catch (XPathException e) {
-            caughtException = e;
+            captureAndLogOnce(e);
             return false;
         }
     }
@@ -201,8 +210,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.isEmpty();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return false;
         }
     }
@@ -212,8 +220,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.isPersistentSet();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return false;
         }
     }
@@ -223,8 +230,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             return sequence.itemAt(pos);
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
             return null;
         }
     }
@@ -239,8 +245,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             sequence.removeDuplicates();
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
         }
     }
 
@@ -249,8 +254,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             sequence.setIsCached(cached);
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
         }
     }
 
@@ -259,8 +263,7 @@ public abstract class DeferredFunctionCall implements Sequence {
             realize();
             sequence.setSelfAsContext(contextId);
         } catch (XPathException e) {
-            caughtException = e;
-            LOG.error("Exception in deferred function: {}", e.getMessage());
+            captureAndLogOnce(e);
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/DeferredFunctionCallErrorTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/DeferredFunctionCallErrorTest.java
@@ -1,0 +1,154 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.exist.dom.QName;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test: an error raised inside a deferred (tail-call) function must be logged once, not
+ * re-logged on every {@link Sequence} accessor.
+ *
+ * <p>{@link DeferredFunctionCall} runs its body lazily and caches any exception, re-throwing it on
+ * every later access. Its non-throwing {@code Sequence} accessor methods can't propagate the checked
+ * {@link XPathException}, so they catch it and return a default — but they also logged it every time,
+ * so a consumer that touches the same deferred value through several accessors (the serializer and the
+ * html-templating engine both do) produced one log line per accessor. This asserts the body runs once
+ * and the failure is logged once, however many accessors are called.</p>
+ */
+public class DeferredFunctionCallErrorTest {
+
+    private static final QName FN = new QName("boom", "http://exist-db.org/test");
+    private static final String DEFERRED_LOGGER = "org.exist.xquery.DeferredFunctionCall";
+
+    private CountingAppender appender;
+
+    @Before
+    public void attachAppender() {
+        appender = new CountingAppender();
+        appender.start();
+        // The test log4j2 config sets the root logger to OFF, which would filter these events before
+        // any appender sees them. Install a dedicated LoggerConfig for DeferredFunctionCall at level
+        // ALL with our counting appender so the errors it logs are captured.
+        final Logger logger = (Logger) LogManager.getLogger(DEFERRED_LOGGER);
+        final LoggerContext ctx = logger.getContext();
+        final Configuration config = ctx.getConfiguration();
+        config.addAppender(appender);
+        final LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+                .withLoggerName(DEFERRED_LOGGER)
+                .withLevel(Level.ALL)
+                .withAdditivity(false)
+                .withConfig(config)
+                .build();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        config.addLogger(DEFERRED_LOGGER, loggerConfig);
+        ctx.updateLoggers();
+    }
+
+    @After
+    public void detachAppender() {
+        final Logger logger = (Logger) LogManager.getLogger(DEFERRED_LOGGER);
+        final LoggerContext ctx = logger.getContext();
+        ctx.getConfiguration().removeLogger(DEFERRED_LOGGER);
+        ctx.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    public void errorIsComputedOnceAndLoggedOnce() throws XPathException {
+        final AtomicInteger executeCount = new AtomicInteger();
+        final DeferredFunctionCall dfc = new DeferredFunctionCall(new FunctionSignature(FN)) {
+            @Override
+            protected Sequence execute() throws XPathException {
+                executeCount.incrementAndGet();
+                throw new XPathException((Expression) null, ErrorCodes.FOER0000, "boom");
+            }
+
+            @Override
+            public boolean containsReference(final Item item) {
+                return false;
+            }
+
+            @Override
+            public boolean contains(final Item item) {
+                return false;
+            }
+        };
+
+        // Touch the deferred value through several non-throwing accessors, as a consumer
+        // (e.g. the serializer or the templating engine) does while inspecting a result sequence.
+        dfc.getItemCountLong();
+        dfc.isEmpty();
+        dfc.hasOne();
+        dfc.hasMany();
+        dfc.getCardinality();
+        dfc.itemAt(0);
+        dfc.getItemType();
+
+        assertEquals("deferred body must run exactly once", 1, executeCount.get());
+        assertEquals("the error must be logged once, not once per accessor", 1, appender.count.get());
+
+        // the failure must still surface to the caller through a throwing accessor — the fix de-dupes
+        // the logging, it does not hide the error.
+        try {
+            dfc.iterate();
+            fail("the deferred error should surface through a throwing accessor");
+        } catch (final XPathException expected) {
+            // expected: realize() re-throws the cached exception
+        }
+        assertEquals("the body must still run only once", 1, executeCount.get());
+        assertEquals("surfacing the error must not add a log line", 1, appender.count.get());
+    }
+
+    private static final class CountingAppender extends AbstractAppender {
+        private final AtomicInteger count = new AtomicInteger();
+
+        CountingAppender() {
+            super("deferred-fn-counter", null, null, false, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            if (event.getMessage().getFormattedMessage().contains("Exception in deferred function")) {
+                count.incrementAndGet();
+            }
+        }
+    }
+}


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

An error raised inside a **deferred (tail-call) function** is logged repeatedly — once for every `Sequence` accessor a consumer calls on the result — and because each line carries the full call stack, a single failure becomes many long lines in the log. This is the cause of the "epically long" error output people see from the HTML-templating framework (and tools built on it). This PR makes the failure log **once**, with no change to evaluation behavior.

## Background — what a "deferred function" is

A tail-recursive XQuery function isn't recursed on the JVM stack; `FunctionCall` returns a `DeferredFunctionCall` (eXist's tail-call trampoline) whose body runs lazily. The HTML-templating framework's recursive model processing is a common way to produce these.

`DeferredFunctionCall` runs its body once, caches any exception, and re-throws the cached exception on every later access. It has about fourteen **non-throwing** `Sequence` accessor methods — `getCardinality`, `isEmpty`, `hasOne`, `hasMany`, `getItemCountLong`, `itemAt`, `getItemType`, `getDocumentSet`, `isPersistentSet`, … — none of which is declared to throw the checked `XPathException`. Each catches the exception and returns a default (empty / `null` / `false` / `0`), in an identical catch block.

## The bug

Every one of those ~14 catch blocks also **logged** the error:

```java
} catch (XPathException e) {
    caughtException = e;
    LOG.error("Exception in deferred function: {}", e.getMessage());   // logged every time
    return <default>;
}
```

A consumer that touches the same deferred value through several accessors — the serializer and the templating engine both do (`isEmpty`, `hasOne`, `getItemCountLong`, `itemAt`, …) — re-enters the catch once per accessor, and `realize()` re-throwing the cached exception guarantees every later accessor hits it too. So the one failure is logged N times. And since `XPathException.getMessage()` appends the accumulated `In function:` call stack (a frame per function boundary the exception crossed), each of those N lines is long for a deep templating/recursion chain.

## What changed

`DeferredFunctionCall.java` — one private helper, used by every catch block:

```java
private void captureAndLogOnce(final XPathException e) {
    if (caughtException == null) {   // realize() re-throws the cached exception on later access;
        caughtException = e;         // only the first capture logs.
        LOG.error("Exception in deferred function: {}", e.getMessage());
    }
}
```

Each catch becomes `captureAndLogOnce(e)`. **Behavior is otherwise unchanged**: the failure is still cached, the non-throwing accessors still return the same defaults, and the error still surfaces to the caller through the *throwing* accessors (`iterate()`, `getStringValue()`, …). Only the duplicate log lines stop. One file, no public API change.

The "swallow to a default" behavior of the non-throwing accessors is intentionally left as-is — it's inherent to the `Sequence` interface (those methods can't throw the checked `XPathException`), and the error still propagates through a throwing accessor.

## Reproducer / test

A bare query does **not** trigger this: for straightforward recursion the trampoline in `FunctionCall` unwinds the deferred and the error propagates once (a probe of ten candidate queries logged it zero times). The repeat-logging needs a `DeferredFunctionCall` reaching the non-throwing accessors before a throwing one, which is the serializer/templating path. So the regression test demonstrates the defect deterministically at the unit level:

`DeferredFunctionCallErrorTest` builds a `DeferredFunctionCall` whose `execute()` throws, calls seven non-throwing accessors on it, and counts `"Exception in deferred function"` log lines via a counting log4j2 appender. It asserts the body runs **once**, the error is logged **once** (was 7), and the error still **surfaces** through a throwing accessor.

(Note for maintainers: the exist-core test `log4j2.xml` sets `<Root level="OFF">`, so these events are filtered before any appender unless the test installs a dedicated `LoggerConfig` at level `ALL` — which the test does.)

## Test plan

- [x] New regression test `DeferredFunctionCallErrorTest` — logged-once + body-runs-once + error-still-surfaces; fails (7 logs) against unfixed code, passes after.
- [x] No regression: 2,014 XQSuite tests (`XQuery3Tests` + `CoreTests`) + `XQueryTest` (99, the tail-recursion JUnit path the fix rides on) all green.
- [x] Codacy PMD clean on the changed Java (the fix and the test).
