### PR TITLE
[bugfix] RESTServer: set Content-Type for JSON results

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -2221,6 +2221,32 @@ public class RESTServer {
         }
     }
 
+    /**
+     * Set the response Content-Type for a JSON REST result, unless one has
+     * already been set. The default media-type carried in the serialization
+     * properties is the XML type, so for a JSON result fall back to
+     * application/json unless the query requested a different (non-XML-default)
+     * media-type via output:media-type.
+     *
+     * @param response the HTTP response
+     * @param outputProperties the serialization properties
+     */
+    private static void setJsonResponseContentType(final HttpServletResponse response, final Properties outputProperties) {
+        if (response.containsHeader("Content-Type")) {
+            return;
+        }
+        String mimeType = outputProperties.getProperty(OutputKeys.MEDIA_TYPE);
+        if (mimeType == null || MimeType.XML_TYPE.getName().equals(mimeType)) {
+            mimeType = MimeType.JSON_TYPE.getName();
+        } else {
+            final int semicolon = mimeType.indexOf(';');
+            if (semicolon != Constants.STRING_NOT_FOUND) {
+                mimeType = mimeType.substring(0, semicolon);
+            }
+        }
+        response.setContentType(mimeType + "; charset=" + getEncoding(outputProperties));
+    }
+
     private void writeResultJSON(final HttpServletResponse response,
         final DBBroker broker, final Txn transaction, final Sequence results, int howmany,
         int start, final Properties outputProperties, final boolean wrap, final long compilationTime, final long executionTime)
@@ -2239,6 +2265,11 @@ public class RESTServer {
         } else {
             howmany = 0;
         }
+
+        // The XML path honors output:media-type, but the JSON path historically
+        // left Content-Type unset, so output:media-type was silently ignored for
+        // JSON results. Set it here, before the output stream is opened.
+        setJsonResponseContentType(response, outputProperties);
 
         final Serializer serializer = broker.borrowSerializer();
         outputProperties.setProperty(Serializer.GENERATE_DOC_EVENTS, "false");

--- a/exist-core/src/main/java/org/exist/util/MimeType.java
+++ b/exist-core/src/main/java/org/exist/util/MimeType.java
@@ -55,6 +55,8 @@ public class MimeType {
         new MimeType("text/html", BINARY);
     public final static MimeType TEXT_TYPE =
         new MimeType("text/plain", BINARY);
+    public final static MimeType JSON_TYPE =
+        new MimeType("application/json", BINARY);
     public final static MimeType URL_ENCODED_TYPE =
     	new MimeType("application/x-www-form-urlencoded", BINARY);
     public final static MimeType EXPATH_PKG_TYPE =

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -1303,6 +1303,81 @@ try {
     }
 
     /**
+     * A POST query requesting JSON serialization (method="json") must return an
+     * application/json Content-Type. Regression test: writeResultJSON previously
+     * never called response.setContentType(), so the JSON result was emitted with
+     * the wrong (or no) media type and output:media-type was silently ignored.
+     */
+    @Test
+    public void postQueryJsonContentType() throws IOException {
+        final String queryJson = """
+                <query xmlns="http://exist.sourceforge.net/NS/exist" method="json">
+                    <text>1 + 1</text>
+                </query>""";
+        final HttpURLConnection connect = getConnection(getCollectionUri());
+        try {
+            connect.setRequestProperty("Authorization", "Basic " + credentials);
+            connect.setRequestMethod("POST");
+            connect.setDoOutput(true);
+            connect.setRequestProperty("Content-Type", "application/xml");
+            try (final Writer writer = new OutputStreamWriter(connect.getOutputStream(), UTF_8)) {
+                writer.write(queryJson);
+            }
+
+            connect.connect();
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+
+            String contentType = connect.getContentType();
+            final int semicolon = contentType.indexOf(';');
+            if (semicolon > 0) {
+                contentType = contentType.substring(0, semicolon).trim();
+            }
+            assertEquals("Server returned content type " + contentType, "application/json", contentType);
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    /**
+     * An explicit media-type must be honored for JSON results rather than being
+     * overridden by the application/json default.
+     */
+    @Test
+    public void postQueryJsonExplicitMediaType() throws IOException {
+        final String queryJson = """
+                <query xmlns="http://exist.sourceforge.net/NS/exist" method="json">
+                    <properties>
+                        <property name="media-type" value="application/vnd.api+json"/>
+                    </properties>
+                    <text>1 + 1</text>
+                </query>""";
+        final HttpURLConnection connect = getConnection(getCollectionUri());
+        try {
+            connect.setRequestProperty("Authorization", "Basic " + credentials);
+            connect.setRequestMethod("POST");
+            connect.setDoOutput(true);
+            connect.setRequestProperty("Content-Type", "application/xml");
+            try (final Writer writer = new OutputStreamWriter(connect.getOutputStream(), UTF_8)) {
+                writer.write(queryJson);
+            }
+
+            connect.connect();
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+
+            String contentType = connect.getContentType();
+            final int semicolon = contentType.indexOf(';');
+            if (semicolon > 0) {
+                contentType = contentType.substring(0, semicolon).trim();
+            }
+            assertEquals("Server returned content type " + contentType, "application/vnd.api+json", contentType);
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    /**
      * By default there should be NO doctype serialized.
      */
     @Test


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

The REST server's JSON result writer (`RESTServer.writeResultJSON`) never set the response `Content-Type`. As a result, query results serialized as JSON — a POST `<query method="json">` (the JSON result envelope used by the query sandbox in eXide and other clients) — were returned **without** a `Content-Type` header, and `output:media-type` was silently ignored on that path. Clients then received JSON under the wrong media type, which is the "XML Parsing Error in console" class of failure (browsers try to parse a JSON body as XML).

The XML writer (`writeResultXML`) already honors `output:media-type` and sets `Content-Type`; the JSON writer simply never did.

## Fix

In `writeResultJSON`, set the response `Content-Type` before the output stream is opened (mirroring the XML path):

- if the response already carries a `Content-Type`, leave it;
- otherwise default to `application/json`, **but** honor an explicit `output:media-type` when the query set one to something other than the XML default (so a custom type like `application/vnd.api+json` is respected).

The logic lives in a small private helper (`setJsonResponseContentType`) so the (already large) `writeResultJSON` method gains no extra branching. A reusable `MimeType.JSON_TYPE` constant (`application/json`) is added alongside the existing `XML_TYPE`/`HTML_TYPE`/`TEXT_TYPE`.

## Tests

Two new cases in `RESTServiceTest`:

- `postQueryJsonContentType` — a `method="json"` query returns `Content-Type: application/json`.
- `postQueryJsonExplicitMediaType` — an explicit `media-type` is honored rather than overridden by the `application/json` default.

Both pass; the change introduces no new PMD findings (the touched method drops back under the NPath threshold).

## Context

This is an independent eXist-core bug that surfaced in discussion of the eXide login work (the same underlying gap behind eXist-db/eXide#253). It's worth fixing on its own because the JSON result envelope is used by any REST/JSON client, not just eXide — eXide's own login has separately moved onto Roaster. A companion effort adds reusable Accept-header content negotiation to the `request` module; this PR is just the narrow Content-Type bug and stands alone.
