### PR TITLE
[doc] AGENTS.md: add XQSuite-vs-Java test-selection rubric; remove stale Known Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,23 @@ Add to `ErrorCodes.java` in a labeled block for your feature area:
 public static final ErrorCode FOXX0001 = new ErrorCode("FOXX0001", "Description");
 ```
 
+### Choosing XQSuite vs Java tests
+
+Default to **XQSuite** (`%test:` annotations) for anything that is XQuery-level behavior — it's idiomatic, runs in-process, and lives beside the XQuery code.
+
+Use **Java** only when XQSuite structurally can't express or exercise the behavior:
+
+1. The unit under test is **Java, not XQuery** (a util/algorithm class) — pure JUnit.
+2. The function needs a **context XQSuite doesn't provide** — above all an HTTP request/response context. `request:`/`response:`/`session:` functions throw `XPDY0002` with no live request. Test via Java with a mocked `RequestWrapper` + `context.setHttpContext(...)` (see `GetData2Test`), or over real HTTP (`RESTServiceTest`).
+3. The behavior **IS the HTTP/transport layer** — status codes, response headers (e.g. `Content-Type`), serialization wire format, end-to-end content negotiation → Java HTTP integration test (`RESTServiceTest`).
+4. Behavior depends on **Java-level wiring** — broker pool, locking/concurrency, transactions, startup/config.
+
+Within Java, use the lightest vehicle that exercises the real behavior: pure unit test for pure logic; mocked-request unit test for request-bound function logic (`GetData2Test` pattern); full HTTP integration test only when you need the real request pipeline / transport.
+
+One-line test: "Can this be a pure XQuery assertion, runnable without an HTTP request or Java-internal state?" → XQSuite. Otherwise → Java, lightest form.
+
+Concrete precedent: PR eXist-db/exist#6477 (request-module content negotiation) — `request:negotiate-content-type` / `request:parse-accept-header` couldn't be XQSuite-tested (request-bound), so they use `AcceptHeaderTest` (pure logic) + `RESTServiceTest` (HTTP wiring).
+
 ## Git & PR Workflow
 
 ### Remotes
@@ -215,12 +232,6 @@ eXist-db uses the [exist-xqts-runner](https://github.com/eXist-db/exist-xqts-run
 ### XQuery 4.0 Reference Implementations
 - **BaseX**: reference implementation for XQuery 4.0 features including XQUF and ixml
 - **Saxon**: reference implementation for XQuery 4.0, XPath 4.0, and XSLT 4.0
-
-## Known Issues
-
-- `groupby.collation` test is flaky — occasionally throws `ArrayIndexOutOfBoundsException`. Pre-existing FLWOR bug.
-- eXist doesn't check HOF return types, only arity (issue #3382). `fn:filter` uses `effectiveBooleanValue()` instead of validating `xs:boolean` return type.
-- `fn:doc()` can only load documents from the XML database, not from the local filesystem via `file://` URIs (by design — security boundary).
 
 ---
 


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Two documentation-only changes to `AGENTS.md`:

1. Adds a "Choosing XQSuite vs Java tests" subsection that standardizes when a new test for eXist core should be written in XQSuite versus Java.
2. Removes the "Known Issues" section, whose three entries are all stale.

## Why

`AGENTS.md` is the canonical, repo-rooted home for contributor conventions, so guidance placed here is visible to any session or contributor working in the repo. The rubric captures a recurring decision (XQSuite vs Java, and which Java vehicle) that otherwise gets re-derived case by case. The Known Issues section, meanwhile, had drifted out of date and was actively misleading.

## The test-selection rubric

- Default to **XQSuite** (`%test:` annotations) for XQuery-level behavior.
- Reach for **Java** only when XQSuite structurally can't express or exercise the behavior: a pure-Java unit; a function needing a context XQSuite doesn't provide (above all an HTTP request/response context — `request:`/`response:`/`session:` throw `XPDY0002` with no live request); behavior that *is* the HTTP/transport layer; or behavior depending on Java-level wiring (broker pool, locking, transactions, startup/config).
- Within Java, use the lightest vehicle that exercises the real behavior (pure unit → mocked-request unit → full HTTP integration test).
- Cites the request-module content-negotiation work (#6477) as a concrete precedent.

## Why the Known Issues section was removed

All three entries were verified against current `develop` and found stale:

- **`groupby.collation` "flaky" / `ArrayIndexOutOfBoundsException`** — unsubstantiated. No issue, PR, commit, or CI log backs the claim; it entered via a bulk doc-add commit with no linked bug. The test is deterministic (fixed expected result, codepoint collation) and passes. Leaving an unbacked "known flake" in the guide risks agents dismissing real CI failures as expected.
- **fn:filter / #3382** — fixed. #3382 is closed, and `fn:filter` now raises `XPTY0004` when the predicate function does not return `xs:boolean`.
- **fn:doc() `file://` restriction** — unsubstantiated. `DocUtils` already routed `file:`/URL paths through `SourceFactory` when this entry was added (2026-03-15), so `fn:doc` could load `file:` documents all along. The later #6207 work only added security-gating (e.g. an absolute `file:///etc/passwd` is blocked there) — it did not lift a block that never existed.

Two of the three were never true, and the third is fixed, so the section is removed rather than left partially correct.

## Notes

Documentation only — no code or test changes.
