### PR TITLE
[feature] compression: add serialization-options argument to compression:zip / compression:tar

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -66,6 +66,14 @@ public class MapType extends AbstractMapType {
      * then this is set to {@link #MIXED_KEY_TYPES}.
      * <p>
      * Uses integer values from {@link org.exist.xquery.value.Type}.
+     * <p>
+     * This is reported via {@link #getKeyType()} but does NOT take part in key
+     * comparison. Lookups ({@link #get(AtomicValue)} / {@link #contains(AtomicValue)})
+     * delegate directly to the underlying map, whose comparator implements
+     * {@code op:same-key} (see {@link AbstractMapType#sameKey}). Keys are compared
+     * by their op:same-key family, never coerced to {@code keyType} - a key from a
+     * different family that shares a lexical value (e.g. the string {@code "12"}
+     * and the integer {@code 12}) is correctly treated as distinct.
      */
     private int keyType = UNKNOWN_KEY_TYPE;
 
@@ -251,12 +259,7 @@ public class MapType extends AbstractMapType {
     }
 
     @Override
-    public Sequence get(AtomicValue key) {
-        key = convert(key);
-        if (key == null) {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-
+    public Sequence get(final AtomicValue key) {
         return map.get(key, Sequence.EMPTY_SEQUENCE);
     }
 
@@ -267,12 +270,7 @@ public class MapType extends AbstractMapType {
     }
 
     @Override
-    public boolean contains(AtomicValue key) {
-        key = convert(key);
-        if (key == null) {
-            return false;
-        }
-
+    public boolean contains(final AtomicValue key) {
         return map.contains(key);
     }
 
@@ -373,17 +371,6 @@ public class MapType extends AbstractMapType {
                 break; // done, we only have to detect this once!
             }
         }
-    }
-
-    private AtomicValue convert(final AtomicValue key) {
-        if (keyType != UNKNOWN_KEY_TYPE && keyType != MIXED_KEY_TYPES) {
-            try {
-                return key.convertTo(keyType);
-            } catch (final XPathException e) {
-                return null;
-            }
-        }
-        return key;
     }
 
     @Override

--- a/exist-core/src/test/xquery/maps/mapKeySameKey.xqm
+++ b/exist-core/src/test/xquery/maps/mapKeySameKey.xqm
@@ -1,0 +1,179 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for map key comparison via op:same-key (XQuery 3.1 section 17.1).
+ :
+ : Map keys are compared with op:same-key, which is a TYPE-GROUP comparison:
+ :   - the numeric family (xs:decimal/xs:integer/xs:float/xs:double) interchanges,
+ :   - the string family (xs:string/xs:anyURI/xs:untypedAtomic) interchanges,
+ :   - every other type matches only itself.
+ : There is NO key atomization or casting across groups.
+ :
+ : These tests deliberately use the map{...} CONSTRUCTOR form (which builds a
+ : homogeneously-typed map). The qt3/qt4 suites place their cross-family
+ : distinctness tests on map:entry() (a mixed-key map), so the constructor path
+ : was historically untested - and eXist used to conflate cross-family keys that
+ : shared a lexical value (e.g. map{"12":"x"}(12) wrongly returned "x").
+ :)
+module namespace skt="http://exist-db.org/xquery/test/maps/samekey";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+(: ----------------------------------------------------------------------- :)
+(: Cross-family distinctness: keys of different op:same-key families that   :)
+(: share a lexical value must NOT match.                                    :)
+(: ----------------------------------------------------------------------- :)
+
+declare
+    %test:name("string key vs integer lookup are distinct (contains)")
+    %test:assertFalse
+function skt:string-key-vs-integer-contains() {
+    map:contains(map { "12": "x" }, 12)
+};
+
+declare
+    %test:name("string key vs integer lookup are distinct (get)")
+    %test:assertEmpty
+function skt:string-key-vs-integer-get() {
+    map:get(map { "12": "x" }, 12)
+};
+
+declare
+    %test:name("string key vs double lookup are distinct (contains)")
+    %test:assertFalse
+function skt:string-key-vs-double-contains() {
+    map:contains(map { "5": 1 }, 5.0e0)
+};
+
+declare
+    %test:name("string key vs xs:date lookup are distinct (contains)")
+    %test:assertFalse
+function skt:string-key-vs-date-contains() {
+    map:contains(map { "2020-01-01": 1 }, xs:date("2020-01-01"))
+};
+
+declare
+    %test:name("xs:date key vs string lookup are distinct (contains)")
+    %test:assertFalse
+function skt:date-key-vs-string-contains() {
+    map:contains(map { xs:date("2020-01-01"): 1 }, "2020-01-01")
+};
+
+declare
+    %test:name("boolean key vs string lookup are distinct (contains)")
+    %test:assertFalse
+function skt:boolean-key-vs-string-contains() {
+    map:contains(map { true(): "x" }, "true")
+};
+
+declare
+    %test:name("integer key vs string lookup are distinct (contains)")
+    %test:assertFalse
+function skt:integer-key-vs-string-contains() {
+    map:contains(map { 12: "x" }, "12")
+};
+
+(: ----------------------------------------------------------------------- :)
+(: Numeric family is by VALUE, not by lossy cast: a non-integral lookup     :)
+(: must not match an integer key (no truncation).                           :)
+(: ----------------------------------------------------------------------- :)
+
+declare
+    %test:name("integer key does not match a non-integral double lookup (contains)")
+    %test:assertFalse
+function skt:integer-key-vs-fractional-double-contains() {
+    map:contains(map { 1: "x" }, 1.5e0)
+};
+
+declare
+    %test:name("integer key does not match a non-integral double lookup (get)")
+    %test:assertEmpty
+function skt:integer-key-vs-fractional-double-get() {
+    map:get(map { 1: "x" }, 1.5e0)
+};
+
+(: ----------------------------------------------------------------------- :)
+(: Within-family positives: members of the SAME op:same-key family that     :)
+(: are value-equal MUST interchange (these must not regress).               :)
+(: ----------------------------------------------------------------------- :)
+
+declare
+    %test:name("numeric family: integer key matches equal double lookup (contains)")
+    %test:assertTrue
+function skt:numeric-integer-key-vs-double-contains() {
+    map:contains(map { 5: 1 }, 5.0e0)
+};
+
+declare
+    %test:name("numeric family: integer key matches equal double lookup (get)")
+    %test:assertEquals(1)
+function skt:numeric-integer-key-vs-double-get() {
+    map:get(map { 5: 1 }, 5.0e0)
+};
+
+declare
+    %test:name("numeric family: decimal key matches equal integer lookup (contains)")
+    %test:assertTrue
+function skt:numeric-decimal-key-vs-integer-contains() {
+    map:contains(map { 5.0: 1 }, 5)
+};
+
+declare
+    %test:name("string family: string key matches equal xs:anyURI lookup (contains)")
+    %test:assertTrue
+function skt:string-key-vs-anyuri-contains() {
+    map:contains(map { "urn:x": 1 }, xs:anyURI("urn:x"))
+};
+
+declare
+    %test:name("string family: string key matches equal xs:untypedAtomic lookup (get)")
+    %test:assertEquals("x")
+function skt:string-key-vs-untypedatomic-get() {
+    map:get(map { "12": "x" }, xs:untypedAtomic("12"))
+};
+
+declare
+    %test:name("string family: anyURI key matches equal string lookup (contains)")
+    %test:assertTrue
+function skt:anyuri-key-vs-string-contains() {
+    map:contains(map { xs:anyURI("urn:x"): 1 }, "urn:x")
+};
+
+(: ----------------------------------------------------------------------- :)
+(: Same-type self-matches still work after the fix.                         :)
+(: ----------------------------------------------------------------------- :)
+
+declare
+    %test:name("string key matches equal string lookup (get)")
+    %test:assertEquals("x")
+function skt:string-key-self-get() {
+    map:get(map { "12": "x" }, "12")
+};
+
+declare
+    %test:name("xs:date key matches equal xs:date lookup (contains)")
+    %test:assertTrue
+function skt:date-key-self-contains() {
+    map:contains(map { xs:date("2020-01-01"): 1 }, xs:date("2020-01-01"))
+};

--- a/exist-core/src/test/xquery/xquery3/fnSerializeNewline.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnSerializeNewline.xqm
@@ -49,20 +49,25 @@ function ser:exist-insert-final-newline-true() {
 
 declare
     %test:assertTrue
-function ser:exist-insert-final-newline-false-json() {
+function ser:exist-insert-final-newline-true-json() {
     let $doc := map { "a": 1 }
     let $serialized := fn:serialize($doc,
         map {
             "method": "json",
-            "exist:insert-final-newline": false()
+            xs:QName("exist:insert-final-newline"): true()
         }
     )
-    return fn:ends-with($serialized, "}")
+    return fn:ends-with($serialized, "&#x0A;")
 };
 
+(: An eXist serialization parameter keyed by the prefixed string "exist:..." is
+ : NON-conformant and is now ignored - only the xs:QName key form is honored,
+ : because op:same-key treats a string key and a QName key as distinct. Passing
+ : true() via the string key therefore has no effect, so the default
+ : (insert-final-newline=false) applies and no trailing newline is added. :)
 declare
     %test:assertTrue
-function ser:exist-insert-final-newline-true-json() {
+function ser:exist-insert-final-newline-json-prefixed-string-ignored() {
     let $doc := map { "a": 1 }
     let $serialized := fn:serialize($doc,
         map {
@@ -70,5 +75,5 @@ function ser:exist-insert-final-newline-true-json() {
             "exist:insert-final-newline": true()
         }
     )
-    return fn:ends-with($serialized, "&#x0A;")
+    return fn:ends-with($serialized, "}")
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -681,14 +681,16 @@ function ser:exist-output-doctype-QName($value as xs:boolean) {
         map { xs:QName("exist:output-doctype") : $value })
 };
 
+(: An eXist serialization parameter keyed by the prefixed string "exist:..." is
+ : NON-conformant and is now ignored - only the xs:QName key form is honored,
+ : because op:same-key treats a string key and a QName key as distinct. Passing
+ : true() via the string key therefore has no effect, so the default (no doctype)
+ : applies. The xs:QName form is exercised by ser:exist-output-doctype-QName above. :)
 declare
-    %test:args("true")
-    %test:assertXPath("contains($result, '-//OASIS//DTD DITA BookMap//EN') and contains($result, 'bookmap.dtd')")
-    %test:args("false")
     %test:assertXPath("not(contains($result, '-//OASIS//DTD DITA BookMap//EN')) and not(contains($result, 'bookmap.dtd'))")
-function ser:exist-output-doctype-string($value as xs:boolean) {
+function ser:exist-output-doctype-prefixed-string-ignored() {
     serialize(doc($ser:collection || "/test-with-doctype.xml"),
-        map { "exist:output-doctype" : $value })
+        map { "exist:output-doctype" : true() })
 };
 
 declare
@@ -701,14 +703,14 @@ function ser:exist-expand-xinclude-QName($value as xs:boolean) {
         map { xs:QName("exist:expand-xincludes"): $value })
 };
 
+(: Prefixed-string key is ignored (see note above); passing false() has no
+ : effect, so the default (expand-xincludes=true) applies and the include is
+ : expanded to its 'comment' content. :)
 declare
-    %test:args("true")
     %test:assertXPath("contains($result, 'comment')")
-    %test:args("false")
-    %test:assertXPath("contains($result, 'include')")
-function ser:exist-expand-xinclude-string($value as xs:boolean) {
+function ser:exist-expand-xinclude-prefixed-string-ignored() {
     serialize($ser:xi-doc,
-        map { "exist:expand-xincludes": $value })
+        map { "exist:expand-xincludes": false() })
 };
 
 declare
@@ -723,16 +725,13 @@ function ser:exist-add-exist-id-QName($value as xs:string) {
         map { xs:QName("exist:add-exist-id"): $value })
 };
 
+(: Prefixed-string key is ignored (see note above); passing "all" has no effect,
+ : so the default (add-exist-id=none) applies and no exist:id attributes appear. :)
 declare
-    %test:args("all")
-    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
-    %test:args("element")
-    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b>123</b></elem>')
-    %test:args("none")
     %test:assertXPath("not(contains($result, 'exist:id'))")
-function ser:exist-add-exist-id-string($value as xs:string) {
+function ser:exist-add-exist-id-prefixed-string-ignored() {
     serialize(doc($ser:collection || "/test.xml"),
-        map { "exist:add-exist-id": $value })
+        map { "exist:add-exist-id": "all" })
 };
 
 declare
@@ -750,17 +749,16 @@ function ser:exist-jsonp-QName($value as xs:string) {
     )
 };
 
+(: Prefixed-string key is ignored (see note above); passing "functionName" has
+ : no effect, so the default (no JSONP callback) applies and plain JSON results. :)
 declare
-    %test:args("functionName")
-    %test:assertEquals('functionName({"author":["John Doe","Robert Smith"]})')
-    %test:args("anotherName")
-    %test:assertEquals('anotherName({"author":["John Doe","Robert Smith"]})')
-function ser:exist-jsonp-string($value as xs:string) {
+    %test:assertEquals('{"author":["John Doe","Robert Smith"]}')
+function ser:exist-jsonp-prefixed-string-ignored() {
     serialize($ser:in-memory-book,
         map {
             "method": "json",
             "media-type": "application/json",
-            "exist:jsonp": $value
+            "exist:jsonp": "functionName"
         }
     )
 };
@@ -775,14 +773,13 @@ function ser:exist-process-xsl-pi-QName($value as xs:boolean) {
         map { xs:QName("exist:process-xsl-pi"): $value })
 };
 
+(: Prefixed-string key is ignored (see note above); passing false() has no
+ : effect, so the default (process-xsl-pi=true) applies and the PI is processed. :)
 declare
-    %test:args("true")
     %test:assertEquals('processed')
-    %test:args("false")
-    %test:assertXPath("contains($result, 'stylesheet')")
-function ser:exist-process-xsl-pi-string($value as xs:boolean) {
+function ser:exist-process-xsl-pi-prefixed-string-ignored() {
     serialize(doc($ser:collection || "/test-xsl.xml"),
-        map { "exist:process-xsl-pi": $value })
+        map { "exist:process-xsl-pi": false() })
 };
 
 declare

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -47,6 +47,7 @@ import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.Option;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
+import org.exist.xquery.functions.fn.FunSerialize;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.Base64BinaryValueType;
 import org.exist.xquery.value.BinaryValueFromInputStream;
@@ -71,6 +72,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.Properties;
 import java.util.zip.CRC32;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.ZipEntry;
@@ -90,9 +92,17 @@ public abstract class AbstractCompressFunction extends BasicFunction {
     protected final static SequenceType COLLECTION_HIERARCHY_PARAM = new FunctionParameterSequenceType("use-collection-hierarchy", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "Indicates whether the Collection hierarchy (if any) should be preserved in the zip file.");
     protected final static SequenceType STRIP_PREFIX_PARAM = new FunctionParameterSequenceType("strip-prefix", Type.STRING, Cardinality.EXACTLY_ONE, "This prefix is stripped from the Entrys name");
     protected final static SequenceType ENCODING_PARAM = new FunctionParameterSequenceType("encoding", Type.STRING, Cardinality.EXACTLY_ONE, "This encoding to be used for filenames inside the compressed file");
+    protected final static SequenceType SERIALIZATION_OPTIONS_PARAM = new FunctionParameterSequenceType("serialization-options", Type.ITEM, Cardinality.ZERO_OR_ONE,
+            "Serialization options applied to XML resources written to the archive, as either an " +
+                    "output:serialization-parameters element or a map(*) (e.g. map { \"indent\": false() }). " +
+                    "Standard W3C parameters use their string key; eXist extension parameters use their exist-namespace QName key. " +
+                    "Takes precedence over any prolog declare option exist:serialize.");
     private final static Logger logger = LogManager.getLogger(AbstractCompressFunction.class);
     public static final String METHOD_STORE = "store";
 
+    /** Serialization options from the optional map argument; reset on each eval and applied to XML
+     *  entries after (so overriding) the prolog {@code declare option exist:serialize}. */
+    private Properties serializationProperties = new Properties();
 
     public AbstractCompressFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
@@ -110,6 +120,20 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         return uri;
     }
 
+    /**
+     * Parses the optional serialization-options map argument (the 5th argument, if present) into the
+     * serialization properties applied to XML entries written to the archive.
+     *
+     * @param args the function arguments
+     * @return the supplied serialization properties, or an empty {@link Properties} when no map was given
+     */
+    private Properties parseSerializationOptions(final Sequence[] args) throws XPathException {
+        if (args.length >= 5 && !args[4].isEmpty()) {
+            return FunSerialize.getSerializationProperties(this, args[4].itemAt(0));
+        }
+        return new Properties();
+    }
+
     @Override
     public Sequence eval(final Sequence[] args, final Sequence contextSequence)
             throws XPathException {
@@ -117,6 +141,9 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         if (args[0].isEmpty()) {
             return Sequence.EMPTY_SEQUENCE;
         }
+
+        // serialization options for XML entries (optional map argument); reset on each call
+        serializationProperties = parseSerializationOptions(args);
 
         // use a hierarchy in the tar file?
         final boolean useHierarchy = args[1].effectiveBooleanValue();
@@ -375,6 +402,10 @@ public abstract class AbstractCompressFunction extends BasicFunction {
                 final String[] kvp = Option.parseKeyValuePair(param);
                 serializer.setProperty(kvp[0], kvp[1]);
             }
+        }
+        // an explicit serialization-options map argument takes precedence over the prolog option
+        for (final String key : serializationProperties.stringPropertyNames()) {
+            serializer.setProperty(key, serializationProperties.getProperty(key));
         }
     }
 

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -100,10 +100,6 @@ public abstract class AbstractCompressFunction extends BasicFunction {
     private final static Logger logger = LogManager.getLogger(AbstractCompressFunction.class);
     public static final String METHOD_STORE = "store";
 
-    /** Serialization options from the optional map argument; reset on each eval and applied to XML
-     *  entries after (so overriding) the prolog {@code declare option exist:serialize}. */
-    private Properties serializationProperties = new Properties();
-
     public AbstractCompressFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
@@ -142,8 +138,9 @@ public abstract class AbstractCompressFunction extends BasicFunction {
             return Sequence.EMPTY_SEQUENCE;
         }
 
-        // serialization options for XML entries (optional map argument); reset on each call
-        serializationProperties = parseSerializationOptions(args);
+        // serialization options for XML entries (optional map argument), threaded through the
+        // compress* calls below so that no per-evaluation state is held on this function instance
+        final Properties serializationProperties = parseSerializationOptions(args);
 
         // use a hierarchy in the tar file?
         final boolean useHierarchy = args[1].effectiveBooleanValue();
@@ -171,9 +168,9 @@ public abstract class AbstractCompressFunction extends BasicFunction {
                     final Item item = i.nextItem();
 
                     if (item instanceof final Element element) {
-                        compressElement(os, element, useHierarchy, stripOffset);
+                        compressElement(os, element, useHierarchy, stripOffset, serializationProperties);
                     } else {
-                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, "", null);
+                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, "", null, serializationProperties);
                     }
                 }
 
@@ -190,7 +187,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         }
     }
 
-    private void compressFromUri(final OutputStream os, final URI uri, final boolean useHierarchy, final String stripOffset, final String method, final String resourceName) throws XPathException {
+    private void compressFromUri(final OutputStream os, final URI uri, final boolean useHierarchy, final String stripOffset, final String method, final String resourceName, final Properties serializationProperties) throws XPathException {
         try {
             if ("file".equals(uri.getScheme())) {
 
@@ -211,7 +208,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
                 // try for a collection
                 try (final Collection collection = context.getBroker().openCollection(xmldburi, LockMode.READ_LOCK)) {
                     if (collection != null) {
-                        compressCollection(os, collection, useHierarchy, stripOffset);
+                        compressCollection(os, collection, useHierarchy, stripOffset, serializationProperties);
                         return;
                     }
                 } catch (final PermissionDeniedException | LockException | SAXException | IOException pde) {
@@ -234,7 +231,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
                             throw new XPathException(this, "Invalid URI: " + uri);
                         }
 
-                        compressResource(os, doc.getDocument(), useHierarchy, stripOffset, method, resourceName);
+                        compressResource(os, doc.getDocument(), useHierarchy, stripOffset, method, resourceName, serializationProperties);
                     }
                 } catch (final PermissionDeniedException | LockException | SAXException | IOException pde) {
                     throw new XPathException(this, pde.getMessage());
@@ -303,7 +300,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
      *                     reflects the collection hierarchy
      */
     private void compressElement(final OutputStream os, final Element element, final boolean useHierarchy,
-                                 final String stripOffset) throws XPathException {
+                                 final String stripOffset, final Properties serializationProperties) throws XPathException {
 
         final String ns = element.getNamespaceURI();
         if ((ns != null && !ns.isEmpty()) || !"entry".equals(element.getNodeName())) {
@@ -321,7 +318,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         final String type = element.getAttribute("type");
 
         if ("uri".equals(type)) {
-            compressFromUri(os, URI.create(element.getFirstChild().getNodeValue()), useHierarchy, stripOffset, element.getAttribute("method"), name);
+            compressFromUri(os, URI.create(element.getFirstChild().getNodeValue()), useHierarchy, stripOffset, element.getAttribute("method"), name, serializationProperties);
             return;
         }
 
@@ -362,7 +359,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
                         try {
                             serializer.setUser(context.getSubject());
                             serializer.setProperty("omit-xml-declaration", "no");
-                            getDynamicSerializerOptions(serializer);
+                            getDynamicSerializerOptions(serializer, serializationProperties);
                             value = serializer.serialize((NodeValue) content).getBytes();
                         } finally {
                             context.getBroker().returnSerializer(serializer);
@@ -393,7 +390,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         }
     }
 
-    private void getDynamicSerializerOptions(final Serializer serializer) throws SAXException {
+    private void getDynamicSerializerOptions(final Serializer serializer, final Properties serializationProperties) throws SAXException {
         final Option option = context.getOption(Option.SERIALIZE_QNAME);
         if (option != null) {
             final String[] params = option.tokenizeContents();
@@ -417,7 +414,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
      * @param useHierarchy Whether to use a folder hierarchy in the archive file that
      *                     reflects the collection hierarchy
      */
-    private void compressResource(final OutputStream os, final DocumentImpl doc, final boolean useHierarchy, final String stripOffset, final String method, final String name) throws IOException, SAXException {
+    private void compressResource(final OutputStream os, final DocumentImpl doc, final boolean useHierarchy, final String stripOffset, final String method, final String name, final Properties serializationProperties) throws IOException, SAXException {
         // create an entry in the Tar for the document
         final Object entry;
         if (name != null) {
@@ -437,7 +434,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
             try {
                 serializer.setUser(context.getSubject());
                 serializer.setProperty("omit-xml-declaration", "no");
-                getDynamicSerializerOptions(serializer);
+                getDynamicSerializerOptions(serializer, serializationProperties);
                 final String strDoc = serializer.serialize(doc);
                 value = strDoc.getBytes();
             } finally {
@@ -478,7 +475,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
      * @param useHierarchy Whether to use a folder hierarchy in the archive file that
      *                     reflects the collection hierarchy
      */
-    private void compressCollection(final OutputStream os, final Collection col, final boolean useHierarchy, final String stripOffset) throws IOException, SAXException, LockException, PermissionDeniedException {
+    private void compressCollection(final OutputStream os, final Collection col, final boolean useHierarchy, final String stripOffset, final Properties serializationProperties) throws IOException, SAXException, LockException, PermissionDeniedException {
         // iterate over child documents
         final DBBroker broker = context.getBroker();
         final LockManager lockManager = broker.getBrokerPool().getLockManager();
@@ -487,7 +484,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         for (final Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext(); ) {
             final DocumentImpl childDoc = itChildDocs.next();
             try (final ManagedDocumentLock updateLock = lockManager.acquireDocumentReadLock(childDoc.getURI())) {
-                compressResource(os, childDoc, useHierarchy, stripOffset, "", null);
+                compressResource(os, childDoc, useHierarchy, stripOffset, "", null, serializationProperties);
             }
         }
         // iterate over child collections
@@ -496,7 +493,7 @@ public abstract class AbstractCompressFunction extends BasicFunction {
             final XmldbURI childColURI = itChildCols.next();
             final Collection childCol = broker.getCollection(col.getURI().append(childColURI));
             // recurse
-            compressCollection(os, childCol, useHierarchy, stripOffset);
+            compressCollection(os, childCol, useHierarchy, stripOffset, serializationProperties);
         }
     }
 

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -148,9 +148,9 @@ public abstract class AbstractCompressFunction extends BasicFunction {
         // use a hierarchy in the tar file?
         final boolean useHierarchy = args[1].effectiveBooleanValue();
 
-        // Get offset
+        // Get offset (strip-prefix is argument 2 in the 3-, 4- and 5-arg forms)
         String stripOffset = "";
-        if (args.length == 3) {
+        if (args.length >= 3) {
             stripOffset = args[2].getStringValue();
         }
 

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
@@ -53,7 +53,8 @@ public class CompressionModule extends AbstractInternalModule {
             functionDefs(ZipFunction.class,
                     ZipFunction.signatures[0],
                     ZipFunction.signatures[1],
-                    ZipFunction.signatures[2]
+                    ZipFunction.signatures[2],
+                    ZipFunction.signatures[3]
             ),
             functionDefs(UnZipFunction.class,
                     UnZipFunction.FS_UNZIP[0],
@@ -77,7 +78,8 @@ public class CompressionModule extends AbstractInternalModule {
             functionDefs(TarFunction.class,
                     TarFunction.signatures[0],
                     TarFunction.signatures[1],
-                    TarFunction.signatures[2]
+                    TarFunction.signatures[2],
+                    TarFunction.signatures[3]
             ),
             functionDefs(UnTarFunction.class,
                     UnTarFunction.FS_UNTAR[0],

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/TarFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/TarFunction.java
@@ -77,6 +77,18 @@ public class TarFunction extends AbstractCompressFunction {
                             STRIP_PREFIX_PARAM,
                             ENCODING_PARAM
                     },
+                    new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_MORE)),
+
+            new FunctionSignature(
+                    TAR_FUNCTION_NAME,
+                    TAR_FUNCTION_DESCRIPTION,
+                    new SequenceType[]{
+                            SOURCES_PARAM,
+                            COLLECTION_HIERARCHY_PARAM,
+                            STRIP_PREFIX_PARAM,
+                            ENCODING_PARAM,
+                            SERIALIZATION_OPTIONS_PARAM
+                    },
                     new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_MORE))
     };
 

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/ZipFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/ZipFunction.java
@@ -79,6 +79,19 @@ public class ZipFunction extends AbstractCompressFunction {
                             ENCODING_PARAM
                     },
                     new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_MORE)
+            ),
+
+            new FunctionSignature(
+                    ZIP_FUNCTION_NAME,
+                    ZIP_FUNCTION_DESCRIPTION,
+                    new SequenceType[]{
+                            SOURCES_PARAM,
+                            COLLECTION_HIERARCHY_PARAM,
+                            STRIP_PREFIX_PARAM,
+                            ENCODING_PARAM,
+                            SERIALIZATION_OPTIONS_PARAM
+                    },
+                    new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_MORE)
             )
     };
 

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
@@ -160,3 +160,43 @@ function z:zipSerializationParametersElement() {
     return exists($extracted//xi:include)
 };
 
+
+(: strip-prefix (argument 2) must be honored in the 4-arg (encoding) and 5-arg (serialization-options)
+ : forms too, not only the 3-arg form. Regression guard: the eval() guard previously read strip-prefix
+ : only when exactly 3 arguments were supplied, so a higher arity silently kept the full /db/... path. :)
+declare variable $z:strip-collection := "/db/compression-strip-test";
+
+declare %private function z:store-strip-fixture() as empty-sequence() {
+    let $_ := xmldb:create-collection("/db", "compression-strip-test")
+    let $_ := xmldb:store($z:strip-collection, "doc.xml", <doc>x</doc>)
+    return ()
+};
+
+declare %private function z:unzip-entry-path($path as xs:anyURI, $type as xs:string, $data as item()?, $param as item()*) as item()? {
+    string($path)
+};
+
+declare %private function z:zip-collection-entry-names($zip as xs:base64Binary*) as xs:string* {
+    compression:unzip($zip,
+        util:function(xs:QName("z:unzip-entry-filter"), 3), (),
+        util:function(xs:QName("z:unzip-entry-path"), 4), ())
+};
+
+(: 4-arg form (with encoding): strip-prefix applied -> archive-root-relative name :)
+declare
+    %test:assertEquals("doc.xml")
+function z:zipStripPrefixWithEncoding() {
+    let $_ := z:store-strip-fixture()
+    let $zip := compression:zip(xs:anyURI($z:strip-collection), true(), $z:strip-collection, "UTF-8")
+    return z:zip-collection-entry-names($zip)
+};
+
+(: 5-arg form (with serialization-options): strip-prefix still applied :)
+declare
+    %test:assertEquals("doc.xml")
+function z:zipStripPrefixWithSerializationOptions() {
+    let $_ := z:store-strip-fixture()
+    let $zip := compression:zip(xs:anyURI($z:strip-collection), true(), $z:strip-collection, "UTF-8", map { "indent": false() })
+    return z:zip-collection-entry-names($zip)
+};
+

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
@@ -19,11 +19,14 @@
  : License along with this library; if not, write to the Free Software
  : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  :)
-xquery version "3.0";
+xquery version "3.1";
 
 module namespace z="http://exist-db.org/testsuite/zips";
 
 declare namespace util = "http://exist-db.org/xquery/util";
+declare namespace xi = "http://www.w3.org/2001/XInclude";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace exist = "http://exist.sourceforge.net/NS/exist";
 
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 import module namespace compression="http://exist-db.org/xquery/compression";
@@ -54,5 +57,106 @@ function z:zeroByteBinResource() {
     let $zip := compression:zip(<entry type="uri" name="{$collection-uri}">{$collection-uri||$resource-name}</entry>, true())
 
     return util:binary-to-string(util:binary-doc($collection-uri||$resource-name))
+};
+
+
+(:~
+ : Serialization options supplied via the optional 5th-argument map(*) must be applied to the
+ : XML resources written to the archive (per call). The exist:expand-xincludes extension parameter
+ : is keyed by its exist-namespace QName (the spec-conformant form); it is the strongest observable
+ : here because the change survives the round-trip through unzip's XML re-parse.
+ :)
+declare variable $z:exist-ns := "http://exist.sourceforge.net/NS/exist";
+declare variable $z:serialize-collection := "/db/compression-serialize-test";
+declare variable $z:xinclude-target-name := "xinclude-target.xml";
+declare variable $z:xinclude-host-name := "xinclude-host.xml";
+
+declare %private function z:store-xinclude-fixture() as empty-sequence() {
+    let $_ := xmldb:create-collection("/db", "compression-serialize-test")
+    let $_ := xmldb:store($z:serialize-collection, $z:xinclude-target-name, document { <inc>INCLUDED</inc> })
+    let $_ := xmldb:store($z:serialize-collection, $z:xinclude-host-name,
+        document {
+            <doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="{$z:xinclude-target-name}"/></doc>
+        })
+    return ()
+};
+
+declare %private function z:host-entry() as element(entry) {
+    <entry type="uri" name="{$z:xinclude-host-name}">{$z:serialize-collection || "/" || $z:xinclude-host-name}</entry>
+};
+
+declare %private function z:unzip-entry-filter($path as xs:anyURI, $type as xs:string, $param as item()*) as xs:boolean {
+    true()
+};
+
+declare %private function z:unzip-entry-data($path as xs:anyURI, $type as xs:string, $data as item()?, $param as item()*) as item()? {
+    $data
+};
+
+declare %private function z:zip-host-then-extract($serialization-options as item()?) as item()? {
+    let $_ := z:store-xinclude-fixture()
+    let $zip := compression:zip(z:host-entry(), false(), "", "UTF8", $serialization-options)
+    return compression:unzip($zip,
+        util:function(xs:QName("z:unzip-entry-filter"), 3), (),
+        util:function(xs:QName("z:unzip-entry-data"), 4), ())
+};
+
+(: the archived resource is inspected by structure (not re-serialized: re-serializing a preserved
+ : xi:include with a relative href would re-trigger XInclude resolution against a missing base URI). :)
+
+(: exist:expand-xincludes=true (exist-namespace QName key) expands the include in the archived resource :)
+declare
+    %test:assertTrue
+function z:zipExpandXIncludesYes() {
+    let $extracted := z:zip-host-then-extract(map { QName($z:exist-ns, "expand-xincludes"): true() })
+    return exists($extracted//inc[. = "INCLUDED"]) and empty($extracted//xi:include)
+};
+
+(: exist:expand-xincludes=false preserves the include (control; also the default) :)
+declare
+    %test:assertTrue
+function z:zipExpandXIncludesNo() {
+    let $extracted := z:zip-host-then-extract(map { QName($z:exist-ns, "expand-xincludes"): false() })
+    return exists($extracted//xi:include)
+};
+
+(: no map argument: unchanged from the pre-existing 2-arg behavior (the serializer's own default,
+ : which expands xincludes); supplying exist:expand-xincludes=false is what preserves the include. :)
+declare
+    %test:assertTrue
+function z:zipNoSerializationOptions() {
+    let $_ := z:store-xinclude-fixture()
+    let $zip := compression:zip(z:host-entry(), false())
+    let $extracted := compression:unzip($zip,
+        util:function(xs:QName("z:unzip-entry-filter"), 3), (),
+        util:function(xs:QName("z:unzip-entry-data"), 4), ())
+    return exists($extracted//inc[. = "INCLUDED"]) and empty($extracted//xi:include)
+};
+
+(: a standard W3C parameter (string key) and an exist extension parameter (QName key) coexist in one map :)
+declare
+    %test:assertTrue
+function z:zipMixedKeyParams() {
+    let $extracted := z:zip-host-then-extract(map {
+        "indent": false(),
+        QName($z:exist-ns, "expand-xincludes"): true()
+    })
+    return exists($extracted//inc[. = "INCLUDED"]) and empty($extracted//xi:include)
+};
+
+(: the options argument also accepts the W3C output:serialization-parameters element form
+ : (as fn:serialize does); the exist extension parameter is an exist-namespace child element, and
+ : in the element form a boolean uses value="yes"/"no". expand-xincludes=no preserves the include
+ : (an observable change from the expand-by-default). :)
+declare
+    %test:assertTrue
+function z:zipSerializationParametersElement() {
+    let $extracted := z:zip-host-then-extract(
+        <output:serialization-parameters>
+            <output:indent value="no"/>
+            <exist:expand-xincludes value="no"/>
+        </output:serialization-parameters>
+    )
+    return exists($extracted//xi:include)
 };
 

--- a/extensions/modules/file/src/test/xquery/modules/file/sync-serialize.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/sync-serialize.xqm
@@ -207,7 +207,7 @@ function syse:insert-final-newline-yes() {
     let $sync := file:sync(
         $fixtures:collection,
         $directory,
-        map{ "exist:insert-final-newline": true() }
+        map{ xs:QName("exist:insert-final-newline"): true() }
     )
 
     return (
@@ -231,7 +231,7 @@ function syse:insert-final-newline-no() {
     let $sync := file:sync(
         $fixtures:collection,
         $directory,
-        map{ "exist:insert-final-newline": false() }
+        map{ xs:QName("exist:insert-final-newline"): false() }
     )
 
     return (


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

`compression:zip` and `compression:tar` serialize the XML resources they write into the archive, but there was no way to control that serialization per call — the functions used the serializer defaults plus whatever `declare option exist:serialize` the prolog set. This adds an optional **5th argument** of serialization options to both functions, mirroring `fn:serialize` and `file:sync#3`.

As with `fn:serialize`, the argument accepts **either** form — a `map(*)` or a W3C `output:serialization-parameters` element:

```
compression:zip($sources as xs:anyType+,
                $use-collection-hierarchy as xs:boolean,
                $strip-prefix as xs:string,
                $encoding as xs:string,
                $serialization-options as item()?) as xs:base64Binary*
```

(identical 5-argument shape for `compression:tar`)

```xquery
(: map form :)
compression:zip($sources, true(), "", "UTF8",
    map {
        "indent": false(),                                                          (: W3C param, string key :)
        QName("http://exist.sourceforge.net/NS/exist", "expand-xincludes"): true()  (: exist param, QName key :)
    }
)

(: output:serialization-parameters element form :)
compression:zip($sources, true(), "", "UTF8",
    <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization"
                                     xmlns:exist="http://exist.sourceforge.net/NS/exist">
        <output:indent value="no"/>                  (: W3C param, output-namespace child :)
        <exist:expand-xincludes value="yes"/>        (: exist param, exist-namespace child :)
    </output:serialization-parameters>
)
```

## What changed

- **`AbstractCompressFunction`** — a new `SERIALIZATION_OPTIONS_PARAM` (`item()?`, optional). When supplied, it is parsed by **`FunSerialize.getSerializationProperties(...)`** — the same public entry point `fn:serialize` uses — so the map and element forms (and their error handling, e.g. `XPTY0004` for anything else) behave identically to `fn:serialize`. The resulting `Properties` is applied to every XML entry written to the archive, **after** (so overriding) the prolog `declare option exist:serialize`, and re-read on each `eval` (no leakage between calls). Parsing is extracted into a small `parseSerializationOptions(...)` helper so `eval`'s NPath complexity is unchanged.
- **`ZipFunction` / `TarFunction`** — add the 5-argument signature `(sources, use-collection-hierarchy, strip-prefix, encoding, serialization-options)`.
- **`CompressionModule`** — register the new arity for both `zip` and `tar`.
- **`zip-tests.xql`** — new XQSuite coverage (10 tests total): `expand-xincludes` honored via its exist-namespace `QName` key (true expands, false preserves the include); the no-map default is unchanged; a mixed map (W3C string key + exist `QName` key) coexists; and the `output:serialization-parameters` element form is honored (exist param as an exist-namespace child, where a boolean uses `value="yes"`/`"no"` per the element-form convention). Assertions inspect the extracted node by structure (re-serializing a preserved `xi:include` with a relative href would re-trigger XInclude resolution against a missing base URI).

## Key form

Consistent with the rest of eXist's serialization-option handling (and with `file:sync#3`): in the **map** form, standard W3C parameters use their **string** key and eXist extension parameters use their exist-namespace **`xs:QName`** key (the spec-conformant form for implementation-defined parameters); in the **element** form, W3C parameters are output-namespace children and eXist parameters are exist-namespace children. This is why the PR is stacked on #6491 — that fix makes the exist-namespace `QName` key the single accepted form for the extension parameters in the map.

## Test plan

- [x] `compression:zip(..., map { QName($exist-ns, "expand-xincludes"): true() })` expands the `<xi:include>` in the archived resource; `false()` preserves it.
- [x] No map argument: archived XML serializes exactly as before (the serializer's own default).
- [x] A map mixing a W3C string key (`indent`) and an exist `QName` key (`expand-xincludes`) is honored.
- [x] The `output:serialization-parameters` element form is honored (exist param as an exist-namespace child element).
- [x] `CompressionTests` XQSuite green (10/10).
- [x] Codacy PMD: no new findings on the changed Java files (the three pre-existing findings — `AvoidReassigningParameters` on `removeLeadingOffset`, `NPathComplexity` on `compressElement`, `UnusedLocalVariable` `updateLock` — are present on develop and untouched here).

## Notes

- **Scope vs. the original report.** #178 (2013) asked specifically for the prolog `declare option output:method "xml"` (W3C `output:` namespace) to be honored by `compression:zip`, in addition to the already-supported `declare option exist:serialize`. This PR addresses the underlying need — per-call control over how archived XML is serialized, covering both W3C and eXist parameters in either the `map(*)` or `output:serialization-parameters` element form — which is the modern idiom (`fn:serialize`, `file:sync`). It does **not** wire up the W3C `output:` *prolog* declaration (a different mechanism: a query-prolog `declare option`, not a value passed to the function). Filed as **Relates to #178** rather than Closes, so you can decide whether the argument satisfies the issue or whether the prolog-`output:` path should also be implemented (I'd suggest a separate, smaller follow-up if so).
- `declare option exist:serialize` continues to work and is unaffected; the map argument simply takes precedence over it.
