### PR TITLE
[bugfix] External variable: supplied value overrides declared default

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -748,6 +748,7 @@ throws PermissionDeniedException, EXistException, XPathException
                     final VariableDeclaration decl = new VariableDeclaration(context, qn, defaultValue);
                     decl.setSequenceType(type);
                     decl.setASTNode(ext);
+                    decl.setExternal(true);
                     if (external == null) {
                         path.add(decl);
                     }

--- a/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
@@ -44,6 +44,10 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
     Optional<Expression> expression;
     SequenceType sequenceType = null;
     boolean analyzeDone = false;
+    /** True for an external variable declaration ({@code declare variable $x external [:= ...]}). When
+     *  it carries a default value, eval() prefers a value supplied by the external environment over
+     *  that default, per XQuery 3.1 §4.15. */
+    private boolean external = false;
 
     public VariableDeclaration(final XQueryContext context, final QName qname, final Expression expr) {
         super(context);
@@ -53,6 +57,16 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
 
     public QName getName() {
         return qname;
+    }
+
+    /**
+     * Marks this as an external variable declaration. Set by the parser for
+     * {@code declare variable $x external} (with or without a default value).
+     *
+     * @param external whether this declaration is external
+     */
+    public void setExternal(final boolean external) {
+        this.external = external;
     }
 
     /**
@@ -91,6 +105,18 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
         }
         analyzeExpression(contextInfo);
         var.setIsInitialized(true);
+    }
+
+    /**
+     * The global variable for this declaration if the external environment has already supplied it a
+     * value (i.e. it was bound before execution), otherwise {@code null}. Lets an external variable's
+     * supplied value take precedence over its declared default.
+     *
+     * @return the supplied variable, or {@code null} if none was supplied
+     */
+    private @Nullable Variable suppliedExternalValue() {
+        final Variable existing = context.resolveGlobalVariable(qname);
+        return existing != null && existing.getValue() != null ? existing : null;
     }
 
     private @Nullable Module findDeclaringModule(@Nullable final Module[] modules) {
@@ -142,24 +168,34 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
             try {
                 context.prologEnter(this);
                 if (expression.isPresent()) {
-                    // normal variable declaration or external var with default value
-                    final Sequence seq = expression.get().eval(contextSequence, null);
-                    final Variable var;
-                    if (myModule != null) {
-                        var = myModule.declareVariable(qname, seq);
-                        var.setSequenceType(sequenceType);
-                        var.checkType();
+                    // An external variable declared *with* a default value: a value supplied by the
+                    // external environment takes precedence over the default (XQuery 3.1 §4.15). A
+                    // plain (non-external) global declaration always evaluates its expression.
+                    final Variable supplied = external && myModule == null
+                            ? suppliedExternalValue() : null;
+                    if (supplied != null) {
+                        supplied.setSequenceType(sequenceType);
+                        supplied.checkType();
                     } else {
-                        var = new VariableImpl(qname);
-                        var.setValue(seq);
-                        var.setSequenceType(sequenceType);
-                        var.checkType();
-                        context.declareGlobalVariable(var);
-                    }
+                        // normal variable declaration, or external var falling back to its default
+                        final Sequence seq = expression.get().eval(contextSequence, null);
+                        final Variable var;
+                        if (myModule != null) {
+                            var = myModule.declareVariable(qname, seq);
+                            var.setSequenceType(sequenceType);
+                            var.checkType();
+                        } else {
+                            var = new VariableImpl(qname);
+                            var.setValue(seq);
+                            var.setSequenceType(sequenceType);
+                            var.checkType();
+                            context.declareGlobalVariable(var);
+                        }
 
-                    if (context.getProfiler().isEnabled()) {
-                        //Note : that we use seq but we return Sequence.EMPTY_SEQUENCE
-                        context.getProfiler().end(this, "", seq);
+                        if (context.getProfiler().isEnabled()) {
+                            //Note : that we use seq but we return Sequence.EMPTY_SEQUENCE
+                            context.getProfiler().end(this, "", seq);
+                        }
                     }
                 } else {
                     // external variable without default

--- a/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
@@ -47,7 +47,7 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
     /** True for an external variable declaration ({@code declare variable $x external [:= ...]}). When
      *  it carries a default value, eval() prefers a value supplied by the external environment over
      *  that default, per XQuery 3.1 §4.15. */
-    private boolean external = false;
+    private boolean isExternal = false;
 
     public VariableDeclaration(final XQueryContext context, final QName qname, final Expression expr) {
         super(context);
@@ -66,7 +66,7 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
      * @param external whether this declaration is external
      */
     public void setExternal(final boolean external) {
-        this.external = external;
+        this.isExternal = external;
     }
 
     /**
@@ -171,7 +171,7 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
                     // An external variable declared *with* a default value: a value supplied by the
                     // external environment takes precedence over the default (XQuery 3.1 §4.15). A
                     // plain (non-external) global declaration always evaluates its expression.
-                    final Variable supplied = external && myModule == null
+                    final Variable supplied = isExternal && myModule == null
                             ? suppliedExternalValue() : null;
                     if (supplied != null) {
                         supplied.setSequenceType(sequenceType);

--- a/exist-core/src/test/java/org/exist/xquery/ExternalVariableDefaultOverrideTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ExternalVariableDefaultOverrideTest.java
@@ -29,6 +29,7 @@ import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XQueryService;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * A value supplied for an external variable by the external environment must take precedence over the
@@ -74,7 +75,7 @@ public class ExternalVariableDefaultOverrideTest {
         final XQueryService service = server.getRoot().getService(XQueryService.class);
         try {
             service.query("declare variable $required external; $required");
-            org.junit.Assert.fail("expected XPDY0002 for an unbound external variable with no default");
+            fail("expected XPDY0002 for an unbound external variable with no default");
         } catch (final XMLDBException expected) {
             // XPDY0002: no value specified for external variable
         }

--- a/exist-core/src/test/java/org/exist/xquery/ExternalVariableDefaultOverrideTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ExternalVariableDefaultOverrideTest.java
@@ -1,0 +1,90 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A value supplied for an external variable by the external environment must take precedence over the
+ * variable's declared default value (XQuery 3.1 §4.15 External Variables). Previously eXist always
+ * evaluated the default for an {@code external := ...} declaration, ignoring a supplied value.
+ */
+public class ExternalVariableDefaultOverrideTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer server = new ExistXmldbEmbeddedServer(false, true, true);
+
+    @Test
+    public void suppliedValueOverridesDefault() throws XMLDBException {
+        final XQueryService service = server.getRoot().getService(XQueryService.class);
+        service.declareVariable("greeting", "supplied");
+        final ResourceSet result = service.query(
+                "declare variable $greeting external := 'default'; $greeting");
+        assertEquals(1, result.getSize());
+        assertEquals("supplied", result.getResource(0).getContent());
+    }
+
+    @Test
+    public void typedSuppliedValueOverridesDefault() throws XMLDBException {
+        final XQueryService service = server.getRoot().getService(XQueryService.class);
+        service.declareVariable("n", 21);
+        final ResourceSet result = service.query(
+                "declare variable $n as xs:integer external := 0; $n * 2");
+        assertEquals(1, result.getSize());
+        assertEquals("42", result.getResource(0).getContent());
+    }
+
+    @Test
+    public void defaultUsedWhenNotSupplied() throws XMLDBException {
+        final XQueryService service = server.getRoot().getService(XQueryService.class);
+        final ResourceSet result = service.query(
+                "declare variable $absent external := 'default'; $absent");
+        assertEquals(1, result.getSize());
+        assertEquals("default", result.getResource(0).getContent());
+    }
+
+    @Test
+    public void missingRequiredExternalStillErrors() throws XMLDBException {
+        final XQueryService service = server.getRoot().getService(XQueryService.class);
+        try {
+            service.query("declare variable $required external; $required");
+            org.junit.Assert.fail("expected XPDY0002 for an unbound external variable with no default");
+        } catch (final XMLDBException expected) {
+            // XPDY0002: no value specified for external variable
+        }
+    }
+
+    @Test
+    public void plainGlobalInitializerUnaffected() throws XMLDBException {
+        final XQueryService service = server.getRoot().getService(XQueryService.class);
+        final ResourceSet result = service.query("declare variable $x := 'internal'; $x");
+        assertEquals(1, result.getSize());
+        assertEquals("internal", result.getResource(0).getContent());
+    }
+}


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## What & why

A value supplied for an external variable by the external environment should take precedence over the variable's declared default value (XQuery 3.1 [§4.15 External Variables](https://www.w3.org/TR/xquery-31/#id-external-variables): *"If a value is supplied by the external environment for an external variable, that value is used; otherwise, if a default value is specified, the default is used."*).

eXist evaluated the default **unconditionally** for a `declare variable $x external := …` declaration, so a value bound before execution — via `XQueryContext.declareVariable` (the XMLDB `XQueryService.declareVariable`, `util:eval`'s external-variables argument, REST/API callers, etc.) — was silently ignored whenever the declaration carried a default. Only externals *without* a default honored a supplied value.

```xquery
(: with $greeting bound to "supplied" by the caller :)
declare variable $greeting external := "default";
$greeting
(: before: "default"   after: "supplied" :)
```

## How

`VariableDeclaration` was constructed identically for a plain internal global (`declare variable $x := …`) and an external-with-default (`declare variable $x external := …`), so `eval()` couldn't tell them apart and always evaluated the initializer.

- The tree parser (`XQueryTree.g`) now marks the declaration as external via a new `VariableDeclaration.setExternal(true)`.
- `VariableDeclaration.eval()`: for an external declaration with a default, it first checks whether a value was already supplied (a non-null global value bound before execution) and, if so, uses it (applying the declared sequence type) instead of evaluating the default.

Behavior is unchanged for: non-external globals (always evaluate their initializer), external variables without a default, and defaulted externals with no supplied value.

## Test plan

- New `ExternalVariableDefaultOverrideTest` (exist-core), 5 cases, all green locally:
  - supplied value overrides default; typed supplied value (`xs:integer` 21 → 42) overrides default; default used when not supplied; missing required external still raises `XPDY0002`; a plain internal global with an initializer is unaffected.
- Requesting the full CI suite for regression coverage across the XQuery prolog/variable paths.

## Motivation

Enables parameterized server-side queries (binding `$param` values at call time) over HTTP — e.g. an editor running a stored `.xq` against the database the way `basex -bname=value` does — without forcing query authors to drop default values from their external-variable declarations.
