### PR TITLE
[test] Cover arrow-operator placeholder edge cases (#6471)

### DIFF
--- a/exist-core/src/test/xquery/xquery3/arrowop.xql
+++ b/exist-core/src/test/xquery/xquery3/arrowop.xql
@@ -348,3 +348,28 @@ declare
 function ao:nested-partial-after-arrow() {
     ("a|b", "c", "d|e") => for-each(ao:npe-map1(?))
 };
+
+(:~
+    https://github.com/eXist-db/exist/issues/6471
+    EXPR => f(args) is the call f(EXPR, args), with any argument placeholder following the prepended
+    left operand. A placeholder that pushes the arity past the function's maximum is therefore an
+    unknown-function error: here xs:string has only arity 1, so 1 => xs:string(?) is xs:string(1, ?),
+    and xs:string#2 does not exist (XPST0017).
+ ~:)
+declare
+    %test:assertError("XPST0017")
+function ao:placeholder-exceeds-arity() {
+    1 => xs:string(?)
+};
+
+(:~
+    https://github.com/eXist-db/exist/issues/6471
+    A placeholder on the RHS of the arrow yields a partial function application of f(EXPR, ?). This
+    exercises the variadic fn:concat (the existing ao:placeholder-partial-application covers a fixed
+    arity via fn:substring): ("1" => concat(?)) is concat("1", ?), applied to "1" giving "11".
+ ~:)
+declare
+    %test:assertEquals("11")
+function ao:placeholder-partial-application-variadic() {
+    ("1" => concat(?))("1")
+};


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

Adds two XQSuite regression tests to `arrowop.xql` for argument-placeholder behavior on the right-hand side of the arrow operator, prompted by #6471. 

## What changed

`exist-core/src/test/xquery/xquery3/arrowop.xql` — two new test functions:

- **`ao:placeholder-exceeds-arity`** — `1 => xs:string(?)` is `xs:string(1, ?)`, and `xs:string#2` does not exist, so it raises `XPST0017`. This arity-overflow case was not previously covered.
- **`ao:placeholder-partial-application-variadic`** — `("1" => concat(?))("1")` yields `"11"`, exercising a partial application over the variadic `fn:concat` (the existing `ao:placeholder-partial-application` covers fixed arity via `fn:substring`).

## Test plan

- [x] Full XQuery3 suite green: 1063 tests (+2), 0 failures, 0 errors.
- [x] Module still compiles with the `XPST0017` case present (the error surfaces per-test via `%test:assertError`, not at module load).
