### PR TITLE
Improve function resolution

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3506,16 +3506,7 @@ throws PermissionDeniedException, EXistException, XPathException
         )*
     )
     {
-        step = FunctionFactory.createFunction(context, fn, path, params);
-        if (isPartial) {
-            if (!(step instanceof FunctionCall)) {
-                if (step instanceof CastExpression) {
-                    step = ((CastExpression)step).toFunction();
-                }
-                step = FunctionFactory.wrap(context, (Function)step);
-            }
-            step = new PartialFunctionApplication(context, (FunctionCall) step);
-        }
+        step = FunctionFactory.createFunctionCall(context, fn, path, params, isPartial);
     }
     ;
 

--- a/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
@@ -49,13 +49,6 @@ public abstract class AbstractInternalModule implements InternalModule {
     protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
     private final Map<String, List<?>> parameters;
 
-    public static class FunctionComparator implements Comparator<FunctionDef> {
-        @Override
-        public int compare(final FunctionDef o1, final FunctionDef o2) {
-            return o1.getSignature().getFunctionId().compareTo(o2.getSignature().getFunctionId());
-        }
-    }
-
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters) {
         // Defensive-copy + sort so the caller's static final array is left intact
         // and getFunctionDef() can binary-search regardless of declaration order.
@@ -78,12 +71,11 @@ public abstract class AbstractInternalModule implements InternalModule {
      * eXist 7 without source changes; call sites should migrate to
      * {@link #AbstractInternalModule(FunctionDef[], Map)}.
      *
-     * @param functions         the array of functions
-     * @param parameters        configuration parameters
-     * @param functionsOrdered  ignored as of #6378
-     *
+     * @param functions        the array of functions
+     * @param parameters       configuration parameters
+     * @param functionsOrdered ignored as of #6378
      * @deprecated since 7.0.0; the {@code functionsOrdered} parameter has no effect.
-     *             Use {@link #AbstractInternalModule(FunctionDef[], Map)}.
+     * Use {@link #AbstractInternalModule(FunctionDef[], Map)}.
      */
     @Deprecated(since = "7.0.0", forRemoval = true)
     public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters,
@@ -100,7 +92,7 @@ public abstract class AbstractInternalModule implements InternalModule {
      * Get a parameter.
      *
      * @param paramName the name of the parameter
-     * @return the value of tyhe parameter
+     * @return the value of type parameter
      */
     protected List<?> getParameter(final String paramName) {
         return parameters.get(paramName);
@@ -142,6 +134,7 @@ public abstract class AbstractInternalModule implements InternalModule {
         return binarySearch(new FunctionId(qname, arity));
     }
 
+    @Nullable
     private FunctionDef binarySearch(final FunctionId id) {
         int low = 0;
         int high = mFunctions.length - 1;
@@ -163,16 +156,17 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     @Override
     public List<FunctionSignature> getFunctionsByName(final QName qname) {
-        final List<FunctionSignature> funcs = new ArrayList<>();
+        final List<FunctionSignature> matchingFunctions = new ArrayList<>();
         for (FunctionDef mFunction : mFunctions) {
             final FunctionSignature sig = mFunction.getSignature();
             if (sig.getName().compareTo(qname) == 0) {
-                funcs.add(sig);
+                matchingFunctions.add(sig);
             }
         }
-        return funcs;
+        return matchingFunctions;
     }
 
+    @Override
     public Iterator<QName> getGlobalVariables() {
         return mGlobalVariables.keySet().iterator();
     }
@@ -228,7 +222,7 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     @Override
     @Nullable
-    public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) throws XPathException {
+    public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) {
         return mGlobalVariables.get(qname);
     }
 
@@ -249,6 +243,13 @@ public abstract class AbstractInternalModule implements InternalModule {
 
         if (!keepGlobals) {
             mGlobalVariables.clear();
+        }
+    }
+
+    public static class FunctionComparator implements Comparator<FunctionDef> {
+        @Override
+        public int compare(final FunctionDef o1, final FunctionDef o2) {
+            return o1.getSignature().getFunctionId().compareTo(o2.getSignature().getFunctionId());
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -70,7 +70,7 @@ public class ArrowOperator extends AbstractExpression {
 
     @Override
     public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
-        if(getContext().getXQueryVersion() < 31) {
+        if (getContext().getXQueryVersion() < 31) {
             throw new XPathException(this,
                 ErrorCodes.EXXQDY0003,
                 "arrow operator is not available before XQuery 3.1");
@@ -84,16 +84,24 @@ public class ArrowOperator extends AbstractExpression {
             return;
         }
 
-        // Statically-named function: compile the arrow to the equivalent call
-        // f(leftExpr, parameters...), exactly as the parser builds a normal function call (the
-        // functionCall rule in XQueryTree.g). The left-hand side becomes a real argument
-        // expression — so it keeps its static context (fixing the lost-variable-scope bug, e.g.
-        // EXPR => util:eval()) — and a '?' placeholder yields a partial function application
-        // (fixing the placeholder arity bug). This replaces the previous dynamic FunctionReference
-        // dispatch, which pre-evaluated the left-hand side and modelled it as a placeholder.
+        namedCall = getNamedFunctionCall();
+        namedCall.analyze(contextInfo);
+    }
+
+    /**
+     * Statically-named function: compile the arrow to the equivalent call f(leftExpr, parameters...),
+     * exactly as the parser builds a normal function call (the functionCall rule in XQueryTree.g).
+     * The left-hand side becomes a real argument expression
+     * — so it keeps its static context (fixing the lost-variable-scope bug, e.g. EXPR => util:eval())
+     * — and a '?' placeholder yields a partial function application (fixing the placeholder arity bug).
+     * This replaces the previous dynamic FunctionReference dispatch, which pre-evaluated the left-hand side and
+     * modeled it as a placeholder.
+     */
+    private Expression getNamedFunctionCall() throws XPathException {
         final XQueryAST ast = new XQueryAST();
         ast.setLine(getLine());
         ast.setColumn(getColumn());
+
         final List<Expression> callArgs = new ArrayList<>(parameters.size() + 1);
         callArgs.add(toArgument(leftExpr));
         boolean partial = false;
@@ -105,20 +113,22 @@ public class ArrowOperator extends AbstractExpression {
                 callArgs.add(toArgument(param));
             }
         }
+
         Expression call = FunctionFactory.createFunction(context, qname, ast, null, callArgs);
         if (partial) {
             // mirror the functionCall rule: a '?' placeholder turns the call into a partial
             // function application yielding a function item of the remaining arity.
             if (!(call instanceof FunctionCall)) {
+                // => xs:string(?) is treated as a cast expression
                 if (call instanceof CastExpression) {
                     call = ((CastExpression) call).toFunction();
                 }
                 call = FunctionFactory.wrap(context, (Function) call);
             }
-            call = new PartialFunctionApplication(context, (FunctionCall) call);
+            return new PartialFunctionApplication(context, (FunctionCall) call);
         }
-        namedCall = call;
-        namedCall.analyze(contextInfo);
+
+        return call;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -77,8 +77,7 @@ public class ArrowOperator extends AbstractExpression {
         }
         this.cachedContextInfo = contextInfo;
         if (qname == null) {
-            // Dynamic (higher-order) right-hand side: analyze the operands as they are. The function
-            // to call is resolved at evaluation time by evaluating funcSpec.
+            // The function call on the right hand side is resolved at evaluation time by evaluating funcSpec.
             leftExpr.analyze(contextInfo);
             funcSpec.analyze(contextInfo);
             return;
@@ -114,21 +113,7 @@ public class ArrowOperator extends AbstractExpression {
             }
         }
 
-        Expression call = FunctionFactory.createFunction(context, qname, ast, null, callArgs);
-        if (partial) {
-            // mirror the functionCall rule: a '?' placeholder turns the call into a partial
-            // function application yielding a function item of the remaining arity.
-            if (!(call instanceof FunctionCall)) {
-                // => xs:string(?) is treated as a cast expression
-                if (call instanceof CastExpression) {
-                    call = ((CastExpression) call).toFunction();
-                }
-                call = FunctionFactory.wrap(context, (Function) call);
-            }
-            return new PartialFunctionApplication(context, (FunctionCall) call);
-        }
-
-        return call;
+        return FunctionFactory.createFunctionCall(context, qname, ast, null, callArgs, partial);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/ExternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExternalModule.java
@@ -30,88 +30,90 @@ import java.util.Map;
 /**
  * An external library module implemented in XQuery and loaded
  * through the "import module" directive.
- * 
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
 public interface ExternalModule extends Module {
 
-    public void setNamespace(String prefix, String namespace);
+    void setNamespace(String prefix, String namespace);
 
-    public void setDescription(String desc);
+    void setDescription(String desc);
 
-    public void addMetadata(String key, String value);
+    void addMetadata(String key, String value);
 
-    public Map<String, String> getMetadata();
+    Map<String, String> getMetadata();
 
     /**
      * Declare a new function. Called by the XQuery compiler
      * when parsing a library module for every function declaration.
-     * 
+     *
      * @param func the function to add
      */
-    public void declareFunction(UserDefinedFunction func) throws XPathException;
+    void declareFunction(UserDefinedFunction func) throws XPathException;
 
     /**
      * Try to find the function identified by qname. Returns null
      * if the function is undefined.
-     * 
-     * @param qname the name of the function to look for
-     * @param arity arity of the function to look for
+     *
+     * @param qname         the name of the function to look for
+     * @param arity         arity of the function to look for
      * @param callerContext context of the caller - needed to check if
      *                      found function should be visible
-     * @throws XPathException in case of a dynamic error
      * @return the function found
+     * @throws XPathException in case of a dynamic error
      */
-    public UserDefinedFunction getFunction(QName qname, int arity, XQueryContext callerContext) throws XPathException;
+    UserDefinedFunction getFunction(QName qname, int arity, XQueryContext callerContext) throws XPathException;
 
-    public void declareVariable(QName qname, VariableDeclaration decl) throws XPathException;
+    void declareVariable(QName qname, VariableDeclaration decl) throws XPathException;
 
     /**
      * Analyze declared variables. Needs to be called when the module was imported dynamically.
      *
      * @throws XPathException in case of static errors
      */
-    public void analyzeGlobalVars() throws XPathException;
+    void analyzeGlobalVars() throws XPathException;
 
-    public Collection<VariableDeclaration> getVariableDeclarations();
+    Collection<VariableDeclaration> getVariableDeclarations();
 
     /**
      * Get the source object this module has been read from.
-     *
+     * <p>
      * This is required for query access control.
+     *
      * @return The source object this module has been read from.
      */
-    public Source getSource();
+    Source getSource();
 
     /**
      * Set the source object this module has been read from.
-     * 
+     * <p>
      * This is required to check the validity of a compiled expression.
+     *
      * @param source the source instance
      */
-    public void setSource(Source source);
+    void setSource(Source source);
 
-    public XQueryContext getContext();
+    XQueryContext getContext();
 
     /**
      * Set the XQueryContext of this module. This will be a sub-context
-     * of the main context as parts of the static context are shared. 
-     * 
+     * of the main context as parts of the static context are shared.
+     *
      * @param context the context to set
      */
-    public void setContext(XQueryContext context);
+    void setContext(XQueryContext context);
 
     /**
      * Is this module still valid or should it be reloaded from its source?
      *
      * @return true if module should be reloaded
      */
-    public boolean moduleIsValid();
+    boolean moduleIsValid();
 
     /**
      * Returns the root expression associated with this context.
      *
-     * @return  root expression
+     * @return root expression
      */
-    public Expression getRootExpression();
+    Expression getRootExpression();
 }

--- a/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
@@ -31,34 +31,32 @@ import javax.annotation.Nullable;
 
 /**
  * Default implementation of an {@link org.exist.xquery.ExternalModule}.
- * 
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
 public class ExternalModuleImpl implements ExternalModule {
 
-    private String mNamespaceURI;
-    private String mPrefix;
-
-    private String description = "User Defined Module";
-    private Map<String, String> metadata = null;
-
-    private boolean isReady = false;
-
     final private TreeMap<FunctionId, UserDefinedFunction> mFunctionMap = new TreeMap<>();
     final private TreeMap<QName, VariableDeclaration> mGlobalVariables = new TreeMap<>();
     final private TreeMap<QName, Variable> mStaticVariables = new TreeMap<>();
-
+    private String mNamespaceURI;
+    private String mPrefix;
+    private String description = "User Defined Module";
+    private Map<String, String> metadata = null;
+    private boolean isReady = false;
     private Source mSource = null;
 
     private XQueryContext mContext = null;
 
     private boolean needsReset = true;
+    private Expression rootExpression = null;
 
     public ExternalModuleImpl(String namespaceURI, String prefix) {
         mNamespaceURI = namespaceURI;
         mPrefix = prefix;
     }
 
+    @Override
     public void setNamespace(String prefix, String namespace) {
         this.mPrefix = prefix;
         this.mNamespaceURI = namespace;
@@ -73,21 +71,22 @@ public class ExternalModuleImpl implements ExternalModule {
         this.isReady = ready;
     }
 
+    @Override
     public boolean isReady() {
         return isReady;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getDescription()
-     */
+    @Override
     public String getDescription() {
         return description;
     }
 
+    @Override
     public void setDescription(String desc) {
         this.description = desc;
     }
 
+    @Override
     public void addMetadata(String key, String value) {
         if (metadata == null) {
             metadata = new HashMap<>();
@@ -99,66 +98,57 @@ public class ExternalModuleImpl implements ExternalModule {
         metadata.put(key, value);
     }
 
+    @Override
     public Map<String, String> getMetadata() {
         return metadata;
     }
 
-    /* (non-Javadoc)
-    * @see org.exist.xquery.Module#getReleaseVersion()
-    */
+    @Override
     public String getReleaseVersion() {
         return "user-defined";
     }
 
-    public UserDefinedFunction getFunction(QName qname, int arity, XQueryContext callerContext) 
-    throws XPathException {
+    @Override
+    public UserDefinedFunction getFunction(QName qname, int arity, XQueryContext callerContext)
+            throws XPathException {
         final FunctionId id = new FunctionId(qname, arity);
         final UserDefinedFunction fn = mFunctionMap.get(id);
-        if (fn == null)
-        	{return null;}
+        if (fn == null) {
+            return null;
+        }
         if (callerContext != getContext() && fn.getSignature().isPrivate()) {
-        	throw new XPathException(fn, ErrorCodes.XPST0017, "Calling a private function from outside its module");
+            throw new XPathException(fn, ErrorCodes.XPST0017, "Calling a private function from outside its module");
         }
         return fn;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.ExternalModule#declareFunction(org.exist.xquery.UserDefinedFunction)
-     */
+    @Override
     public void declareFunction(UserDefinedFunction func) throws XPathException {
         final QName name = func.getSignature().getName();
         if (!name.getNamespaceURI().equals(getNamespaceURI())) {
             throw new XPathException(func, ErrorCodes.XQST0048,
-                "It is a static error if a function or variable declared in a library module" +
-                " is not in the target namespace of the library module: " + name);
+                    "It is a static error if a function or variable declared in a library module" +
+                            " is not in the target namespace of the library module: " + name);
         }
         mFunctionMap.put(func.getSignature().getFunctionId(), func);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getNamespaceURI()
-     */
+    @Override
     public String getNamespaceURI() {
         return mNamespaceURI;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getDefaultPrefix()
-     */
+    @Override
     public String getDefaultPrefix() {
         return mPrefix;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#isInternalModule()
-     */
+    @Override
     public boolean isInternalModule() {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#listFunctions()
-     */
+    @Override
     public FunctionSignature[] listFunctions() {
         final List<FunctionSignature> signatures = new ArrayList<>(mFunctionMap.size());
         for (UserDefinedFunction userDefinedFunction : mFunctionMap.values()) {
@@ -169,14 +159,13 @@ public class ExternalModuleImpl implements ExternalModule {
         return signatures.toArray(result);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getSignatureForFunction(org.exist.dom.QName)
-     */
+    @Override
     public Iterator<FunctionSignature> getSignaturesForFunction(QName qname) {
         final ArrayList<FunctionSignature> signatures = new ArrayList<>(2);
         for (final UserDefinedFunction func : mFunctionMap.values()) {
-            if (func.getName().compareTo(qname) == 0)
-                {signatures.add(func.getSignature());}
+            if (func.getName().compareTo(qname) == 0) {
+                signatures.add(func.getSignature());
+            }
         }
         return signatures.iterator();
     }
@@ -193,18 +182,17 @@ public class ExternalModuleImpl implements ExternalModule {
         return matchingFunctions;
     }
 
-
+    @Override
     public Iterator<QName> getGlobalVariables() {
         return mGlobalVariables.keySet().iterator();
     }
 
+    @Override
     public Collection<VariableDeclaration> getVariableDeclarations() {
         return mGlobalVariables.values();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#declareVariable(org.exist.dom.QName, java.lang.Object)
-     */
+    @Override
     public Variable declareVariable(QName qname, Object value) throws XPathException {
         final Sequence val = XPathUtil.javaObjectToXPath(value, mContext, null);
         Variable var = mStaticVariables.computeIfAbsent(qname, VariableImpl::new);
@@ -212,32 +200,39 @@ public class ExternalModuleImpl implements ExternalModule {
         return var;
     }
 
+    @Override
     public Variable declareVariable(Variable var) {
         mStaticVariables.put(var.getQName(), var);
         return var;
     }
 
+    @Override
     public void declareVariable(QName qname, VariableDeclaration decl) throws XPathException {
-        if (!qname.getNamespaceURI().equals(getNamespaceURI()))
-            {throw new XPathException(decl, ErrorCodes.XQST0048, "It is a static error" +
-                " if a function or variable declared in a library module is" + 
-                " not in the target namespace of the library module.");}
+        if (!qname.getNamespaceURI().equals(getNamespaceURI())) {
+            throw new XPathException(decl, ErrorCodes.XQST0048, "It is a static error" +
+                    " if a function or variable declared in a library module is" +
+                    " not in the target namespace of the library module.");
+        }
         mGlobalVariables.put(qname, decl);
     }
 
+    @Override
     public boolean isVarDeclared(QName qname) {
-        if (mGlobalVariables.get(qname) != null)
-            {return true;}
+        if (mGlobalVariables.get(qname) != null) {
+            return true;
+        }
         return mStaticVariables.get(qname) != null;
     }
 
     @Override
-    @Nullable public Variable resolveVariable(final QName qname) throws XPathException {
+    @Nullable
+    public Variable resolveVariable(final QName qname) throws XPathException {
         return resolveVariable(null, qname);
     }
 
     @Override
-    @Nullable public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) throws XPathException {
+    @Nullable
+    public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) throws XPathException {
         final VariableDeclaration decl = mGlobalVariables.get(qname);
         Variable var = mStaticVariables.get(qname);
         if (isReady && decl != null && (var == null || var.getValue() == null)) {
@@ -268,26 +263,31 @@ public class ExternalModuleImpl implements ExternalModule {
         return var;
     }
 
+    @Override
     public void analyzeGlobalVars() throws XPathException {
         for (final VariableDeclaration decl : mGlobalVariables.values()) {
             decl.analyzeExpression(new AnalyzeContextInfo());
         }
     }
 
+    @Override
     public Source getSource() {
         return mSource;
     }
 
+    @Override
     public void setSource(Source source) {
         mSource = source;
     }
 
-    public void setContext(XQueryContext context) {
-        mContext = context;
-    }
-
+    @Override
     public XQueryContext getContext() {
         return mContext;
+    }
+
+    @Override
+    public void setContext(XQueryContext context) {
+        mContext = context;
     }
 
     @Override
@@ -300,6 +300,7 @@ public class ExternalModuleImpl implements ExternalModule {
         // deprecated, ignore
     }
 
+    @Override
     public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
         // prevent recursive calls by checking needsReset
         if (needsReset) {
@@ -314,23 +315,22 @@ public class ExternalModuleImpl implements ExternalModule {
         }
     }
 
-    private Expression rootExpression = null;
+    /**
+     * Returns the root expression associated with this context.
+     *
+     * @return root expression
+     */
+    @Override
+    public Expression getRootExpression() {
+        return rootExpression;
+    }
 
     /**
      * Set the root expression for this context.
      *
-     * @param  expr the root expression
+     * @param expr the root expression
      */
     protected void setRootExpression(Expression expr) {
         rootExpression = expr;
-    }
-
-    /**
-     * Returns the root expression associated with this context.
-     *
-     * @return  root expression
-     */
-    public Expression getRootExpression() {
-        return  rootExpression;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
@@ -181,6 +181,19 @@ public class ExternalModuleImpl implements ExternalModule {
         return signatures.iterator();
     }
 
+    @Override
+    public List<FunctionSignature> getFunctionsByName(final QName qname) {
+        final List<FunctionSignature> matchingFunctions = new ArrayList<>();
+        for (final UserDefinedFunction func : mFunctionMap.values()) {
+            final FunctionSignature sig = func.getSignature();
+            if (sig.getName().compareTo(qname) == 0) {
+                matchingFunctions.add(sig);
+            }
+        }
+        return matchingFunctions;
+    }
+
+
     public Iterator<QName> getGlobalVariables() {
         return mGlobalVariables.keySet().iterator();
     }

--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -22,7 +22,10 @@
 package org.exist.xquery;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.dom.QName;
@@ -214,8 +217,7 @@ public abstract class Function extends PathExpr {
     public void setArguments(final List<Expression> arguments) throws XPathException {
         if ((!mySignature.isVariadic()) && arguments.size() != mySignature.getArgumentCount()) {
             throw new XPathException(this, ErrorCodes.XPST0017,
-                    "Number of arguments of function " + getName() + " doesn't match function signature (expected "
-                            + mySignature.getArgumentCount() + ", got " + arguments.size() + ')');
+                    functionNotFoundErrorDescription(context, mySignature.getName(), mySignature.getArgumentCount()));
         }
         steps.clear();
 
@@ -622,4 +624,48 @@ public abstract class Function extends PathExpr {
             return Type.ITEM;
         }
     }
+
+    /**
+     * Raise an error with an actionable description for a function that could not be resolved
+     * Checks if a function with the same name exists at other arities
+     *
+     * @param callContext XQueryContext in which to resolve function name
+     * @param qname the function name
+     * @param argumentCount the number of arguments this function is called with
+     */
+    public static String functionNotFoundErrorDescription(final XQueryContext callContext, final QName qname, final int argumentCount) {
+        final String uri = qname.getNamespaceURI();
+
+        // Check local declared functions
+        final Iterator<FunctionSignature> localSigs = callContext.getSignaturesForFunction(qname);
+
+        // Also check external modules
+        final List<FunctionSignature> allSignatures = new ArrayList<>();
+        while (localSigs.hasNext()) {
+            allSignatures.add(localSigs.next());
+        }
+
+        final Module[] modules = callContext.getModules(uri);
+        if (modules != null) {
+            for (final Module module : modules) {
+                allSignatures.addAll(module.getFunctionsByName(qname));
+            }
+        }
+
+        if (allSignatures.isEmpty()) {
+            return "Function " + qname.getStringValue() + "() is not defined in module namespace: " + uri;
+        }
+
+        return String.format("""
+            Unexpectedly received %d parameter(s) in call to function '%s()'.
+            Defined function signatures are:
+            %s
+            in module namespace: %s""",
+                argumentCount,
+                qname.getStringValue(),
+                allSignatures.stream().map(FunctionSignature::toString).collect(Collectors.joining("\n")),
+                uri
+        );
+    }
+
 }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -291,11 +291,11 @@ public class FunctionFactory {
 
     private static JavaCall javaFunctionBinding(XQueryContext context,
             XQueryAST ast, List<Expression> params, QName qname) throws XPathException {
-        //Only allow java binding if specified in config file <xquery enable-java-binding="yes">
-        final String javabinding = (String) context.getBroker().getConfiguration()
+        // Only allow java binding if specified in config file <xquery enable-java-binding="yes">
+        final String javaBinding = (String) context.getBroker().getConfiguration()
             .getProperty(PROPERTY_ENABLE_JAVA_BINDING);
-        if(javabinding == null || !"yes".equals(javabinding)) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
+        if (!"yes".equals(javaBinding)) {
+            throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017,
                 "Java binding is disabled in the current configuration (see conf.xml)." +
                 " Call to " + qname.getStringValue() + " denied.");
         }
@@ -307,45 +307,45 @@ public class FunctionFactory {
 
     private static Function functionCall(final XQueryContext context,
             final XQueryAST ast, final List<Expression> params, final QName qname) throws XPathException {
-        Function fn = null;
+
         final String uri = qname.getNamespaceURI();
         final Module[] modules = context.getModules(uri);
-        if (modules != null) {
-            // Function might belongs to a module
-            for (int i = 0; i < modules.length; i++) {
-                final Module module = modules[i];
-                final boolean throwOnNotFound = i == modules.length - 1;
-                if (module.isInternalModule()) {
-                    // Function is from an Internal Module
-                    fn = getInternalModuleFunction(context, ast, params, qname, module, throwOnNotFound);
-                } else {
-                    // Function is from an imported XQuery module
-                    fn = getXQueryModuleFunction(context, ast, params, qname, module, throwOnNotFound);
-                }
 
-                if (fn != null) {
-                    break;
-                }
+        if (modules == null) {
+            return getUserDefinedFunction(context, ast, params, qname);
+        }
+
+        // Function might belong to a module
+        for (final Module module : modules) {
+            final Function fn;
+
+            if (module.isInternalModule()) {
+                // Function is from an Internal Module
+                fn = getInternalModuleFunction(context, ast, params, qname, module, false);
+            } else {
+                // Function is from an imported XQuery module
+                fn = getXQueryModuleFunction(context, ast, params, qname, module, false);
+            }
+            // return early on first match
+            if (fn != null) {
+                return fn;
             }
         }
 
-        if (fn == null) {
-            // Function is a user-defined XQuery function in the same module as the caller
-            fn = getUserDefinedFunction(context, ast, params, qname);
-        }
-
-        return fn;
+        throw new XPathException(ast.getLine(), ast.getColumn(),
+                ErrorCodes.XPST0017, "Function " + qname.getStringValue() + "() " +
+                " is not defined in module namespace: " + qname.getNamespaceURI());
     }
 
     /**
-     * Gets a Java function from an Java XQuery Extension Module
+     * Get a function implemented in Java from an XQuery Extension Module
      *
      * @param throwOnNotFound true to throw an XPST0017 if the functions is not found, false to just return null
      */
     private static @Nullable Function getInternalModuleFunction(final XQueryContext context,
             final XQueryAST ast, final List<Expression> params, QName qname, Module module,
             final boolean throwOnNotFound) throws XPathException {
-        //For internal modules: create a new function instance from the class
+        // For internal modules: create a new function instance from the class
         FunctionDef def = ((InternalModule) module).getFunctionDef(qname, params.size());
         //TODO: rethink: xsl namespace function should search xpath one too
         if (def == null && Namespaces.XSL_NS.equals(qname.getNamespaceURI())) {
@@ -404,22 +404,23 @@ public class FunctionFactory {
     }
 
     /**
-     * Gets an user defined function from the XQuery
+     * Get a user-defined function from the XQuery context
      */
     private static FunctionCall getUserDefinedFunction(XQueryContext context, XQueryAST ast, List<Expression> params, QName qname) throws XPathException {
-        final FunctionCall fc;
         final UserDefinedFunction func = context.resolveFunction(qname, params.size());
-        if (func != null) {
-            fc = new FunctionCall(context, func);
-            fc.setLocation(ast.getLine(), ast.getColumn());
-            fc.setArguments(params);
-        } else {
-            //Create a forward reference which will be resolved later
-            fc = new FunctionCall(context, qname, params);
-            fc.setLocation(ast.getLine(), ast.getColumn());
-            context.addForwardReference(fc);
+
+        if (func == null) {
+            // Create a forward reference which will be resolved later
+            final FunctionCall forwardReference = new FunctionCall(context, qname, params);
+            forwardReference.setLocation(ast.getLine(), ast.getColumn());
+            context.addForwardReference(forwardReference);
+            return forwardReference;
         }
-        return fc;
+
+        final FunctionCall functionCall = new FunctionCall(context, func);
+        functionCall.setLocation(ast.getLine(), ast.getColumn());
+        functionCall.setArguments(params);
+        return functionCall;
     }
 
     /**
@@ -478,7 +479,7 @@ public class FunctionFactory {
             } else {
                 fc = new FunctionCall(((ExternalModule) module).getContext(), qname, params);
                 fc.setLocation(ast.getLine(), ast.getColumn());
-                if(((ExternalModule) module).getContext() == context) {
+                if (((ExternalModule) module).getContext() == context) {
                     context.addForwardReference(fc);
                 } else {
                     context.getRootContext().addForwardReference(fc);
@@ -495,7 +496,7 @@ public class FunctionFactory {
     /**
      * Wrap a function call into a user defined function.
      * This is used to handle dynamic function calls or partial
-     * function applications on built in functions.
+     * function applications on built-in functions.
      * 
      * @param context current context
      * @param call the function call to be wrapped

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -158,11 +158,20 @@ public class FunctionFactory {
         final String uri = qname.getNamespaceURI();
 
         if (optimizeStringFunctions && (Namespaces.XPATH_FUNCTIONS_NS.equals(uri) || Namespaces.XSL_NS.equals(uri))) {
-            return switch (local)  {
-                case "starts-with" -> startsWith(context, ast, parent, params);
-                case "ends-with" -> endsWith(context, ast, parent, params);
-                case "contains" -> contains(context, ast, parent, params);
-                case "equals" -> equals(context, ast, parent, params);
+            return switch (local) {
+                case "starts-with" ->
+                        optimizeStringFunction(context, ast, parent, params, "starts-with", StringTruncationOperator.RIGHT);
+                case "ends-with" ->
+                        optimizeStringFunction(context, ast, parent, params, "ends-with", StringTruncationOperator.LEFT);
+                case "contains" ->
+                        optimizeStringFunction(context, ast, parent, params, "contains", StringTruncationOperator.BOTH);
+                case "equals" -> {
+                    final GeneralComparison op = optimizeStringFunction(context, ast, parent, params, "equals", StringTruncationOperator.EQUALS);
+                    if (params.size() < 3) {
+                        op.setCollation(new StringValue("?strength=identical"));
+                    }
+                    yield op;
+                }
                 default -> functionCall(context, ast, params, qname);
             };
         }
@@ -185,127 +194,47 @@ public class FunctionFactory {
     }
 
     /**
-     * starts-with(node-set, string)
+     * Optimize a function call that compares strings into a general comparison
+     *
+     * @param context      The XQuery context
+     * @param ast          The parsed AST
+     * @param parent       The parent expression
+     * @param params       The list of parameters
+     * @param functionName The name of the function to optimize
+     * @param operator     The StringTruncationOperator to optimize with
+     * @return The optimized GeneralComparison
+     * @throws XPathException If the provided parameters are incorrect
      */
-    private static GeneralComparison startsWith(XQueryContext context,
-            XQueryAST ast, PathExpr parent, List<Expression> params) throws XPathException {
-        if (params.size() < 2) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function starts-with() requires two or three arguments");
+    private static GeneralComparison optimizeStringFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params,
+            final String functionName,
+            final StringTruncationOperator operator
+    ) throws XPathException {
+        if (params.size() < 2 || params.size() > 3) {
+            throw new XPathException(ast,
+                    ErrorCodes.XPST0017, "Function " + functionName + "() requires two or three arguments");
         }
-        if (params.size() > 3) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function starts-with() requires two or three arguments");
-        }
-        final PathExpr p0 = (PathExpr) params.getFirst();
-        final PathExpr p1 = (PathExpr) params.get(1);
-        if (p1.getLength() == 0) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                "Second argument of starts-with() is empty");
-        }
-        final GeneralComparison op = new GeneralComparison(context, p0, p1,
-            Comparison.EQ, StringTruncationOperator.RIGHT);
-        op.setLocation(ast.getLine(), ast.getColumn());
-        //TODO : not sure for parent -pb
-        context.getProfiler().message(parent, Profiler.OPTIMIZATIONS,
-                "OPTIMIZATION", "Rewritten start-with as a general comparison with a right truncations");
-        if (params.size() == 3) {
-            op.setCollation((Expression) params.get(2));
-        }
-        return op;
-    }
 
-    /**
-     * ends-with(node-set, string)
-     */
-    private static GeneralComparison endsWith(XQueryContext context, XQueryAST ast,
-            PathExpr parent, List<Expression> params) throws XPathException {
-        if (params.size() < 2) {
-            throw new XPathException(ast.getLine(), ast.getColumn(), 
-        		ErrorCodes.XPST0017, "Function ends-with() requires two or three arguments");
-        }
-        if (params.size() > 3) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function ends-with() requires two or three arguments");
-        }
         final PathExpr p0 = (PathExpr) params.getFirst();
         final PathExpr p1 = (PathExpr) params.get(1);
-        if (p1.getLength() == 0) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                "Second argument of ends-with() is empty");
-        }
-        final GeneralComparison op = new GeneralComparison(context, p0, p1, Comparison.EQ, StringTruncationOperator.LEFT);
-        //TODO : not sure for parent -pb
-        context.getProfiler().message(parent, Profiler.OPTIMIZATIONS,
-            "OPTIMIZATION", "Rewritten ends-with as a general comparison with a left truncations");
-        op.setLocation(ast.getLine(), ast.getColumn());
-        if(params.size() == 3) {
-            op.setCollation((Expression) params.get(2));
-        }
-        return op;
-    }
 
-    /**
-     * contains(node-set, string)
-     */
-    private static GeneralComparison contains(XQueryContext context, XQueryAST ast,
-            PathExpr parent, List<Expression> params) throws XPathException {
-        if (params.size() < 2) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function contains() requires two or three arguments");
+        if (p1.getSubExpressionCount() == 0) {
+            throw new XPathException(ast, ErrorCodes.XPTY0004, "Second argument of " + functionName + "() is empty");
         }
-        if (params.size() > 3) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function contains() requires two or three arguments");
-        }
-        final PathExpr p0 = (PathExpr) params.getFirst();
-        final PathExpr p1 = (PathExpr) params.get(1);
-        if (p1.getLength() == 0) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                "Second argument of contains() is empty");
-        }
-        final GeneralComparison op = new GeneralComparison(context, p0, p1,
-            Comparison.EQ, StringTruncationOperator.BOTH);
-        //TODO : not sure for parent -pb
-        context.getProfiler().message(parent, Profiler.OPTIMIZATIONS,
-            "OPTIMIZATION", "Rewritten contains() as a general comparison with left and right truncations");
-        op.setLocation(ast.getLine(), ast.getColumn());
-        if (params.size() == 3) {
-            op.setCollation((Expression) params.get(2));
-        }
-        return op;
-    }
 
-    /**
-     * equals(node-set, string)
-     */
-    private static GeneralComparison equals(XQueryContext context, XQueryAST ast,
-            PathExpr parent, List<Expression> params) throws XPathException {
-        if (params.size() < 2) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function equals() requires two or three arguments");
-        }
-        if (params.size() > 3) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Function equals() requires two or three arguments");
-        }
-        final PathExpr p0 = (PathExpr) params.getFirst();
-        final PathExpr p1 = (PathExpr) params.get(1);
-        if (p1.getLength() == 0) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                "Second argument of equals() is empty");
-        }
-        final GeneralComparison op = new GeneralComparison(context, p0, p1,
-            Comparison.EQ, StringTruncationOperator.EQUALS);
-        //TODO : not sure for parent -pb
-        context.getProfiler().message(parent, Profiler.OPTIMIZATIONS,
-            "OPTIMIZATION", "Rewritten contains() as a general comparison with no truncations");
+        final GeneralComparison op = new GeneralComparison(context, p0, p1, Comparison.EQ, operator);
         op.setLocation(ast.getLine(), ast.getColumn());
+        //TODO : not sure for parent -pb
+        context.getProfiler().message(parent, Profiler.OPTIMIZATIONS, "OPTIMIZATION",
+                "Rewritten " + functionName + "() as a general comparison with a right truncations");
+
         if (params.size() == 3) {
-            op.setCollation((Expression) params.get(2));
-        } else {
-            op.setCollation(new StringValue("?strength=identical"));
+            op.setCollation(params.get(2));
         }
+
         return op;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -329,7 +329,7 @@ public class FunctionFactory {
         final Module[] modules = context.getModules(uri);
 
         if (modules == null) {
-            return getUserDefinedFunction(context, ast, params, qname);
+            return getLocalDefinedFunction(context, ast, params, qname);
         }
 
         // Function might belong to a module
@@ -352,6 +352,31 @@ public class FunctionFactory {
         throw new XPathException(ast.getLine(), ast.getColumn(),
                 ErrorCodes.XPST0017, "Function " + qname.getStringValue() + "() " +
                 " is not defined in module namespace: " + qname.getNamespaceURI());
+    }
+
+    /**
+     * Get a user-defined function from the XQuery context
+     */
+    private static FunctionCall getLocalDefinedFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname
+    ) throws XPathException {
+        final UserDefinedFunction func = context.resolveFunction(qname, params.size());
+
+        if (func == null) {
+            // Create a forward reference which will be resolved later
+            final FunctionCall forwardReference = new FunctionCall(context, qname, params);
+            forwardReference.setLocation(ast.getLine(), ast.getColumn());
+            context.addForwardReference(forwardReference);
+            return forwardReference;
+        }
+
+        final FunctionCall functionCall = new FunctionCall(context, func);
+        functionCall.setLocation(ast.getLine(), ast.getColumn());
+        functionCall.setArguments(params);
+        return functionCall;
     }
 
     /**
@@ -423,31 +448,6 @@ public class FunctionFactory {
         fn.setArguments(params);
         fn.setASTNode(ast);
         return new InternalFunctionCall(fn);
-    }
-
-    /**
-     * Get a user-defined function from the XQuery context
-     */
-    private static FunctionCall getUserDefinedFunction(
-            final XQueryContext context,
-            final XQueryAST ast,
-            final List<Expression> params,
-            final QName qname
-    ) throws XPathException {
-        final UserDefinedFunction func = context.resolveFunction(qname, params.size());
-
-        if (func == null) {
-            // Create a forward reference which will be resolved later
-            final FunctionCall forwardReference = new FunctionCall(context, qname, params);
-            forwardReference.setLocation(ast.getLine(), ast.getColumn());
-            context.addForwardReference(forwardReference);
-            return forwardReference;
-        }
-
-        final FunctionCall functionCall = new FunctionCall(context, func);
-        functionCall.setLocation(ast.getLine(), ast.getColumn());
-        functionCall.setArguments(params);
-        return functionCall;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -54,40 +54,54 @@ public class FunctionFactory {
      * These names must not be used as unprefixed function calls (XPST0003).
      */
     private static final Set<String> RESERVED_FUNCTION_NAMES = Set.of(
-        "array", "attribute", "comment", "document-node", "element",
-        "function", "if", "item", "map", "namespace-node", "node",
-        "processing-instruction", "schema-attribute", "schema-element",
-        "switch", "text", "typeswitch"
+            "array", "attribute", "comment", "document-node", "element",
+            "function", "if", "item", "map", "namespace-node", "node",
+            "processing-instruction", "schema-attribute", "schema-element",
+            "switch", "text", "typeswitch"
     );
 
-    public static Expression createFunction(final XQueryContext context,final  XQueryAST ast, final PathExpr parent, final List<Expression> params) throws XPathException {
+    public static Expression createFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params
+    ) throws XPathException {
         final QName qname = getQName(context, ast);
         return createFunction(context, qname, ast, parent, params);
     }
 
-    private static QName getQName(final XQueryContext context, final XQueryAST ast) throws XPathException {
+    private static QName getQName(
+            final XQueryContext context,
+            final XQueryAST ast
+    ) throws XPathException {
         final String rawName = ast.getText();
         final QName qname;
         try {
             qname = QName.parse(context, rawName, context.getDefaultFunctionNamespace());
-        } catch(final QName.IllegalQNameException xpe) {
-            throw new XPathException(ast, ErrorCodes.XPST0081, "Invalid qname " +  rawName + ". " + xpe.getMessage());
+        } catch (final QName.IllegalQNameException xpe) {
+            throw new XPathException(ast, ErrorCodes.XPST0081, "Invalid qname " + rawName + ". " + xpe.getMessage());
         }
 
         // Check for reserved function names — unprefixed reserved names cannot be
         // used as function calls (XPST0003). Prefixed names like fn:item() are not
         // subject to the reserved name restriction (they just won't be found → XPST0017).
-        if (rawName != null && !rawName.contains(":") && !rawName.contains("{")) {
+        if (!rawName.contains(":") && !rawName.contains("{")) {
             final String local = qname.getLocalPart();
             if (RESERVED_FUNCTION_NAMES.contains(local)) {
                 throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0003,
-                    "'" + local + "' is a reserved function name and cannot be used as a function call");
+                        "'" + local + "' is a reserved function name and cannot be used as a function call");
             }
         }
         return qname;
     }
 
-    public static Expression createFunction(XQueryContext context, QName qname, XQueryAST ast, PathExpr parent, List<Expression> params) throws XPathException {
+    public static Expression createFunction(
+            final XQueryContext context,
+            final QName qname,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params
+    ) throws XPathException {
         return createFunction(context, qname, ast, parent, params, true);
     }
 
@@ -95,31 +109,44 @@ public class FunctionFactory {
      * Make sure that partially applied functions are wrapped correctly
      * the QName is read from the given AST
      *
-     * @param context the XQuery context
-     * @param ast the AST node of the function
-     * @param parent the parent expression of the function
-     * @param params the parameters to the function
+     * @param context   the XQuery context
+     * @param ast       the AST node of the function
+     * @param parent    the parent expression of the function
+     * @param params    the parameters to the function
      * @param isPartial is this a partially applied function with placeholders?
      * @return either a FunctionCall or a PartialFunctionApplication
      * @throws XPathException if an error occurs creating the function
      */
-    public static Expression createFunctionCall(final XQueryContext context, final XQueryAST ast, final PathExpr parent, final List<Expression> params, final boolean isPartial) throws XPathException {
+    public static Expression createFunctionCall(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params,
+            final boolean isPartial
+    ) throws XPathException {
         return createFunctionCall(context, getQName(context, ast), ast, parent, params, isPartial);
     }
 
     /**
      * Make sure that partially applied functions are wrapped correctly
      *
-     * @param context the XQuery context
-     * @param qname the name of the function
-     * @param ast the AST node of the function
-     * @param parent the parent expression of the function
-     * @param params the parameters to the function
+     * @param context   the XQuery context
+     * @param qname     the name of the function
+     * @param ast       the AST node of the function
+     * @param parent    the parent expression of the function
+     * @param params    the parameters to the function
      * @param isPartial is this a partially applied function with placeholders?
      * @return either a FunctionCall or a PartialFunctionApplication
      * @throws XPathException if an error occurs creating the function
      */
-    public static Expression createFunctionCall(final XQueryContext context, final QName qname, final XQueryAST ast, final PathExpr parent, final List<Expression> params, final boolean isPartial) throws XPathException {
+    public static Expression createFunctionCall(
+            final XQueryContext context,
+            final QName qname,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params,
+            final boolean isPartial
+    ) throws XPathException {
         Expression fc = createFunction(context, qname, ast, parent, params);
         if (!isPartial) {
             return fc;
@@ -141,19 +168,23 @@ public class FunctionFactory {
      * optimizes some function calls like starts-with, ends-with or
      * contains.
      *
-     * @param context the XQuery context
-     * @param qname the name of the function
-     * @param ast the AST node of the function
-     * @param parent the parent expression of the function
-     * @param params the parameters to the function
+     * @param context                 the XQuery context
+     * @param qname                   the name of the function
+     * @param ast                     the AST node of the function
+     * @param parent                  the parent expression of the function
+     * @param params                  the parameters to the function
      * @param optimizeStringFunctions true if string functions be optimized
-     *
      * @return the function expression
-     *
      * @throws XPathException if an error occurs creating the function
      */
-    public static Expression createFunction(XQueryContext context, QName qname, XQueryAST ast, PathExpr parent, List<Expression> params,
-        boolean optimizeStringFunctions) throws XPathException {
+    public static Expression createFunction(
+            final XQueryContext context,
+            final QName qname,
+            final XQueryAST ast,
+            final PathExpr parent,
+            final List<Expression> params,
+            final boolean optimizeStringFunctions
+    ) throws XPathException {
         final String local = qname.getLocalPart();
         final String uri = qname.getNamespaceURI();
 
@@ -238,11 +269,15 @@ public class FunctionFactory {
         return op;
     }
 
-    private static CastExpression castExpression(XQueryContext context,
-            XQueryAST ast, List<Expression> params, QName qname) throws XPathException {
+    private static CastExpression castExpression(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname
+    ) throws XPathException {
         if (params.size() != 1) {
             throw new XPathException(ast.getLine(), ast.getColumn(),
-        		ErrorCodes.XPST0017, "Wrong number of arguments for constructor function");
+                    ErrorCodes.XPST0017, "Wrong number of arguments for constructor function");
         }
         final Expression arg = params.getFirst();
         final int code;
@@ -251,28 +286,32 @@ public class FunctionFactory {
         } catch (final XPathException e) {
             // Unknown type name in xs: namespace → XPST0017 (no such function)
             throw new XPathException(ast.getLine(), ast.getColumn(),
-                ErrorCodes.XPST0017, "Unknown constructor function: " + qname.getStringValue());
+                    ErrorCodes.XPST0017, "Unknown constructor function: " + qname.getStringValue());
         }
         // No constructor function exists for xs:NOTATION, xs:anyAtomicType, or xs:anySimpleType
         // (per QT4 §4.6.3 — XPST0017 since no function with this name and arity exists)
         if (code == Type.NOTATION || code == Type.ANY_ATOMIC_TYPE || code == Type.ANY_SIMPLE_TYPE) {
             throw new XPathException(ast.getLine(), ast.getColumn(),
-                ErrorCodes.XPST0017, "No constructor function exists for " + qname.getStringValue());
+                    ErrorCodes.XPST0017, "No constructor function exists for " + qname.getStringValue());
         }
         final CastExpression castExpr = new CastExpression(context, arg, code, Cardinality.ZERO_OR_ONE);
         castExpr.setLocation(ast.getLine(), ast.getColumn());
         return castExpr;
     }
 
-    private static JavaCall javaFunctionBinding(XQueryContext context,
-            XQueryAST ast, List<Expression> params, QName qname) throws XPathException {
+    private static JavaCall javaFunctionBinding(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname
+    ) throws XPathException {
         // Only allow java binding if specified in config file <xquery enable-java-binding="yes">
         final String javaBinding = (String) context.getBroker().getConfiguration()
-            .getProperty(PROPERTY_ENABLE_JAVA_BINDING);
+                .getProperty(PROPERTY_ENABLE_JAVA_BINDING);
         if (!"yes".equals(javaBinding)) {
             throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017,
-                "Java binding is disabled in the current configuration (see conf.xml)." +
-                " Call to " + qname.getStringValue() + " denied.");
+                    "Java binding is disabled in the current configuration (see conf.xml)." +
+                            " Call to " + qname.getStringValue() + " denied.");
         }
         final JavaCall call = new JavaCall(context, qname);
         call.setLocation(ast.getLine(), ast.getColumn());
@@ -280,9 +319,12 @@ public class FunctionFactory {
         return call;
     }
 
-    private static Function functionCall(final XQueryContext context,
-            final XQueryAST ast, final List<Expression> params, final QName qname) throws XPathException {
-
+    private static Function functionCall(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname
+    ) throws XPathException {
         final String uri = qname.getNamespaceURI();
         final Module[] modules = context.getModules(uri);
 
@@ -317,9 +359,14 @@ public class FunctionFactory {
      *
      * @param throwOnNotFound true to throw an XPST0017 if the functions is not found, false to just return null
      */
-    private static @Nullable Function getInternalModuleFunction(final XQueryContext context,
-            final XQueryAST ast, final List<Expression> params, QName qname, Module module,
-            final boolean throwOnNotFound) throws XPathException {
+    private static @Nullable Function getInternalModuleFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            QName qname,
+            Module module,
+            final boolean throwOnNotFound
+    ) throws XPathException {
         // For internal modules: create a new function instance from the class
         FunctionDef def = ((InternalModule) module).getFunctionDef(qname, params.size());
         //TODO: rethink: xsl namespace function should search xpath one too
@@ -381,7 +428,12 @@ public class FunctionFactory {
     /**
      * Get a user-defined function from the XQuery context
      */
-    private static FunctionCall getUserDefinedFunction(XQueryContext context, XQueryAST ast, List<Expression> params, QName qname) throws XPathException {
+    private static FunctionCall getUserDefinedFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname
+    ) throws XPathException {
         final UserDefinedFunction func = context.resolveFunction(qname, params.size());
 
         if (func == null) {
@@ -403,8 +455,14 @@ public class FunctionFactory {
      *
      * @param throwOnNotFound true to throw an XPST0017 if the functions is not found, false to just return null
      */
-    private static FunctionCall getXQueryModuleFunction(final XQueryContext context,
-            final XQueryAST ast, final List<Expression> params, final QName qname, final Module module, final boolean throwOnNotFound) throws XPathException {
+    private static FunctionCall getXQueryModuleFunction(
+            final XQueryContext context,
+            final XQueryAST ast,
+            final List<Expression> params,
+            final QName qname,
+            final Module module,
+            final boolean throwOnNotFound
+    ) throws XPathException {
         final FunctionCall fc;
         final UserDefinedFunction func = ((ExternalModule) module).getFunction(qname, params.size(), context);
         if (func == null) {
@@ -420,8 +478,8 @@ public class FunctionFactory {
                 if (!otherArities.isEmpty()) {
                     final StringBuilder msg = new StringBuilder();
                     msg.append("Unexpectedly received ").append(params.size())
-                       .append(" parameter(s) in call to function '")
-                       .append(qname.getStringValue()).append("()'. ");
+                            .append(" parameter(s) in call to function '")
+                            .append(qname.getStringValue()).append("()'. ");
                     msg.append("Defined function signatures are:\r\n");
                     for (final FunctionSignature sig : otherArities) {
                         msg.append(sig.toString()).append("\r\n");
@@ -448,9 +506,9 @@ public class FunctionFactory {
                     return null;
                 }
 
-            // If not, postpone the function resolution
-            // Register a forward reference with the root module, so it gets resolved
-            // when the main query has been compiled.
+                // If not, postpone the function resolution
+                // Register a forward reference with the root module, so it gets resolved
+                // when the main query has been compiled.
             } else {
                 fc = new FunctionCall(((ExternalModule) module).getContext(), qname, params);
                 fc.setLocation(ast.getLine(), ast.getColumn());
@@ -467,71 +525,76 @@ public class FunctionFactory {
         }
         return fc;
     }
- 
+
     /**
      * Wrap a function call into a user defined function.
      * This is used to handle dynamic function calls or partial
      * function applications on built-in functions.
-     * 
+     *
      * @param context current context
-     * @param call the function call to be wrapped
+     * @param call    the function call to be wrapped
      * @return a new function call referencing an inline function
      * @throws XPathException in case of a static error
      */
-    public static FunctionCall wrap(XQueryContext context, Function call) throws XPathException {
-		final int argCount = call.getArgumentCount();
-		final QName[] variables = new QName[argCount];
-		final List<Expression> innerArgs = new ArrayList<>(argCount);
-		final List<Expression> wrapperArgs = new ArrayList<>(argCount);
-		final FunctionSignature signature = call.getSignature();
-		// the parameters of the newly created inline function:
-		final List<SequenceType> newParamTypes = new ArrayList<>();
-		final SequenceType[] paramTypes = signature.getArgumentTypes();
-		for (int i = 0; i < argCount; i++) {
-			final Expression param = call.getArgument(i);
-			wrapperArgs.add(param);
-			QName varName = new QName("vp" + i, XMLConstants.NULL_NS_URI);
-			variables[i] = varName;
-			final VariableReference ref = new VariableReference(context, varName);
-			innerArgs.add(ref);
-			
-			// copy parameter sequence types
-			// overloaded functions like concat may have an arbitrary number of arguments
-			if (i < paramTypes.length)
-				{newParamTypes.add(paramTypes[i]);}
-			else
-				// overloaded function: add last sequence type
-				{newParamTypes.add(paramTypes[paramTypes.length - 1]);}
-		}
-		final SequenceType[] newParamArray = newParamTypes.toArray(new SequenceType[0]);
-		final FunctionSignature newSignature = new FunctionSignature(signature);
-                newSignature.setArgumentTypes(newParamArray);
+    public static FunctionCall wrap(
+            final XQueryContext context,
+            final Function call
+    ) throws XPathException {
+        final int argCount = call.getArgumentCount();
+        final QName[] variables = new QName[argCount];
+        final List<Expression> innerArgs = new ArrayList<>(argCount);
+        final List<Expression> wrapperArgs = new ArrayList<>(argCount);
+        final FunctionSignature signature = call.getSignature();
+        // the parameters of the newly created inline function:
+        final List<SequenceType> newParamTypes = new ArrayList<>();
+        final SequenceType[] paramTypes = signature.getArgumentTypes();
+        for (int i = 0; i < argCount; i++) {
+            final Expression param = call.getArgument(i);
+            wrapperArgs.add(param);
+            QName varName = new QName("vp" + i, XMLConstants.NULL_NS_URI);
+            variables[i] = varName;
+            final VariableReference ref = new VariableReference(context, varName);
+            innerArgs.add(ref);
 
-		final UserDefinedFunction func = new UserDefinedFunction(context, newSignature);
-		// This wrapper exists to lift a built-in Function into a FunctionCall
-		// so that it can be used as a function item. Per F&O 3.1 section
-		// 16.1.1, the static and dynamic context of the call to
-		// fn:function-lookup -- and of named function references -- forms
-		// part of the closure of the returned function. When the wrapped
-		// built-in is itself context-dependent (fn:position#0,
-		// fn:node-name#0, fn:lang#1, fn:default-collation,
-		// fn:static-base-uri, ...), the wrapper must forward that captured
-		// focus into the body. Each Function subclass declares its own
-		// context-dependency via Function.isContextDependent(); the default
-		// is false, so non-context-dependent built-ins (fn:concat,
-		// fn:string-length#1, ...) and user-defined functions do not pay
-		// the propagation cost.
-		func.setPropagateContextToBody(call.isContextDependent());
-		for (final QName varName: variables) {
-			func.addVariable(varName);
-		}
+            // copy parameter sequence types
+            // overloaded functions like concat may have an arbitrary number of arguments
+            if (i < paramTypes.length) {
+                newParamTypes.add(paramTypes[i]);
+            } else
+            // overloaded function: add last sequence type
+            {
+                newParamTypes.add(paramTypes[paramTypes.length - 1]);
+            }
+        }
+        final SequenceType[] newParamArray = newParamTypes.toArray(new SequenceType[0]);
+        final FunctionSignature newSignature = new FunctionSignature(signature);
+        newSignature.setArgumentTypes(newParamArray);
 
-		call.setArguments(innerArgs);
+        final UserDefinedFunction func = new UserDefinedFunction(context, newSignature);
+        // This wrapper exists to lift a built-in Function into a FunctionCall
+        // so that it can be used as a function item. Per F&O 3.1 section
+        // 16.1.1, the static and dynamic context of the call to
+        // fn:function-lookup -- and of named function references -- forms
+        // part of the closure of the returned function. When the wrapped
+        // built-in is itself context-dependent (fn:position#0,
+        // fn:node-name#0, fn:lang#1, fn:default-collation,
+        // fn:static-base-uri, ...), the wrapper must forward that captured
+        // focus into the body. Each Function subclass declares its own
+        // context-dependency via Function.isContextDependent(); the default
+        // is false, so non-context-dependent built-ins (fn:concat,
+        // fn:string-length#1, ...) and user-defined functions do not pay
+        // the propagation cost.
+        func.setPropagateContextToBody(call.isContextDependent());
+        for (final QName varName : variables) {
+            func.addVariable(varName);
+        }
 
-		func.setFunctionBody(call);
-		
-		final FunctionCall wrappedCall = new FunctionCall(context, func);
-		wrappedCall.setArguments(wrapperArgs);
-		return wrappedCall;
-	}
+        call.setArguments(innerArgs);
+
+        func.setFunctionBody(call);
+
+        final FunctionCall wrappedCall = new FunctionCall(context, func);
+        wrappedCall.setArguments(wrapperArgs);
+        return wrappedCall;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -60,18 +60,23 @@ public class FunctionFactory {
         "switch", "text", "typeswitch"
     );
 
-    public static Expression createFunction(XQueryContext context, XQueryAST ast, PathExpr parent, List<Expression> params) throws XPathException {
-    	QName qname = null;
+    public static Expression createFunction(final XQueryContext context,final  XQueryAST ast, final PathExpr parent, final List<Expression> params) throws XPathException {
+        final QName qname = getQName(context, ast);
+        return createFunction(context, qname, ast, parent, params);
+    }
+
+    private static QName getQName(final XQueryContext context, final XQueryAST ast) throws XPathException {
+        final String rawName = ast.getText();
+        final QName qname;
         try {
-            qname = QName.parse(context, ast.getText(), context.getDefaultFunctionNamespace());
+            qname = QName.parse(context, rawName, context.getDefaultFunctionNamespace());
         } catch(final QName.IllegalQNameException xpe) {
-            throw new XPathException(ast, ErrorCodes.XPST0081, "Invalid qname " +  ast.getText() + ". " + xpe.getMessage());
+            throw new XPathException(ast, ErrorCodes.XPST0081, "Invalid qname " +  rawName + ". " + xpe.getMessage());
         }
 
         // Check for reserved function names — unprefixed reserved names cannot be
         // used as function calls (XPST0003). Prefixed names like fn:item() are not
         // subject to the reserved name restriction (they just won't be found → XPST0017).
-        final String rawName = ast.getText();
         if (rawName != null && !rawName.contains(":") && !rawName.contains("{")) {
             final String local = qname.getLocalPart();
             if (RESERVED_FUNCTION_NAMES.contains(local)) {
@@ -79,12 +84,53 @@ public class FunctionFactory {
                     "'" + local + "' is a reserved function name and cannot be used as a function call");
             }
         }
-
-        return createFunction(context, qname, ast, parent, params);
+        return qname;
     }
 
     public static Expression createFunction(XQueryContext context, QName qname, XQueryAST ast, PathExpr parent, List<Expression> params) throws XPathException {
         return createFunction(context, qname, ast, parent, params, true);
+    }
+
+    /**
+     * Make sure that partially applied functions are wrapped correctly
+     * the QName is read from the given AST
+     *
+     * @param context the XQuery context
+     * @param ast the AST node of the function
+     * @param parent the parent expression of the function
+     * @param params the parameters to the function
+     * @param isPartial is this a partially applied function with placeholders?
+     * @return either a FunctionCall or a PartialFunctionApplication
+     * @throws XPathException if an error occurs creating the function
+     */
+    public static Expression createFunctionCall(final XQueryContext context, final XQueryAST ast, final PathExpr parent, final List<Expression> params, final boolean isPartial) throws XPathException {
+        return createFunctionCall(context, getQName(context, ast), ast, parent, params, isPartial);
+    }
+
+    /**
+     * Make sure that partially applied functions are wrapped correctly
+     *
+     * @param context the XQuery context
+     * @param qname the name of the function
+     * @param ast the AST node of the function
+     * @param parent the parent expression of the function
+     * @param params the parameters to the function
+     * @param isPartial is this a partially applied function with placeholders?
+     * @return either a FunctionCall or a PartialFunctionApplication
+     * @throws XPathException if an error occurs creating the function
+     */
+    public static Expression createFunctionCall(final XQueryContext context, final QName qname, final XQueryAST ast, final PathExpr parent, final List<Expression> params, final boolean isPartial) throws XPathException {
+        Expression fc = createFunction(context, qname, ast, parent, params);
+        if (!isPartial) {
+            return fc;
+        }
+        if (fc instanceof CastExpression) {
+            fc = ((CastExpression) fc).toFunction();
+        }
+        if (!(fc instanceof FunctionCall)) {
+            fc = FunctionFactory.wrap(context, (Function) fc);
+        }
+        return new PartialFunctionApplication(context, (FunctionCall) fc);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -22,13 +22,12 @@
 package org.exist.xquery;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.exist.Namespaces;
 import org.exist.dom.QName;
-import org.exist.source.Source;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.Constants.StringTruncationOperator;
 import org.exist.xquery.parser.XQueryAST;
@@ -38,8 +37,6 @@ import org.exist.xquery.value.Type;
 
 import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
-
-import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 
 public class FunctionFactory {
 
@@ -88,7 +85,7 @@ public class FunctionFactory {
         if (!rawName.contains(":") && !rawName.contains("{")) {
             final String local = qname.getLocalPart();
             if (RESERVED_FUNCTION_NAMES.contains(local)) {
-                throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0003,
+                throw new XPathException(ast, ErrorCodes.XPST0003,
                         "'" + local + "' is a reserved function name and cannot be used as a function call");
             }
         }
@@ -245,8 +242,8 @@ public class FunctionFactory {
             final StringTruncationOperator operator
     ) throws XPathException {
         if (params.size() < 2 || params.size() > 3) {
-            throw new XPathException(ast,
-                    ErrorCodes.XPST0017, "Function " + functionName + "() requires two or three arguments");
+            throw new XPathException(ast, ErrorCodes.XPST0017,
+                    "Function " + functionName + "() requires two or three arguments");
         }
 
         final PathExpr p0 = (PathExpr) params.getFirst();
@@ -257,7 +254,7 @@ public class FunctionFactory {
         }
 
         final GeneralComparison op = new GeneralComparison(context, p0, p1, Comparison.EQ, operator);
-        op.setLocation(ast.getLine(), ast.getColumn());
+        op.setASTNode(ast);
         //TODO : not sure for parent -pb
         context.getProfiler().message(parent, Profiler.OPTIMIZATIONS, "OPTIMIZATION",
                 "Rewritten " + functionName + "() as a general comparison using " + operator);
@@ -276,8 +273,7 @@ public class FunctionFactory {
             final QName qname
     ) throws XPathException {
         if (params.size() != 1) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                    ErrorCodes.XPST0017, "Wrong number of arguments for constructor function");
+            throw new XPathException(ast, ErrorCodes.XPST0017, "Wrong number of arguments for constructor function");
         }
         final Expression arg = params.getFirst();
         final int code;
@@ -285,17 +281,15 @@ public class FunctionFactory {
             code = Type.getType(qname);
         } catch (final XPathException e) {
             // Unknown type name in xs: namespace → XPST0017 (no such function)
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                    ErrorCodes.XPST0017, "Unknown constructor function: " + qname.getStringValue());
+            throw new XPathException(ast, ErrorCodes.XPST0017, "Unknown constructor function: " + qname.getStringValue());
         }
         // No constructor function exists for xs:NOTATION, xs:anyAtomicType, or xs:anySimpleType
         // (per QT4 §4.6.3 — XPST0017 since no function with this name and arity exists)
         if (code == Type.NOTATION || code == Type.ANY_ATOMIC_TYPE || code == Type.ANY_SIMPLE_TYPE) {
-            throw new XPathException(ast.getLine(), ast.getColumn(),
-                    ErrorCodes.XPST0017, "No constructor function exists for " + qname.getStringValue());
+            throw new XPathException(ast, ErrorCodes.XPST0017, "No constructor function exists for " + qname.getStringValue());
         }
         final CastExpression castExpr = new CastExpression(context, arg, code, Cardinality.ZERO_OR_ONE);
-        castExpr.setLocation(ast.getLine(), ast.getColumn());
+        castExpr.setASTNode(ast);
         return castExpr;
     }
 
@@ -309,16 +303,26 @@ public class FunctionFactory {
         final String javaBinding = (String) context.getBroker().getConfiguration()
                 .getProperty(PROPERTY_ENABLE_JAVA_BINDING);
         if (!"yes".equals(javaBinding)) {
-            throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017,
+            throw new XPathException(ast, ErrorCodes.XPST0017,
                     "Java binding is disabled in the current configuration (see conf.xml)." +
                             " Call to " + qname.getStringValue() + " denied.");
         }
         final JavaCall call = new JavaCall(context, qname);
-        call.setLocation(ast.getLine(), ast.getColumn());
+        call.setASTNode(ast);
         call.setArguments(params);
         return call;
     }
 
+    /**
+     * Returns a Function if it can be resolved
+     *
+     * @param context The current XQuery context
+     * @param ast The current XQuery AST node
+     * @param params the list of parameters of the function call
+     * @param qname the QName of the function
+     * @return a FunctionCall, an InternalFunctionCall, or a ForwardReference
+     * @throws XPathException if the function could not be resolved
+     */
     private static Function functionCall(
             final XQueryContext context,
             final XQueryAST ast,
@@ -326,32 +330,71 @@ public class FunctionFactory {
             final QName qname
     ) throws XPathException {
         final String uri = qname.getNamespaceURI();
+        final int paramCount = params.size();
         final Module[] modules = context.getModules(uri);
 
         if (modules == null) {
-            return getLocalDefinedFunction(context, ast, params, qname);
+            final FunctionCall localFn = getLocalDefinedFunction(context, qname, params);
+            localFn.setASTNode(ast);
+            return localFn;
         }
+
+        // a possible list of candidates with other arities when none match
+        List<FunctionSignature> otherArities = null;
 
         // Function might belong to a module
         for (final Module module : modules) {
             final Function fn;
-
             if (module.isInternalModule()) {
-                // Function is from an Internal Module
-                fn = getInternalModuleFunction(context, ast, params, qname, module, false);
+                // Function is from an Internal Module (needs AST)
+                fn = getInternalModuleFunction(context, module, qname, params, ast);
             } else {
                 // Function is from an imported XQuery module
-                fn = getXQueryModuleFunction(context, ast, params, qname, module, false);
+                fn = getXQueryModuleFunction(context, module, qname, params);
             }
+
             // return early on first match
             if (fn != null) {
+                if (context.getConfiguration() != null &&
+                        (Boolean) context.getConfiguration().getProperty(PROPERTY_DISABLE_DEPRECATED_FUNCTIONS) &&
+                        fn.getSignature().isDeprecated()) {
+                    throw new XPathException(ast, ErrorCodes.XPST0017,
+                            "Access to deprecated functions is not allowed. Call to '" + qname.getStringValue() +
+                                    "()' denied. " + fn.getSignature().getDeprecated());
+                }
+                fn.setASTNode(ast);
                 return fn;
+            }
+
+            // gather candidates, if any
+            final List<FunctionSignature> functionsMatchingByName = module.getFunctionsByName(qname);
+
+            if (!functionsMatchingByName.isEmpty()) {
+                // hot code, lazy initialization of list
+                if (otherArities == null) {
+                    otherArities = new ArrayList<>();
+                }
+                otherArities.addAll(functionsMatchingByName);
             }
         }
 
-        throw new XPathException(ast.getLine(), ast.getColumn(),
-                ErrorCodes.XPST0017, "Function " + qname.getStringValue() + "() " +
-                " is not defined in module namespace: " + qname.getNamespaceURI());
+        final String msg;
+        if (otherArities == null || otherArities.isEmpty()) {
+            msg = "Function " + qname.getStringValue() + "() is not defined in module namespace: " + uri;
+        } else {
+            msg = String.format("""
+                Unexpectedly received %d parameter(s) in call to function '%s()'.
+                Defined function signatures are:
+                %s
+                in module namespace: %s""",
+                paramCount,
+                qname.getStringValue(),
+                otherArities.stream().map(FunctionSignature::toString).collect(Collectors.joining("\n")),
+                uri
+            );
+        }
+
+        throw new XPathException(ast, ErrorCodes.XPST0017, msg);
     }
 
     /**
@@ -359,171 +402,85 @@ public class FunctionFactory {
      */
     private static FunctionCall getLocalDefinedFunction(
             final XQueryContext context,
-            final XQueryAST ast,
-            final List<Expression> params,
-            final QName qname
+            final QName qname,
+            final List<Expression> params
     ) throws XPathException {
         final UserDefinedFunction func = context.resolveFunction(qname, params.size());
 
         if (func == null) {
             // Create a forward reference which will be resolved later
             final FunctionCall forwardReference = new FunctionCall(context, qname, params);
-            forwardReference.setLocation(ast.getLine(), ast.getColumn());
             context.addForwardReference(forwardReference);
             return forwardReference;
         }
 
         final FunctionCall functionCall = new FunctionCall(context, func);
-        functionCall.setLocation(ast.getLine(), ast.getColumn());
         functionCall.setArguments(params);
         return functionCall;
     }
 
     /**
      * Get a function implemented in Java from an XQuery Extension Module
-     *
-     * @param throwOnNotFound true to throw an XPST0017 if the functions is not found, false to just return null
      */
-    private static @Nullable Function getInternalModuleFunction(
+    @Nullable
+    private static Function  getInternalModuleFunction(
             final XQueryContext context,
-            final XQueryAST ast,
+            final Module module,
+            final QName qname,
             final List<Expression> params,
-            QName qname,
-            Module module,
-            final boolean throwOnNotFound
+            final XQueryAST ast
     ) throws XPathException {
         // For internal modules: create a new function instance from the class
-        FunctionDef def = ((InternalModule) module).getFunctionDef(qname, params.size());
-        //TODO: rethink: xsl namespace function should search xpath one too
-        if (def == null && Namespaces.XSL_NS.equals(qname.getNamespaceURI())) {
-            //Search xpath namespace
-            final Module[] _modules_ = context.getModules(Namespaces.XPATH_FUNCTIONS_NS);
-            if (isNotEmpty(_modules_)) {
-                // there can be only one!
-                for (final Module _module_ : _modules_) {
-                    if (_module_ != null) {
-                        final QName _qname_ = new QName(qname.getLocalPart(), Namespaces.XPATH_FUNCTIONS_NS, qname.getPrefix());
-                        def = ((InternalModule) _module_).getFunctionDef(qname, params.size());
-                        if (def != null) {
-                            module = _module_;
-                            qname = _qname_;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        final InternalModule im = (InternalModule) module;
+        FunctionDef def = im.getFunctionDef(qname, params.size());
+
         if (def == null) {
-            final List<FunctionSignature> funcs = ((InternalModule) module).getFunctionsByName(qname);
-            if (funcs.isEmpty()) {
-                if (throwOnNotFound) {
-                    throw new XPathException(ast.getLine(), ast.getColumn(),
-                            ErrorCodes.XPST0017, "Function " + qname.getStringValue() + "() " +
-                            " is not defined in module namespace: " + qname.getNamespaceURI());
-                } else {
-                    return null;
-                }
-            } else {
-                final StringBuilder buf = new StringBuilder();
-                buf.append("Unexpectedly received ");
-                buf.append(params.size());
-                buf.append(" parameter(s) in call to function ");
-                buf.append("'");
-                buf.append(qname.getStringValue());
-                buf.append("()'. ");
-                buf.append("Defined function signatures are:\r\n");
-                for (final FunctionSignature sig : funcs) {
-                    buf.append(sig.toString()).append("\r\n");
-                }
-                throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017, buf.toString());
-            }
+            return null;
         }
-        if (context.getConfiguration() != null &&
-                (Boolean) context.getConfiguration().getProperty(PROPERTY_DISABLE_DEPRECATED_FUNCTIONS) &&
-                def.getSignature().isDeprecated()) {
-            throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017,
-                    "Access to deprecated functions is not allowed. Call to '" + qname.getStringValue() + "()' denied. " + def.getSignature().getDeprecated());
-        }
+
         final Function fn = Function.createFunction(context, ast, module, def);
         fn.setArguments(params);
-        fn.setASTNode(ast);
         return new InternalFunctionCall(fn);
     }
 
     /**
-     * Gets an XQuery function from an XQuery Module
-     *
-     * @param throwOnNotFound true to throw an XPST0017 if the functions is not found, false to just return null
+     * Returns an XQuery function from a Module if found
      */
+    @Nullable
     private static FunctionCall getXQueryModuleFunction(
             final XQueryContext context,
-            final XQueryAST ast,
-            final List<Expression> params,
-            final QName qname,
             final Module module,
-            final boolean throwOnNotFound
+            final QName qname,
+            final List<Expression> params
     ) throws XPathException {
         final FunctionCall fc;
         final UserDefinedFunction func = ((ExternalModule) module).getFunction(qname, params.size(), context);
-        if (func == null) {
-            // check if the module has been compiled already
-            if (module.isReady()) {
-                // Check if function exists at other arities to give a better error message
-                final List<FunctionSignature> otherArities = new ArrayList<>();
-                final Iterator<FunctionSignature> sigs = module.getSignaturesForFunction(qname);
-                while (sigs.hasNext()) {
-                    otherArities.add(sigs.next());
-                }
 
-                if (!otherArities.isEmpty()) {
-                    final StringBuilder msg = new StringBuilder();
-                    msg.append("Unexpectedly received ").append(params.size())
-                            .append(" parameter(s) in call to function '")
-                            .append(qname.getStringValue()).append("()'. ");
-                    msg.append("Defined function signatures are:\r\n");
-                    for (final FunctionSignature sig : otherArities) {
-                        msg.append(sig.toString()).append("\r\n");
-                    }
-                    if (throwOnNotFound) {
-                        throw new XPathException(ast.getLine(), ast.getColumn(),
-                                ErrorCodes.XPST0017, msg.toString());
-                    } else {
-                        return null;
-                    }
-                }
-
-                final StringBuilder msg = new StringBuilder("Function ")
-                        .append(qname.getStringValue()).append('#').append(params.size())
-                        .append(" is not defined in namespace '").append(qname.getNamespaceURI()).append('\'');
-                if (module instanceof ExternalModule externalModule) {
-                    final Source moduleSource = externalModule.getSource();
-                    msg.append(" for module: ").append(moduleSource.pathOrShortIdentifier());
-                }
-                if (throwOnNotFound) {
-                    throw new XPathException(ast.getLine(), ast.getColumn(),
-                            ErrorCodes.XPST0017, msg.toString());
-                } else {
-                    return null;
-                }
-
-                // If not, postpone the function resolution
-                // Register a forward reference with the root module, so it gets resolved
-                // when the main query has been compiled.
-            } else {
-                fc = new FunctionCall(((ExternalModule) module).getContext(), qname, params);
-                fc.setLocation(ast.getLine(), ast.getColumn());
-                if (((ExternalModule) module).getContext() == context) {
-                    context.addForwardReference(fc);
-                } else {
-                    context.getRootContext().addForwardReference(fc);
-                }
-            }
-        } else {
+        if (func != null) {
             fc = new FunctionCall(context, func);
             fc.setArguments(params);
-            fc.setLocation(ast.getLine(), ast.getColumn());
+            return fc;
         }
-        return fc;
+
+        // check if the module has been compiled already
+        if (module.isReady()) {
+            return null;
+        }
+
+        // If not, postpone the function resolution
+        // Register a forward reference with the root module, so it gets resolved
+        // when the main query has been compiled.
+        final FunctionCall forwardReference = new FunctionCall(((ExternalModule) module).getContext(), qname, params);
+
+        final XQueryContext forwardReferenceContext;
+        if (((ExternalModule) module).getContext() == context) {
+            forwardReferenceContext = context;
+        } else {
+            forwardReferenceContext = context.getRootContext();
+        }
+        forwardReferenceContext.addForwardReference(forwardReference);
+
+        return forwardReference;
     }
 
     /**
@@ -557,12 +514,11 @@ public class FunctionFactory {
             innerArgs.add(ref);
 
             // copy parameter sequence types
-            // overloaded functions like concat may have an arbitrary number of arguments
+            // the one variadic function (fn:concat) may have an arbitrary number of arguments
             if (i < paramTypes.length) {
                 newParamTypes.add(paramTypes[i]);
-            } else
-            // overloaded function: add last sequence type
-            {
+            } else {
+                // handle fn:concat add last sequence type
                 newParamTypes.add(paramTypes[paramTypes.length - 1]);
             }
         }
@@ -571,19 +527,13 @@ public class FunctionFactory {
         newSignature.setArgumentTypes(newParamArray);
 
         final UserDefinedFunction func = new UserDefinedFunction(context, newSignature);
-        // This wrapper exists to lift a built-in Function into a FunctionCall
-        // so that it can be used as a function item. Per F&O 3.1 section
-        // 16.1.1, the static and dynamic context of the call to
-        // fn:function-lookup -- and of named function references -- forms
-        // part of the closure of the returned function. When the wrapped
-        // built-in is itself context-dependent (fn:position#0,
-        // fn:node-name#0, fn:lang#1, fn:default-collation,
-        // fn:static-base-uri, ...), the wrapper must forward that captured
-        // focus into the body. Each Function subclass declares its own
-        // context-dependency via Function.isContextDependent(); the default
-        // is false, so non-context-dependent built-ins (fn:concat,
-        // fn:string-length#1, ...) and user-defined functions do not pay
-        // the propagation cost.
+        // Wrap built-in Function into a FunctionCall, so that it can be used as a function item.
+        // Per F&O 3.1 section 16.1.1, the static and dynamic context of the call to fn:function-lookup -- and of named
+        // function references -- forms part of the closure of the returned function. When the wrapped built-in is
+        // itself context-dependent (like fn:position#0, fn:node-name#0, fn:lang#1, ...), the wrapper must forward
+        // that captured focus into the body of the function. context-dependency is declared via
+        // Function.isContextDependent(); the default is false for non-context-dependent built-ins (fn:concat,
+        // fn:string-length#1, ...) and user-defined functions
         func.setPropagateContextToBody(call.isContextDependent());
         for (final QName varName : variables) {
             func.addVariable(varName);

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -339,9 +339,6 @@ public class FunctionFactory {
             return localFn;
         }
 
-        // a possible list of candidates with other arities when none match
-        List<FunctionSignature> otherArities = null;
-
         // Function might belong to a module
         for (final Module module : modules) {
             final Function fn;
@@ -365,36 +362,10 @@ public class FunctionFactory {
                 fn.setASTNode(ast);
                 return fn;
             }
-
-            // gather candidates, if any
-            final List<FunctionSignature> functionsMatchingByName = module.getFunctionsByName(qname);
-
-            if (!functionsMatchingByName.isEmpty()) {
-                // hot code, lazy initialization of list
-                if (otherArities == null) {
-                    otherArities = new ArrayList<>();
-                }
-                otherArities.addAll(functionsMatchingByName);
-            }
         }
 
-        final String msg;
-        if (otherArities == null || otherArities.isEmpty()) {
-            msg = "Function " + qname.getStringValue() + "() is not defined in module namespace: " + uri;
-        } else {
-            msg = String.format("""
-                Unexpectedly received %d parameter(s) in call to function '%s()'.
-                Defined function signatures are:
-                %s
-                in module namespace: %s""",
-                paramCount,
-                qname.getStringValue(),
-                otherArities.stream().map(FunctionSignature::toString).collect(Collectors.joining("\n")),
-                uri
-            );
-        }
-
-        throw new XPathException(ast, ErrorCodes.XPST0017, msg);
+        throw new XPathException(ast, ErrorCodes.XPST0017,
+                Function.functionNotFoundErrorDescription(context, qname, paramCount));
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -89,7 +89,7 @@ public class FunctionFactory {
 
     /**
      * Create a function call.
-     *
+     * <p>
      * This method handles all calls to built-in or user-defined
      * functions. It also deals with constructor functions and
      * optimizes some function calls like starts-with, ends-with or
@@ -100,43 +100,42 @@ public class FunctionFactory {
      * @param ast the AST node of the function
      * @param parent the parent expression of the function
      * @param params the parameters to the function
-     * @param optimizeStrFuncs true if string functions be optimized
+     * @param optimizeStringFunctions true if string functions be optimized
      *
      * @return the function expression
      *
      * @throws XPathException if an error occurs creating the function
      */
     public static Expression createFunction(XQueryContext context, QName qname, XQueryAST ast, PathExpr parent, List<Expression> params,
-        boolean optimizeStrFuncs) throws XPathException {
+        boolean optimizeStringFunctions) throws XPathException {
         final String local = qname.getLocalPart();
         final String uri = qname.getNamespaceURI();
-        Expression step = null;
-        if (optimizeStrFuncs && (Namespaces.XPATH_FUNCTIONS_NS.equals(uri) || Namespaces.XSL_NS.equals(uri))) {
-            if("starts-with".equals(local)) {
-                step = startsWith(context, ast, parent, params);
-            } else if("ends-with".equals(local)) {
-                step = endsWith(context, ast, parent, params);
-            } else if("contains".equals(local)) {
-                step = contains(context, ast, parent, params);
-            } else if("equals".equals(local)) {
-                step = equals(context, ast, parent, params);
-            }
+
+        if (optimizeStringFunctions && (Namespaces.XPATH_FUNCTIONS_NS.equals(uri) || Namespaces.XSL_NS.equals(uri))) {
+            return switch (local)  {
+                case "starts-with" -> startsWith(context, ast, parent, params);
+                case "ends-with" -> endsWith(context, ast, parent, params);
+                case "contains" -> contains(context, ast, parent, params);
+                case "equals" -> equals(context, ast, parent, params);
+                default -> functionCall(context, ast, params, qname);
+            };
+        }
+
         //Check if the namespace belongs to one of the schema namespaces.
         //If yes, the function is a constructor function
-        } else if (uri.equals(Namespaces.SCHEMA_NS) ||
-                uri.equals(Namespaces.XPATH_DATATYPES_NS)) {
-            step = castExpression(context, ast, params, qname);
+        if (uri.equals(Namespaces.SCHEMA_NS) || uri.equals(Namespaces.XPATH_DATATYPES_NS)) {
+            return castExpression(context, ast, params, qname);
+        }
+
         //Check if the namespace URI starts with "java:". If yes, treat
         //the function call as a call to an arbitrary Java function.
-        } else if (uri.startsWith("java:")) {
-            step = javaFunctionBinding(context, ast, params, qname);
+        if (uri.startsWith("java:")) {
+            return javaFunctionBinding(context, ast, params, qname);
         }
+
         //None of the above matched: function is either a built-in function or
         //a user-defined function
-        if (step == null) {
-            step = functionCall(context, ast, params, qname);
-        }
-        return step;
+        return functionCall(context, ast, params, qname);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -253,14 +253,14 @@ public class FunctionFactory {
         final PathExpr p1 = (PathExpr) params.get(1);
 
         if (p1.getSubExpressionCount() == 0) {
-            throw new XPathException(ast, ErrorCodes.XPTY0004, "Second argument of " + functionName + "() is empty");
+            throw new XPathException(ast, ErrorCodes.XPST0017, "Second argument of " + functionName + "() is empty");
         }
 
         final GeneralComparison op = new GeneralComparison(context, p0, p1, Comparison.EQ, operator);
         op.setLocation(ast.getLine(), ast.getColumn());
         //TODO : not sure for parent -pb
         context.getProfiler().message(parent, Profiler.OPTIMIZATIONS, "OPTIMIZATION",
-                "Rewritten " + functionName + "() as a general comparison with a right truncations");
+                "Rewritten " + functionName + "() as a general comparison using " + operator);
 
         if (params.size() == 3) {
             op.setCollation(params.get(2));

--- a/exist-core/src/main/java/org/exist/xquery/InternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/InternalModule.java
@@ -57,12 +57,4 @@ public interface InternalModule extends Module {
 	 */
 	FunctionDef getFunctionDef(QName qname, int argCount);
 	
-	/**
-	 * Returns all functions defined in this module matching the
-	 * specified qname.
-	 * 
-	 * @param qname function QName to match
-	 * @return all functions defined in this module
-	 */
-	List<FunctionSignature> getFunctionsByName(QName qname);
 }

--- a/exist-core/src/main/java/org/exist/xquery/InternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/InternalModule.java
@@ -21,8 +21,6 @@
  */
 package org.exist.xquery;
 
-import java.util.List;
-
 import org.exist.dom.QName;
 
 /**

--- a/exist-core/src/main/java/org/exist/xquery/Module.java
+++ b/exist-core/src/main/java/org/exist/xquery/Module.java
@@ -22,6 +22,7 @@
 package org.exist.xquery;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.exist.dom.QName;
 import org.exist.xquery.value.Sequence;
@@ -97,7 +98,16 @@ public interface Module {
 	 * @return the function signature or null if the function is not defined.
 	 */
 	@Nullable Iterator<FunctionSignature> getSignaturesForFunction(QName qname);
-	
+
+	/**
+	 * Returns all functions defined in this module matching the
+	 * specified qname.
+	 *
+	 * @param qname function QName to match
+	 * @return all functions defined in this module
+	 */
+	List<FunctionSignature> getFunctionsByName(QName qname);
+
 	@Nullable Variable resolveVariable(@Nullable AnalyzeContextInfo contextInfo, QName qname) throws XPathException;
 	@Nullable Variable resolveVariable(QName qname) throws XPathException;
 	

--- a/exist-core/src/main/java/org/exist/xquery/Module.java
+++ b/exist-core/src/main/java/org/exist/xquery/Module.java
@@ -32,117 +32,120 @@ import javax.annotation.Nullable;
 /**
  * Defines an XQuery library module. A module consists of function definitions
  * and global variables. It is uniquely identified by a namespace URI and an optional
- * default namespace prefix. All functions provided by the module have to be defined 
+ * default namespace prefix. All functions provided by the module have to be defined
  * in the module's namespace.
- * 
+ * <p>
  * Modules can be either internal or external: internal modules are collections of Java
  * classes, each being a subclass of {@link org.exist.xquery.Function}. External modules
  * are defined by the XQuery "module" directive and can be loaded with "import module".
- * 
+ * <p>
  * Modules are dynamically loaded by class {@link org.exist.xquery.XQueryContext}, either
  * during the initialization phase of the query engine (for the standard library modules) or
- * upon an "import module" directive. 
- * 
+ * upon an "import module" directive.
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
 public interface Module {
-	
-	/**
-	 * Returns the namespace URI that uniquely identifies this module.
-	 * 
-	 * @return namespace URI 
-	 */
-	public String getNamespaceURI();
-	
-	/**
-	 * Returns an optional default prefix (used if no prefix is supplied with
-	 * the "import module" directive).
-	 * 
-	 * @return optional default prefix 
-	 */
-	public String getDefaultPrefix();
-	
-	/**
-	 * Return a short description of this module to be displayed to a user.
-	 * 
-	 * @return short description of this module
-	 */
-	public String getDescription();
 
-	/**
-	 * Returns the release version in which the module was firstly available.
-	 * 
-	 * @return available from which release version
-	 */
-	public String getReleaseVersion();
-
-	
-	/**
-	 * Is this an internal module?
-	 * 
-	 * @return True if is internal module.
-	 */
-	public boolean isInternalModule();
-	
-	/**
-	 * Returns the signatures of all functions defined within this module.
-	 * 
-	 * @return signatures of all functions
-	 */
-	public FunctionSignature[] listFunctions();
-	
-	/**
-	 * Try to find the signature of the function identified by its QName.
-	 * 
-	 * @param qname the function name
-	 * @return the function signature or null if the function is not defined.
-	 */
-	@Nullable Iterator<FunctionSignature> getSignaturesForFunction(QName qname);
-
-	/**
-	 * Returns all functions defined in this module matching the
-	 * specified qname.
-	 *
-	 * @param qname function QName to match
-	 * @return all functions defined in this module
-	 */
-	List<FunctionSignature> getFunctionsByName(QName qname);
-
-	@Nullable Variable resolveVariable(@Nullable AnalyzeContextInfo contextInfo, QName qname) throws XPathException;
-	@Nullable Variable resolveVariable(QName qname) throws XPathException;
-	
-	public Variable declareVariable(QName qname, Object value) throws XPathException;
-	
-    public Variable declareVariable(Variable var);
-    
-    public boolean isVarDeclared(QName qname);
-    
     /**
-     * Returns an iterator over all global variables in this modules, which were
+     * Returns the namespace URI that uniquely identifies this module.
+     *
+     * @return namespace URI
+     */
+    String getNamespaceURI();
+
+    /**
+     * Returns an optional default prefix (used if no prefix is supplied with
+     * the "import module" directive).
+     *
+     * @return optional default prefix
+     */
+    String getDefaultPrefix();
+
+    /**
+     * Return a short description of this module to be displayed to a user.
+     *
+     * @return short description of this module
+     */
+    String getDescription();
+
+    /**
+     * Returns the release version in which the module was firstly available.
+     *
+     * @return available from which release version
+     */
+    String getReleaseVersion();
+
+
+    /**
+     * Is this an internal module?
+     *
+     * @return True if is internal module.
+     */
+    boolean isInternalModule();
+
+    /**
+     * Returns the signatures of all functions defined within this module.
+     *
+     * @return signatures of all functions
+     */
+    FunctionSignature[] listFunctions();
+
+    /**
+     * Try to find the signature of the function identified by its QName.
+     *
+     * @param qname the function name
+     * @return the function signature or null if the function is not defined.
+     */
+    @Nullable
+    Iterator<FunctionSignature> getSignaturesForFunction(QName qname);
+
+    /**
+     * Returns all functions defined in this module matching the
+     * specified qname.
+     *
+     * @param qname function QName to match
+     * @return all functions defined in this module
+     */
+    List<FunctionSignature> getFunctionsByName(QName qname);
+
+    @Nullable
+    Variable resolveVariable(@Nullable AnalyzeContextInfo contextInfo, QName qname) throws XPathException;
+
+    @Nullable
+    Variable resolveVariable(QName qname) throws XPathException;
+
+    Variable declareVariable(QName qname, Object value) throws XPathException;
+
+    Variable declareVariable(Variable var);
+
+    boolean isVarDeclared(QName qname);
+
+    /**
+     * Returns an iterator over all global variables in this module, which were
      * either declared with "declare variable" (for external modules) or set in the
      * module implementation (internal modules).
-	 *
-	 * @return an iterator over the names of the global variables
+     *
+     * @return an iterator over the names of the global variables
      */
-    public Iterator<QName> getGlobalVariables();
+    Iterator<QName> getGlobalVariables();
 
-	/**
-	 * Reset the module's internal state for being reused.
-	 *
-	 * @param context the xquery context
-	 *
-	 * @deprecated use {@link #reset(XQueryContext, boolean)} instead
-	 */
-	@Deprecated
+    /**
+     * Reset the module's internal state for being reused.
+     *
+     * @param context the xquery context
+     * @deprecated use {@link #reset(XQueryContext, boolean)} instead
+     */
+    @Deprecated
     void reset(XQueryContext context);
 
-	/**
-	 * Reset the module's internal state for being reused.
-	 *
-	 * @param xqueryContext the xquery context
-	 * @param keepGlobals true to keep global declarations
-	 */
-	public void reset(XQueryContext xqueryContext, boolean keepGlobals);
+    /**
+     * Reset the module's internal state for being reused.
+     *
+     * @param xqueryContext the xquery context
+     * @param keepGlobals   true to keep global declarations
+     */
+    void reset(XQueryContext xqueryContext, boolean keepGlobals);
 
     /**
      * Check if this module has been fully loaded
@@ -150,7 +153,7 @@ public interface Module {
      *
      * @return false while the module is being compiled.
      */
-    public boolean isReady();
+    boolean isReady();
 
     void setContextItem(Sequence contextItem);
 }

--- a/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
@@ -92,10 +92,10 @@ public class NamedFunctionReference extends AbstractExpression {
 		}
 		final Expression fun = FunctionFactory.createFunction(context, funcName, ast, null, args, false);
         switch (fun) {
-            case null -> throw new XPathException(self, ErrorCodes.XPST0017, "Function not found: " + funcName);
+            case null -> throw new XPathException(self, ErrorCodes.XPST0017, Function.functionNotFoundErrorDescription(context, funcName, arity));
             case FunctionCall functionCall -> {
                 if (functionCall.getFunction() == null) {
-                    throw new XPathException(self, ErrorCodes.XPST0017, "Function not found: " + funcName);
+                    throw new XPathException(self, ErrorCodes.XPST0017, Function.functionNotFoundErrorDescription(context, funcName, arity));
                 }
                 // clear line and column as it will be misleading. should be set later to point
                 // to the location from where the function is called.

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2986,48 +2986,57 @@ public class XQueryContext implements BinaryValueManager, Context {
             final UserDefinedFunction func = call.getContext().resolveFunction(call.getQName(), call.getArgumentCount());
 
             if (func == null) {
-                // Check if function exists at other arities to give a better error message
-                final QName qname = call.getQName();
-                final int argCount = call.getArgumentCount();
-                final XQueryContext callContext = call.getContext();
-
-                // Check local declared functions
-                final Iterator<FunctionSignature> localSigs = callContext.getSignaturesForFunction(qname);
-
-                // Also check external modules
-                final List<FunctionSignature> allSignatures = new ArrayList<>();
-                while (localSigs.hasNext()) {
-                    allSignatures.add(localSigs.next());
-                }
-
-                final Module[] modules = callContext.getModules(qname.getNamespaceURI());
-                if (modules != null) {
-                    for (final Module module : modules) {
-                        if (module != null) {
-                            final Iterator<FunctionSignature> modSigs = module.getSignaturesForFunction(qname);
-                            while (modSigs.hasNext()) {
-                                allSignatures.add(modSigs.next());
-                            }
-                        }
-                    }
-                }
-
-                if (!allSignatures.isEmpty()) {
-                    final StringBuilder msg = new StringBuilder();
-                    msg.append("Unexpectedly received ").append(argCount)
-                       .append(" parameter(s) in call to function '")
-                       .append(qname.getStringValue()).append("()'. ");
-                    msg.append("Defined function signatures are:\r\n");
-                    for (final FunctionSignature sig : allSignatures) {
-                        msg.append(sig.toString()).append("\r\n");
-                    }
-                    throw new XPathException(call, ErrorCodes.XPST0017, msg.toString());
-                }
-
-                throw new XPathException(call, ErrorCodes.XPST0017, "Call to undeclared function: " + qname.getStringValue());
+                throw new XPathException(call, ErrorCodes.XPST0017, functionNotFoundErrorDescription(call));
             }
             call.resolveForwardReference(func);
         }
+    }
+
+    /**
+     * Raise an error with an actionable description for a function that could not be resolved
+     * Checks if a function with the same name exists at other arities
+     *
+     * @param call FunctionCall that could not be resolved
+     */
+    private static String functionNotFoundErrorDescription(FunctionCall call) {
+        final QName qname = call.getQName();
+        final int argCount = call.getArgumentCount();
+        final XQueryContext callContext = call.getContext();
+
+        // Check local declared functions
+        final Iterator<FunctionSignature> localSigs = callContext.getSignaturesForFunction(qname);
+
+        // Also check external modules
+        final List<FunctionSignature> allSignatures = new ArrayList<>();
+        while (localSigs.hasNext()) {
+            allSignatures.add(localSigs.next());
+        }
+
+        final Module[] modules = callContext.getModules(qname.getNamespaceURI());
+        if (modules != null) {
+            for (final Module module : modules) {
+                if (module != null) {
+                    final Iterator<FunctionSignature> modSigs = module.getSignaturesForFunction(qname);
+                    while (modSigs.hasNext()) {
+                        allSignatures.add(modSigs.next());
+                    }
+                }
+            }
+        }
+
+        if (!allSignatures.isEmpty()) {
+            final StringBuilder msg = new StringBuilder();
+            msg.append("Unexpectedly received ").append(argCount)
+               .append(" parameter(s) in call to function '")
+               .append(qname.getStringValue()).append("()'. ");
+            msg.append("Defined function signatures are:\r\n");
+            for (final FunctionSignature sig : allSignatures) {
+                msg.append(sig.toString()).append("\r\n");
+            }
+            return msg.toString();
+        }
+
+        return "Call to undeclared function: " + qname.getStringValue();
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2983,60 +2983,16 @@ public class XQueryContext implements BinaryValueManager, Context {
     public void resolveForwardReferences() throws XPathException {
         while (!forwardReferences.isEmpty()) {
             final FunctionCall call = forwardReferences.pop();
-            final UserDefinedFunction func = call.getContext().resolveFunction(call.getQName(), call.getArgumentCount());
+            final QName qname = call.getQName();
+            final int argumentCount = call.getArgumentCount();
+            final UserDefinedFunction func = call.getContext().resolveFunction(qname, argumentCount);
 
             if (func == null) {
-                throw new XPathException(call, ErrorCodes.XPST0017, functionNotFoundErrorDescription(call));
+                throw new XPathException(call, ErrorCodes.XPST0017,
+                        Function.functionNotFoundErrorDescription(call.getContext(), qname, argumentCount));
             }
             call.resolveForwardReference(func);
         }
-    }
-
-    /**
-     * Raise an error with an actionable description for a function that could not be resolved
-     * Checks if a function with the same name exists at other arities
-     *
-     * @param call FunctionCall that could not be resolved
-     */
-    private static String functionNotFoundErrorDescription(FunctionCall call) {
-        final QName qname = call.getQName();
-        final int argCount = call.getArgumentCount();
-        final XQueryContext callContext = call.getContext();
-
-        // Check local declared functions
-        final Iterator<FunctionSignature> localSigs = callContext.getSignaturesForFunction(qname);
-
-        // Also check external modules
-        final List<FunctionSignature> allSignatures = new ArrayList<>();
-        while (localSigs.hasNext()) {
-            allSignatures.add(localSigs.next());
-        }
-
-        final Module[] modules = callContext.getModules(qname.getNamespaceURI());
-        if (modules != null) {
-            for (final Module module : modules) {
-                if (module != null) {
-                    final Iterator<FunctionSignature> modSigs = module.getSignaturesForFunction(qname);
-                    while (modSigs.hasNext()) {
-                        allSignatures.add(modSigs.next());
-                    }
-                }
-            }
-        }
-
-        if (!allSignatures.isEmpty()) {
-            final StringBuilder msg = new StringBuilder();
-            msg.append("Unexpectedly received ").append(argCount)
-               .append(" parameter(s) in call to function '")
-               .append(qname.getStringValue()).append("()'. ");
-            msg.append("Defined function signatures are:\r\n");
-            for (final FunctionSignature sig : allSignatures) {
-                msg.append(sig.toString()).append("\r\n");
-            }
-            return msg.toString();
-        }
-
-        return "Call to undeclared function: " + qname.getStringValue();
     }
 
     /**

--- a/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.*;
 public class GetXMLResourceNoLockTest {
 
 	@ClassRule
-	public static final ExistWebServer existWebServer = new ExistWebServer(false, false, false, true);
+	public static final ExistWebServer existWebServer = new ExistWebServer(true, false, false, true);
 
     private static String EMPTY_BINARY_FILE = "What's an up dog?";
     private static XmldbURI DOCUMENT_NAME_URI = XmldbURI.create("empty.txt");


### PR DESCRIPTION
-- update --

All function not found error messages throughout the codebase now all go through one method that compiles the actionable message (all occasions were this made sense).
<img width="859" height="321" alt="Screenshot 2026-06-19 at 12 19 20" src="https://github.com/user-attachments/assets/5f6e8214-d4a0-4135-90c3-6165842cf7df" />



Fixes 

- improve not found error message for namespaces spread over more than one module
- check deprecated functions in external modules as well
- drop code path that attempts to resolve functions in the XSL namespace in XPath namespace instead

Add a new helper function to FunctionFactory to keep logic from to two call sites in one place:
- ArrowOperator
- XqueryTree.g

Reformat and refactor for readability and maintainability
- FunctionFactory
- Use Function.setASTNode(ast) instead of Function.setLocation(line, number)
- Use XPathException constructor with AST as first parameter
- improve and fix JavaDoc
- simplify and improve internal helpers
- align interfaces for internal and external modules

Smaller refactorings for readability and maintainability in 
- ArrowOperator
- XqueryContext

Tests 

One test kept failing on my local machine with a fixed port (could not bind to 8088)
I switched it to using a random port instead. Please review this with care as well.

