### PR TITLE
[feature] Enable HTTP/2 for jetty

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -435,6 +435,21 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>jetty-http2-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
         </dependency>
@@ -1033,6 +1048,9 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-jmx:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty.ee10:jetty-ee10-annotations:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-security:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty.http2:jetty-http2-server:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-alpn-server:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-alpn-java-server:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>${project.groupId}:exist-jetty-config:jar:${project.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-client:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.mina:mina-core</ignoredUnusedDeclaredDependency>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
@@ -31,6 +31,11 @@
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
               </New>
             </Item>
+            <Item>
+              <New class="org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory">
+                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+              </New>
+            </Item>
           </Array>
         </Arg>
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.http.host" deprecated="jetty.host"/></Default></Property></Set>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
@@ -11,8 +11,30 @@
   <Call name="addIfAbsentConnectionFactory">
     <Arg>
       <New class="org.eclipse.jetty.server.SslConnectionFactory">
-        <Arg name="next">http/1.1</Arg>
+        <Arg name="next">alpn</Arg>
         <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+      </New>
+    </Arg>
+  </Call>
+
+  <Call name="addConnectionFactory">
+    <Arg>
+      <New class="org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory">
+        <Arg name="protocols">
+          <Array type="String">
+            <Item>h2</Item>
+            <Item>http/1.1</Item>
+          </Array>
+        </Arg>
+        <Set name="defaultProtocol">http/1.1</Set>
+      </New>
+    </Arg>
+  </Call>
+
+  <Call name="addConnectionFactory">
+    <Arg>
+      <New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
+        <Arg name="config"><Ref refid="sslHttpConfig" /></Arg>
       </New>
     </Arg>
   </Call>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
@@ -41,6 +41,8 @@
         <Item>.*MD5.*</Item>
         <Item>.*DES.*</Item>
         <Item>.*DSS.*</Item>
+        <Item>.*_CBC_.*</Item>
+        <Item>.*_SHA$</Item>
       </Array>
     </Arg>
   </Call>
@@ -55,6 +57,8 @@
         <Item>SSLv2</Item>
         <Item>SSLv2Hello</Item>
         <Item>SSLv3</Item>
+        <Item>TLSv1</Item>
+        <Item>TLSv1.1</Item>
       </Array>
     </Arg>
   </Call>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
@@ -76,6 +76,8 @@
       <Set name="multiPartCompliance"><Call class="org.eclipse.jetty.http.MultiPartCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.multiPartCompliance" default="RFC7578"/></Arg></Call></Set>
       <Set name="httpCompliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230_LEGACY"/></Arg></Call></Set>
       <Set name="uriCompliance"><Call class="org.eclipse.jetty.http.UriCompliance" name="valueOf"><Arg><Property name="jetty.uri.compliance" default="UNSAFE"/></Arg></Call></Set>
+      <Set name="useInputDirectByteBuffers"><Property name="jetty.httpConfig.useInputDirectByteBuffers" default="true" /></Set>
+      <Set name="useOutputDirectByteBuffers"><Property name="jetty.httpConfig.useOutputDirectByteBuffers" default="true" /></Set>
     </New>
 
     <!-- =========================================================== -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
@@ -31,6 +31,11 @@
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
               </New>
             </Item>
+            <Item>
+              <New class="org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory">
+                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+              </New>
+            </Item>
           </Array>
         </Arg>
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.http.host" deprecated="jetty.host"/></Default></Property></Set>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -371,6 +371,22 @@
                 <artifactId>jetty-http</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>jetty-http2-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-server</artifactId>
+                <version>${jetty.version}</version>
+                <scope>runtime</scope>
+            </dependency>
             <!-- Jetty 12 ee10 modules (Jakarta EE 10 / Servlet 6.0) -->
             <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>


### PR DESCRIPTION
outcome:

(plain)

```
curl -i http://localhost:8080/exist/apps/dashboard/index.html            
HTTP/1.1 200 OK
Server: Jetty(12.1.10)
Date: Tue, 16 Jun 2026 20:20:42 GMT
Vary: Accept-Encoding
Last-Modified: Tue, 16 Jun 2026 19:57:47 GMT
Created: Tue, 16 Jun 2026 19:57:47 GMT
Content-Type: text/html;charset=utf-8
Content-Length: 881
```

(force http2)
```
curl -i --http2 http://localhost:8080/exist/apps/dashboard/index.html 
HTTP/1.1 101 Switching Protocols
Upgrade: h2c
Connection: Upgrade

HTTP/2 200 
server: Jetty(12.1.10)
date: Tue, 16 Jun 2026 19:45:40 GMT
vary: Accept-Encoding
last-modified: Tue, 16 Jun 2026 19:43:17 GMT
created: Tue, 16 Jun 2026 19:43:17 GMT
content-type: text/html;charset=utf-8
content-length: 881
```


(https):

```
curl -i https://localhost:8443/exist/apps/dashboard/index.html --insecure
**HTTP/2 200** 
server: Jetty(12.1.10)
date: Tue, 16 Jun 2026 20:13:41 GMT
vary: Accept-Encoding
last-modified: Tue, 16 Jun 2026 19:57:47 GMT
created: Tue, 16 Jun 2026 19:57:47 GMT
content-type: text/html;charset=utf-8
content-length: 881

```



----

Browsers will only use HTTP/2 with Jetty if all the protocol and TLS prerequisites are met; if you see HTTP/1.1 in Safari/Chrome, it usually means you are hitting cleartext HTTP or your HTTPS/ALPN/TLS setup is incomplete.
Key points to check
	•	Use HTTPS, not HTTP. All major browsers only speak HTTP/2 as  h2  over TLS, not cleartext  h2c , so  http://...  will stay on HTTP/1.1 while  curl --http2-prior-knowledge  can still talk h2c.
	•	ALPN must advertise  h2 . Your Jetty TLS connector has to be configured with HTTP/2 support (http2 module /  HTTP2ServerConnectionFactory ) and ALPN so that the TLS handshake offers  h2  to the browser.
	•	Cipher suites and protocol order. HTTP/2 requires modern ciphers; Jetty usually needs you to prefer HTTP/2‑compatible ciphers and list HTTP/2 before HTTP/1.1 in the protocol preference, otherwise some browsers will negotiate down to HTTP/1.1.
	•	Hostnames and certificates. Use a proper hostname with a certificate whose CN/SAN matches it; some browsers have special rules or limitations for  localhost  or raw IPs with TLS that can interfere with HTTP/2

