### PR TITLE
[test] Cover boost-config + facet drill-down in the ft:highlight regression

### DIFF
--- a/extensions/indexes/lucene/src/test/xquery/lucene/facet-drilldown-highlight.xqm
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facet-drilldown-highlight.xqm
@@ -67,17 +67,47 @@ declare variable $fdh:DOC2 :=
         <section><para>map:merge combines maps; array and map are XDM types.</para></section>
     </article>;
 
+(: A second collection whose index carries a boost (boost="2.0" on the para field). With a boost
+ : config present, every query is additionally wrapped in a FunctionScoreQuery, so under facet
+ : drill-down the query stored on the match is FunctionScoreQuery(DrillDownQuery(content)). That is
+ : the case the FunctionScoreQuery branch in LuceneUtil.extractTerms must unwrap to reach the
+ : DrillDownQuery (whose visit() is an opaque leaf); without it, boosted faceted highlights are empty. :)
+declare variable $fdh:BOOST-COLLECTION := "/db/lucene-test-facet-highlight-boost";
+declare variable $fdh:BOOST-CONFIG := "/db/system/config/db/lucene-test-facet-highlight-boost";
+
+declare variable $fdh:BOOST-XCONF :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index>
+            <lucene>
+                <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                <text qname="para" boost="2.0">
+                    <field name="content" expression="."/>
+                    <facet dimension="kind" expression="'para'"/>
+                </text>
+                <text qname="caption">
+                    <field name="content" expression="."/>
+                    <facet dimension="kind" expression="'caption'"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
 declare
     %test:setUp
 function fdh:setup() {
     let $_ := (xmldb:create-collection("/db/system", "config"), xmldb:create-collection("/db/system/config", "db"))
     let $conf := xmldb:create-collection("/db/system/config/db", "lucene-test-facet-highlight")
     let $col := xmldb:create-collection("/db", "lucene-test-facet-highlight")
+    let $boostConf := xmldb:create-collection("/db/system/config/db", "lucene-test-facet-highlight-boost")
+    let $boostCol := xmldb:create-collection("/db", "lucene-test-facet-highlight-boost")
     return (
         xmldb:store($conf, "collection.xconf", $fdh:XCONF),
         xmldb:store($col, "doc1.xml", $fdh:DOC1),
         xmldb:store($col, "doc2.xml", $fdh:DOC2),
-        xmldb:reindex($col)
+        xmldb:reindex($col),
+        xmldb:store($boostConf, "collection.xconf", $fdh:BOOST-XCONF),
+        xmldb:store($boostCol, "doc1.xml", $fdh:DOC1),
+        xmldb:reindex($boostCol)
     )
 };
 
@@ -85,7 +115,9 @@ declare
     %test:tearDown
 function fdh:tearDown() {
     if (xmldb:collection-available($fdh:COLLECTION)) then xmldb:remove($fdh:COLLECTION) else (),
-    if (xmldb:collection-available($fdh:CONFIG)) then xmldb:remove($fdh:CONFIG) else ()
+    if (xmldb:collection-available($fdh:CONFIG)) then xmldb:remove($fdh:CONFIG) else (),
+    if (xmldb:collection-available($fdh:BOOST-COLLECTION)) then xmldb:remove($fdh:BOOST-COLLECTION) else (),
+    if (xmldb:collection-available($fdh:BOOST-CONFIG)) then xmldb:remove($fdh:BOOST-CONFIG) else ()
 };
 
 (: control: a plain (unfaceted) query highlights fine :)
@@ -128,4 +160,24 @@ declare
 function fdh:drilldown-excludes-other-facet() {
     let $opts := map { "facets": map { "kind": "para" } }
     return count(collection($fdh:COLLECTION)//caption[ft:query(., "content:(array)", $opts)])
+};
+
+(: regression: boost config + facet drill-down must STILL highlight. With a boost the match query is
+   FunctionScoreQuery(DrillDownQuery(content)); the FunctionScoreQuery branch in extractTerms unwraps
+   to the DrillDownQuery and then its base query. Empty before the fix (and on develop). :)
+declare
+    %test:assertTrue
+function fdh:faceted-query-highlights-with-boost() {
+    let $opts := map { "facets": map { "kind": "para" } }
+    let $hit := (collection($fdh:BOOST-COLLECTION)//para[ft:query(., "content:(array)", $opts)])[1]
+    return exists(ft:highlight-field-matches($hit, "content")//exist:match)
+};
+
+(: the highlighted term is the queried term, under boost + drill-down :)
+declare
+    %test:assertTrue
+function fdh:faceted-highlight-marks-the-term-with-boost() {
+    let $opts := map { "facets": map { "kind": "para" } }
+    let $hit := (collection($fdh:BOOST-COLLECTION)//para[ft:query(., "content:(array)", $opts)])[1]
+    return lower-case(string(ft:highlight-field-matches($hit, "content")//exist:match[1])) = "array"
 };


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

Test-only follow-up to #6454 (merged), which fixed `ft:highlight-field-matches` under facet drill-down. That fix had two parts in `LuceneUtil.extractTerms`: `extractTermsFromDrillDown` now uses `DrillDownQuery.getBaseQuery()` instead of rewriting, and a new `FunctionScoreQuery` case unwraps `getWrappedQuery()` and recurses.

The second part exists specifically for the **boost-config + facet** combination: when an index carries a boost, the query stored on each match is `FunctionScoreQuery(DrillDownQuery(content))`, and `DrillDownQuery.visit()` is an opaque `visitLeaf` — so without unwrapping the `FunctionScoreQuery` to reach the drill-down's base query, highlight extraction marks nothing. That path shipped in #6454 without a dedicated test; this PR adds one.

## What changed

- `extensions/indexes/lucene/src/test/xquery/lucene/facet-drilldown-highlight.xqm` — adds a second, boost-configured collection (`boost="2.0"` on the `para` field) and two assertions against it:
  - a faceted query still highlights under boost;
  - the highlighted term is the queried term under boost + drill-down.

No production code changes — the fix is already in `develop` via #6454.

## Test plan

- [x] Full lucene XQuery suite green: `LuceneTests` 668 tests, 0 failures, 0 errors (36 pre-existing skips).
- [x] Confirmed the two new assertions **fail** when the `FunctionScoreQuery` unwrap is removed and **pass** with it — i.e. they genuinely guard that path, not just the already-covered plain-facet path.
