### PR TITLE
XSD 1.1 validation and catalog  fixes. 

### DIFF
--- a/exist-core/src/main/java/org/exist/resolver/RecordingContentHandler.java
+++ b/exist-core/src/main/java/org/exist/resolver/RecordingContentHandler.java
@@ -1,0 +1,120 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.resolver;
+
+import org.exist.util.sax.event.contenthandler.Characters;
+import org.exist.util.sax.event.contenthandler.ContentHandlerEvent;
+import org.exist.util.sax.event.contenthandler.EndDocument;
+import org.exist.util.sax.event.contenthandler.EndElement;
+import org.exist.util.sax.event.contenthandler.EndPrefixMapping;
+import org.exist.util.sax.event.contenthandler.IgnorableWhitespace;
+import org.exist.util.sax.event.contenthandler.ProcessingInstruction;
+import org.exist.util.sax.event.contenthandler.SetDocumentLocator;
+import org.exist.util.sax.event.contenthandler.SkippedEntity;
+import org.exist.util.sax.event.contenthandler.StartDocument;
+import org.exist.util.sax.event.contenthandler.StartElement;
+import org.exist.util.sax.event.contenthandler.StartPrefixMapping;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Records every {@link ContentHandler} callback it receives as a {@link ContentHandlerEvent}, so
+ * they can later be {@link #replay(ContentHandler) replayed} against a different {@link
+ * ContentHandler} -- used by {@link
+ * ResolverFactory#catalogSaxProducer(org.exist.storage.DBBroker, org.exist.xmldb.XmldbURI)} to
+ * avoid a second broker round-trip when the xmlresolver catalog loader asks for the same
+ * document's SAX events twice.
+ */
+final class RecordingContentHandler implements ContentHandler {
+
+    private final List<ContentHandlerEvent> events = new ArrayList<>();
+
+    boolean hasRecording() {
+        return !events.isEmpty();
+    }
+
+    void replay(final ContentHandler target) throws SAXException {
+        for (final ContentHandlerEvent event : events) {
+            event.apply(target);
+        }
+    }
+
+    @Override
+    public void setDocumentLocator(final Locator locator) {
+        events.add(new SetDocumentLocator(locator));
+    }
+
+    @Override
+    public void startDocument() {
+        events.add(StartDocument.INSTANCE);
+    }
+
+    @Override
+    public void endDocument() {
+        events.add(EndDocument.INSTANCE);
+    }
+
+    @Override
+    public void startPrefixMapping(final String prefix, final String uri) {
+        events.add(new StartPrefixMapping(prefix, uri));
+    }
+
+    @Override
+    public void endPrefixMapping(final String prefix) {
+        events.add(new EndPrefixMapping(prefix));
+    }
+
+    @Override
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts) {
+        events.add(new StartElement(uri, localName, qName, atts));
+    }
+
+    @Override
+    public void endElement(final String uri, final String localName, final String qName) {
+        events.add(new EndElement(uri, localName, qName));
+    }
+
+    @Override
+    public void characters(final char[] ch, final int start, final int length) {
+        events.add(new Characters(ch, start, length));
+    }
+
+    @Override
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) {
+        events.add(new IgnorableWhitespace(ch, start, length));
+    }
+
+    @Override
+    public void processingInstruction(final String target, final String data) {
+        events.add(new ProcessingInstruction(target, data));
+    }
+
+    @Override
+    public void skippedEntity(final String name) {
+        events.add(new SkippedEntity(name));
+    }
+}

--- a/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
+++ b/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
@@ -33,21 +33,38 @@
 package org.exist.resolver;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.serializers.Serializer;
+import org.exist.xmldb.XmldbURI;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xmlresolver.CatalogManager;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.XMLResolverConfiguration;
 import org.xmlresolver.utils.SaxProducer;
 
+import javax.xml.transform.OutputKeys;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Factory for creating Resolvers.
@@ -115,10 +132,12 @@ public interface ResolverFactory {
             strCatalogUri = sanitizeCatalogUri(strCatalogUri);
             if (catalog._2.isPresent()) {
                 final URI catalogUri = new URI(strCatalogUri);
-                // Register the catalog URI with the configuration first (mirrors what
-                // XMLResolverConfiguration#addCatalog(URI, InputSource) does internally),
-                // then have the manager load it directly from SAX events -- the manager
-                // caches the result by URI, so the resolver never tries to dereference it.
+                // Register the catalog URI with the configuration, then have the manager
+                // load it directly from SAX events -- the manager caches the result by
+                // URI, so the resolver never tries to dereference it. This is the same
+                // add-then-load order that XMLResolverConfiguration#addCatalog(URI,
+                // InputSource) uses internally (verified against xmlresolver 6.0.23), just
+                // split across two calls since that overload only accepts an InputSource.
                 resolverConfiguration.addCatalog(strCatalogUri);
                 manager.loadCatalog(catalogUri, catalog._2.get());
             } else {
@@ -127,6 +146,121 @@ public interface ResolverFactory {
         }
 
         return new Resolver(resolverConfiguration);
+    }
+
+    /**
+     * Resolve a list of catalog URLs into a single {@link Resolver}, streaming any catalog
+     * that is stored in the database directly from SAX events (see {@link #catalogSaxProducer(DBBroker, XmldbURI)})
+     * rather than first serializing it to a {@link String}.
+     *
+     * @param broker the broker to use for reading any catalogs stored in the database.
+     * @param catalogUrls the catalog URLs, e.g. as obtained from {@code Shared.getUrls(...)}.
+     *
+     * @return the resolver configured for the given catalogs.
+     *
+     * @throws URISyntaxException if one of the catalog URLs is invalid.
+     */
+    static Resolver resolveCatalogs(final DBBroker broker, final String[] catalogUrls) throws URISyntaxException {
+        final List<Tuple2<String, Optional<SaxProducer>>> catalogs = new ArrayList<>();
+        for (String catalogUrl : catalogUrls) {
+
+            /* NOTE(AR): Catalog URL if stored in database must start with
+               URI Scheme xmldb:// so that the XML Resolver can use
+               org.exist.protocolhandler.protocols.xmldb.Handler
+               to resolve any relative URI resources from the database.
+             */
+            final Optional<SaxProducer> maybeSaxProducer;
+            if (catalogUrl.startsWith("xmldb:exist://") || catalogUrl.startsWith("/db")) {
+                catalogUrl = fixupExistCatalogUri(catalogUrl);
+                maybeSaxProducer = Optional.of(catalogSaxProducer(broker, XmldbURI.create(catalogUrl)));
+            } else {
+                maybeSaxProducer = Optional.empty();
+            }
+
+            catalogs.add(Tuple(catalogUrl, maybeSaxProducer));
+        }
+        return newResolverFromSax(catalogs);
+    }
+
+    /**
+     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
+     * at {@code documentUri} directly to whatever {@link ContentHandler} the catalog loader
+     * supplies, avoiding having to first serialize the document to a {@link String} and have
+     * the catalog loader re-parse it from an {@link InputSource}.
+     *
+     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
+     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
+     * load the entries). Re-serializing the document from the database on each invocation would
+     * mean a second broker round-trip per catalog per call, and the two passes could see
+     * different content if the document is concurrently modified in between -- so instead, the
+     * first invocation's events are recorded (see {@link RecordingContentHandler}) and replayed
+     * for any subsequent invocation, without touching the broker again.</p>
+     *
+     * @param broker the broker to use for reading the document. Must remain valid for as long
+     *               as the returned {@link SaxProducer}'s first invocation.
+     * @param documentUri the URI of the catalog document stored in the database.
+     *
+     * @return a producer that serializes the document's SAX events once, replaying them for any
+     *         further invocation.
+     */
+    static SaxProducer catalogSaxProducer(final DBBroker broker, final XmldbURI documentUri) {
+        final RecordingContentHandler recorder = new RecordingContentHandler();
+        return (contentHandler, dtdHandler, errorHandler) -> {
+            if (!recorder.hasRecording()) {
+                streamCatalogDocument(broker, documentUri, recorder);
+            }
+            recorder.replay(contentHandler);
+        };
+    }
+
+    /**
+     * As {@link #catalogSaxProducer(DBBroker, XmldbURI)}, but acquires (and releases) a fresh
+     * broker for the given {@code subject} only for the first invocation, for callers that do
+     * not already hold a broker valid for the lifetime of the returned {@link SaxProducer}.
+     *
+     * @param brokerPool the broker pool to acquire a broker from for the first invocation.
+     * @param subject the subject to acquire the broker as.
+     * @param documentUri the URI of the catalog document stored in the database.
+     *
+     * @return a producer that serializes the document's SAX events once, replaying them for any
+     *         further invocation.
+     */
+    static SaxProducer catalogSaxProducer(final BrokerPool brokerPool, final Subject subject, final XmldbURI documentUri) {
+        final RecordingContentHandler recorder = new RecordingContentHandler();
+        return (contentHandler, dtdHandler, errorHandler) -> {
+            if (!recorder.hasRecording()) {
+                try (final DBBroker broker = brokerPool.get(Optional.of(subject))) {
+                    streamCatalogDocument(broker, documentUri, recorder);
+                } catch (final EXistException e) {
+                    throw new IOException(e.getMessage(), e);
+                }
+            }
+            recorder.replay(contentHandler);
+        };
+    }
+
+    private static void streamCatalogDocument(final DBBroker broker, final XmldbURI documentUri, final ContentHandler contentHandler)
+            throws IOException, SAXException {
+        try (final LockedDocument lockedDocument = broker.getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
+            if (lockedDocument == null) {
+                throw new IOException("No such document: " + documentUri);
+            }
+            final DocumentImpl doc = lockedDocument.getDocument();
+
+            final Properties outputProperties = new Properties();
+            outputProperties.setProperty(OutputKeys.METHOD, "XML");
+            outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            outputProperties.setProperty(OutputKeys.INDENT, "no");
+            outputProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
+
+            final Serializer serializer = broker.getSerializer();
+            serializer.reset();
+            serializer.setProperties(outputProperties);
+            serializer.setSAXHandlers(contentHandler, null);
+            serializer.toSAX(doc);
+        } catch (final PermissionDeniedException e) {
+            throw new IOException(e.getMessage(), e);
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
+++ b/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
@@ -34,9 +34,11 @@ package org.exist.resolver;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.xml.sax.InputSource;
+import org.xmlresolver.CatalogManager;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.XMLResolverConfiguration;
+import org.xmlresolver.utils.SaxProducer;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -76,6 +78,49 @@ public interface ResolverFactory {
             strCatalogUri = sanitizeCatalogUri(strCatalogUri);
             if (catalog._2.isPresent()) {
                 resolverConfiguration.addCatalog(new URI(strCatalogUri), catalog._2.get());
+            } else {
+                resolverConfiguration.addCatalog(strCatalogUri);
+            }
+        }
+
+        return new Resolver(resolverConfiguration);
+    }
+
+    /**
+     * Create a Resolver that is configured for specific catalogs, where catalogs that are
+     * not retrievable directly via their URI (e.g. catalogs stored inside the database) are
+     * instead supplied as a {@link SaxProducer} that streams the catalog's SAX events directly,
+     * avoiding having to first serialize the catalog document to a {@link String}/{@link InputSource}
+     * and then have the catalog loader re-parse it.
+     *
+     * @param catalogs the list of catalogs, the first entry in the tuple is their URI (and/or location),
+     *                 and the optional second argument is a {@link SaxProducer} for obtaining their
+     *                 content directly as SAX events.
+     *
+     * @return the resolver
+     *
+     * @throws URISyntaxException if one of the catalog URI is invalid
+     */
+    static Resolver newResolverFromSax(final List<Tuple2<String, Optional<SaxProducer>>> catalogs) throws URISyntaxException {
+        final XMLResolverConfiguration resolverConfiguration = new XMLResolverConfiguration();
+        resolverConfiguration.setFeature(ResolverFeature.RESOLVER_LOGGER_CLASS, "org.xmlresolver.logging.SystemLogger");
+        resolverConfiguration.setFeature(ResolverFeature.CATALOG_LOADER_CLASS, "org.xmlresolver.loaders.ValidatingXmlLoader");
+        resolverConfiguration.setFeature(ResolverFeature.CLASSPATH_CATALOGS, true);
+        resolverConfiguration.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+
+        final CatalogManager manager = resolverConfiguration.getFeature(ResolverFeature.CATALOG_MANAGER);
+
+        for (final Tuple2<String, Optional<SaxProducer>> catalog : catalogs) {
+            String strCatalogUri = catalog._1;
+            strCatalogUri = sanitizeCatalogUri(strCatalogUri);
+            if (catalog._2.isPresent()) {
+                final URI catalogUri = new URI(strCatalogUri);
+                // Register the catalog URI with the configuration first (mirrors what
+                // XMLResolverConfiguration#addCatalog(URI, InputSource) does internally),
+                // then have the manager load it directly from SAX events -- the manager
+                // caches the result by URI, so the resolver never tries to dereference it.
+                resolverConfiguration.addCatalog(strCatalogUri);
+                manager.loadCatalog(catalogUri, catalog._2.get());
             } else {
                 resolverConfiguration.addCatalog(strCatalogUri);
             }

--- a/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
+++ b/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
@@ -136,6 +136,31 @@ public class XercesXmlResolverAdapter implements XMLEntityResolver {
     }
 
     /**
+     * As the other overloads, but accepting whichever concrete resolver type {@code
+     * Shared#resolveCatalogArgument} returns -- either an {@link org.xmlresolver.Resolver}
+     * (wrapped via this adapter) or a {@link org.exist.validation.resolver.SearchResourceResolver}
+     * (which already implements Xerces' {@link XMLEntityResolver} directly, so no wrapping is
+     * needed).
+     *
+     * @param xmlReader the Xerces XML Reader
+     * @param resolver the resolver, or null to unset the property
+     *
+     * @throws SAXNotSupportedException if the property is not supported by the XMLReader
+     * @throws SAXNotRecognizedException if the property is not recognised by the XMLReader
+     */
+    public static void setXmlReaderEntityResolver(final XMLReader xmlReader, @Nullable final org.w3c.dom.ls.LSResourceResolver resolver) throws SAXNotSupportedException, SAXNotRecognizedException {
+        if (resolver instanceof Resolver xmlResolver) {
+            setXmlReaderEntityResolver(xmlReader, xmlResolver);
+        } else if (resolver instanceof XMLEntityResolver xmlEntityResolver) {
+            setXmlReaderEntityResolver(xmlReader, xmlEntityResolver);
+        } else if (resolver == null) {
+            setXmlReaderEntityResolver(xmlReader, (XMLEntityResolver) null);
+        } else {
+            throw new SAXNotSupportedException("Unsupported LSResourceResolver implementation: " + resolver.getClass().getName());
+        }
+    }
+
+    /**
      * Get the underlying resolver.
      *
      * @return the underlying resolver.

--- a/exist-core/src/main/java/org/exist/validation/ValidationContentHandler.java
+++ b/exist-core/src/main/java/org/exist/validation/ValidationContentHandler.java
@@ -24,6 +24,7 @@ package org.exist.validation;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -36,7 +37,7 @@ public class ValidationContentHandler extends DefaultHandler {
 
     private boolean isFirstElement = true;
     private String namespaceUri = null;
-
+    private Attributes rootAttributes = null;
 
     /**
      * @see org.xml.sax.helpers.DefaultHandler#startElement(String, String, String, Attributes)
@@ -47,6 +48,9 @@ public class ValidationContentHandler extends DefaultHandler {
 
         if (isFirstElement) {
             namespaceUri = uri;
+            // SAX may reuse/mutate the Attributes instance after this call returns, so take
+            // a defensive copy for callers that want to inspect the root element's attributes later.
+            rootAttributes = new AttributesImpl(attributes);
             isFirstElement = false;
         }
     }
@@ -58,5 +62,14 @@ public class ValidationContentHandler extends DefaultHandler {
      */
     public String getNamespaceUri() {
         return namespaceUri;
+    }
+
+    /**
+     * Get the attributes of the root element, as seen during parsing.
+     *
+     * @return the root element's attributes, or {@code null} if no element has been seen yet.
+     */
+    public Attributes getRootAttributes() {
+        return rootAttributes;
     }
 }

--- a/exist-core/src/main/java/org/exist/validation/ValidationReport.java
+++ b/exist-core/src/main/java/org/exist/validation/ValidationReport.java
@@ -136,13 +136,14 @@ public class ValidationReport implements ErrorHandler {
     }
 
     /**
-     * Discard previously recorded errors/warnings so the report can be
+     * Discard previously recorded errors/warnings/exception so the report can be
      * reused for a second validation pass (e.g. retrying with a different
      * validator), while keeping start/duration/namespace tracking intact.
      */
     public void clear() {
         validationReport.clear();
         lastItem = null;
+        throwed = null;
     }
 
     public List<String> getTextValidationReport() {

--- a/exist-core/src/main/java/org/exist/validation/ValidationReport.java
+++ b/exist-core/src/main/java/org/exist/validation/ValidationReport.java
@@ -135,6 +135,16 @@ public class ValidationReport implements ErrorHandler {
         return validationReport;
     }
 
+    /**
+     * Discard previously recorded errors/warnings so the report can be
+     * reused for a second validation pass (e.g. retrying with a different
+     * validator), while keeping start/duration/namespace tracking intact.
+     */
+    public void clear() {
+        validationReport.clear();
+        lastItem = null;
+    }
+
     public List<String> getTextValidationReport() {
 
         final List<String> textReport = new ArrayList<>();

--- a/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
+++ b/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
@@ -28,16 +28,9 @@ import org.apache.xerces.xni.XMLResourceIdentifier;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.apache.xerces.xni.parser.XMLInputSource;
-import org.exist.EXistException;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.resolver.ResolverFactory;
-import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
-import org.exist.storage.serializers.Serializer;
 import org.exist.validation.internal.DatabaseResources;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.InputSource;
@@ -45,14 +38,12 @@ import org.xml.sax.SAXException;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.utils.SaxProducer;
 
-import javax.xml.transform.OutputKeys;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -123,12 +114,9 @@ public class SearchResourceResolver implements XMLEntityResolver {
                  */
                 try {
                     final Optional<SaxProducer> maybeSaxProducer;
-                    if (catalogPath.startsWith("xmldb:exist://")) {
+                    if (catalogPath.startsWith("xmldb:exist://") || catalogPath.startsWith("/db")) {
                         catalogPath = ResolverFactory.fixupExistCatalogUri(catalogPath);
-                        maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogPath)));
-                    } else if (catalogPath.startsWith("/db")) {
-                        catalogPath = ResolverFactory.fixupExistCatalogUri(catalogPath);
-                        maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogPath)));
+                        maybeSaxProducer = Optional.of(ResolverFactory.catalogSaxProducer(brokerPool, subject, XmldbURI.create(catalogPath)));
                     } else {
                         maybeSaxProducer = Optional.empty();
                     }
@@ -181,44 +169,5 @@ public class SearchResourceResolver implements XMLEntityResolver {
     private String getXisDetails(final XMLInputSource xis) {
         return "PublicId='%s' SystemId='%s' BaseSystemId='%s' Encoding='%s' ".formatted(
                 xis.getPublicId(), xis.getSystemId(), xis.getBaseSystemId(), xis.getEncoding());
-    }
-
-    /**
-     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
-     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
-     * loader supplies, avoiding having to first serialize the document to a {@link String} and
-     * have the catalog loader re-parse it from an {@link InputSource}.
-     *
-     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
-     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
-     * load the entries), so each invocation re-acquires the document lock and re-serializes it.</p>
-     *
-     * @param documentUri the URI of the catalog document stored in the database.
-     * @return a producer that re-serializes the document's SAX events on each invocation.
-     */
-    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
-        return (contentHandler, dtdHandler, errorHandler) -> {
-            try (final DBBroker broker = brokerPool.get(Optional.of(subject));
-                 final LockedDocument lockedDocument = broker.getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
-                if (lockedDocument == null) {
-                    throw new IOException("No such document: " + documentUri);
-                }
-                final DocumentImpl doc = lockedDocument.getDocument();
-
-                final Properties outputProperties = new Properties();
-                outputProperties.setProperty(OutputKeys.METHOD, "XML");
-                outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-                outputProperties.setProperty(OutputKeys.INDENT, "no");
-                outputProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
-
-                final Serializer serializer = broker.getSerializer();
-                serializer.reset();
-                serializer.setProperties(outputProperties);
-                serializer.setSAXHandlers(contentHandler, null);
-                serializer.toSAX(doc);
-            } catch (final EXistException | PermissionDeniedException e) {
-                throw new IOException(e.getMessage(), e);
-            }
-        };
     }
 }

--- a/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
+++ b/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
@@ -33,13 +33,17 @@ import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.validation.internal.DatabaseResources;
 import org.exist.xmldb.XmldbURI;
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.utils.SaxProducer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -52,9 +56,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Resolve a resource by searching in database. Schema's are queried
  * directly, DTD are searched in catalog files.
  *
+ * <p>Implements both {@link XMLEntityResolver} (Xerces' XNI interface, used by the default
+ * SAX-parser-based dynamic-discovery pipeline) and {@link LSResourceResolver} ({@code
+ * javax.xml.validation}'s interface, used by the XSD-1.1-capable {@link javax.xml.validation.Validator}
+ * pipeline and by {@code validation:jaxv()}'s {@link javax.xml.validation.SchemaFactory}) so that
+ * directory-search catalogs work the same way regardless of which pipeline ends up validating.
+ * {@link LSResourceResolver} is XSD-only (no DTD/catalog equivalent), so {@link #resolveResource}
+ * only ever performs the XML-Schema-by-namespace search, mirroring {@link #resolveEntity}'s
+ * namespace branch.</p>
+ *
  * @author Dannes Wessels (dizzzz@exist-db.org)
  */
-public class SearchResourceResolver implements XMLEntityResolver {
+public class SearchResourceResolver implements XMLEntityResolver, LSResourceResolver {
     private static final Logger LOG = LogManager.getLogger(SearchResourceResolver.class);
 
     private final String collectionPath;
@@ -159,6 +172,147 @@ public class SearchResourceResolver implements XMLEntityResolver {
         }
 
         return xis;
+    }
+
+    /**
+     * Resolves an {@code xs:import}/{@code xs:include}, or the instance's own root schema
+     * reference during dynamic discovery (confirmed by experiment: {@code javax.xml.validation}'s
+     * dynamic-discovery {@link javax.xml.validation.Validator} consults the configured
+     * {@link LSResourceResolver} for the root schema location too, not just nested imports), by
+     * searching for an XSD declaring {@code namespaceURI} under {@code collectionPath} -- the same
+     * lookup {@link #resolveEntity}'s namespace branch performs for the XNI pipeline.
+     *
+     * <p>{@code systemId}/{@code baseURI} are intentionally ignored: unlike {@link #resolveEntity},
+     * there is no DTD/catalog case to consider here (LSResourceResolver is XSD-only), and the
+     * directory-search contract is "find an XSD by namespace", not "fetch whatever URI is named" --
+     * the result always comes from the permission-checked {@code findXSD} search, never from a
+     * caller/document-supplied location.</p>
+     */
+    @Override
+    @Nullable
+    public LSInput resolveResource(final String type, @Nullable final String namespaceURI,
+            @Nullable final String publicId, @Nullable final String systemId, @Nullable final String baseURI) {
+        if (namespaceURI == null) {
+            return null;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Searching namespace '{}' in database from {}... (LSResourceResolver)", namespaceURI, collectionPath);
+        }
+
+        final DatabaseResources databaseResources = new DatabaseResources(brokerPool);
+        String resourcePath = databaseResources.findXSD(collectionPath, namespaceURI, subject);
+        if (resourcePath == null) {
+            return null;
+        }
+        resourcePath = ResolverFactory.fixupExistCatalogUri(resourcePath);
+
+        try {
+            final InputStream is = URI.create(resourcePath).toURL().openStream();
+            return new DatabaseLSInput(publicId, systemId, baseURI, is);
+        } catch (final IOException e) {
+            LOG.error("Could not open resolved schema resource '{}': {}", resourcePath, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Minimal {@link LSInput} wrapping an already-opened {@link InputStream} -- there is no
+     * JDK-stock implementation of this interface available to depend on.
+     */
+    private static final class DatabaseLSInput implements LSInput {
+        private final String publicId;
+        private final String systemId;
+        private final String baseURI;
+        private InputStream byteStream;
+
+        DatabaseLSInput(@Nullable final String publicId, @Nullable final String systemId,
+                @Nullable final String baseURI, final InputStream byteStream) {
+            this.publicId = publicId;
+            this.systemId = systemId;
+            this.baseURI = baseURI;
+            this.byteStream = byteStream;
+        }
+
+        @Override
+        public Reader getCharacterStream() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterStream(final Reader characterStream) {
+            // not used: this implementation only ever supplies a byte stream
+        }
+
+        @Override
+        public InputStream getByteStream() {
+            return byteStream;
+        }
+
+        @Override
+        public void setByteStream(final InputStream byteStream) {
+            this.byteStream = byteStream;
+        }
+
+        @Override
+        public String getStringData() {
+            return null;
+        }
+
+        @Override
+        public void setStringData(final String stringData) {
+            // not used: this implementation only ever supplies a byte stream
+        }
+
+        @Override
+        public String getSystemId() {
+            return systemId;
+        }
+
+        @Override
+        public void setSystemId(final String systemId) {
+            // immutable: this instance is only ever built once per resolveResource() call
+        }
+
+        @Override
+        public String getPublicId() {
+            return publicId;
+        }
+
+        @Override
+        public void setPublicId(final String publicId) {
+            // immutable: this instance is only ever built once per resolveResource() call
+        }
+
+        @Override
+        public String getBaseURI() {
+            return baseURI;
+        }
+
+        @Override
+        public void setBaseURI(final String baseURI) {
+            // immutable: this instance is only ever built once per resolveResource() call
+        }
+
+        @Override
+        public String getEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setEncoding(final String encoding) {
+            // not used: the schema document carries its own encoding declaration, if any
+        }
+
+        @Override
+        public boolean getCertifiedText() {
+            return false;
+        }
+
+        @Override
+        public void setCertifiedText(final boolean certifiedText) {
+            // not used
+        }
     }
 
     private String getXriDetails(final XMLResourceIdentifier xrid) {

--- a/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
+++ b/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
@@ -73,11 +73,13 @@ public class SearchResourceResolver implements XMLEntityResolver, LSResourceReso
     private final String collectionPath;
     private final Subject subject;
     private final BrokerPool brokerPool;
+    private final DatabaseResources databaseResources;
 
     public SearchResourceResolver(final BrokerPool brokerPool, final Subject subject, final String collectionPath) {
         this.brokerPool = brokerPool;
         this.subject = subject;
         this.collectionPath = collectionPath;
+        this.databaseResources = new DatabaseResources(brokerPool);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Specified collectionPath={}", collectionPath);
@@ -98,15 +100,10 @@ public class SearchResourceResolver implements XMLEntityResolver, LSResourceReso
 
 
         String resourcePath = null;
-        final DatabaseResources databaseResources = new DatabaseResources(brokerPool);
 
         if (xri.getNamespace() != null) {
             // XML Schema search
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Searching namespace '{}' in database from {}...", xri.getNamespace(), collectionPath);
-            }
-
-            resourcePath = databaseResources.findXSD(collectionPath, xri.getNamespace(), subject);
+            resourcePath = findXsdResourcePathByNamespace(xri.getNamespace());
 
         } else if (xri.getPublicId() != null) {
             // Catalog search
@@ -196,16 +193,10 @@ public class SearchResourceResolver implements XMLEntityResolver, LSResourceReso
             return null;
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Searching namespace '{}' in database from {}... (LSResourceResolver)", namespaceURI, collectionPath);
-        }
-
-        final DatabaseResources databaseResources = new DatabaseResources(brokerPool);
-        String resourcePath = databaseResources.findXSD(collectionPath, namespaceURI, subject);
+        final String resourcePath = findXsdResourcePathByNamespace(namespaceURI);
         if (resourcePath == null) {
             return null;
         }
-        resourcePath = ResolverFactory.fixupExistCatalogUri(resourcePath);
 
         try {
             final InputStream is = URI.create(resourcePath).toURL().openStream();
@@ -214,6 +205,25 @@ public class SearchResourceResolver implements XMLEntityResolver, LSResourceReso
             LOG.error("Could not open resolved schema resource '{}': {}", resourcePath, e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Searches {@code collectionPath} for an XSD declaring {@code namespaceURI} as its target
+     * namespace, shared between {@link #resolveEntity}'s namespace branch and {@link #resolveResource}.
+     * The result is already normalized via {@link ResolverFactory#fixupExistCatalogUri} (idempotent,
+     * so {@link #resolveEntity}'s own uniform fixup at the end of that method is a harmless no-op
+     * for this path).
+     *
+     * @return the fixed-up resource path, or {@code null} if no matching schema was found.
+     */
+    @Nullable
+    private String findXsdResourcePathByNamespace(final String namespaceURI) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Searching namespace '{}' in database from {}...", namespaceURI, collectionPath);
+        }
+
+        final String resourcePath = databaseResources.findXSD(collectionPath, namespaceURI, subject);
+        return resourcePath == null ? null : ResolverFactory.fixupExistCatalogUri(resourcePath);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
+++ b/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
@@ -38,21 +38,16 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.serializers.Serializer;
-import org.exist.util.serializer.SAXSerializer;
-import org.exist.util.serializer.SerializerPool;
 import org.exist.validation.internal.DatabaseResources;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
 import org.xmlresolver.Resolver;
+import org.xmlresolver.utils.SaxProducer;
 
 import javax.xml.transform.OutputKeys;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -127,22 +122,18 @@ public class SearchResourceResolver implements XMLEntityResolver {
                    to resolve any relative URI resources from the database.
                  */
                 try {
-                    final Optional<InputSource> maybeInputSource;
+                    final Optional<SaxProducer> maybeSaxProducer;
                     if (catalogPath.startsWith("xmldb:exist://")) {
                         catalogPath = ResolverFactory.fixupExistCatalogUri(catalogPath);
-                        maybeInputSource = Optional.of(new InputSource(new StringReader(serializeDocument(XmldbURI.create(catalogPath)))));
+                        maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogPath)));
                     } else if (catalogPath.startsWith("/db")) {
                         catalogPath = ResolverFactory.fixupExistCatalogUri(catalogPath);
-                        maybeInputSource = Optional.of(new InputSource(new StringReader(serializeDocument(XmldbURI.create(catalogPath)))));
+                        maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogPath)));
                     } else {
-                        maybeInputSource = Optional.empty();
+                        maybeSaxProducer = Optional.empty();
                     }
 
-                    if (maybeInputSource.isPresent()) {
-                        maybeInputSource.get().setSystemId(catalogPath);
-                    }
-
-                    final Resolver resolver = ResolverFactory.newResolver(List.of(Tuple(catalogPath, maybeInputSource)));
+                    final Resolver resolver = ResolverFactory.newResolverFromSax(List.of(Tuple(catalogPath, maybeSaxProducer)));
                     final InputSource source = resolver.resolveEntity(xri.getPublicId(), "");
                     if (source != null) {
                         resourcePath = source.getSystemId();
@@ -192,16 +183,28 @@ public class SearchResourceResolver implements XMLEntityResolver {
                 xis.getPublicId(), xis.getSystemId(), xis.getBaseSystemId(), xis.getEncoding());
     }
 
-    // TODO(AR) remove this when PR https://github.com/xmlresolver/xmlresolver/pull/98 is merged
-    private String serializeDocument(final XmldbURI documentUri) throws SAXException, IOException {
-        try (final DBBroker broker = brokerPool.get(Optional.of(subject));
-             final LockedDocument lockedDocument = broker.getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
-            if (lockedDocument == null) {
-                throw new IOException("No such document: " + documentUri);
-            }
-            final DocumentImpl doc = lockedDocument.getDocument();
+    /**
+     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
+     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
+     * loader supplies, avoiding having to first serialize the document to a {@link String} and
+     * have the catalog loader re-parse it from an {@link InputSource}.
+     *
+     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
+     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
+     * load the entries), so each invocation re-acquires the document lock and re-serializes it.</p>
+     *
+     * @param documentUri the URI of the catalog document stored in the database.
+     * @return a producer that re-serializes the document's SAX events on each invocation.
+     */
+    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
+        return (contentHandler, dtdHandler, errorHandler) -> {
+            try (final DBBroker broker = brokerPool.get(Optional.of(subject));
+                 final LockedDocument lockedDocument = broker.getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
+                if (lockedDocument == null) {
+                    throw new IOException("No such document: " + documentUri);
+                }
+                final DocumentImpl doc = lockedDocument.getDocument();
 
-            try (final StringWriter stringWriter = new StringWriter()) {
                 final Properties outputProperties = new Properties();
                 outputProperties.setProperty(OutputKeys.METHOD, "XML");
                 outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
@@ -210,25 +213,12 @@ public class SearchResourceResolver implements XMLEntityResolver {
 
                 final Serializer serializer = broker.getSerializer();
                 serializer.reset();
-                SAXSerializer sax = null;
-                try {
-                    sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-                    sax.setOutput(stringWriter, outputProperties);
-                    serializer.setProperties(outputProperties);
-                    serializer.setSAXHandlers(sax, sax);
-                    serializer.toSAX(doc);
-                } catch (final SAXNotSupportedException | SAXNotRecognizedException e) {
-                    throw new SAXException(e.getMessage(), e);
-                } finally {
-                    if (sax != null) {
-                        SerializerPool.getInstance().returnObject(sax);
-                    }
-                }
-
-                return stringWriter.toString();
+                serializer.setProperties(outputProperties);
+                serializer.setSAXHandlers(contentHandler, null);
+                serializer.toSAX(doc);
+            } catch (final EXistException | PermissionDeniedException e) {
+                throw new IOException(e.getMessage(), e);
             }
-        } catch (final EXistException | PermissionDeniedException e) {
-            throw new IOException(e.getMessage(), e);
-        }
+        };
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/GrammarTooling.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/GrammarTooling.java
@@ -148,9 +148,10 @@ public class GrammarTooling extends BasicFunction  {
             
             final int before = countTotalNumberOfGrammar(grammarpool);
             LOG.debug("Clearing {} grammars", before);
-            
+
             clearGrammarPool(grammarpool);
-            
+            Jaxp.clearXsd11DetectionCache();
+
             final int after = countTotalNumberOfGrammar(grammarpool);
             LOG.debug("Remained {} grammars", after);
             

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -24,10 +24,7 @@ package org.exist.xquery.functions.validation;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.Locale;
 
 import javax.annotation.Nullable;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,21 +44,14 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import com.evolvedbinary.j8fu.tuple.Tuple2;
-
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.resolver.ResolverFactory;
 import org.exist.resolver.XercesXmlResolverAdapter;
-import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.lock.Lock;
-import org.exist.storage.serializers.Serializer;
 import org.exist.util.Configuration;
 import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.XMLReaderObjectFactory;
@@ -70,7 +60,6 @@ import org.exist.validation.GrammarPool;
 import org.exist.validation.ValidationContentHandler;
 import org.exist.validation.ValidationReport;
 import org.exist.validation.resolver.SearchResourceResolver;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -79,25 +68,22 @@ import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
-import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
+import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
+import org.xml.sax.Parser;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.DefaultHandler;
 import org.xmlresolver.Resolver;
-import org.xmlresolver.utils.SaxProducer;
 
-import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
@@ -108,22 +94,26 @@ import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
  */
 public class Jaxp extends BasicFunction {
 
-    private static final String simpleFunctionTxt =
-            "Validate document by parsing $instance. Optionally "
-            + "grammar caching can be enabled. Supported grammars types "
-            + "are '.xsd' and '.dtd'.";
-    
-    private static final String extendedFunctionTxt =
-            "Validate document by parsing $instance. Optionally "
-            + "grammar caching can be enabled and "
-            + "an XML catalog can be specified. Supported grammars types "
-            + "are '.xsd' and '.dtd'.";
-    
-    private static final String documentTxt = "The document referenced as xs:anyURI, a node (element or result of fn:doc()) "
-            + "or as a Java file object.";
-    
+    private static final String XSD_1_1_NS = "http://www.w3.org/XML/XMLSchema/v1.1";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private static final String simpleFunctionTxt = """
+            Validate document by parsing $instance. Optionally \
+            grammar caching can be enabled. Supported grammars types \
+            are '.xsd' and '.dtd'.""";
+
+    private static final String extendedFunctionTxt = """
+            Validate document by parsing $instance. Optionally \
+            grammar caching can be enabled and \
+            an XML catalog can be specified. Supported grammars types \
+            are '.xsd' and '.dtd'.""";
+
+    private static final String documentTxt = """
+            The document referenced as xs:anyURI, a node (element or result of fn:doc()) \
+            or as a Java file object.""";
+
     private static final String catalogTxt = "The catalogs referenced as xs:anyURI's.";
-    
+
     private static final String cacheTxt = "Set the flag to true() to enable grammar caching.";
 
     private final BrokerPool brokerPool;
@@ -140,7 +130,7 @@ public class Jaxp extends BasicFunction {
         },
         new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
         Shared.simplereportText)),
-        
+
         new FunctionSignature(
         new QName("jaxp", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
         extendedFunctionTxt,
@@ -153,7 +143,7 @@ public class Jaxp extends BasicFunction {
             catalogTxt),},
         new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
         Shared.simplereportText)),
-        
+
         new FunctionSignature(
         new QName("jaxp-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
         simpleFunctionTxt + " An XML report is returned.",
@@ -164,7 +154,7 @@ public class Jaxp extends BasicFunction {
             cacheTxt),},
         new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
         Shared.xmlreportText)),
-        
+
         new FunctionSignature(
         new QName("jaxp-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
         extendedFunctionTxt + " An XML report is returned.",
@@ -177,7 +167,7 @@ public class Jaxp extends BasicFunction {
             catalogTxt),},
         new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
         Shared.xmlreportText)),
-        
+
         new FunctionSignature(
         new QName("jaxp-parse", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
         "Parse document in validating mode, all defaults are filled in according to the " +
@@ -202,8 +192,8 @@ public class Jaxp extends BasicFunction {
     public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
         final ValidationReport report = new ValidationReport();
 
-        final MemTreeBuilder instanceBuilder;
-        final ContentHandler contenthandler;
+        MemTreeBuilder instanceBuilder;
+        ContentHandler contenthandler;
         if (isCalledAs("jaxp-parse")) {
             instanceBuilder = context.getDocumentBuilder();
             contenthandler = new DocumentBuilderReceiver(this, instanceBuilder, true); // (namespace?)
@@ -214,6 +204,7 @@ public class Jaxp extends BasicFunction {
 
         InputSource instance = null;
         Resolver catalogResolver = null;
+        boolean usedDirectorySearchCatalog = false;
         try {
             report.start();
 
@@ -247,34 +238,16 @@ public class Jaxp extends BasicFunction {
                 if (singleUrl.endsWith("/")) {
                     // Search grammar in collection specified by URL. Just one collection is used.
                     LOG.debug("Search for grammar in {}", singleUrl);
+                    usedDirectorySearchCatalog = true;
                     final XMLEntityResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), catalogUrls[0]);
                     XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
                 } else if (singleUrl.endsWith(".xml")) {
-                    LOG.debug("Using catalogs {}", getStrings(catalogUrls));
-
-                    final List<Tuple2<String, Optional<SaxProducer>>> catalogs = new ArrayList<>();
-                    for (String catalogUrl : catalogUrls) {
-
-                        /* NOTE(AR): Catalog URL if stored in database must start with
-                           URI Scheme xmldb:// so that the XML Resolver can use
-                           org.exist.protocolhandler.protocols.xmldb.Handler
-                           to resolve any relative URI resources from the database.
-                         */
-                        final Optional<SaxProducer> maybeSaxProducer;
-                        if (catalogUrl.startsWith("xmldb:exist://")) {
-                            catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                            maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
-                        } else if (catalogUrl.startsWith("/db")) {
-                            catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                            maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
-                        } else {
-                            maybeSaxProducer = Optional.empty();
-                        }
-
-                        catalogs.add(Tuple(catalogUrl, maybeSaxProducer));
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Using catalogs {}", String.join(" ", catalogUrls));
                     }
-                    final Resolver resolver = ResolverFactory.newResolverFromSax(catalogs);
+
+                    final Resolver resolver = ResolverFactory.resolveCatalogs(context.getBroker(), catalogUrls);
                     catalogResolver = resolver;
                     XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
@@ -300,15 +273,35 @@ public class Jaxp extends BasicFunction {
 
             /* The bundled Xerces XSD 1.1 support is only wired into the JAXP
                SchemaFactory/Validator API, not into this dynamic-discovery
-               SAXParser pipeline (see plans/catalog-dtd.plan.md). When that
-               shows up as "no declaration found" for the root element and the
-               instance actually references a schema, retry once with the
-               XSD-1.1-capable Validator before giving up. DTD-only documents
-               never produce this cvc-* signature, so they never retry. */
-            if (!report.isValid() && isMissingElementDeclaration(report)
-                    && hasSchemaLocationHint(args[0].itemAt(0))) {
+               SAXParser pipeline. When that shows up as "no declaration found"
+               for the root element and the instance actually references a
+               schema, retry once with the XSD-1.1-capable Validator before
+               giving up. DTD-only documents never produce this cvc-* signature,
+               so they never retry. */
+            if (!report.isValid() && isMissingElementDeclaration(report) && hasSchemaLocationHint(contenthandler, instanceBuilder)) {
                 LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
                 report.clear();
+
+                if (usedDirectorySearchCatalog) {
+                    LOG.warn("Directory-search catalogs have no equivalent resource resolver for the XSD 1.1 " +
+                            "retry validator -- schema/entity resolution will proceed without a catalog.");
+                }
+
+                // The first pass already fed `contenthandler` (and, for jaxp-parse,
+                // `instanceBuilder`) a complete document; reusing either for the retry
+                // would silently double-build the result. Start over with a fresh
+                // content handler/builder so the retry produces a single, clean document.
+                if (isCalledAs("jaxp-parse")) {
+                    context.pushDocumentContext();
+                    try {
+                        instanceBuilder = context.getDocumentBuilder();
+                    } finally {
+                        context.popDocumentContext();
+                    }
+                    contenthandler = new DocumentBuilderReceiver(this, instanceBuilder, true);
+                } else {
+                    contenthandler = new ValidationContentHandler();
+                }
 
                 final Validator validator = newXsd11Validator(catalogResolver);
                 validator.setErrorHandler(report);
@@ -370,6 +363,7 @@ public class Jaxp extends BasicFunction {
                 } finally {
                     context.popDocumentContext();
                 }
+
             }
 
         }
@@ -377,7 +371,7 @@ public class Jaxp extends BasicFunction {
 
     // ####################################
 
-    
+    @SuppressWarnings("deprecation") // org.xml.sax.Parser is the only way to force this Xerces fork's message locale
     private XMLReader getXMLReader() throws ParserConfigurationException, SAXException {
 
         // setup sax factory ; be sure just one instance!
@@ -394,6 +388,17 @@ public class Jaxp extends BasicFunction {
         final XMLReader xmlReader = saxParser.getXMLReader();
 
         xmlReader.setFeature(FEATURE_SECURE_PROCESSING, true);
+
+        // Force English error messages, regardless of server locale: isMissingElementDeclaration()
+        // below matches on this Xerces fork's formatted "cvc-elt.1.a:" message text, which is
+        // otherwise sensitive to the JVM's default locale.
+        if (xmlReader instanceof Parser legacyParser) {
+            try {
+                legacyParser.setLocale(Locale.ENGLISH);
+            } catch (final SAXException ex) {
+                LOG.debug("Could not force the XMLReader's locale to English: {}", ex.getMessage());
+            }
+        }
 
         setXmlReaderFeature(xmlReader, Namespaces.SAX_VALIDATION, true);
         setXmlReaderFeature(xmlReader, Namespaces.SAX_VALIDATION_DYNAMIC, false);
@@ -415,9 +420,6 @@ public class Jaxp extends BasicFunction {
         }
     }
 
-    private static final String XSD_1_1_NS = "http://www.w3.org/XML/XMLSchema/v1.1";
-    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
-
     /**
      * @return true if any reported error is the "no global declaration for
      * the root element" signature ({@code cvc-elt.1.a}) produced when this
@@ -429,51 +431,30 @@ public class Jaxp extends BasicFunction {
     }
 
     /**
-     * Cheaply peeks at the root element's attributes to check whether the
-     * instance references a schema via {@code xsi:schemaLocation} /
-     * {@code xsi:noNamespaceSchemaLocation}, without validating it. Used to
-     * decide whether the XSD 1.1 fallback retry could possibly help (a
-     * DTD-only document never produces the cvc-elt.1.a signature in the
-     * first place, but this guards against retrying on documents that
-     * reference no schema at all).
+     * Cheaply checks whether the instance document references a schema via
+     * {@code xsi:schemaLocation}/{@code xsi:noNamespaceSchemaLocation}, using
+     * only data already captured by the first (failed) parse -- no re-parsing
+     * of the instance is needed. Used to decide whether the XSD 1.1 fallback
+     * retry could possibly help (a DTD-only document never produces the
+     * cvc-elt.1.a signature in the first place, but this guards against
+     * retrying on documents that reference no schema at all).
+     *
+     * @param contenthandler the content handler used for the first parse pass.
+     * @param instanceBuilder for {@code jaxp-parse}, the document builder used for the first
+     *                        parse pass; {@code null} for {@code jaxp}/{@code jaxp-report}.
      */
-    private boolean hasSchemaLocationHint(final Item item) throws XPathException, IOException {
-        final InputSource probe = Shared.getInputSource(item, context);
-        try {
-            final SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(true);
-            final XMLReader reader = factory.newSAXParser().getXMLReader();
-
-            final boolean[] found = {false};
-            reader.setContentHandler(new DefaultHandler() {
-                @Override
-                public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
-                    found[0] = attributes.getValue(XSI_NS, "schemaLocation") != null
-                            || attributes.getValue(XSI_NS, "noNamespaceSchemaLocation") != null;
-                    throw StopAfterRootElement.INSTANCE;
-                }
-            });
-
-            try {
-                reader.parse(probe);
-            } catch (final StopAfterRootElement stop) {
-                // expected: we only need the root element's attributes
-            }
-            return found[0];
-
-        } catch (final ParserConfigurationException | SAXException ex) {
-            throw new IOException(ex.getMessage(), ex);
-        } finally {
-            Shared.closeInputSource(probe);
+    private static boolean hasSchemaLocationHint(final ContentHandler contenthandler, @Nullable final MemTreeBuilder instanceBuilder) {
+        if (contenthandler instanceof ValidationContentHandler handler) {
+            final Attributes attrs = handler.getRootAttributes();
+            return attrs != null
+                    && (attrs.getValue(XSI_NS, "schemaLocation") != null || attrs.getValue(XSI_NS, "noNamespaceSchemaLocation") != null);
         }
-    }
-
-    /**
-     * Sentinel used to abort {@link #hasSchemaLocationHint(Item)}'s probe
-     * parse immediately after the root element's attributes are seen.
-     */
-    private static final class StopAfterRootElement extends SAXException {
-        private static final StopAfterRootElement INSTANCE = new StopAfterRootElement();
+        if (instanceBuilder != null) {
+            final Element root = instanceBuilder.getDocument().getDocumentElement();
+            return root != null
+                    && (root.hasAttributeNS(XSI_NS, "schemaLocation") || root.hasAttributeNS(XSI_NS, "noNamespaceSchemaLocation"));
+        }
+        return false;
     }
 
     /**
@@ -494,45 +475,6 @@ public class Jaxp extends BasicFunction {
         return validator;
     }
 
-    /**
-     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
-     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
-     * loader supplies, avoiding having to first serialize the document to a {@link String} and
-     * have the catalog loader re-parse it from an {@link InputSource}.
-     *
-     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
-     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
-     * load the entries), so each invocation re-acquires the document lock and re-serializes it.</p>
-     *
-     * @param documentUri the URI of the catalog document stored in the database.
-     * @return a producer that re-serializes the document's SAX events on each invocation.
-     */
-    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
-        return (contentHandler, dtdHandler, errorHandler) -> {
-            try (final LockedDocument lockedDocument = context.getBroker().getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
-                if (lockedDocument == null) {
-                    throw new IOException("No such document: " + documentUri);
-                }
-
-                final DocumentImpl doc = lockedDocument.getDocument();
-
-                final Properties outputProperties = new Properties();
-                outputProperties.setProperty(OutputKeys.METHOD, "XML");
-                outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-                outputProperties.setProperty(OutputKeys.INDENT, "no");
-                outputProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
-
-                final Serializer serializer = context.getBroker().getSerializer();
-                serializer.reset();
-                serializer.setProperties(outputProperties);
-                serializer.setSAXHandlers(contentHandler, null);
-                serializer.toSAX(doc);
-            } catch (final PermissionDeniedException e) {
-                throw new IOException(e.getMessage(), e);
-            }
-        };
-    }
-
     // No-go ...processor is in validating mode
     private Path preparseDTD(StreamSource instance, String systemId)
             throws IOException, TransformerConfigurationException, TransformerException {
@@ -551,15 +493,6 @@ public class Jaxp extends BasicFunction {
         transformer.transform(instance, result);
 
         return tmp;
-    }
-
-    private static String getStrings(String[] data) {
-        final StringBuilder sb = new StringBuilder();
-        for (final String field : data) {
-            sb.append(field);
-            sb.append(" ");
-        }
-        return sb.toString();
     }
 
     /*

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -22,15 +22,27 @@
 package org.exist.xquery.functions.validation;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -44,7 +56,6 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
@@ -74,6 +85,7 @@ import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
 import org.w3c.dom.Element;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -96,6 +108,7 @@ public class Jaxp extends BasicFunction {
 
     private static final String XSD_1_1_NS = "http://www.w3.org/XML/XMLSchema/v1.1";
     private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String XSD_VERSIONING_NS = "http://www.w3.org/2007/XMLSchema-versioning";
 
     private static final String simpleFunctionTxt = """
             Validate document by parsing $instance. Optionally \
@@ -203,8 +216,7 @@ public class Jaxp extends BasicFunction {
         }
 
         InputSource instance = null;
-        Resolver catalogResolver = null;
-        boolean usedDirectorySearchCatalog = false;
+        LSResourceResolver catalogResolver = null;
         try {
             report.start();
 
@@ -238,8 +250,12 @@ public class Jaxp extends BasicFunction {
                 if (singleUrl.endsWith("/")) {
                     // Search grammar in collection specified by URL. Just one collection is used.
                     LOG.debug("Search for grammar in {}", singleUrl);
-                    usedDirectorySearchCatalog = true;
-                    final XMLEntityResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), catalogUrls[0]);
+                    // SearchResourceResolver implements both XMLEntityResolver (for this SAX
+                    // pipeline) and LSResourceResolver (for the XSD 1.1 validator below), so
+                    // directory-search catalogs work the same way regardless of which pipeline
+                    // ends up validating.
+                    final SearchResourceResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), catalogUrls[0]);
+                    catalogResolver = resolver;
                     XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
                 } else if (singleUrl.endsWith(".xml")) {
@@ -266,51 +282,82 @@ public class Jaxp extends BasicFunction {
                 xmlReader.setProperty(XMLReaderObjectFactory.APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL, grammarPool);
             }
 
-            // Jaxp document
-            LOG.debug("Start parsing document");
-            xmlReader.parse(instance);
-            LOG.debug("Stopped parsing document");
-
             /* The bundled Xerces XSD 1.1 support is only wired into the JAXP
                SchemaFactory/Validator API, not into this dynamic-discovery
-               SAXParser pipeline. When that shows up as "no declaration found"
-               for the root element and the instance actually references a
-               schema, retry once with the XSD-1.1-capable Validator before
-               giving up. DTD-only documents never produce this cvc-* signature,
-               so they never retry. */
-            if (!report.isValid() && isMissingElementDeclaration(report) && hasSchemaLocationHint(contenthandler, instanceBuilder)) {
-                LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
-                report.clear();
+               SAXParser pipeline -- it's a hard limitation of the dependency,
+               not a configuration gap (see plans/catalog-dtd.plan.md). Rather
+               than always discovering this by parsing with the wrong pipeline
+               and failing, peek (best-effort, see detectXsd11ViaSchemaLocation)
+               at the schema the instance's own hint points to and pick the
+               right pipeline up front when that succeeds. If the peek can't
+               tell (catalog-mediated location, unresolvable hint, etc.), fall
+               through to the unchanged default pipeline below, which still
+               retries with the XSD 1.1 validator on the cvc-elt.1.a failure
+               signature -- the peek is purely an optimization, never a
+               correctness requirement. */
+            final boolean useXsd11UpFront;
+            final InputSource peekInstance = Shared.getInputSource(args[0].itemAt(0), context);
+            try {
+                useXsd11UpFront = detectXsd11ViaSchemaLocation(peekInstance);
+            } finally {
+                Shared.closeInputSource(peekInstance);
+            }
 
-                if (usedDirectorySearchCatalog) {
-                    LOG.warn("Directory-search catalogs have no equivalent resource resolver for the XSD 1.1 " +
-                            "retry validator -- schema/entity resolution will proceed without a catalog.");
-                }
-
-                // The first pass already fed `contenthandler` (and, for jaxp-parse,
-                // `instanceBuilder`) a complete document; reusing either for the retry
-                // would silently double-build the result. Start over with a fresh
-                // content handler/builder so the retry produces a single, clean document.
-                if (isCalledAs("jaxp-parse")) {
-                    context.pushDocumentContext();
-                    try {
-                        instanceBuilder = context.getDocumentBuilder();
-                    } finally {
-                        context.popDocumentContext();
-                    }
-                    contenthandler = new DocumentBuilderReceiver(this, instanceBuilder, true);
-                } else {
-                    contenthandler = new ValidationContentHandler();
-                }
+            if (useXsd11UpFront) {
+                LOG.debug("Detected XSD 1.1 schema (vc:minVersion) via the instance's schemaLocation hint " +
+                        "before parsing; using the XSD 1.1 validator directly.");
 
                 final Validator validator = newXsd11Validator(catalogResolver);
                 validator.setErrorHandler(report);
+                validator.validate(new SAXSource(instance), new SAXResult(contenthandler));
 
-                final InputSource retryInstance = Shared.getInputSource(args[0].itemAt(0), context);
-                try {
-                    validator.validate(new SAXSource(retryInstance), new SAXResult(contenthandler));
-                } finally {
-                    Shared.closeInputSource(retryInstance);
+            } else {
+                // Jaxp document
+                LOG.debug("Start parsing document");
+                xmlReader.parse(instance);
+                LOG.debug("Stopped parsing document");
+
+                /* Safety net: the up-front peek above didn't (or couldn't) detect XSD 1.1.
+                   When that shows up as "no declaration found" for the root element, retry once
+                   with the XSD-1.1-capable Validator before giving up -- but only when retrying
+                   could plausibly help: either the instance carries an explicit schemaLocation
+                   hint (the no-catalog case, where Xerces' own default resolution would have used
+                   it), or a catalog/resolver IS configured (system catalog, .xml catalog, or
+                   directory-search), since any of those can resolve a schema purely by the root
+                   element's namespace -- the directory-search fixtures in this codebase, for
+                   example, carry no schemaLocation hint at all and rely entirely on namespace-based
+                   lookup. DTD-only documents with neither a hint nor a catalog never produce this
+                   cvc-* signature in the first place, so they never retry. */
+                if (!report.isValid() && isMissingElementDeclaration(report)
+                        && (catalogResolver != null || hasSchemaLocationHint(contenthandler, instanceBuilder))) {
+                    LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
+                    report.clear();
+
+                    // The first pass already fed `contenthandler` (and, for jaxp-parse,
+                    // `instanceBuilder`) a complete document; reusing either for the retry
+                    // would silently double-build the result. Start over with a fresh
+                    // content handler/builder so the retry produces a single, clean document.
+                    if (isCalledAs("jaxp-parse")) {
+                        context.pushDocumentContext();
+                        try {
+                            instanceBuilder = context.getDocumentBuilder();
+                        } finally {
+                            context.popDocumentContext();
+                        }
+                        contenthandler = new DocumentBuilderReceiver(this, instanceBuilder, true);
+                    } else {
+                        contenthandler = new ValidationContentHandler();
+                    }
+
+                    final Validator validator = newXsd11Validator(catalogResolver);
+                    validator.setErrorHandler(report);
+
+                    final InputSource retryInstance = Shared.getInputSource(args[0].itemAt(0), context);
+                    try {
+                        validator.validate(new SAXSource(retryInstance), new SAXResult(contenthandler));
+                    } finally {
+                        Shared.closeInputSource(retryInstance);
+                    }
                 }
             }
 
@@ -434,10 +481,12 @@ public class Jaxp extends BasicFunction {
      * Cheaply checks whether the instance document references a schema via
      * {@code xsi:schemaLocation}/{@code xsi:noNamespaceSchemaLocation}, using
      * only data already captured by the first (failed) parse -- no re-parsing
-     * of the instance is needed. Used to decide whether the XSD 1.1 fallback
-     * retry could possibly help (a DTD-only document never produces the
-     * cvc-elt.1.a signature in the first place, but this guards against
-     * retrying on documents that reference no schema at all).
+     * of the instance is needed. One of two ways the XSD 1.1 fallback retry's
+     * guard decides retrying could plausibly help when there's no catalog/resolver
+     * configured at all (the other being a configured catalog/resolver, which can
+     * resolve a schema purely by namespace with no hint present -- see the retry
+     * guard in {@code eval()}). A DTD-only document with neither produces the
+     * cvc-elt.1.a signature in the first place, so it never reaches this check.
      *
      * @param contenthandler the content handler used for the first parse pass.
      * @param instanceBuilder for {@code jaxp-parse}, the document builder used for the first
@@ -458,6 +507,141 @@ public class Jaxp extends BasicFunction {
     }
 
     /**
+     * Best-effort, pre-parse check for whether the instance's referenced schema is XSD 1.1
+     * (declares {@code vc:minVersion} containing "1.1"), so the right validation pipeline can
+     * be chosen up front instead of discovering the mismatch only after a failed first attempt
+     * (see {@link #isMissingElementDeclaration(ValidationReport)}). Resolves the schemaLocation
+     * hint(s) only via simple relative-URI resolution against the instance's own base URI --
+     * it does NOT replicate the full catalog/entity-resolver chain used for the real parse.
+     * Returns {@code false} (never throws) whenever any step can't be completed; the
+     * retry-after-failure check in {@code eval()} remains the safety net for those cases
+     * (catalog-mediated locations, an unresolvable hint, etc.).
+     *
+     * @param peekInstance a fresh, not-yet-consumed InputSource for the same instance document.
+     */
+    private static boolean detectXsd11ViaSchemaLocation(final InputSource peekInstance) {
+        final Map<String, String> rootAttrs = peekRootAttributes(peekInstance);
+        final String baseUri = peekInstance.getSystemId();
+        if (rootAttrs == null || baseUri == null) {
+            return false;
+        }
+
+        final List<String> candidateLocations = new ArrayList<>();
+        final String noNsLocation = rootAttrs.get(clark(XSI_NS, "noNamespaceSchemaLocation"));
+        if (noNsLocation != null) {
+            candidateLocations.add(noNsLocation);
+        }
+        final String schemaLocation = rootAttrs.get(clark(XSI_NS, "schemaLocation"));
+        if (schemaLocation != null) {
+            // xsi:schemaLocation is a list of "namespace location" pairs; we only need the locations.
+            final String[] tokens = schemaLocation.trim().split("\\s+");
+            for (int i = 1; i < tokens.length; i += 2) {
+                candidateLocations.add(tokens[i]);
+            }
+        }
+
+        for (final String location : candidateLocations) {
+            if (isXsd11Schema(baseUri, location)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolves {@code location} relative to {@code baseUri} (the same xmldb:// normalization
+     * the catalog mechanism uses, so this works for documents stored in the database), opens it,
+     * and checks whether its root element declares {@code vc:minVersion} containing "1.1".
+     * Returns {@code false} for any resolution/read failure -- this is a best-effort peek, not
+     * a substitute for the real catalog-aware resolution the actual validation pass performs.
+     *
+     * <p>{@code location} is the literal, attacker/document-author-controlled value of the
+     * instance's own {@code xsi:schemaLocation}/{@code noNamespaceSchemaLocation} hint -- if it's
+     * an absolute URI (e.g. {@code file:///etc/passwd}, {@code http://internal-host/...}, or even
+     * an absolute {@code xmldb://some-other-host:1234/db/...} naming a remote eXist instance),
+     * {@link URI#resolve(String)} returns it verbatim, ignoring {@code baseUri} entirely. Opening
+     * that unconditionally would let any caller make this (unprivileged, security-context-free)
+     * peek fetch arbitrary local files or issue arbitrary outbound requests (file read, or a
+     * network connection -- {@code org.exist.protocolhandler.protocols.xmldb.Handler} dispatches
+     * to XML-RPC against whatever host an absolute {@code xmldb://} URI names) using the server
+     * process's own OS-level/network access, regardless of the calling Subject's DB permissions --
+     * this is NOT the same trust boundary as the real validation pass, which only fetches whatever
+     * a configured catalog/resolver permits. So only resolutions that land in the exact same
+     * scheme+authority (host/port) as {@code baseUri} are attempted -- i.e. genuinely relative
+     * locations within the instance's own origin, never a different scheme or host. Anything else
+     * falls through to the unchanged, already-accepted-risk default pipeline below, exactly as if
+     * this peek didn't exist.</p>
+     */
+    private static boolean isXsd11Schema(final String baseUri, final String location) {
+        try {
+            final URI baseUriNormalized = new URI(ResolverFactory.fixupExistCatalogUri(baseUri));
+            final URI resolvedUri = baseUriNormalized.resolve(location);
+            if (!Objects.equals(baseUriNormalized.getScheme(), resolvedUri.getScheme())
+                    || !Objects.equals(baseUriNormalized.getAuthority(), resolvedUri.getAuthority())) {
+                LOG.debug("Refusing to peek candidate schema '{}': resolved to a different origin ('{}') than " +
+                        "the instance's own base URI ('{}') -- leaving this to the default pipeline/catalog instead.",
+                        location, resolvedUri, baseUriNormalized);
+                return false;
+            }
+            try (final InputStream is = resolvedUri.toURL().openStream()) {
+                final InputSource schemaSource = new InputSource(is);
+                schemaSource.setSystemId(resolvedUri.toString());
+                final Map<String, String> schemaRootAttrs = peekRootAttributes(schemaSource);
+                if (schemaRootAttrs == null) {
+                    return false;
+                }
+                final String minVersion = schemaRootAttrs.get(clark(XSD_VERSIONING_NS, "minVersion"));
+                return minVersion != null && minVersion.contains("1.1");
+            }
+        } catch (final URISyntaxException | IOException ex) {
+            LOG.debug("Could not peek candidate schema '{}' relative to '{}': {}", location, baseUri, ex.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Reads only as far as the root element's start tag and returns its attributes, keyed by
+     * Clark-notation {@code {namespace}localName} (see {@link #clark(String, String)}) -- cheaper
+     * than a full (validating) parse since StAX stops pulling events the moment the caller stops
+     * asking for them, and avoids the exception-as-control-flow pattern a SAX-based equivalent
+     * would need to abort early. DTD processing and external entities are disabled; this reads
+     * untrusted instance documents as well as schema documents.
+     *
+     * @return the root element's attributes, or {@code null} if the source couldn't be read/parsed.
+     */
+    @Nullable
+    private static Map<String, String> peekRootAttributes(final InputSource source) {
+        try {
+            final XMLInputFactory factory = XMLInputFactory.newInstance();
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+
+            final XMLStreamReader reader = factory.createXMLStreamReader(source.getByteStream());
+            try {
+                while (reader.hasNext()) {
+                    if (reader.next() == XMLStreamConstants.START_ELEMENT) {
+                        final Map<String, String> attrs = new HashMap<>();
+                        for (int i = 0; i < reader.getAttributeCount(); i++) {
+                            attrs.put(clark(reader.getAttributeNamespace(i), reader.getAttributeLocalName(i)), reader.getAttributeValue(i));
+                        }
+                        return attrs;
+                    }
+                }
+                return null;
+            } finally {
+                reader.close();
+            }
+        } catch (final XMLStreamException ex) {
+            LOG.debug("Could not peek root element attributes: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    private static String clark(@Nullable final String namespaceUri, final String localName) {
+        return (namespaceUri == null ? "" : "{" + namespaceUri + "}") + localName;
+    }
+
+    /**
      * @param resolver catalog resolver to use for schema/entity resolution, or null.
      * @return a {@link Validator} for the only XSD 1.1-capable pipeline this
      * Xerces fork supports: {@link SchemaFactory}/{@link Schema} with no
@@ -465,7 +649,7 @@ public class Jaxp extends BasicFunction {
      * from the instance's own schemaLocation hint, mirroring how the default
      * SAXParser pipeline behaves for XSD 1.0.
      */
-    private Validator newXsd11Validator(@Nullable final Resolver resolver) throws SAXException {
+    private Validator newXsd11Validator(@Nullable final LSResourceResolver resolver) throws SAXException {
         final SchemaFactory schemaFactory = SchemaFactory.newInstance(XSD_1_1_NS);
         final Schema schema = schemaFactory.newSchema();
         final Validator validator = schema.newValidator();

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -70,7 +70,6 @@ import org.exist.util.io.TemporaryFileManager;
 import org.exist.validation.GrammarPool;
 import org.exist.validation.ValidationContentHandler;
 import org.exist.validation.ValidationReport;
-import org.exist.validation.resolver.SearchResourceResolver;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -94,7 +93,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
-import org.xmlresolver.Resolver;
 
 import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
@@ -230,56 +228,23 @@ public class Jaxp extends BasicFunction {
             // Get inputstream for instance document
             instance = Shared.getInputSource(args[0].itemAt(0), context);
 
-            // Handle catalog
+            // Handle catalog. SearchResourceResolver implements both XMLEntityResolver (for
+            // this SAX pipeline) and LSResourceResolver (for the XSD 1.1 validator below), so
+            // directory-search catalogs work the same way regardless of which pipeline ends up
+            // validating.
             if (args.length == 2) {
                 LOG.debug("No Catalog specified");
 
-            } else if (args[2].isEmpty()) {
-                // Use system catalog
-                LOG.debug("Using system catalog.");
-                final Configuration config = brokerPool.getConfiguration();
-                final Resolver resolver = (Resolver) config.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER);
-                catalogResolver = resolver;
-                XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
-
             } else {
-                // Get URL for catalog
-                final String[] catalogUrls = Shared.getUrls(args[2]);
-                final String singleUrl = catalogUrls[0];
-
-                if (singleUrl.endsWith("/")) {
-                    // Search grammar in collection specified by URL. Just one collection is used.
-                    LOG.debug("Search for grammar in {}", singleUrl);
-                    // SearchResourceResolver implements both XMLEntityResolver (for this SAX
-                    // pipeline) and LSResourceResolver (for the XSD 1.1 validator below), so
-                    // directory-search catalogs work the same way regardless of which pipeline
-                    // ends up validating.
-                    final SearchResourceResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), catalogUrls[0]);
-                    catalogResolver = resolver;
-                    XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
-
-                } else if (singleUrl.endsWith(".xml")) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Using catalogs {}", String.join(" ", catalogUrls));
-                    }
-
-                    final Resolver resolver = ResolverFactory.resolveCatalogs(context.getBroker(), catalogUrls);
-                    catalogResolver = resolver;
-                    XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
-
-                } else {
-                    LOG.error("Catalog URLs should end on / or .xml");
-                }
-
+                catalogResolver = Shared.resolveCatalogArgument(this, brokerPool, context.getBroker(), context.getSubject(), args[2]);
+                XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, catalogResolver);
             }
 
             // Use grammarpool
             final boolean useCache = ((BooleanValue) args[1].itemAt(0)).getValue();
             if (useCache) {
                 LOG.debug("Grammar caching enabled.");
-                final Configuration config = brokerPool.getConfiguration();
-                final GrammarPool grammarPool = (GrammarPool) config.getProperty(GrammarPool.GRAMMAR_POOL_ELEMENT);
-                xmlReader.setProperty(XMLReaderObjectFactory.APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL, grammarPool);
+                xmlReader.setProperty(XMLReaderObjectFactory.APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL, getGrammarPool());
             }
 
             /* The bundled Xerces XSD 1.1 support is only wired into the JAXP
@@ -287,27 +252,18 @@ public class Jaxp extends BasicFunction {
                SAXParser pipeline -- it's a hard limitation of the dependency,
                not a configuration gap (see plans/catalog-dtd.plan.md). Rather
                than always discovering this by parsing with the wrong pipeline
-               and failing, peek (best-effort, see detectXsd11ViaSchemaLocation)
-               at the schema the instance's own hint points to and pick the
-               right pipeline up front when that succeeds. If the peek can't
-               tell (catalog-mediated location, unresolvable hint, etc.), fall
-               through to the unchanged default pipeline below, which still
-               retries with the XSD 1.1 validator on the cvc-elt.1.a failure
-               signature -- the peek is purely an optimization, never a
-               correctness requirement. */
-            final boolean useXsd11UpFront;
-            final InputSource peekInstance = Shared.getInputSource(args[0].itemAt(0), context);
-            try {
-                useXsd11UpFront = detectXsd11ViaSchemaLocation(peekInstance);
-            } finally {
-                Shared.closeInputSource(peekInstance);
-            }
-
-            if (useXsd11UpFront) {
+               and failing, peek (best-effort) at the schema the instance's own
+               hint points to and pick the right pipeline up front when that
+               succeeds. If the peek can't tell (catalog-mediated location,
+               unresolvable hint, etc.), fall through to the unchanged default
+               pipeline below, which still retries with the XSD 1.1 validator
+               on the cvc-elt.1.a failure signature -- the peek is purely an
+               optimization, never a correctness requirement. */
+            if (peekIsXsd11ViaSchemaLocation(args)) {
                 LOG.debug("Detected XSD 1.1 schema (vc:minVersion) via the instance's schemaLocation hint " +
                         "before parsing; using the XSD 1.1 validator directly.");
 
-                final Validator validator = newXsd11Validator(catalogResolver);
+                final Validator validator = newXsd11Validator(catalogResolver, useCache);
                 validator.setErrorHandler(report);
                 validator.validate(new SAXSource(instance), new SAXResult(contenthandler));
 
@@ -317,48 +273,9 @@ public class Jaxp extends BasicFunction {
                 xmlReader.parse(instance);
                 LOG.debug("Stopped parsing document");
 
-                /* Safety net: the up-front peek above didn't (or couldn't) detect XSD 1.1.
-                   When that shows up as "no declaration found" for the root element, retry once
-                   with the XSD-1.1-capable Validator before giving up -- but only when retrying
-                   could plausibly help: either the instance carries an explicit schemaLocation
-                   hint (the no-catalog case, where Xerces' own default resolution would have used
-                   it), or a catalog/resolver IS configured (system catalog, .xml catalog, or
-                   directory-search), since any of those can resolve a schema purely by the root
-                   element's namespace -- the directory-search fixtures in this codebase, for
-                   example, carry no schemaLocation hint at all and rely entirely on namespace-based
-                   lookup. DTD-only documents with neither a hint nor a catalog never produce this
-                   cvc-* signature in the first place, so they never retry. */
-                if (!report.isValid() && isMissingElementDeclaration(report)
-                        && (catalogResolver != null || hasSchemaLocationHint(contenthandler, instanceBuilder))) {
-                    LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
-                    report.clear();
-
-                    // The first pass already fed `contenthandler` (and, for jaxp-parse,
-                    // `instanceBuilder`) a complete document; reusing either for the retry
-                    // would silently double-build the result. Start over with a fresh
-                    // content handler/builder so the retry produces a single, clean document.
-                    if (isCalledAs("jaxp-parse")) {
-                        context.pushDocumentContext();
-                        try {
-                            instanceBuilder = context.getDocumentBuilder();
-                        } finally {
-                            context.popDocumentContext();
-                        }
-                        contenthandler = new DocumentBuilderReceiver(this, instanceBuilder, true);
-                    } else {
-                        contenthandler = new ValidationContentHandler();
-                    }
-
-                    final Validator validator = newXsd11Validator(catalogResolver);
-                    validator.setErrorHandler(report);
-
-                    final InputSource retryInstance = Shared.getInputSource(args[0].itemAt(0), context);
-                    try {
-                        validator.validate(new SAXSource(retryInstance), new SAXResult(contenthandler));
-                    } finally {
-                        Shared.closeInputSource(retryInstance);
-                    }
-                }
+                final ParseTarget retried = retryWithXsd11ValidatorIfNeeded(args, report, catalogResolver, contenthandler, instanceBuilder, useCache);
+                contenthandler = retried.contenthandler();
+                instanceBuilder = retried.instanceBuilder();
             }
 
             // Distill namespace from document
@@ -471,8 +388,13 @@ public class Jaxp extends BasicFunction {
      * @return true if any reported error is the "no global declaration for
      * the root element" signature ({@code cvc-elt.1.a}) produced when this
      * Xerces fork's dynamic-discovery pipeline meets an XSD 1.1-only schema.
+     *
+     * <p>Package-private (not {@code private}) so {@code
+     * IsMissingElementDeclarationTest}, in this package, can pin this match against
+     * the bundled Xerces fork's actual message text directly, without going through
+     * the full {@code validation:jaxp()} pipeline.</p>
      */
-    private static boolean isMissingElementDeclaration(final ValidationReport report) {
+    static boolean isMissingElementDeclaration(final ValidationReport report) {
         return report.getValidationReportItemList().stream()
                 .anyMatch(item -> item.getMessage() != null && item.getMessage().startsWith("cvc-elt.1.a:"));
     }
@@ -504,6 +426,104 @@ public class Jaxp extends BasicFunction {
                     && (root.hasAttributeNS(XSI_NS, "schemaLocation") || root.hasAttributeNS(XSI_NS, "noNamespaceSchemaLocation"));
         }
         return false;
+    }
+
+    /**
+     * The content handler/document builder pair currently receiving parse events. Used to thread
+     * the (possibly freshly-rebuilt, see {@link #retryWithXsd11ValidatorIfNeeded}) pair back out
+     * of a retry attempt without a mutable shared field.
+     *
+     * @param contenthandler the content handler currently wired up to receive SAX events.
+     * @param instanceBuilder for {@code jaxp-parse}, the document builder backing {@code contenthandler};
+     *                        {@code null} for {@code jaxp}/{@code jaxp-report}.
+     */
+    private record ParseTarget(ContentHandler contenthandler, @Nullable MemTreeBuilder instanceBuilder) {
+    }
+
+    /**
+     * Acquires a fresh, disposable {@link InputSource} for the instance and runs
+     * {@link #detectXsd11ViaSchemaLocation(InputSource)} against it.
+     */
+    private boolean peekIsXsd11ViaSchemaLocation(final Sequence[] args) throws XPathException, IOException {
+        final InputSource peekInstance = Shared.getInputSource(args[0].itemAt(0), context);
+        try {
+            return detectXsd11ViaSchemaLocation(peekInstance);
+        } finally {
+            Shared.closeInputSource(peekInstance);
+        }
+    }
+
+    /**
+     * Safety net for when {@link #peekIsXsd11ViaSchemaLocation} didn't (or couldn't) detect XSD 1.1
+     * up front: after the default pipeline's first parse, retries once with the XSD-1.1-capable
+     * {@link Validator} when retrying could plausibly help -- but only then. Retrying is plausible
+     * when the failure is specifically the "no global declaration for the root element" signature
+     * ({@link #isMissingElementDeclaration(ValidationReport)}) <em>and</em> either the instance
+     * carries an explicit schemaLocation hint (the no-catalog case, where Xerces' own default
+     * resolution would have used it), or a catalog/resolver is configured (system catalog, .xml
+     * catalog, or directory-search), since any of those can resolve a schema purely by the root
+     * element's namespace -- the directory-search fixtures in this codebase, for example, carry no
+     * schemaLocation hint at all and rely entirely on namespace-based lookup. DTD-only documents
+     * with neither a hint nor a catalog never produce this cvc-* signature in the first place, so
+     * they never retry.
+     *
+     * @param contenthandler the content handler used for the first (failed) parse pass.
+     * @param instanceBuilder for {@code jaxp-parse}, the document builder used for the first parse
+     *                        pass; {@code null} for {@code jaxp}/{@code jaxp-report}.
+     * @param useCache whether grammar caching was requested (see {@code cache-grammars}); honored
+     *                 by the XSD 1.1 validator built here the same way it is for the default
+     *                 pipeline.
+     * @return {@code contenthandler}/{@code instanceBuilder} unchanged if no retry was attempted;
+     *         otherwise a <em>fresh</em> pair -- the first pass already fed the original pair a
+     *         complete document, so reusing either for the retry would silently double-build the
+     *         result (see {@code jaxp:xsd11_parse_single_root} in jaxp.xql).
+     */
+    private ParseTarget retryWithXsd11ValidatorIfNeeded(final Sequence[] args, final ValidationReport report,
+            @Nullable final LSResourceResolver catalogResolver, final ContentHandler contenthandler,
+            @Nullable final MemTreeBuilder instanceBuilder, final boolean useCache) throws XPathException, IOException, SAXException {
+        // Three independent reasons retrying can't help, checked in order: the first pass
+        // already succeeded; the failure isn't the cvc-elt.1.a signature retrying addresses;
+        // or there's no way to resolve a schema for the retry to use (no catalog/resolver
+        // configured, and no schemaLocation hint on the instance either).
+        if (report.isValid()) {
+            return new ParseTarget(contenthandler, instanceBuilder);
+        }
+        if (!isMissingElementDeclaration(report)) {
+            return new ParseTarget(contenthandler, instanceBuilder);
+        }
+        if (catalogResolver == null && !hasSchemaLocationHint(contenthandler, instanceBuilder)) {
+            return new ParseTarget(contenthandler, instanceBuilder);
+        }
+
+        LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
+        report.clear();
+
+        final ContentHandler retryContenthandler;
+        final MemTreeBuilder retryInstanceBuilder;
+        if (isCalledAs("jaxp-parse")) {
+            context.pushDocumentContext();
+            try {
+                retryInstanceBuilder = context.getDocumentBuilder();
+            } finally {
+                context.popDocumentContext();
+            }
+            retryContenthandler = new DocumentBuilderReceiver(this, retryInstanceBuilder, true);
+        } else {
+            retryInstanceBuilder = null;
+            retryContenthandler = new ValidationContentHandler();
+        }
+
+        final Validator validator = newXsd11Validator(catalogResolver, useCache);
+        validator.setErrorHandler(report);
+
+        final InputSource retryInstance = Shared.getInputSource(args[0].itemAt(0), context);
+        try {
+            validator.validate(new SAXSource(retryInstance), new SAXResult(retryContenthandler));
+        } finally {
+            Shared.closeInputSource(retryInstance);
+        }
+
+        return new ParseTarget(retryContenthandler, retryInstanceBuilder);
     }
 
     /**
@@ -642,15 +662,42 @@ public class Jaxp extends BasicFunction {
     }
 
     /**
+     * @return the shared {@link GrammarPool} used to honor {@code cache-grammars}, on whichever
+     * pipeline (the default SAX {@code xmlReader} or the XSD 1.1 {@link SchemaFactory}) ends up
+     * validating.
+     */
+    private GrammarPool getGrammarPool() {
+        final Configuration config = brokerPool.getConfiguration();
+        return (GrammarPool) config.getProperty(GrammarPool.GRAMMAR_POOL_ELEMENT);
+    }
+
+    /**
      * @param resolver catalog resolver to use for schema/entity resolution, or null.
+     * @param useCache whether grammar caching was requested (see {@code cache-grammars}); when
+     *                 true, wires the same shared {@link GrammarPool} the default SAX pipeline
+     *                 uses (see {@code eval()}) into the underlying Xerces {@link SchemaFactory}
+     *                 via the same {@code APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL} property --
+     *                 the bundled Xerces fork's {@code BaseSchemaFactory} (the XSD 1.1
+     *                 implementation's superclass) supports it, even though {@code
+     *                 javax.xml.validation.SchemaFactory} doesn't declare it generically.
+     *                 Without this, {@code cache-grammars} would be silently ignored whenever
+     *                 validation routes through the XSD 1.1 validator.
      * @return a {@link Validator} for the only XSD 1.1-capable pipeline this
      * Xerces fork supports: {@link SchemaFactory}/{@link Schema} with no
      * pre-supplied schema documents, so it dynamically discovers the schema
      * from the instance's own schemaLocation hint, mirroring how the default
      * SAXParser pipeline behaves for XSD 1.0.
      */
-    private Validator newXsd11Validator(@Nullable final LSResourceResolver resolver) throws SAXException {
+    private Validator newXsd11Validator(@Nullable final LSResourceResolver resolver, final boolean useCache) throws SAXException {
         final SchemaFactory schemaFactory = SchemaFactory.newInstance(XSD_1_1_NS);
+        if (useCache) {
+            LOG.debug("Grammar caching enabled for XSD 1.1 validator.");
+            try {
+                schemaFactory.setProperty(XMLReaderObjectFactory.APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL, getGrammarPool());
+            } catch (final SAXNotRecognizedException | SAXNotSupportedException ex) {
+                LOG.debug("XSD 1.1 SchemaFactory does not support grammar pool caching: {}", ex.getMessage());
+            }
+        }
         final Schema schema = schemaFactory.newSchema();
         final Validator validator = schema.newValidator();
         if (resolver != null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -29,11 +29,13 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import javax.annotation.Nullable;
 import javax.xml.parsers.ParserConfigurationException;
@@ -108,6 +110,33 @@ public class Jaxp extends BasicFunction {
     private static final String XSD_1_1_NS = "http://www.w3.org/XML/XMLSchema/v1.1";
     private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
     private static final String XSD_VERSIONING_NS = "http://www.w3.org/2007/XMLSchema-versioning";
+
+    /**
+     * Bound on the size of {@link #XSD11_DETECTION_CACHE} (see there for what it caches).
+     */
+    private static final int XSD11_DETECTION_CACHE_MAX_ENTRIES = 256;
+
+    /**
+     * Cache key for {@link #XSD11_DETECTION_CACHE}: the requesting Subject's name plus the
+     * resolved schema URI. Including the Subject prevents a Subject without read permission on
+     * the schema resource from observing a boolean populated by a different (permitted)
+     * Subject's earlier, permission-checked fetch -- a cache hit skips {@link
+     * #isXsd11Schema(String, String, String)}'s {@code openStream()} entirely, so without this
+     * the cache itself would bypass whatever permission check that open would otherwise perform.
+     */
+    private record Xsd11DetectionCacheKey(String subjectName, String resolvedSchemaUri) {
+    }
+
+    /**
+     * Bounded (see {@link #XSD11_DETECTION_CACHE_MAX_ENTRIES}), LRU-evicted cache of
+     * "does the schema at this resolved URI declare vc:minVersion 1.1?", so that validating many
+     * documents against the same schema doesn't re-fetch and re-peek it every time. Cleared by
+     * {@code validation:clear-grammar-cache()} (see {@link GrammarTooling}) alongside the Xerces
+     * grammar pool, so operators have one function to clear every validation-related cache.
+     */
+    private static final Cache<Xsd11DetectionCacheKey, Boolean> XSD11_DETECTION_CACHE = Caffeine.newBuilder()
+            .maximumSize(XSD11_DETECTION_CACHE_MAX_ENTRIES)
+            .build();
 
     private static final String simpleFunctionTxt = """
             Validate document by parsing $instance. Optionally \
@@ -443,12 +472,12 @@ public class Jaxp extends BasicFunction {
 
     /**
      * Acquires a fresh, disposable {@link InputSource} for the instance and runs
-     * {@link #detectXsd11ViaSchemaLocation(InputSource)} against it.
+     * {@link #detectXsd11ViaSchemaLocation(String, InputSource)} against it.
      */
     private boolean peekIsXsd11ViaSchemaLocation(final Sequence[] args) throws XPathException, IOException {
         final InputSource peekInstance = Shared.getInputSource(args[0].itemAt(0), context);
         try {
-            return detectXsd11ViaSchemaLocation(peekInstance);
+            return detectXsd11ViaSchemaLocation(context.getSubject().getName(), peekInstance);
         } finally {
             Shared.closeInputSource(peekInstance);
         }
@@ -538,9 +567,11 @@ public class Jaxp extends BasicFunction {
      * retry-after-failure check in {@code eval()} remains the safety net for those cases
      * (catalog-mediated locations, an unresolvable hint, etc.).
      *
+     * @param subjectName the requesting Subject's name, used to scope {@link #XSD11_DETECTION_CACHE}
+     *                     (see there for why).
      * @param peekInstance a fresh, not-yet-consumed InputSource for the same instance document.
      */
-    private static boolean detectXsd11ViaSchemaLocation(final InputSource peekInstance) {
+    private static boolean detectXsd11ViaSchemaLocation(final String subjectName, final InputSource peekInstance) {
         final Map<String, String> rootAttrs = peekRootAttributes(peekInstance);
         final String baseUri = peekInstance.getSystemId();
         if (rootAttrs == null || baseUri == null) {
@@ -562,7 +593,7 @@ public class Jaxp extends BasicFunction {
         }
 
         for (final String location : candidateLocations) {
-            if (isXsd11Schema(baseUri, location)) {
+            if (isXsd11Schema(subjectName, baseUri, location)) {
                 return true;
             }
         }
@@ -575,6 +606,8 @@ public class Jaxp extends BasicFunction {
      * and checks whether its root element declares {@code vc:minVersion} containing "1.1".
      * Returns {@code false} for any resolution/read failure -- this is a best-effort peek, not
      * a substitute for the real catalog-aware resolution the actual validation pass performs.
+     * Package-private (not {@code private}) so {@code JaxpSchemaLocationSecurityTest}/
+     * {@code JaxpXsd11DetectionCacheTest}, both in this package, can call it directly.
      *
      * <p>{@code location} is the literal, attacker/document-author-controlled value of the
      * instance's own {@code xsi:schemaLocation}/{@code noNamespaceSchemaLocation} hint -- if it's
@@ -600,8 +633,13 @@ public class Jaxp extends BasicFunction {
      * way to get a {@code file:} base URI here), which already requires the caller to have used
      * {@code util:} Java-interop functions to construct that object in the first place -- a
      * separate, pre-existing privilege boundary this peek doesn't change either way.</p>
+     *
+     * <p>{@code subjectName} scopes {@link #XSD11_DETECTION_CACHE}: a cache hit skips this
+     * method's permission-checked {@code openStream()} entirely, so without scoping by Subject,
+     * a Subject without read permission on the schema resource could observe a boolean populated
+     * by a different (permitted) Subject's earlier fetch -- a cross-Subject information leak.</p>
      */
-    private static boolean isXsd11Schema(final String baseUri, final String location) {
+    static boolean isXsd11Schema(final String subjectName, final String baseUri, final String location) {
         try {
             final URI baseUriNormalized = new URI(ResolverFactory.fixupExistCatalogUri(baseUri));
             final URI resolvedUri = baseUriNormalized.resolve(location);
@@ -613,7 +651,7 @@ public class Jaxp extends BasicFunction {
                 return false;
             }
 
-            final String cacheKey = resolvedUri.toString();
+            final Xsd11DetectionCacheKey cacheKey = new Xsd11DetectionCacheKey(subjectName, resolvedUri.toString());
             final Boolean cached = getCachedXsd11Detection(cacheKey);
             if (cached != null) {
                 return cached;
@@ -643,44 +681,22 @@ public class Jaxp extends BasicFunction {
         }
     }
 
-    /**
-     * Bounded (see {@link #XSD11_DETECTION_CACHE_MAX_ENTRIES}), LRU-evicted cache of
-     * "does the schema at this resolved URI declare vc:minVersion 1.1?", so that validating many
-     * documents against the same schema doesn't re-fetch and re-peek it every time. Cleared by
-     * {@code validation:clear-grammar-cache()} (see {@link GrammarTooling}) alongside the Xerces
-     * grammar pool, so operators have one function to clear every validation-related cache.
-     */
-    private static final int XSD11_DETECTION_CACHE_MAX_ENTRIES = 256;
-
-    private static final Map<String, Boolean> XSD11_DETECTION_CACHE = new LinkedHashMap<>(16, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {
-            return size() > XSD11_DETECTION_CACHE_MAX_ENTRIES;
-        }
-    };
-
     @Nullable
-    private static Boolean getCachedXsd11Detection(final String resolvedUri) {
-        synchronized (XSD11_DETECTION_CACHE) {
-            return XSD11_DETECTION_CACHE.get(resolvedUri);
-        }
+    private static Boolean getCachedXsd11Detection(final Xsd11DetectionCacheKey key) {
+        return XSD11_DETECTION_CACHE.getIfPresent(key);
     }
 
-    private static void cacheXsd11Detection(final String resolvedUri, final boolean isXsd11) {
-        synchronized (XSD11_DETECTION_CACHE) {
-            XSD11_DETECTION_CACHE.put(resolvedUri, isXsd11);
-        }
+    private static void cacheXsd11Detection(final Xsd11DetectionCacheKey key, final boolean isXsd11) {
+        XSD11_DETECTION_CACHE.put(key, isXsd11);
     }
 
     /**
-     * Discards all cached {@link #isXsd11Schema(String, String)} results. Package-private so
-     * {@link GrammarTooling}'s {@code clear-grammar-cache()} can clear this alongside the Xerces
-     * grammar pool.
+     * Discards all cached {@link #isXsd11Schema(String, String, String)} results. Package-private
+     * so {@link GrammarTooling}'s {@code clear-grammar-cache()} can clear this alongside the
+     * Xerces grammar pool.
      */
     static void clearXsd11DetectionCache() {
-        synchronized (XSD11_DETECTION_CACHE) {
-            XSD11_DETECTION_CACHE.clear();
-        }
+        XSD11_DETECTION_CACHE.invalidateAll();
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -591,6 +591,14 @@ public class Jaxp extends BasicFunction {
      * locations within the instance's own origin, never a different scheme or host. Anything else
      * falls through to the unchanged, already-accepted-risk default pipeline below, exactly as if
      * this peek didn't exist.</p>
+     *
+     * <p>Residual nuance, not a new gap: {@code file:} URIs have no authority component at all
+     * (it's always empty), so this check cannot distinguish {@code file:///a/instance.xml} from
+     * an absolute {@code file:///etc/passwd} hint -- both have scheme {@code file} and empty
+     * authority. This only matters for Java-{@link java.io.File}-backed instance items (the only
+     * way to get a {@code file:} base URI here), which already requires the caller to have used
+     * {@code util:} Java-interop functions to construct that object in the first place -- a
+     * separate, pre-existing privilege boundary this peek doesn't change either way.</p>
      */
     private static boolean isXsd11Schema(final String baseUri, final String location) {
         try {

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -22,8 +22,6 @@
 package org.exist.xquery.functions.validation;
 
 import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -68,8 +66,6 @@ import org.exist.util.Configuration;
 import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.util.io.TemporaryFileManager;
-import org.exist.util.serializer.SAXSerializer;
-import org.exist.util.serializer.SerializerPool;
 import org.exist.validation.GrammarPool;
 import org.exist.validation.ValidationContentHandler;
 import org.exist.validation.ValidationReport;
@@ -98,6 +94,7 @@ import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xmlresolver.Resolver;
+import org.xmlresolver.utils.SaxProducer;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -256,7 +253,7 @@ public class Jaxp extends BasicFunction {
                 } else if (singleUrl.endsWith(".xml")) {
                     LOG.debug("Using catalogs {}", getStrings(catalogUrls));
 
-                    final List<Tuple2<String, Optional<InputSource>>> catalogs = new ArrayList<>();
+                    final List<Tuple2<String, Optional<SaxProducer>>> catalogs = new ArrayList<>();
                     for (String catalogUrl : catalogUrls) {
 
                         /* NOTE(AR): Catalog URL if stored in database must start with
@@ -264,23 +261,20 @@ public class Jaxp extends BasicFunction {
                            org.exist.protocolhandler.protocols.xmldb.Handler
                            to resolve any relative URI resources from the database.
                          */
-                        final Optional<InputSource> maybeInputSource;
+                        final Optional<SaxProducer> maybeSaxProducer;
                         if (catalogUrl.startsWith("xmldb:exist://")) {
                             catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                            maybeInputSource = Optional.of(new InputSource(new StringReader(serializeDocument(XmldbURI.create(catalogUrl)))));
+                            maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
                         } else if (catalogUrl.startsWith("/db")) {
                             catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                            maybeInputSource = Optional.of(new InputSource(new StringReader(serializeDocument(XmldbURI.create(catalogUrl)))));
+                            maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
                         } else {
-                            maybeInputSource = Optional.empty();
+                            maybeSaxProducer = Optional.empty();
                         }
 
-                        if (maybeInputSource.isPresent()) {
-                            maybeInputSource.get().setSystemId(catalogUrl);
-                        }
-                        catalogs.add(Tuple(catalogUrl, maybeInputSource));
+                        catalogs.add(Tuple(catalogUrl, maybeSaxProducer));
                     }
-                    final Resolver resolver = ResolverFactory.newResolver(catalogs);
+                    final Resolver resolver = ResolverFactory.newResolverFromSax(catalogs);
                     catalogResolver = resolver;
                     XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
@@ -500,16 +494,28 @@ public class Jaxp extends BasicFunction {
         return validator;
     }
 
-    // TODO(AR) remove this when PR https://github.com/xmlresolver/xmlresolver/pull/98 is merged
-    private String serializeDocument(final XmldbURI documentUri) throws SAXException, IOException {
-        try (final LockedDocument lockedDocument = context.getBroker().getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
-            if (lockedDocument == null) {
-                throw new IOException("No such document: " + documentUri);
-            }
+    /**
+     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
+     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
+     * loader supplies, avoiding having to first serialize the document to a {@link String} and
+     * have the catalog loader re-parse it from an {@link InputSource}.
+     *
+     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
+     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
+     * load the entries), so each invocation re-acquires the document lock and re-serializes it.</p>
+     *
+     * @param documentUri the URI of the catalog document stored in the database.
+     * @return a producer that re-serializes the document's SAX events on each invocation.
+     */
+    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
+        return (contentHandler, dtdHandler, errorHandler) -> {
+            try (final LockedDocument lockedDocument = context.getBroker().getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
+                if (lockedDocument == null) {
+                    throw new IOException("No such document: " + documentUri);
+                }
 
-            final DocumentImpl doc = lockedDocument.getDocument();
+                final DocumentImpl doc = lockedDocument.getDocument();
 
-            try (final StringWriter stringWriter = new StringWriter()) {
                 final Properties outputProperties = new Properties();
                 outputProperties.setProperty(OutputKeys.METHOD, "XML");
                 outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
@@ -518,26 +524,13 @@ public class Jaxp extends BasicFunction {
 
                 final Serializer serializer = context.getBroker().getSerializer();
                 serializer.reset();
-                SAXSerializer sax = null;
-                try {
-                    sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-                    sax.setOutput(stringWriter, outputProperties);
-                    serializer.setProperties(outputProperties);
-                    serializer.setSAXHandlers(sax, sax);
-                    serializer.toSAX(doc);
-                } catch (final SAXNotSupportedException | SAXNotRecognizedException e) {
-                    throw new SAXException(e.getMessage(), e);
-                } finally {
-                    if (sax != null) {
-                        SerializerPool.getInstance().returnObject(sax);
-                    }
-                }
-
-                return stringWriter.toString();
+                serializer.setProperties(outputProperties);
+                serializer.setSAXHandlers(contentHandler, null);
+                serializer.toSAX(doc);
+            } catch (final PermissionDeniedException e) {
+                throw new IOException(e.getMessage(), e);
             }
-        } catch (final PermissionDeniedException e) {
-            throw new IOException(e.getMessage(), e);
-        }
+        };
     }
 
     // No-go ...processor is in validating mode

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -40,8 +41,13 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 
@@ -77,17 +83,20 @@ import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
+import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
+import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
 import org.xmlresolver.Resolver;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
@@ -207,6 +216,7 @@ public class Jaxp extends BasicFunction {
         }
 
         InputSource instance = null;
+        Resolver catalogResolver = null;
         try {
             report.start();
 
@@ -229,6 +239,7 @@ public class Jaxp extends BasicFunction {
                 LOG.debug("Using system catalog.");
                 final Configuration config = brokerPool.getConfiguration();
                 final Resolver resolver = (Resolver) config.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER);
+                catalogResolver = resolver;
                 XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
             } else {
@@ -270,6 +281,7 @@ public class Jaxp extends BasicFunction {
                         catalogs.add(Tuple(catalogUrl, maybeInputSource));
                     }
                     final Resolver resolver = ResolverFactory.newResolver(catalogs);
+                    catalogResolver = resolver;
                     XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
 
                 } else {
@@ -291,6 +303,29 @@ public class Jaxp extends BasicFunction {
             LOG.debug("Start parsing document");
             xmlReader.parse(instance);
             LOG.debug("Stopped parsing document");
+
+            /* The bundled Xerces XSD 1.1 support is only wired into the JAXP
+               SchemaFactory/Validator API, not into this dynamic-discovery
+               SAXParser pipeline (see plans/catalog-dtd.plan.md). When that
+               shows up as "no declaration found" for the root element and the
+               instance actually references a schema, retry once with the
+               XSD-1.1-capable Validator before giving up. DTD-only documents
+               never produce this cvc-* signature, so they never retry. */
+            if (!report.isValid() && isMissingElementDeclaration(report)
+                    && hasSchemaLocationHint(args[0].itemAt(0))) {
+                LOG.debug("Retrying validation with XSD 1.1 validator after cvc-elt.1.a");
+                report.clear();
+
+                final Validator validator = newXsd11Validator(catalogResolver);
+                validator.setErrorHandler(report);
+
+                final InputSource retryInstance = Shared.getInputSource(args[0].itemAt(0), context);
+                try {
+                    validator.validate(new SAXSource(retryInstance), new SAXResult(contenthandler));
+                } finally {
+                    Shared.closeInputSource(retryInstance);
+                }
+            }
 
             // Distill namespace from document
             if (contenthandler instanceof ValidationContentHandler handler) {
@@ -379,11 +414,90 @@ public class Jaxp extends BasicFunction {
 
         try {
             xmlReader.setFeature(featureName, value);
-            
+
         } catch (final SAXNotRecognizedException | SAXNotSupportedException ex) {
             LOG.error(ex.getMessage());
 
         }
+    }
+
+    private static final String XSD_1_1_NS = "http://www.w3.org/XML/XMLSchema/v1.1";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    /**
+     * @return true if any reported error is the "no global declaration for
+     * the root element" signature ({@code cvc-elt.1.a}) produced when this
+     * Xerces fork's dynamic-discovery pipeline meets an XSD 1.1-only schema.
+     */
+    private static boolean isMissingElementDeclaration(final ValidationReport report) {
+        return report.getValidationReportItemList().stream()
+                .anyMatch(item -> item.getMessage() != null && item.getMessage().startsWith("cvc-elt.1.a:"));
+    }
+
+    /**
+     * Cheaply peeks at the root element's attributes to check whether the
+     * instance references a schema via {@code xsi:schemaLocation} /
+     * {@code xsi:noNamespaceSchemaLocation}, without validating it. Used to
+     * decide whether the XSD 1.1 fallback retry could possibly help (a
+     * DTD-only document never produces the cvc-elt.1.a signature in the
+     * first place, but this guards against retrying on documents that
+     * reference no schema at all).
+     */
+    private boolean hasSchemaLocationHint(final Item item) throws XPathException, IOException {
+        final InputSource probe = Shared.getInputSource(item, context);
+        try {
+            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setNamespaceAware(true);
+            final XMLReader reader = factory.newSAXParser().getXMLReader();
+
+            final boolean[] found = {false};
+            reader.setContentHandler(new DefaultHandler() {
+                @Override
+                public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
+                    found[0] = attributes.getValue(XSI_NS, "schemaLocation") != null
+                            || attributes.getValue(XSI_NS, "noNamespaceSchemaLocation") != null;
+                    throw StopAfterRootElement.INSTANCE;
+                }
+            });
+
+            try {
+                reader.parse(probe);
+            } catch (final StopAfterRootElement stop) {
+                // expected: we only need the root element's attributes
+            }
+            return found[0];
+
+        } catch (final ParserConfigurationException | SAXException ex) {
+            throw new IOException(ex.getMessage(), ex);
+        } finally {
+            Shared.closeInputSource(probe);
+        }
+    }
+
+    /**
+     * Sentinel used to abort {@link #hasSchemaLocationHint(Item)}'s probe
+     * parse immediately after the root element's attributes are seen.
+     */
+    private static final class StopAfterRootElement extends SAXException {
+        private static final StopAfterRootElement INSTANCE = new StopAfterRootElement();
+    }
+
+    /**
+     * @param resolver catalog resolver to use for schema/entity resolution, or null.
+     * @return a {@link Validator} for the only XSD 1.1-capable pipeline this
+     * Xerces fork supports: {@link SchemaFactory}/{@link Schema} with no
+     * pre-supplied schema documents, so it dynamically discovers the schema
+     * from the instance's own schemaLocation hint, mirroring how the default
+     * SAXParser pipeline behaves for XSD 1.0.
+     */
+    private Validator newXsd11Validator(@Nullable final Resolver resolver) throws SAXException {
+        final SchemaFactory schemaFactory = SchemaFactory.newInstance(XSD_1_1_NS);
+        final Schema schema = schemaFactory.newSchema();
+        final Validator validator = schema.newValidator();
+        if (resolver != null) {
+            validator.setResourceResolver(resolver);
+        }
+        return validator;
     }
 
     // TODO(AR) remove this when PR https://github.com/xmlresolver/xmlresolver/pull/98 is merged

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -29,6 +29,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -611,19 +612,74 @@ public class Jaxp extends BasicFunction {
                         location, resolvedUri, baseUriNormalized);
                 return false;
             }
+
+            final String cacheKey = resolvedUri.toString();
+            final Boolean cached = getCachedXsd11Detection(cacheKey);
+            if (cached != null) {
+                return cached;
+            }
+
             try (final InputStream is = resolvedUri.toURL().openStream()) {
                 final InputSource schemaSource = new InputSource(is);
                 schemaSource.setSystemId(resolvedUri.toString());
                 final Map<String, String> schemaRootAttrs = peekRootAttributes(schemaSource);
                 if (schemaRootAttrs == null) {
+                    // Couldn't even parse the candidate as XML -- not a stable fact about a real
+                    // schema (e.g. case from #6 in detectXsd11ViaSchemaLocation finding a location
+                    // that doesn't actually exist), so don't cache it; let the next call retry.
                     return false;
                 }
                 final String minVersion = schemaRootAttrs.get(clark(XSD_VERSIONING_NS, "minVersion"));
-                return minVersion != null && minVersion.contains("1.1");
+                final boolean result = minVersion != null && minVersion.contains("1.1");
+                cacheXsd11Detection(cacheKey, result);
+                return result;
             }
         } catch (final URISyntaxException | IOException ex) {
+            // Not cached: this may be a transient failure (lock contention, a brief network blip
+            // for an xmldb:// catalog served over XML-RPC, etc); a permanently-cached false would
+            // wrongly keep a legitimate schema on the slower retry-after-failure path forever.
             LOG.debug("Could not peek candidate schema '{}' relative to '{}': {}", location, baseUri, ex.getMessage());
             return false;
+        }
+    }
+
+    /**
+     * Bounded (see {@link #XSD11_DETECTION_CACHE_MAX_ENTRIES}), LRU-evicted cache of
+     * "does the schema at this resolved URI declare vc:minVersion 1.1?", so that validating many
+     * documents against the same schema doesn't re-fetch and re-peek it every time. Cleared by
+     * {@code validation:clear-grammar-cache()} (see {@link GrammarTooling}) alongside the Xerces
+     * grammar pool, so operators have one function to clear every validation-related cache.
+     */
+    private static final int XSD11_DETECTION_CACHE_MAX_ENTRIES = 256;
+
+    private static final Map<String, Boolean> XSD11_DETECTION_CACHE = new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {
+            return size() > XSD11_DETECTION_CACHE_MAX_ENTRIES;
+        }
+    };
+
+    @Nullable
+    private static Boolean getCachedXsd11Detection(final String resolvedUri) {
+        synchronized (XSD11_DETECTION_CACHE) {
+            return XSD11_DETECTION_CACHE.get(resolvedUri);
+        }
+    }
+
+    private static void cacheXsd11Detection(final String resolvedUri, final boolean isXsd11) {
+        synchronized (XSD11_DETECTION_CACHE) {
+            XSD11_DETECTION_CACHE.put(resolvedUri, isXsd11);
+        }
+    }
+
+    /**
+     * Discards all cached {@link #isXsd11Schema(String, String)} results. Package-private so
+     * {@link GrammarTooling}'s {@code clear-grammar-cache()} can clear this alongside the Xerces
+     * grammar pool.
+     */
+    static void clearXsd11DetectionCache() {
+        synchronized (XSD11_DETECTION_CACHE) {
+            XSD11_DETECTION_CACHE.clear();
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -21,18 +21,36 @@
  */
 package org.exist.xquery.functions.validation;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
 
 import javax.xml.XMLConstants;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.resolver.ResolverFactory;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.serializers.Serializer;
+import org.exist.util.Configuration;
+import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.ValidationReport;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -45,6 +63,13 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
+
+import org.xml.sax.InputSource;
+import org.xmlresolver.Resolver;
+import org.xmlresolver.utils.SaxProducer;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *   xQuery function for validation of XML instance documents
@@ -73,8 +98,13 @@ public class Jaxv extends BasicFunction  {
             "The namespace URI to designate a schema language. Depending on the " +
             "jaxv.SchemaFactory implementation the following values are valid:" +
             "(XSD 1.0) http://www.w3.org/2001/XMLSchema http://www.w3.org/XML/XMLSchema/v1.0, " +
-            "(XSD 1.1) http://www.w3.org/XML/XMLSchema/v1.1, " + 
+            "(XSD 1.1) http://www.w3.org/XML/XMLSchema/v1.1, " +
             "(RELAX NG 1.0) http://relaxng.org/ns/structure/1.0";
+
+    private static final String catalogTxt = "The catalogs referenced as xs:anyURI's. An empty " +
+            "sequence uses the system catalog. A directory-search catalog (a collection URI ending " +
+            "in '/') is not supported here, as javax.xml.validation.Validator has no equivalent of " +
+            "the SAX entity resolver used for that case in validation:jaxp().";
 
     // Setup function signature
     public final static FunctionSignature[] signatures = {
@@ -107,8 +137,24 @@ public class Jaxv extends BasicFunction  {
                 new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                     Shared.simplereportText)
             ),
-        
-        
+
+        new FunctionSignature(
+                new QName("jaxv", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
+                extendedFunctionTxt+" Optionally an XML catalog can be specified for schema/entity resolution.",
+                new SequenceType[]{
+                    new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
+                        instanceText),
+                    new FunctionParameterSequenceType("grammars", Type.ITEM, Cardinality.ONE_OR_MORE,
+                        grammarText),
+                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.EXACTLY_ONE,
+                        languageText),
+                    new FunctionParameterSequenceType("catalogs", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                        catalogTxt),
+                },
+                new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
+                    Shared.simplereportText)
+            ),
+
         new FunctionSignature(
                 new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
                 extendedFunctionTxt+" An XML report is returned.",
@@ -121,7 +167,7 @@ public class Jaxv extends BasicFunction  {
                 new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
                     Shared.xmlreportText)
             ),
-            
+
         new FunctionSignature(
                 new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
                 extendedFunctionTxt+" An XML report is returned.",
@@ -135,20 +181,40 @@ public class Jaxv extends BasicFunction  {
                    },
                 new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
                     Shared.xmlreportText)
+            ),
+
+        new FunctionSignature(
+                new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
+                extendedFunctionTxt+" An XML report is returned. Optionally an XML catalog can be specified for schema/entity resolution.",
+                new SequenceType[]{
+                    new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
+                        instanceText),
+                    new FunctionParameterSequenceType("grammars", Type.ITEM, Cardinality.ONE_OR_MORE,
+                        grammarText),
+                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.EXACTLY_ONE,
+                        languageText),
+                    new FunctionParameterSequenceType("catalogs", Type.ITEM, Cardinality.ZERO_OR_MORE,
+                        catalogTxt),
+                },
+                new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
+                    Shared.xmlreportText)
             )
-                        
+
     };
     
     
+    private final BrokerPool brokerPool;
+
     public Jaxv(XQueryContext context, FunctionSignature signature) {
         super(context, signature);
+        brokerPool = context.getBroker().getBrokerPool();
     }
 
 
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
 
         // Check input parameters
-        if (args.length != 2  && args.length != 3) {
+        if (args.length != 2 && args.length != 3 && args.length != 4) {
             return Sequence.EMPTY_SEQUENCE;
         }
 
@@ -160,13 +226,13 @@ public class Jaxv extends BasicFunction  {
 
         try {
             report.start();
-            
+
             // Get inputstream for instance document
             instance=Shared.getStreamSource(args[0].itemAt(0), context);
 
             // Validate using resource speciefied in second parameter
             grammars = Shared.getStreamSource(args[1], context);
-           
+
             // Check input
             for (final StreamSource grammar : grammars) {
                 final String grammarUrl = grammar.getSystemId();
@@ -177,23 +243,81 @@ public class Jaxv extends BasicFunction  {
             }
 
             // Fetch third argument if available, and override defailt value
-            if (args.length == 3) {
+            if (args.length >= 3) {
                 schemaLang = args[2].getStringValue();
             }
-            
+
             // Get language specific factory
             SchemaFactory factory = null;
             try {
                 factory = SchemaFactory.newInstance(schemaLang);
-                
+
             } catch (final IllegalArgumentException ex) {
                 final String msg = "Schema language '" + schemaLang + "' is not supported. " + ex.getMessage();
                 LOG.error(msg);
                 throw new XPathException(this, msg);
             }
-            
-            
-            // Create grammar
+
+
+            // Handle catalog (fourth argument). Must be set on the SchemaFactory, and
+            // BEFORE newSchema() is called: that's when xs:import/xs:include resolution
+            // happens (schema compilation), not at validate() time. javax.xml.validation
+            // only accepts an LSResourceResolver, so unlike validation:jaxp() the
+            // directory-search/collection case (a catalog URL ending in '/') has no
+            // equivalent here -- org.xmlresolver.Resolver implements LSResourceResolver
+            // directly, but SearchResourceResolver only implements the Xerces-specific
+            // XMLEntityResolver (XNI) interface.
+            if (args.length == 4) {
+                if (args[3].isEmpty()) {
+                    // Use system catalog
+                    LOG.debug("Using system catalog.");
+                    final Configuration config = brokerPool.getConfiguration();
+                    final Resolver resolver = (Resolver) config.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER);
+                    factory.setResourceResolver(resolver);
+
+                } else {
+                    final String[] catalogUrls = Shared.getUrls(args[3]);
+                    final String singleUrl = catalogUrls[0];
+
+                    if (singleUrl.endsWith("/")) {
+                        LOG.warn("Directory-search catalogs ('{}') are not supported by validation:jaxv() -- " +
+                                "schema/entity resolution will proceed without a catalog.", singleUrl);
+
+                    } else if (singleUrl.endsWith(".xml")) {
+                        LOG.debug("Using catalogs {}", getStrings(catalogUrls));
+
+                        final List<Tuple2<String, Optional<SaxProducer>>> catalogs = new ArrayList<>();
+                        for (String catalogUrl : catalogUrls) {
+
+                            /* NOTE(AR): Catalog URL if stored in database must start with
+                               URI Scheme xmldb:// so that the XML Resolver can use
+                               org.exist.protocolhandler.protocols.xmldb.Handler
+                               to resolve any relative URI resources from the database.
+                             */
+                            final Optional<SaxProducer> maybeSaxProducer;
+                            if (catalogUrl.startsWith("xmldb:exist://")) {
+                                catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
+                                maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
+                            } else if (catalogUrl.startsWith("/db")) {
+                                catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
+                                maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
+                            } else {
+                                maybeSaxProducer = Optional.empty();
+                            }
+
+                            catalogs.add(Tuple(catalogUrl, maybeSaxProducer));
+                        }
+                        final Resolver resolver = ResolverFactory.newResolverFromSax(catalogs);
+                        factory.setResourceResolver(resolver);
+
+                    } else {
+                        LOG.error("Catalog URLs should end on / or .xml");
+                    }
+                }
+            }
+
+            // Create grammar -- xs:import/xs:include resolution (via the resolver set
+            // above, if any) happens here, during schema compilation.
             final Schema schema = factory.newSchema(grammars);
 
             // Setup validator
@@ -234,8 +358,54 @@ public class Jaxv extends BasicFunction  {
             } finally {
                 context.popDocumentContext();
             }
-        } 
+        }
     }
 
-    
+    private static String getStrings(String[] data) {
+        final StringBuilder sb = new StringBuilder();
+        for (final String field : data) {
+            sb.append(field);
+            sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
+     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
+     * loader supplies, avoiding having to first serialize the document to a {@link String} and
+     * have the catalog loader re-parse it from an {@link InputSource}.
+     *
+     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
+     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
+     * load the entries), so each invocation re-acquires the document lock and re-serializes.</p>
+     *
+     * @param documentUri the URI of the catalog document stored in the database.
+     * @return a producer that re-serializes the document's SAX events on each invocation.
+     */
+    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
+        return (contentHandler, dtdHandler, errorHandler) -> {
+            try (final LockedDocument lockedDocument = context.getBroker().getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
+                if (lockedDocument == null) {
+                    throw new IOException("No such document: " + documentUri);
+                }
+
+                final DocumentImpl doc = lockedDocument.getDocument();
+
+                final Properties outputProperties = new Properties();
+                outputProperties.setProperty(OutputKeys.METHOD, "XML");
+                outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                outputProperties.setProperty(OutputKeys.INDENT, "no");
+                outputProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
+
+                final Serializer serializer = context.getBroker().getSerializer();
+                serializer.reset();
+                serializer.setProperties(outputProperties);
+                serializer.setSAXHandlers(contentHandler, null);
+                serializer.toSAX(doc);
+            } catch (final PermissionDeniedException e) {
+                throw new IOException(e.getMessage(), e);
+            }
+        };
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -21,36 +21,22 @@
  */
 package org.exist.xquery.functions.validation;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
 
 import javax.xml.XMLConstants;
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import com.evolvedbinary.j8fu.tuple.Tuple2;
-
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.resolver.ResolverFactory;
-import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.lock.Lock;
-import org.exist.storage.serializers.Serializer;
 import org.exist.util.Configuration;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.ValidationReport;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -64,12 +50,7 @@ import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
-import org.xml.sax.InputSource;
 import org.xmlresolver.Resolver;
-import org.xmlresolver.utils.SaxProducer;
-
-import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *   xQuery function for validation of XML instance documents
@@ -78,37 +59,36 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author Dannes Wessels (dizzzz@exist-db.org)
  */
 public class Jaxv extends BasicFunction  {
-    
-    
-    private static final String extendedFunctionTxt=
-        "Validate document specified by $instance using the schemas in $grammars. " +
-        "Based on functionality provided by 'javax.xml.validation.Validator'. Only " +
-        "'.xsd' grammars are supported.";
 
-    private static final String instanceText=
-            "The document referenced as xs:anyURI, a node (element or returned by fn:doc()) " +
-            "or as a Java file object.";
+    private static final String extendedFunctionTxt = """
+        Validate document specified by $instance using the schemas in $grammars.
+        Based on functionality provided by 'javax.xml.validation.Validator'. Only
+        '.xsd' grammars are supported.""";
 
-    private static final String grammarText=
-            "One of more XML Schema documents (.xsd), " +
-            "referenced as xs:anyURI, a node (element or returned by fn:doc()) " +
-            "or as Java file objects.";
-    
-    private static final String languageText=
-            "The namespace URI to designate a schema language. Depending on the " +
-            "jaxv.SchemaFactory implementation the following values are valid:" +
-            "(XSD 1.0) http://www.w3.org/2001/XMLSchema http://www.w3.org/XML/XMLSchema/v1.0, " +
-            "(XSD 1.1) http://www.w3.org/XML/XMLSchema/v1.1, " +
-            "(RELAX NG 1.0) http://relaxng.org/ns/structure/1.0";
+    private static final String instanceText = """
+            The document referenced as xs:anyURI, a node (element or returned by fn:doc())
+            or as a Java file object.""";
 
-    private static final String catalogTxt = "The catalogs referenced as xs:anyURI's. An empty " +
-            "sequence uses the system catalog. A directory-search catalog (a collection URI ending " +
-            "in '/') is not supported here, as javax.xml.validation.Validator has no equivalent of " +
-            "the SAX entity resolver used for that case in validation:jaxp().";
+    private static final String grammarText = """
+            One of more XML Schema documents (.xsd),
+            referenced as xs:anyURI, a node (element or returned by fn:doc())
+            or as Java file objects.""";
+
+    private static final String languageText = """
+            The namespace URI to designate a schema language. Depending on the
+            jaxv.SchemaFactory implementation the following values are valid:
+            (XSD 1.0) http://www.w3.org/2001/XMLSchema http://www.w3.org/XML/XMLSchema/v1.0,
+            (XSD 1.1) http://www.w3.org/XML/XMLSchema/v1.1,
+            (RELAX NG 1.0) http://relaxng.org/ns/structure/1.0""";
+
+    private static final String catalogTxt = """
+            The catalogs referenced as xs:anyURI's. An empty
+            sequence uses the system catalog. A directory-search catalog (a collection URI ending
+            in '/') is not supported here, as javax.xml.validation.Validator has no equivalent of
+            the SAX entity resolver used for that case in validation:jaxp().""";
 
     // Setup function signature
     public final static FunctionSignature[] signatures = {
-        
         new FunctionSignature(
                 new QName("jaxv", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
                 extendedFunctionTxt,
@@ -121,7 +101,7 @@ public class Jaxv extends BasicFunction  {
                 new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                     Shared.simplereportText)
             ),
-        
+
         new FunctionSignature(
                 new QName("jaxv", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
                 extendedFunctionTxt,
@@ -132,7 +112,6 @@ public class Jaxv extends BasicFunction  {
                         grammarText),
                     new FunctionParameterSequenceType("language", Type.STRING, Cardinality.EXACTLY_ONE,
                         languageText),
-                    
                 },
                 new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                     Shared.simplereportText)
@@ -140,7 +119,7 @@ public class Jaxv extends BasicFunction  {
 
         new FunctionSignature(
                 new QName("jaxv", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
-                extendedFunctionTxt+" Optionally an XML catalog can be specified for schema/entity resolution.",
+                extendedFunctionTxt + " Optionally an XML catalog can be specified for schema/entity resolution.",
                 new SequenceType[]{
                     new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
                         instanceText),
@@ -157,7 +136,7 @@ public class Jaxv extends BasicFunction  {
 
         new FunctionSignature(
                 new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
-                extendedFunctionTxt+" An XML report is returned.",
+                extendedFunctionTxt + " An XML report is returned.",
                 new SequenceType[]{
                     new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
                         instanceText),
@@ -170,7 +149,7 @@ public class Jaxv extends BasicFunction  {
 
         new FunctionSignature(
                 new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
-                extendedFunctionTxt+" An XML report is returned.",
+                extendedFunctionTxt + " An XML report is returned.",
                 new SequenceType[]{
                     new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
                         instanceText),
@@ -185,7 +164,7 @@ public class Jaxv extends BasicFunction  {
 
         new FunctionSignature(
                 new QName("jaxv-report", ValidationModule.NAMESPACE_URI, ValidationModule.PREFIX),
-                extendedFunctionTxt+" An XML report is returned. Optionally an XML catalog can be specified for schema/entity resolution.",
+                extendedFunctionTxt + " An XML report is returned. Optionally an XML catalog can be specified for schema/entity resolution.",
                 new SequenceType[]{
                     new FunctionParameterSequenceType("instance", Type.ITEM, Cardinality.EXACTLY_ONE,
                         instanceText),
@@ -201,15 +180,13 @@ public class Jaxv extends BasicFunction  {
             )
 
     };
-    
-    
+
     private final BrokerPool brokerPool;
 
     public Jaxv(XQueryContext context, FunctionSignature signature) {
         super(context, signature);
         brokerPool = context.getBroker().getBrokerPool();
     }
-
 
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
 
@@ -218,10 +195,9 @@ public class Jaxv extends BasicFunction  {
             return Sequence.EMPTY_SEQUENCE;
         }
 
-
         final ValidationReport report = new ValidationReport();
         StreamSource instance = null;
-        StreamSource[] grammars =null;
+        StreamSource[] grammars = null;
         String schemaLang = XMLConstants.W3C_XML_SCHEMA_NS_URI;
 
         try {
@@ -258,7 +234,6 @@ public class Jaxv extends BasicFunction  {
                 throw new XPathException(this, msg);
             }
 
-
             // Handle catalog (fourth argument). Must be set on the SchemaFactory, and
             // BEFORE newSchema() is called: that's when xs:import/xs:include resolution
             // happens (schema compilation), not at validate() time. javax.xml.validation
@@ -284,30 +259,11 @@ public class Jaxv extends BasicFunction  {
                                 "schema/entity resolution will proceed without a catalog.", singleUrl);
 
                     } else if (singleUrl.endsWith(".xml")) {
-                        LOG.debug("Using catalogs {}", getStrings(catalogUrls));
-
-                        final List<Tuple2<String, Optional<SaxProducer>>> catalogs = new ArrayList<>();
-                        for (String catalogUrl : catalogUrls) {
-
-                            /* NOTE(AR): Catalog URL if stored in database must start with
-                               URI Scheme xmldb:// so that the XML Resolver can use
-                               org.exist.protocolhandler.protocols.xmldb.Handler
-                               to resolve any relative URI resources from the database.
-                             */
-                            final Optional<SaxProducer> maybeSaxProducer;
-                            if (catalogUrl.startsWith("xmldb:exist://")) {
-                                catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                                maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
-                            } else if (catalogUrl.startsWith("/db")) {
-                                catalogUrl = ResolverFactory.fixupExistCatalogUri(catalogUrl);
-                                maybeSaxProducer = Optional.of(catalogSaxProducer(XmldbURI.create(catalogUrl)));
-                            } else {
-                                maybeSaxProducer = Optional.empty();
-                            }
-
-                            catalogs.add(Tuple(catalogUrl, maybeSaxProducer));
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Using catalogs {}", String.join(" ", catalogUrls));
                         }
-                        final Resolver resolver = ResolverFactory.newResolverFromSax(catalogs);
+
+                        final Resolver resolver = ResolverFactory.resolveCatalogs(context.getBroker(), catalogUrls);
                         factory.setResourceResolver(resolver);
 
                     } else {
@@ -316,7 +272,7 @@ public class Jaxv extends BasicFunction  {
                 }
             }
 
-            // Create grammar -- xs:import/xs:include resolution (via the resolver set
+            // Create grammar -- xs:import/xs:include resolution (via the resolver se
             // above, if any) happens here, during schema compilation.
             final Schema schema = factory.newSchema(grammars);
 
@@ -326,7 +282,6 @@ public class Jaxv extends BasicFunction  {
 
             // Perform validation
             validator.validate(instance);
-
 
         } catch (final MalformedURLException ex) {
             LOG.error(ex.getMessage());
@@ -359,53 +314,5 @@ public class Jaxv extends BasicFunction  {
                 context.popDocumentContext();
             }
         }
-    }
-
-    private static String getStrings(String[] data) {
-        final StringBuilder sb = new StringBuilder();
-        for (final String field : data) {
-            sb.append(field);
-            sb.append(" ");
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Builds a {@link SaxProducer} that streams the SAX events of the catalog document stored
-     * at {@code documentUri} directly to whatever {@link org.xml.sax.ContentHandler} the catalog
-     * loader supplies, avoiding having to first serialize the document to a {@link String} and
-     * have the catalog loader re-parse it from an {@link InputSource}.
-     *
-     * <p>The xmlresolver {@code ValidatingXmlLoader} invokes {@link SaxProducer#produce} twice
-     * (once to validate the catalog against the OASIS XML Catalog RNG schema, once to actually
-     * load the entries), so each invocation re-acquires the document lock and re-serializes.</p>
-     *
-     * @param documentUri the URI of the catalog document stored in the database.
-     * @return a producer that re-serializes the document's SAX events on each invocation.
-     */
-    private SaxProducer catalogSaxProducer(final XmldbURI documentUri) {
-        return (contentHandler, dtdHandler, errorHandler) -> {
-            try (final LockedDocument lockedDocument = context.getBroker().getXMLResource(documentUri, Lock.LockMode.READ_LOCK)) {
-                if (lockedDocument == null) {
-                    throw new IOException("No such document: " + documentUri);
-                }
-
-                final DocumentImpl doc = lockedDocument.getDocument();
-
-                final Properties outputProperties = new Properties();
-                outputProperties.setProperty(OutputKeys.METHOD, "XML");
-                outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-                outputProperties.setProperty(OutputKeys.INDENT, "no");
-                outputProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
-
-                final Serializer serializer = context.getBroker().getSerializer();
-                serializer.reset();
-                serializer.setProperties(outputProperties);
-                serializer.setSAXHandlers(contentHandler, null);
-                serializer.toSAX(doc);
-            } catch (final PermissionDeniedException e) {
-                throw new IOException(e.getMessage(), e);
-            }
-        };
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -32,12 +32,8 @@ import javax.xml.validation.Validator;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
-import org.exist.resolver.ResolverFactory;
 import org.exist.storage.BrokerPool;
-import org.exist.util.Configuration;
-import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.ValidationReport;
-import org.exist.validation.resolver.SearchResourceResolver;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -51,7 +47,7 @@ import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
-import org.xmlresolver.Resolver;
+import org.w3c.dom.ls.LSResourceResolver;
 
 /**
  *   xQuery function for validation of XML instance documents
@@ -243,34 +239,8 @@ public class Jaxv extends BasicFunction  {
             // SAX pipeline), so the directory-search/collection case (a catalog URL ending
             // in '/') works here too.
             if (args.length == 4) {
-                if (args[3].isEmpty()) {
-                    // Use system catalog
-                    LOG.debug("Using system catalog.");
-                    final Configuration config = brokerPool.getConfiguration();
-                    final Resolver resolver = (Resolver) config.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER);
-                    factory.setResourceResolver(resolver);
-
-                } else {
-                    final String[] catalogUrls = Shared.getUrls(args[3]);
-                    final String singleUrl = catalogUrls[0];
-
-                    if (singleUrl.endsWith("/")) {
-                        LOG.debug("Search for grammar in {}", singleUrl);
-                        final SearchResourceResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), singleUrl);
-                        factory.setResourceResolver(resolver);
-
-                    } else if (singleUrl.endsWith(".xml")) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Using catalogs {}", String.join(" ", catalogUrls));
-                        }
-
-                        final Resolver resolver = ResolverFactory.resolveCatalogs(context.getBroker(), catalogUrls);
-                        factory.setResourceResolver(resolver);
-
-                    } else {
-                        LOG.error("Catalog URLs should end on / or .xml");
-                    }
-                }
+                final LSResourceResolver resolver = Shared.resolveCatalogArgument(this, brokerPool, context.getBroker(), context.getSubject(), args[3]);
+                factory.setResourceResolver(resolver);
             }
 
             // Create grammar -- xs:import/xs:include resolution (via the resolver se

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -37,6 +37,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.util.Configuration;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.ValidationReport;
+import org.exist.validation.resolver.SearchResourceResolver;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -82,10 +83,9 @@ public class Jaxv extends BasicFunction  {
             (RELAX NG 1.0) http://relaxng.org/ns/structure/1.0""";
 
     private static final String catalogTxt = """
-            The catalogs referenced as xs:anyURI's. An empty
-            sequence uses the system catalog. A directory-search catalog (a collection URI ending
-            in '/') is not supported here, as javax.xml.validation.Validator has no equivalent of
-            the SAX entity resolver used for that case in validation:jaxp().""";
+            The catalogs referenced as xs:anyURI's. An empty \
+            sequence uses the system catalog. A directory-search catalog (a collection URI ending \
+            in '/') searches that collection for an XSD whose target namespace matches an import.""";
 
     // Setup function signature
     public final static FunctionSignature[] signatures = {
@@ -237,11 +237,11 @@ public class Jaxv extends BasicFunction  {
             // Handle catalog (fourth argument). Must be set on the SchemaFactory, and
             // BEFORE newSchema() is called: that's when xs:import/xs:include resolution
             // happens (schema compilation), not at validate() time. javax.xml.validation
-            // only accepts an LSResourceResolver, so unlike validation:jaxp() the
-            // directory-search/collection case (a catalog URL ending in '/') has no
-            // equivalent here -- org.xmlresolver.Resolver implements LSResourceResolver
-            // directly, but SearchResourceResolver only implements the Xerces-specific
-            // XMLEntityResolver (XNI) interface.
+            // only accepts an LSResourceResolver -- org.xmlresolver.Resolver implements it
+            // directly, and SearchResourceResolver also implements it (in addition to the
+            // Xerces-specific XMLEntityResolver/XNI interface it uses for validation:jaxp()'s
+            // SAX pipeline), so the directory-search/collection case (a catalog URL ending
+            // in '/') works here too.
             if (args.length == 4) {
                 if (args[3].isEmpty()) {
                     // Use system catalog
@@ -255,8 +255,9 @@ public class Jaxv extends BasicFunction  {
                     final String singleUrl = catalogUrls[0];
 
                     if (singleUrl.endsWith("/")) {
-                        LOG.warn("Directory-search catalogs ('{}') are not supported by validation:jaxv() -- " +
-                                "schema/entity resolution will proceed without a catalog.", singleUrl);
+                        LOG.debug("Search for grammar in {}", singleUrl);
+                        final SearchResourceResolver resolver = new SearchResourceResolver(brokerPool, context.getSubject(), singleUrl);
+                        factory.setResourceResolver(resolver);
 
                     } else if (singleUrl.endsWith(".xml")) {
                         if (LOG.isDebugEnabled()) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 
@@ -37,12 +38,19 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
+import org.exist.resolver.ResolverFactory;
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.Serializer;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.util.Configuration;
+import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.ValidationReport;
 import org.exist.validation.ValidationReportItem;
 import org.exist.validation.internal.node.NodeInputStream;
+import org.exist.validation.resolver.SearchResourceResolver;
+import org.exist.xquery.BasicFunction;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Base64BinaryDocument;
@@ -54,8 +62,10 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.helpers.AttributesImpl;
+import org.xmlresolver.Resolver;
 
 /**
  *  Shared methods for validation functions.
@@ -281,8 +291,57 @@ public class Shared {
 
         String[] returnUrls = new String[urls.size()];
         returnUrls = urls.toArray(returnUrls);
-        
+
         return returnUrls;
+    }
+
+    /**
+     * Resolves the {@code catalogs} argument shared by {@code validation:jaxp()} and {@code
+     * validation:jaxv()} into an {@link LSResourceResolver}, per the documented contract: an
+     * empty sequence selects the system catalog; a URL ending in '/' is a directory-search
+     * (collection) catalog; a URL ending in '.xml' is an explicit catalog document (which may be
+     * stored in the database). Any other URL form is a caller error.
+     *
+     * @param caller the function requesting resolution, used to attribute a thrown {@link
+     *               XPathException} to the right place.
+     * @param brokerPool the broker pool, used for the system catalog and directory-search cases.
+     * @param broker the broker to use for reading any '.xml' catalog stored in the database.
+     * @param subject the subject to use for directory-search/database access.
+     * @param catalogsArg the catalogs argument: an empty sequence (system catalog), or one or
+     *                     more catalog URLs.
+     *
+     * @return the resolver for {@code catalogsArg}.
+     *
+     * @throws XPathException if a catalog URL doesn't end in '/' or '.xml'.
+     * @throws IOException if a catalog stored in the database could not be read.
+     * @throws URISyntaxException if a catalog URL is not a valid URI.
+     */
+    public static LSResourceResolver resolveCatalogArgument(final BasicFunction caller, final BrokerPool brokerPool,
+            final DBBroker broker, final Subject subject, final Sequence catalogsArg)
+            throws XPathException, IOException, URISyntaxException {
+
+        if (catalogsArg.isEmpty()) {
+            LOG.debug("Using system catalog.");
+            final Configuration config = brokerPool.getConfiguration();
+            return (Resolver) config.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER);
+        }
+
+        final String[] catalogUrls = getUrls(catalogsArg);
+        final String singleUrl = catalogUrls[0];
+
+        if (singleUrl.endsWith("/")) {
+            LOG.debug("Search for grammar in {}", singleUrl);
+            return new SearchResourceResolver(brokerPool, subject, singleUrl);
+
+        } else if (singleUrl.endsWith(".xml")) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using catalogs {}", String.join(" ", catalogUrls));
+            }
+            return ResolverFactory.resolveCatalogs(broker, catalogUrls);
+
+        } else {
+            throw new XPathException(caller, "Catalog URLs should end on / or .xml");
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/ValidationModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/ValidationModule.java
@@ -52,6 +52,8 @@ public class ValidationModule extends AbstractInternalModule {
        new FunctionDef(Jaxv.signatures[1], Jaxv.class),
        new FunctionDef(Jaxv.signatures[2], Jaxv.class),
        new FunctionDef(Jaxv.signatures[3], Jaxv.class),
+       new FunctionDef(Jaxv.signatures[4], Jaxv.class),
+       new FunctionDef(Jaxv.signatures[5], Jaxv.class),
 
        new FunctionDef(Jing.signatures[0], Jing.class),
        new FunctionDef(Jing.signatures[1], Jing.class),

--- a/exist-core/src/test/java/org/exist/resolver/CatalogResolutionRegressionTest.java
+++ b/exist-core/src/test/java/org/exist/resolver/CatalogResolutionRegressionTest.java
@@ -1,0 +1,148 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.resolver;
+
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+import org.xmlresolver.Resolver;
+
+import javax.xml.parsers.SAXParserFactory;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Regression tests for two long-standing catalog-resolution issues, exercised directly against
+ * {@link ResolverFactory} and {@link XercesXmlResolverAdapter} -- the same machinery {@code
+ * org.exist.util.XMLReaderObjectFactory} wires into every pooled {@link XMLReader}, which is what
+ * both {@code fn:parse-xml()} ({@code org.exist.xquery.functions.fn.ParsingFunctions}) and the
+ * default SAX validation pipeline ({@code org.exist.xquery.functions.validation.Jaxp}) use to parse
+ * documents.
+ */
+public class CatalogResolutionRegressionTest {
+
+    /**
+     * Regression test for <a href="https://github.com/eXist-db/exist/issues/1975">#1975</a>:
+     * {@code fn:parse-xml()}/{@code util:parse()} parse an in-memory string with no inherent base
+     * URI. A relative DOCTYPE {@code SYSTEM} identifier would be expanded against the JVM's working
+     * directory before the catalog is even consulted (Xerces' own behaviour, not eXist's), so the
+     * only base-URI-independent way a catalog can resolve such a DTD is by {@code PUBLIC} identifier
+     * -- this proves that path still works, matching how
+     * {@code DatabaseInsertResourcesWithValidationTest} relies on the same {@code -//PLAY//EN}
+     * mechanism elsewhere in the test suite.
+     */
+    @Test
+    public void catalogResolvesPublicEntityWithNoBaseUri() throws Exception {
+        final Path tempDir = Files.createTempDirectory("catalog-1975-test");
+        try {
+            final Path dtd = tempDir.resolve("greeting.dtd");
+            Files.writeString(dtd, "<!ENTITY greeting \"Hello from catalog\">", StandardCharsets.UTF_8);
+
+            final Path catalog = tempDir.resolve("catalog.xml");
+            Files.writeString(catalog, """
+                    <?xml version="1.0"?>
+                    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+                        <public publicId="-//EXIST-TEST//GREETING//EN" uri="%s"/>
+                    </catalog>
+                    """.formatted(dtd.toUri()), StandardCharsets.UTF_8);
+
+            final String resolved = parseWithCatalog(catalog.toUri().toString(),
+                    "<!DOCTYPE root PUBLIC \"-//EXIST-TEST//GREETING//EN\" \"greeting.dtd\">"
+                            + "<root>&greeting;</root>");
+            assertEquals("Hello from catalog", resolved);
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("greeting.dtd"));
+            Files.deleteIfExists(tempDir.resolve("catalog.xml"));
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/eXist-db/exist/issues/2476">#2476</a>:
+     * a configured catalog must decline (return {@code null}) for a systemId it has no entry for,
+     * rather than falling back to fetching the literal (document-author-controlled, here
+     * attacker-controlled) URI itself -- which is what caused the original report's eXist process to
+     * make tens of gigabytes of outbound requests to third-party hosts named in untrusted documents.
+     * This is governed by {@code org.xmlresolver.ResolverFeature#ALWAYS_RESOLVE}, which {@link
+     * ResolverFactory} never sets, relying on the library default of {@code false}.
+     */
+    @Test(timeout = 5000)
+    public void catalogWithoutMatchingEntryDoesNotFetchUnmatchedRemoteSystemId() throws Exception {
+        final Path tempDir = Files.createTempDirectory("catalog-2476-test");
+        try {
+            final Path catalog = tempDir.resolve("catalog.xml");
+            Files.writeString(catalog, """
+                    <?xml version="1.0"?>
+                    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+                        <public publicId="-//SOME//KNOWN//EN" uri="known.dtd"/>
+                    </catalog>
+                    """, StandardCharsets.UTF_8);
+
+            final Resolver resolver = ResolverFactory.newResolver(
+                    List.of(Tuple(catalog.toUri().toString(), Optional.<InputSource>empty())));
+
+            // 203.0.113.1 is TEST-NET-3 (RFC 5737), guaranteed non-routable -- if the resolver
+            // actually attempted to fetch this unmatched systemId itself (the ALWAYS_RESOLVE=true
+            // behavior) rather than declining, this call would hang/time out instead of returning
+            // promptly.
+            final InputSource result = resolver.resolveEntity(null, null, null, "http://203.0.113.1:1/unmatched.dtd");
+            assertNull("a catalog with no matching entry must decline to resolve, not fetch the literal URI itself",
+                    result);
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("catalog.xml"));
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    private static String parseWithCatalog(final String catalogUri, final String xml) throws Exception {
+        final Resolver resolver = ResolverFactory.newResolver(List.of(Tuple(catalogUri, Optional.<InputSource>empty())));
+
+        final SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        final XMLReader xmlReader = factory.newSAXParser().getXMLReader();
+        xmlReader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
+        XercesXmlResolverAdapter.setXmlReaderEntityResolver(xmlReader, resolver);
+
+        final StringBuilder characters = new StringBuilder();
+        xmlReader.setContentHandler(new DefaultHandler() {
+            @Override
+            public void characters(final char[] ch, final int start, final int length) {
+                characters.append(ch, start, length);
+            }
+        });
+
+        // No systemId/base is set on the InputSource -- mirroring fn:parse-xml()/util:parse()
+        // parsing an in-memory string with no inherent base URI, the exact scenario from issue #1975.
+        xmlReader.parse(new InputSource(new StringReader(xml)));
+
+        return characters.toString();
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
@@ -55,6 +55,34 @@ public class JaxpXsdCatalogTest {
             "    <validation mode='no'/>" +
             "</collection>";
 
+    // No schemaLocation hint at all -- directory-search resolves purely by the root
+    // element's namespace, same as MyNameSpace.xsd/valid.xml above. xs:assert only exists
+    // in XSD 1.1, so this proves the XSD 1.1 retry/up-front pipeline is reachable through
+    // SearchResourceResolver (item 6), not just through an explicit schemaLocation hint.
+    private static final String xsd11SearchedSchema =
+            "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' " +
+            "xmlns:vc='http://www.w3.org/2007/XMLSchema-versioning' vc:minVersion='1.1' " +
+            "xmlns='urn:jaxp-test:searched-xsd11' targetNamespace='urn:jaxp-test:searched-xsd11' " +
+            // xs:assert's XPath defaults unprefixed names to NO namespace unless told otherwise --
+            // needed here since elementFormDefault='qualified' puts value1/value2 in the target namespace.
+            "elementFormDefault='qualified' xpathDefaultNamespace='##targetNamespace'>" +
+            "<xs:element name='root'>" +
+            "<xs:complexType>" +
+            "<xs:sequence>" +
+            "<xs:element name='value1' type='xs:integer'/>" +
+            "<xs:element name='value2' type='xs:integer'/>" +
+            "</xs:sequence>" +
+            "<xs:assert test='value2 gt value1'/>" +
+            "</xs:complexType>" +
+            "</xs:element>" +
+            "</xs:schema>";
+
+    private static final String xsd11SearchedValidInstance =
+            "<root xmlns='urn:jaxp-test:searched-xsd11'><value1>20</value1><value2>30</value2></root>";
+
+    private static final String xsd11SearchedInvalidInstance =
+            "<root xmlns='urn:jaxp-test:searched-xsd11'><value1>30</value1><value2>20</value2></root>";
+
     @BeforeClass
     public static void prepareResources() throws XMLDBException, IOException, URISyntaxException {
 
@@ -75,6 +103,7 @@ public class JaxpXsdCatalogTest {
                 ExistXmldbEmbeddedServer.storeResource(schemasCollection, "AnotherNamespace.xsd", InputStreamUtil.readAll(is));
             }
 
+            ExistXmldbEmbeddedServer.storeResource(schemasCollection, "searched-xsd11.xsd", xsd11SearchedSchema.getBytes());
         }
 
         try (Collection parseCollection = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "parse")) {
@@ -95,6 +124,9 @@ public class JaxpXsdCatalogTest {
                 assertNotNull(is);
                 ExistXmldbEmbeddedServer.storeResource(instanceCollection, "invalid.xml", InputStreamUtil.readAll(is));
             }
+
+            ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-valid.xml", xsd11SearchedValidInstance.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-invalid.xml", xsd11SearchedInvalidInstance.getBytes());
         }
     }
 
@@ -188,6 +220,26 @@ public class JaxpXsdCatalogTest {
                 "xs:anyURI('/db/parse/') )";
         final String r = existEmbeddedServer.executeOneValue(query);
         assertXpathEvaluatesTo("2006-05-04T18:13:51.0Z", "//Y", r);
+    }
+
+    // Directory-search catalog + XSD 1.1 schema, resolved purely by namespace (no
+    // schemaLocation hint on the instance). Proves item 6: SearchResourceResolver's
+    // LSResourceResolver support makes directory-search catalogs work with the XSD 1.1
+    // validator pipeline too, not just the default SAX pipeline.
+    @Test
+    public void xsd11SearchedValid() throws XMLDBException, SAXException, XpathException, IOException {
+        final String query = "validation:jaxp-report( " +
+                "doc('/db/parse/instance/searched-xsd11-valid.xml'), false()," +
+                "xs:anyURI('/db/parse/') )";
+        executeAndEvaluate(query, "valid");
+    }
+
+    @Test
+    public void xsd11SearchedInvalid() throws XMLDBException, SAXException, XpathException, IOException {
+        final String query = "validation:jaxp-report( " +
+                "doc('/db/parse/instance/searched-xsd11-invalid.xml'), false()," +
+                "xs:anyURI('/db/parse/') )";
+        executeAndEvaluate(query, "invalid");
     }
 
     private void executeAndEvaluate(final String query, final String expectedValue) throws XMLDBException, SAXException, IOException, XpathException {

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
@@ -55,34 +55,6 @@ public class JaxpXsdCatalogTest {
             "    <validation mode='no'/>" +
             "</collection>";
 
-    // No schemaLocation hint at all -- directory-search resolves purely by the root
-    // element's namespace, same as MyNameSpace.xsd/valid.xml above. xs:assert only exists
-    // in XSD 1.1, so this proves the XSD 1.1 retry/up-front pipeline is reachable through
-    // SearchResourceResolver (item 6), not just through an explicit schemaLocation hint.
-    private static final String xsd11SearchedSchema =
-            "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' " +
-            "xmlns:vc='http://www.w3.org/2007/XMLSchema-versioning' vc:minVersion='1.1' " +
-            "xmlns='urn:jaxp-test:searched-xsd11' targetNamespace='urn:jaxp-test:searched-xsd11' " +
-            // xs:assert's XPath defaults unprefixed names to NO namespace unless told otherwise --
-            // needed here since elementFormDefault='qualified' puts value1/value2 in the target namespace.
-            "elementFormDefault='qualified' xpathDefaultNamespace='##targetNamespace'>" +
-            "<xs:element name='root'>" +
-            "<xs:complexType>" +
-            "<xs:sequence>" +
-            "<xs:element name='value1' type='xs:integer'/>" +
-            "<xs:element name='value2' type='xs:integer'/>" +
-            "</xs:sequence>" +
-            "<xs:assert test='value2 gt value1'/>" +
-            "</xs:complexType>" +
-            "</xs:element>" +
-            "</xs:schema>";
-
-    private static final String xsd11SearchedValidInstance =
-            "<root xmlns='urn:jaxp-test:searched-xsd11'><value1>20</value1><value2>30</value2></root>";
-
-    private static final String xsd11SearchedInvalidInstance =
-            "<root xmlns='urn:jaxp-test:searched-xsd11'><value1>30</value1><value2>20</value2></root>";
-
     @BeforeClass
     public static void prepareResources() throws XMLDBException, IOException, URISyntaxException {
 
@@ -103,7 +75,14 @@ public class JaxpXsdCatalogTest {
                 ExistXmldbEmbeddedServer.storeResource(schemasCollection, "AnotherNamespace.xsd", InputStreamUtil.readAll(is));
             }
 
-            ExistXmldbEmbeddedServer.storeResource(schemasCollection, "searched-xsd11.xsd", xsd11SearchedSchema.getBytes());
+            // No schemaLocation hint at all -- directory-search resolves purely by the root
+            // element's namespace, same as MyNameSpace.xsd/valid.xml above. xs:assert only exists
+            // in XSD 1.1, so this proves the XSD 1.1 retry/up-front pipeline is reachable through
+            // SearchResourceResolver (item 6), not just through an explicit schemaLocation hint.
+            try (final InputStream is = SAMPLES.getSample("validation/parse/schemas/searched-xsd11.xsd")) {
+                assertNotNull(is);
+                ExistXmldbEmbeddedServer.storeResource(schemasCollection, "searched-xsd11.xsd", InputStreamUtil.readAll(is));
+            }
         }
 
         try (Collection parseCollection = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "parse")) {
@@ -125,8 +104,15 @@ public class JaxpXsdCatalogTest {
                 ExistXmldbEmbeddedServer.storeResource(instanceCollection, "invalid.xml", InputStreamUtil.readAll(is));
             }
 
-            ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-valid.xml", xsd11SearchedValidInstance.getBytes());
-            ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-invalid.xml", xsd11SearchedInvalidInstance.getBytes());
+            try (final InputStream is = SAMPLES.getSample("validation/parse/instance/searched-xsd11-valid.xml")) {
+                assertNotNull(is);
+                ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-valid.xml", InputStreamUtil.readAll(is));
+            }
+
+            try (final InputStream is = SAMPLES.getSample("validation/parse/instance/searched-xsd11-invalid.xml")) {
+                assertNotNull(is);
+                ExistXmldbEmbeddedServer.storeResource(instanceCollection, "searched-xsd11-invalid.xml", InputStreamUtil.readAll(is));
+            }
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdNokTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdNokTest.java
@@ -87,10 +87,10 @@ public class ParseXsdNokTest {
         assertXpathEvaluatesTo("valid", "//status/text()", r);
     }
 
-    @Test @Ignore("todo")
+    @Test
     public void xsd_stored_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( doc('/db/tournament/1.5/Tournament-invalid.xml'), " +
-                "doc('/db/tournament/1.5/tournament-schema.sch') )";
+        final String query = "validation:jaxp-report( " +
+                "doc('/db/addressbook/addressbook_invalid.xml'), false(), doc('/db/addressbook/catalog.xml') )";
 
         final ResourceSet results = existEmbeddedServer.executeQuery(query);
         assertEquals(1, results.getSize());
@@ -99,10 +99,10 @@ public class ParseXsdNokTest {
         assertXpathEvaluatesTo("invalid", "//status/text()", r);
     }
 
-    @Test @Ignore("todo")
+    @Test
     public void xsd_anyuri_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( xs:anyURI('xmldb:exist:///db/tournament/1.5/Tournament-valid.xml'), " +
-                "xs:anyURI('xmldb:exist:///db/tournament/1.5/tournament-schema.sch') )";
+        final String query = "validation:jaxp-report( " +
+                "xs:anyURI('/db/addressbook/addressbook_valid.xml'), false(), xs:anyURI('/db/addressbook/catalog.xml') )";
 
         final ResourceSet results = existEmbeddedServer.executeQuery(query);
         assertEquals(1, results.getSize());
@@ -111,10 +111,10 @@ public class ParseXsdNokTest {
         assertXpathEvaluatesTo("valid", "//status/text()", r);
     }
 
-    @Test @Ignore("todo")
+    @Test
     public void xsd_anyuri_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( xs:anyURI('xmldb:exist:///db/tournament/1.5/Tournament-invalid.xml'), " +
-                "xs:anyURI('xmldb:exist:///db/tournament/1.5/tournament-schema.sch') )";
+        final String query = "validation:jaxp-report( " +
+                "xs:anyURI('/db/addressbook/addressbook_invalid.xml'), false(), xs:anyURI('/db/addressbook/catalog.xml') )";
 
         final ResourceSet results = existEmbeddedServer.executeQuery(query);
         assertEquals(1, results.getSize());

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/TournamentSchemaLanguageComparisonTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/TournamentSchemaLanguageComparisonTest.java
@@ -1,0 +1,149 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.validate;
+
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.util.io.InputStreamUtil;
+import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
+import static org.exist.samples.Samples.SAMPLES;
+import static org.junit.Assert.*;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.xml.sax.SAXException;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+/**
+ * The {@code tournament/1.5} sample fixtures ship an XSD, an RNG, and a Schematron schema side by
+ * side, all describing the same {@code Tournament} document shape. Their own embedded comment
+ * explains why: {@code Tournament-valid.xml} and {@code Tournament-invalid.xml} only differ in a
+ * co-occurrence constraint -- for a {@code Singles} tournament, {@code nbrParticipants} must equal
+ * {@code nbrTeams} -- that neither RELAX NG nor W3C XML Schema can express on their own. Schematron
+ * rules are embedded in both {@code Tournament.xsd} (via {@code xsd:appinfo}) and {@code
+ * Tournament.rng} (via RELAX NG annotations) specifically to add that missing constraint, but {@code
+ * validation:jaxp()}/{@code validation:jing()} only enforce the structural grammar, not embedded
+ * Schematron annotations. {@link JingSchematronTest} validates the same pair against {@code
+ * tournament-schema.sch} and correctly reports the second document as invalid.
+ *
+ * <p>Bare RNG bears this out directly: both documents are structurally valid against {@code
+ * Tournament.rng} below, since it doesn't express the co-occurrence constraint either.</p>
+ *
+ * <p>Bare XSD does not -- both documents are structurally <em>invalid</em> against {@code
+ * Tournament.xsd}, but for an unrelated reason: {@code Match} {@code m3} references a {@code Team}
+ * {@code t5} that is never declared in {@code Teams} (only {@code t1}/{@code t2}/{@code t3} exist).
+ * This is a pre-existing defect in this 2001-vintage third-party sample, present identically in both
+ * documents -- caught by XSD's built-in {@code xsd:ID}/{@code xsd:IDREF} referential-integrity check
+ * (which this {@code Tournament.rng} does not declare for the same elements), not by anything related
+ * to the documented co-occurrence constraint. The two XSD tests below assert that both documents fail
+ * with the exact same error, which is itself the point: XSD's verdict does not change based on whether
+ * {@code nbrParticipants} matches {@code nbrTeams}, confirming it can't see that constraint either.</p>
+ */
+public class TournamentSchemaLanguageComparisonTest {
+
+    private static final String[] TEST_RESOURCES =
+            { "Tournament-valid.xml", "Tournament-invalid.xml", "Tournament.xsd", "Tournament.rng" };
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static final String noValidation = "<?xml version='1.0'?>" +
+            "<collection xmlns='http://exist-db.org/collection-config/1.0'>" +
+            "    <validation mode='no'/>" +
+            "</collection>";
+
+    @BeforeClass
+    public static void prepareResources() throws Exception {
+
+        // Switch off validation
+        try (Collection conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/tournament")) {
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
+        }
+
+        try (Collection col15 = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "tournament/1.5")) {
+            for (final String testResource : TEST_RESOURCES) {
+                try (final InputStream is = SAMPLES.getSample("validation/tournament/1.5/" + testResource)) {
+                    assertNotNull(is);
+                    ExistXmldbEmbeddedServer.storeResource(col15, testResource, InputStreamUtil.readAll(is));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void xsdStructureRejectsValidDocumentOnUnrelatedIdrefDefect() throws XMLDBException, SAXException, XpathException, IOException {
+        // No xsi:schemaLocation hint on the instance -- resolved purely by Tournament.xsd's
+        // targetNamespace via directory-search, the same mechanism JaxpXsdCatalogTest's
+        // xsd_searched_* tests use. See the class javadoc for why this is "invalid".
+        executeAndEvaluateMessage("validation:jaxp-report( doc('/db/tournament/1.5/Tournament-valid.xml'), false(), " +
+                        "xs:anyURI('/db/tournament/1.5/') )", "invalid",
+                "cvc-id.1: There is no ID/IDREF binding for IDREF 't5'.");
+    }
+
+    @Test
+    public void xsdStructureRejectsCoOccurrenceViolatingDocumentIdentically() throws XMLDBException, SAXException, XpathException, IOException {
+        // Bare XSD structural validation cannot see the Singles/nbrParticipants-vs-nbrTeams
+        // co-occurrence constraint -- proven here by getting the exact same verdict and error as
+        // the "valid" document above, despite the co-occurrence violation. Only the accompanying
+        // Schematron rules (tested separately in JingSchematronTest) catch that constraint.
+        executeAndEvaluateMessage("validation:jaxp-report( doc('/db/tournament/1.5/Tournament-invalid.xml'), false(), " +
+                        "xs:anyURI('/db/tournament/1.5/') )", "invalid",
+                "cvc-id.1: There is no ID/IDREF binding for IDREF 't5'.");
+    }
+
+    @Test
+    public void rngStructureAcceptsValidDocument() throws XMLDBException, SAXException, XpathException, IOException {
+        executeAndEvaluate("validation:jing-report( doc('/db/tournament/1.5/Tournament-valid.xml'), " +
+                "doc('/db/tournament/1.5/Tournament.rng') )", "valid");
+    }
+
+    @Test
+    public void rngStructureAcceptsCoOccurrenceViolatingDocument() throws XMLDBException, SAXException, XpathException, IOException {
+        // Same co-occurrence limitation as the XSD case above, for RELAX NG.
+        executeAndEvaluate("validation:jing-report( doc('/db/tournament/1.5/Tournament-invalid.xml'), " +
+                "doc('/db/tournament/1.5/Tournament.rng') )", "valid");
+    }
+
+    private void executeAndEvaluate(final String query, final String expectedValue) throws XMLDBException, SAXException, IOException, XpathException {
+        final ResourceSet results = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, results.getSize());
+
+        final String r = (String) results.getResource(0).getContent();
+        assertXpathEvaluatesTo(expectedValue, "//status/text()", r);
+    }
+
+    private void executeAndEvaluateMessage(final String query, final String expectedValue, final String expectedMessage)
+            throws XMLDBException, SAXException, IOException, XpathException {
+        final ResourceSet results = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, results.getSize());
+
+        final String r = (String) results.getResource(0).getContent();
+        assertXpathEvaluatesTo(expectedValue, "//status/text()", r);
+        assertXpathEvaluatesTo(expectedMessage, "//message/text()", r);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/IsMissingElementDeclarationTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/IsMissingElementDeclarationTest.java
@@ -1,0 +1,122 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.validation;
+
+import org.exist.util.XMLReaderObjectFactory;
+import org.exist.validation.ValidationReport;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.Parser;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins {@link Jaxp#isMissingElementDeclaration(ValidationReport)}'s match against the bundled
+ * Xerces fork's <em>actual</em>, real {@code cvc-elt.1.a} message text -- by driving a real
+ * validating parse of a genuinely XSD-1.1-only schema (an {@code xs:assert}, which the bundled
+ * fork's dynamic-discovery SAX pipeline cannot understand) through the same validating-SAX-parser
+ * setup {@code Jaxp.getXMLReader()} uses, rather than asserting against a hand-typed guess at the
+ * message string.
+ *
+ * <p>If a future upgrade of {@code org.exist-db.thirdparty.xerces:xercesImpl} rewords or
+ * restructures this message, this test fails directly and immediately -- instead of the retry
+ * safety net in {@code Jaxp.retryWithXsd11ValidatorIfNeeded} silently stopping to fire, which
+ * would otherwise only surface indirectly (and much less diagnosably) via {@code
+ * JaxpXsdCatalogTest#xsd11SearchedValid}/{@code xsd11SearchedInvalid} failing.</p>
+ */
+public class IsMissingElementDeclarationTest {
+
+    private static final String XSD_1_1_ONLY_SCHEMA = """
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                       xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+                <xs:element name="root">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="value1" type="xs:integer"/>
+                            <xs:element name="value2" type="xs:integer"/>
+                        </xs:sequence>
+                        <xs:assert test="value2 gt value1"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:schema>""";
+
+    private static final String CONFORMING_INSTANCE = """
+            <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \
+            xsi:noNamespaceSchemaLocation="schema.xsd">
+                <value1>1</value1>
+                <value2>2</value2>
+            </root>""";
+
+    @Test
+    public void realCvcElt1aFailureIsRecognized() throws Exception {
+        final Path tempDir = Files.createTempDirectory("is-missing-element-declaration-test");
+        try {
+            Files.writeString(tempDir.resolve("schema.xsd"), XSD_1_1_ONLY_SCHEMA, StandardCharsets.UTF_8);
+            final Path instance = tempDir.resolve("instance.xml");
+            Files.writeString(instance, CONFORMING_INSTANCE, StandardCharsets.UTF_8);
+
+            final ValidationReport report = new ValidationReport();
+
+            final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+            saxFactory.setValidating(true);
+            saxFactory.setNamespaceAware(true);
+            saxFactory.setFeature(XMLReaderObjectFactory.APACHE_FEATURES_VALIDATION_SCHEMA, true);
+
+            final SAXParser saxParser = saxFactory.newSAXParser();
+            final XMLReader xmlReader = saxParser.getXMLReader();
+            xmlReader.setErrorHandler(report);
+
+            // Force English error messages, regardless of the running JVM's default locale --
+            // matching Jaxp.getXMLReader(), since isMissingElementDeclaration() matches on this
+            // exact formatted message text.
+            if (xmlReader instanceof Parser legacyParser) {
+                legacyParser.setLocale(Locale.ENGLISH);
+            }
+
+            try (var instanceStream = Files.newInputStream(instance)) {
+                final InputSource instanceSource = new InputSource(instanceStream);
+                instanceSource.setSystemId(instance.toUri().toString());
+                xmlReader.parse(instanceSource);
+            }
+
+            assertFalse("a conforming XSD-1.1-only instance must fail under the XSD-1.0-only " +
+                    "dynamic-discovery pipeline (that's the whole reason the retry/up-front XSD " +
+                    "1.1 pipeline exists)", report.isValid());
+            assertTrue("Jaxp.isMissingElementDeclaration() must recognize the real cvc-elt.1.a " +
+                    "message this Xerces version actually produces for an XSD-1.1-only schema",
+                    Jaxp.isMissingElementDeclaration(report));
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("schema.xsd"));
+            Files.deleteIfExists(tempDir.resolve("instance.xml"));
+            Files.deleteIfExists(tempDir);
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
@@ -25,7 +25,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,14 +33,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Targeted white-box test for {@code Jaxp.isXsd11Schema(String, String)}'s same-origin
+ * Targeted white-box test for {@code Jaxp.isXsd11Schema(String, String, String)}'s same-origin
  * (scheme + authority) restriction -- the up-front XSD 1.1 detection peek must only ever follow
  * a {@code schemaLocation} hint that resolves to the exact same origin as the instance document's
  * own base URI, since the hint is document-author-controlled and the peek runs unconditionally,
  * before any catalog/permission check would otherwise govern the fetch.
  *
- * <p>Tests the method directly (via reflection, since it's {@code private static}) rather than
- * through the full {@code validation:jaxp()} pipeline: going through the pipeline would also
+ * <p>Tests {@code Jaxp.isXsd11Schema} directly rather than through the full {@code
+ * validation:jaxp()} pipeline: going through the pipeline would also
  * exercise the (separate, pre-existing, unrelated) default Xerces resolution that runs when the
  * peek declines and falls through -- which would independently attempt the same kind of fetch,
  * confounding any attempt to observe whether the peek itself made a network call.</p>
@@ -77,43 +76,37 @@ public class JaxpSchemaLocationSecurityTest {
     }
 
     @Test
-    public void sameOriginRelativeXsd11SchemaIsDetected() throws Exception {
-        assertTrue(invokeIsXsd11Schema(fileBaseUri, "schema11.xsd"));
+    public void sameOriginRelativeXsd11SchemaIsDetected() {
+        assertTrue(Jaxp.isXsd11Schema("test-subject", fileBaseUri, "schema11.xsd"));
     }
 
     @Test
-    public void sameOriginRelativeXsd10SchemaIsNotDetectedAsXsd11() throws Exception {
-        assertFalse(invokeIsXsd11Schema(fileBaseUri, "schema10.xsd"));
+    public void sameOriginRelativeXsd10SchemaIsNotDetectedAsXsd11() {
+        assertFalse(Jaxp.isXsd11Schema("test-subject", fileBaseUri, "schema10.xsd"));
     }
 
     @Test(timeout = 5000)
-    public void crossOriginHttpLocationIsRefused() throws Exception {
+    public void crossOriginHttpLocationIsRefused() {
         // A real instance would never have a `file://` base URI reachable from an unprivileged
         // caller (only Java-object-backed items do, which already requires elevated capability) --
         // this is just the most convenient same-scheme baseline to contrast against. The case that
         // matters is: whatever the base URI's origin, an absolute, different-origin location must
         // never be followed.
-        assertFalse(invokeIsXsd11Schema(fileBaseUri, "http://203.0.113.1:1/evil.xsd"));
+        assertFalse(Jaxp.isXsd11Schema("test-subject", fileBaseUri, "http://203.0.113.1:1/evil.xsd"));
     }
 
     @Test(timeout = 5000)
-    public void crossOriginHttpLocationIsRefusedForDatabaseBaseUri() throws Exception {
+    public void crossOriginHttpLocationIsRefusedForDatabaseBaseUri() {
         // The realistic, unprivileged case: a document stored in the database (xmldb:// base URI)
         // with an absolute http:// schemaLocation hint pointing out to an attacker-controlled host.
-        assertFalse(invokeIsXsd11Schema("xmldb://db/test/instance.xml", "http://203.0.113.1:1/evil.xsd"));
+        assertFalse(Jaxp.isXsd11Schema("test-subject", "xmldb://db/test/instance.xml", "http://203.0.113.1:1/evil.xsd"));
     }
 
     @Test(timeout = 5000)
-    public void crossHostXmldbLocationIsRefused() throws Exception {
+    public void crossHostXmldbLocationIsRefused() {
         // An absolute xmldb:// location naming a different host is not "same scheme" enough --
         // XmldbURL.isEmbedded() treats a non-empty host as a remote XML-RPC target
         // (EmbeddedURLConnection -> XmlrpcInputStream), so this must be refused too.
-        assertFalse(invokeIsXsd11Schema("xmldb://db/test/instance.xml", "xmldb://203.0.113.1:1/db/evil.xsd"));
-    }
-
-    private static boolean invokeIsXsd11Schema(final String baseUri, final String location) throws Exception {
-        final Method method = Jaxp.class.getDeclaredMethod("isXsd11Schema", String.class, String.class);
-        method.setAccessible(true);
-        return (boolean) method.invoke(null, baseUri, location);
+        assertFalse(Jaxp.isXsd11Schema("test-subject", "xmldb://db/test/instance.xml", "xmldb://203.0.113.1:1/db/evil.xsd"));
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
@@ -1,0 +1,119 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.validation;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Targeted white-box test for {@code Jaxp.isXsd11Schema(String, String)}'s same-origin
+ * (scheme + authority) restriction -- the up-front XSD 1.1 detection peek must only ever follow
+ * a {@code schemaLocation} hint that resolves to the exact same origin as the instance document's
+ * own base URI, since the hint is document-author-controlled and the peek runs unconditionally,
+ * before any catalog/permission check would otherwise govern the fetch.
+ *
+ * <p>Tests the method directly (via reflection, since it's {@code private static}) rather than
+ * through the full {@code validation:jaxp()} pipeline: going through the pipeline would also
+ * exercise the (separate, pre-existing, unrelated) default Xerces resolution that runs when the
+ * peek declines and falls through -- which would independently attempt the same kind of fetch,
+ * confounding any attempt to observe whether the peek itself made a network call.</p>
+ */
+public class JaxpSchemaLocationSecurityTest {
+
+    private static Path tempDir;
+    private static String fileBaseUri;
+
+    private static final String XSD_1_1_SCHEMA = """
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                       xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"/>""";
+
+    private static final String XSD_1_0_SCHEMA = """
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>""";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        tempDir = Files.createTempDirectory("jaxp-security-test");
+        final Path instance = tempDir.resolve("instance.xml");
+        Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("schema11.xsd"), XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("schema10.xsd"), XSD_1_0_SCHEMA, StandardCharsets.UTF_8);
+        fileBaseUri = instance.toUri().toString();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        Files.deleteIfExists(tempDir.resolve("instance.xml"));
+        Files.deleteIfExists(tempDir.resolve("schema11.xsd"));
+        Files.deleteIfExists(tempDir.resolve("schema10.xsd"));
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    public void sameOriginRelativeXsd11SchemaIsDetected() throws Exception {
+        assertTrue(invokeIsXsd11Schema(fileBaseUri, "schema11.xsd"));
+    }
+
+    @Test
+    public void sameOriginRelativeXsd10SchemaIsNotDetectedAsXsd11() throws Exception {
+        assertFalse(invokeIsXsd11Schema(fileBaseUri, "schema10.xsd"));
+    }
+
+    @Test(timeout = 5000)
+    public void crossOriginHttpLocationIsRefused() throws Exception {
+        // A real instance would never have a `file://` base URI reachable from an unprivileged
+        // caller (only Java-object-backed items do, which already requires elevated capability) --
+        // this is just the most convenient same-scheme baseline to contrast against. The case that
+        // matters is: whatever the base URI's origin, an absolute, different-origin location must
+        // never be followed.
+        assertFalse(invokeIsXsd11Schema(fileBaseUri, "http://203.0.113.1:1/evil.xsd"));
+    }
+
+    @Test(timeout = 5000)
+    public void crossOriginHttpLocationIsRefusedForDatabaseBaseUri() throws Exception {
+        // The realistic, unprivileged case: a document stored in the database (xmldb:// base URI)
+        // with an absolute http:// schemaLocation hint pointing out to an attacker-controlled host.
+        assertFalse(invokeIsXsd11Schema("xmldb://db/test/instance.xml", "http://203.0.113.1:1/evil.xsd"));
+    }
+
+    @Test(timeout = 5000)
+    public void crossHostXmldbLocationIsRefused() throws Exception {
+        // An absolute xmldb:// location naming a different host is not "same scheme" enough --
+        // XmldbURL.isEmbedded() treats a non-empty host as a remote XML-RPC target
+        // (EmbeddedURLConnection -> XmlrpcInputStream), so this must be refused too.
+        assertFalse(invokeIsXsd11Schema("xmldb://db/test/instance.xml", "xmldb://203.0.113.1:1/db/evil.xsd"));
+    }
+
+    private static boolean invokeIsXsd11Schema(final String baseUri, final String location) throws Exception {
+        final Method method = Jaxp.class.getDeclaredMethod("isXsd11Schema", String.class, String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, baseUri, location);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
@@ -24,7 +24,6 @@ package org.exist.xquery.functions.validation;
 import org.junit.After;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,9 +33,11 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that {@code Jaxp.isXsd11Schema}'s result cache (a) actually caches -- a second call for
- * the same resolved schema URI doesn't re-read the (changed) underlying content -- and (b) is
- * fully cleared by {@code Jaxp.clearXsd11DetectionCache()}, the hook {@code
- * validation:clear-grammar-cache()} calls (see {@link GrammarTooling}).
+ * the same Subject and resolved schema URI doesn't re-read the (changed) underlying content --
+ * (b) is fully cleared by {@code Jaxp.clearXsd11DetectionCache()}, the hook {@code
+ * validation:clear-grammar-cache()} calls (see {@link GrammarTooling}), and (c) is scoped per
+ * Subject, so a different Subject querying the same resolved URI doesn't observe a cached answer
+ * populated by someone else's fetch.
  */
 public class JaxpXsd11DetectionCacheTest {
 
@@ -64,20 +65,20 @@ public class JaxpXsd11DetectionCacheTest {
             final String baseUri = instance.toUri().toString();
 
             // First call: reads the real (XSD 1.1) content from disk.
-            assertTrue(invokeIsXsd11Schema(baseUri, "schema.xsd"));
+            assertTrue(Jaxp.isXsd11Schema("subject-a", baseUri, "schema.xsd"));
 
             // Flip the on-disk content to XSD 1.0 without going through the cache -- if the second
             // call is actually served from cache, it must still report the stale (cached) "true",
             // not re-read this new content.
             Files.writeString(schema, XSD_1_0_SCHEMA, StandardCharsets.UTF_8);
             assertTrue("second call should be served from cache, not re-read the changed file",
-                    invokeIsXsd11Schema(baseUri, "schema.xsd"));
+                    Jaxp.isXsd11Schema("subject-a", baseUri, "schema.xsd"));
 
             // Clearing the cache (what validation:clear-grammar-cache() does) must make the next
             // call re-read the file and observe the now-current (XSD 1.0) content.
             Jaxp.clearXsd11DetectionCache();
             assertFalse("after clearing the cache, the now-current XSD 1.0 content must be observed",
-                    invokeIsXsd11Schema(baseUri, "schema.xsd"));
+                    Jaxp.isXsd11Schema("subject-a", baseUri, "schema.xsd"));
         } finally {
             Files.deleteIfExists(tempDir.resolve("instance.xml"));
             Files.deleteIfExists(tempDir.resolve("schema.xsd"));
@@ -85,9 +86,30 @@ public class JaxpXsd11DetectionCacheTest {
         }
     }
 
-    private static boolean invokeIsXsd11Schema(final String baseUri, final String location) throws Exception {
-        final Method method = Jaxp.class.getDeclaredMethod("isXsd11Schema", String.class, String.class);
-        method.setAccessible(true);
-        return (boolean) method.invoke(null, baseUri, location);
+    @Test
+    public void cacheIsScopedPerSubject() throws Exception {
+        final Path tempDir = Files.createTempDirectory("jaxp-xsd11-cache-subject-test");
+        try {
+            final Path instance = tempDir.resolve("instance.xml");
+            Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
+            final Path schema = tempDir.resolve("schema.xsd");
+            Files.writeString(schema, XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
+
+            final String baseUri = instance.toUri().toString();
+
+            // subject-a's call populates the cache for this resolved URI.
+            assertTrue(Jaxp.isXsd11Schema("subject-a", baseUri, "schema.xsd"));
+
+            // Delete the underlying file so any call that actually has to read it (i.e. a cache
+            // miss) fails/returns false -- if subject-b's call were wrongly served from
+            // subject-a's cache entry, it would still report "true" despite never reading anything.
+            Files.delete(schema);
+            assertFalse("a different Subject must not observe a cache entry populated by another Subject's fetch",
+                    Jaxp.isXsd11Schema("subject-b", baseUri, "schema.xsd"));
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("instance.xml"));
+            Files.deleteIfExists(tempDir.resolve("schema.xsd"));
+            Files.deleteIfExists(tempDir);
+        }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
@@ -1,0 +1,93 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.validation;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that {@code Jaxp.isXsd11Schema}'s result cache (a) actually caches -- a second call for
+ * the same resolved schema URI doesn't re-read the (changed) underlying content -- and (b) is
+ * fully cleared by {@code Jaxp.clearXsd11DetectionCache()}, the hook {@code
+ * validation:clear-grammar-cache()} calls (see {@link GrammarTooling}).
+ */
+public class JaxpXsd11DetectionCacheTest {
+
+    private static final String XSD_1_1_SCHEMA = """
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                       xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"/>""";
+
+    private static final String XSD_1_0_SCHEMA = """
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>""";
+
+    @After
+    public void clearCache() {
+        Jaxp.clearXsd11DetectionCache();
+    }
+
+    @Test
+    public void cachesResultAcrossCallsAndClearCacheInvalidatesIt() throws Exception {
+        final Path tempDir = Files.createTempDirectory("jaxp-xsd11-cache-test");
+        try {
+            final Path instance = tempDir.resolve("instance.xml");
+            Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
+            final Path schema = tempDir.resolve("schema.xsd");
+            Files.writeString(schema, XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
+
+            final String baseUri = instance.toUri().toString();
+
+            // First call: reads the real (XSD 1.1) content from disk.
+            assertTrue(invokeIsXsd11Schema(baseUri, "schema.xsd"));
+
+            // Flip the on-disk content to XSD 1.0 without going through the cache -- if the second
+            // call is actually served from cache, it must still report the stale (cached) "true",
+            // not re-read this new content.
+            Files.writeString(schema, XSD_1_0_SCHEMA, StandardCharsets.UTF_8);
+            assertTrue("second call should be served from cache, not re-read the changed file",
+                    invokeIsXsd11Schema(baseUri, "schema.xsd"));
+
+            // Clearing the cache (what validation:clear-grammar-cache() does) must make the next
+            // call re-read the file and observe the now-current (XSD 1.0) content.
+            Jaxp.clearXsd11DetectionCache();
+            assertFalse("after clearing the cache, the now-current XSD 1.0 content must be observed",
+                    invokeIsXsd11Schema(baseUri, "schema.xsd"));
+        } finally {
+            Files.deleteIfExists(tempDir.resolve("instance.xml"));
+            Files.deleteIfExists(tempDir.resolve("schema.xsd"));
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    private static boolean invokeIsXsd11Schema(final String baseUri, final String location) throws Exception {
+        final Method method = Jaxp.class.getDeclaredMethod("isXsd11Schema", String.class, String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, baseUri, location);
+    }
+}

--- a/exist-core/src/test/xquery/validation/jaxp.xql
+++ b/exist-core/src/test/xquery/validation/jaxp.xql
@@ -1,0 +1,97 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : validation:jaxp() validates by dynamically discovering the grammar from
+ : the instance document's own xsi:(no)NamespaceSchemaLocation hint, unlike
+ : validation:jaxv() (see jaxv.xql) which takes the grammar as an explicit
+ : argument. That dynamic-discovery path needs a real stored document (for a
+ : real base URI to resolve the relative schemaLocation hint against), so
+ : unlike jaxv.xql this module stores fixtures rather than using in-memory
+ : node constructors.
+ :)
+module namespace jaxp ="http://exist-db.org/xquery/test/validation/jaxp";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $jaxp:COLLECTION_NAME := "validation-jaxp-test";
+declare variable $jaxp:COLLECTION := "/db/" || $jaxp:COLLECTION_NAME;
+
+(: No-namespace XSD 1.1 schema -- xs:assert does not exist in XSD 1.0, so a
+   processor that silently falls back to 1.0 grammar parsing fails to load
+   this schema at all, rather than just failing the assertion. :)
+declare variable $jaxp:XSD11 :=
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+        <xs:element name="root">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="value1" type="xs:integer"/>
+                    <xs:element name="value2" type="xs:integer"/>
+                </xs:sequence>
+                <xs:assert test="value2 gt value1"/>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>;
+
+declare variable $jaxp:VALID_XML :=
+    <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema.xsd">
+        <value1>20</value1>
+        <value2>30</value2>
+    </root>;
+
+declare variable $jaxp:INVALID_XML :=
+    <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema.xsd">
+        <value1>30</value1>
+        <value2>20</value2>
+    </root>;
+
+declare
+    %test:setUp
+function jaxp:setup() {
+    xmldb:create-collection("/db", $jaxp:COLLECTION_NAME),
+    xmldb:store($jaxp:COLLECTION, "schema.xsd", $jaxp:XSD11),
+    xmldb:store($jaxp:COLLECTION, "valid.xml", $jaxp:VALID_XML),
+    xmldb:store($jaxp:COLLECTION, "invalid.xml", $jaxp:INVALID_XML)
+};
+
+declare
+    %test:tearDown
+function jaxp:cleanup() {
+    xmldb:remove($jaxp:COLLECTION)
+};
+
+(: validation:jaxp() must dynamically discover and load an XSD 1.1 schema
+   via the instance's own schemaLocation hint, the same as validation:jaxv()
+   already does when given the v1.1 schema-language URI explicitly. :)
+declare
+    %test:assertEquals("valid")
+function jaxp:xsd11_valid() {
+    data(validation:jaxp-report(doc($jaxp:COLLECTION || "/valid.xml"), false())//status)
+};
+
+declare
+    %test:assertEquals("cvc-assertion: Assertion evaluation ('value2 gt value1') for element 'root' on schema type '#AnonType_root' did not succeed. ")
+function jaxp:xsd11_invalid() {
+    data(validation:jaxp-report(doc($jaxp:COLLECTION || "/invalid.xml"), false())//message)
+};

--- a/exist-core/src/test/xquery/validation/jaxp.xql
+++ b/exist-core/src/test/xquery/validation/jaxp.xql
@@ -37,9 +37,11 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare variable $jaxp:COLLECTION_NAME := "validation-jaxp-test";
 declare variable $jaxp:COLLECTION := "/db/" || $jaxp:COLLECTION_NAME;
 
-(: No-namespace XSD 1.1 schema -- xs:assert does not exist in XSD 1.0, so a
-   processor that silently falls back to 1.0 grammar parsing fails to load
-   this schema at all, rather than just failing the assertion. :)
+(:~
+ : No-namespace XSD 1.1 schema -- xs:assert does not exist in XSD 1.0, so a
+ : processor that silently falls back to 1.0 grammar parsing fails to load
+ : this schema at all, rather than just failing the assertion.
+ :)
 declare variable $jaxp:XSD11 :=
     <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
@@ -66,6 +68,9 @@ declare variable $jaxp:INVALID_XML :=
         <value2>20</value2>
     </root>;
 
+(:~
+ : Creates the test collection and stores the XSD 1.1 schema and its valid/invalid instances.
+ :)
 declare
     %test:setUp
 function jaxp:setup() {
@@ -75,23 +80,44 @@ function jaxp:setup() {
     xmldb:store($jaxp:COLLECTION, "invalid.xml", $jaxp:INVALID_XML)
 };
 
+(:~
+ : Removes the test collection.
+ :)
 declare
     %test:tearDown
 function jaxp:cleanup() {
     xmldb:remove($jaxp:COLLECTION)
 };
 
-(: validation:jaxp() must dynamically discover and load an XSD 1.1 schema
-   via the instance's own schemaLocation hint, the same as validation:jaxv()
-   already does when given the v1.1 schema-language URI explicitly. :)
+(:~
+ : validation:jaxp() must dynamically discover and load an XSD 1.1 schema
+ : via the instance's own schemaLocation hint, the same as validation:jaxv()
+ : already does when given the v1.1 schema-language URI explicitly.
+ :)
 declare
     %test:assertEquals("valid")
 function jaxp:xsd11_valid() {
     data(validation:jaxp-report(doc($jaxp:COLLECTION || "/valid.xml"), false())//status)
 };
 
+(:~
+ : The XSD 1.1 fallback must still report genuine assertion failures, not just
+ : confirm that the schema loaded.
+ :)
 declare
     %test:assertEquals("cvc-assertion: Assertion evaluation ('value2 gt value1') for element 'root' on schema type '#AnonType_root' did not succeed. ")
 function jaxp:xsd11_invalid() {
     data(validation:jaxp-report(doc($jaxp:COLLECTION || "/invalid.xml"), false())//message)
+};
+
+(:~
+ : Regression test: the XSD 1.1 retry must not double-build the result document.
+ : jaxp-parse() reuses no content handler/builder between the failed first pass and
+ : the successful retry, so the returned document must have exactly one root element,
+ : not two siblings (one from each pass).
+ :)
+declare
+    %test:assertEquals(1)
+function jaxp:xsd11_parse_single_root() {
+    count(validation:jaxp-parse(doc($jaxp:COLLECTION || "/valid.xml"), false(), ())/*)
 };

--- a/exist-core/src/test/xquery/validation/jaxv.xql
+++ b/exist-core/src/test/xquery/validation/jaxv.xql
@@ -81,3 +81,88 @@ function val:xsd11_invalid() {
     data(validation:jaxv-report($val:XML, $val:XSD11_2, "http://www.w3.org/XML/XMLSchema/v1.1")//message)
 };
 
+(:~
+ : Catalog tests for jaxv()'s new (instance, grammars, language, catalogs)
+ : overload. $val:CATALOG_MAIN_XSD imports "urn:jaxv-test:imported" with the
+ : URN itself (not a resolvable file path) as schemaLocation -- a common XML
+ : Catalogs convention. There's no relative path for Xerces to fall back on,
+ : so the import can only resolve through the stored catalog's <uri> entry
+ : that maps that URN to imported.xsd. This proves the catalog argument is
+ : actually doing the resolution, not just being accepted and ignored.
+ :)
+declare variable $val:CATALOG_COLLECTION_NAME := "validation-jaxv-catalog-test";
+declare variable $val:CATALOG_COLLECTION := "/db/" || $val:CATALOG_COLLECTION_NAME;
+
+declare variable $val:CATALOG_IMPORTED_XSD :=
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="urn:jaxv-test:imported" elementFormDefault="qualified">
+        <xs:simpleType name="ratingType">
+            <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="5"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:schema>;
+
+declare variable $val:CATALOG_DOC :=
+    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+        <uri name="urn:jaxv-test:imported" uri="imported.xsd"/>
+    </catalog>;
+
+declare variable $val:CATALOG_MAIN_XSD :=
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:imp="urn:jaxv-test:imported"
+               targetNamespace="urn:jaxv-test:main" elementFormDefault="qualified">
+        <xs:import namespace="urn:jaxv-test:imported" schemaLocation="urn:jaxv-test:imported"/>
+        <xs:element name="review">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="rating" type="imp:ratingType"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>;
+
+declare variable $val:CATALOG_VALID_XML :=
+    <review xmlns="urn:jaxv-test:main"><rating>4</rating></review>;
+
+declare variable $val:CATALOG_INVALID_XML :=
+    <review xmlns="urn:jaxv-test:main"><rating>9</rating></review>;
+
+declare
+    %test:setUp
+function val:catalog_setup() {
+    xmldb:create-collection("/db", $val:CATALOG_COLLECTION_NAME),
+    xmldb:store($val:CATALOG_COLLECTION, "catalog.xml", $val:CATALOG_DOC),
+    xmldb:store($val:CATALOG_COLLECTION, "imported.xsd", $val:CATALOG_IMPORTED_XSD)
+};
+
+declare
+    %test:tearDown
+function val:catalog_cleanup() {
+    xmldb:remove($val:CATALOG_COLLECTION)
+};
+
+(: Without a catalog, the import can't resolve at all (no schemaLocation hint) --
+   schema compilation itself fails, reported as an exception inside the report
+   rather than an XQuery-level error. Confirms the catalog argument isn't a no-op. :)
+declare
+    %test:assertEquals("invalid")
+function val:catalog_without_catalog_fails() {
+    data(validation:jaxv-report($val:CATALOG_VALID_XML, $val:CATALOG_MAIN_XSD, "http://www.w3.org/2001/XMLSchema")//status)
+};
+
+declare
+    %test:assertEquals("valid")
+function val:catalog_explicit_valid() {
+    data(validation:jaxv-report($val:CATALOG_VALID_XML, $val:CATALOG_MAIN_XSD,
+        "http://www.w3.org/2001/XMLSchema", doc($val:CATALOG_COLLECTION || "/catalog.xml"))//status)
+};
+
+declare
+    %test:assertEquals("invalid")
+function val:catalog_explicit_invalid() {
+    data(validation:jaxv-report($val:CATALOG_INVALID_XML, $val:CATALOG_MAIN_XSD,
+        "http://www.w3.org/2001/XMLSchema", doc($val:CATALOG_COLLECTION || "/catalog.xml"))//status)
+};
+

--- a/exist-core/src/test/xquery/validation/jaxv.xql
+++ b/exist-core/src/test/xquery/validation/jaxv.xql
@@ -143,14 +143,18 @@ declare variable $val:CATALOG_INVALID_XML :=
     <review xmlns="urn:jaxv-test:main"><rating>9</rating></review>;
 
 (:~
- : Creates the test collection and stores the catalog document and the schema it imports.
+ : Creates the test collection and stores the catalog document and the schemas it/the
+ : directory-search tests import. $val:SEARCH_IMPORTED_XSD is stored under a filename that
+ : does NOT match $val:SEARCH_MAIN_XSD's schemaLocation -- only a namespace-keyed directory
+ : search can find it.
  :)
 declare
     %test:setUp
 function val:catalog_setup() {
     xmldb:create-collection("/db", $val:CATALOG_COLLECTION_NAME),
     xmldb:store($val:CATALOG_COLLECTION, "catalog.xml", $val:CATALOG_DOC),
-    xmldb:store($val:CATALOG_COLLECTION, "imported.xsd", $val:CATALOG_IMPORTED_XSD)
+    xmldb:store($val:CATALOG_COLLECTION, "imported.xsd", $val:CATALOG_IMPORTED_XSD),
+    xmldb:store($val:CATALOG_COLLECTION, "searched-imported.xsd", $val:SEARCH_IMPORTED_XSD)
 };
 
 (:~
@@ -193,5 +197,60 @@ declare
 function val:catalog_explicit_invalid() {
     data(validation:jaxv-report($val:CATALOG_INVALID_XML, $val:CATALOG_MAIN_XSD,
         "http://www.w3.org/2001/XMLSchema", doc($val:CATALOG_COLLECTION || "/catalog.xml"))//status)
+};
+
+(:~
+ : Directory-search catalog tests for jaxv()'s fourth argument (a collection URI ending
+ : in '/'). $val:SEARCH_MAIN_XSD imports "urn:jaxv-test:searched" with a schemaLocation
+ : that is not a resolvable path at all -- the import can only resolve through
+ : SearchResourceResolver searching $val:CATALOG_COLLECTION (reused from the catalog
+ : tests above; XQSuite only supports one %test:setUp/%test:tearDown per module, so this
+ : avoids needing a second collection) for an XSD whose targetNamespace matches
+ : "urn:jaxv-test:searched". Proves directory-search catalogs work for jaxv() too, not
+ : just for validation:jaxp().
+ :)
+declare variable $val:SEARCH_IMPORTED_XSD :=
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="urn:jaxv-test:searched" elementFormDefault="qualified">
+        <xs:simpleType name="ratingType">
+            <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1"/>
+                <xs:maxInclusive value="5"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:schema>;
+
+declare variable $val:SEARCH_MAIN_XSD :=
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:imp="urn:jaxv-test:searched"
+               targetNamespace="urn:jaxv-test:searched-main" elementFormDefault="qualified">
+        <xs:import namespace="urn:jaxv-test:searched" schemaLocation="not-a-resolvable-path.xsd"/>
+        <xs:element name="review">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="rating" type="imp:ratingType"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>;
+
+declare variable $val:SEARCH_VALID_XML :=
+    <review xmlns="urn:jaxv-test:searched-main"><rating>4</rating></review>;
+
+declare variable $val:SEARCH_INVALID_XML :=
+    <review xmlns="urn:jaxv-test:searched-main"><rating>9</rating></review>;
+
+declare
+    %test:assertEquals("valid")
+function val:search_catalog_valid() {
+    data(validation:jaxv-report($val:SEARCH_VALID_XML, $val:SEARCH_MAIN_XSD,
+        "http://www.w3.org/2001/XMLSchema", xs:anyURI($val:CATALOG_COLLECTION || "/"))//status)
+};
+
+declare
+    %test:assertEquals("invalid")
+function val:search_catalog_invalid() {
+    data(validation:jaxv-report($val:SEARCH_INVALID_XML, $val:SEARCH_MAIN_XSD,
+        "http://www.w3.org/2001/XMLSchema", xs:anyURI($val:CATALOG_COLLECTION || "/"))//status)
 };
 

--- a/exist-core/src/test/xquery/validation/jaxv.xql
+++ b/exist-core/src/test/xquery/validation/jaxv.xql
@@ -21,6 +21,11 @@
  :)
 xquery version "3.1";
 
+(:~
+ : Tests for validation:jaxv()/jaxv-report(), which validate an instance document
+ : against an explicitly-supplied grammar (unlike validation:jaxp(), which discovers
+ : the grammar dynamically from the instance's own schemaLocation hint -- see jaxp.xql).
+ :)
 module namespace val ="http://exist-db.org/xquery/test/validation";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
@@ -60,21 +65,29 @@ declare variable $val:XSD11_2 := <xs:schema xmlns:xs="http://www.w3.org/2001/XML
                                         <xs:element name="value2" type="xs:integer"/>
                                       </xs:schema>;
 
-(: Verify that for JAXV it is required to specify the XSD version :)
+(:~
+ : Verify that for JAXV it is required to specify the XSD version: without the
+ : v1.1 schema-language URI, the XSD 1.1 xs:assert element is rejected as invalid
+ : content by the (default) XSD 1.0 grammar parser.
+ :)
 declare
     %test:assertEquals("s4s-elt-invalid-content.1: The content of '#AnonType_root' is invalid. Element 'assert' is invalid, misplaced, or occurs too often.")
 function val:xsd11_no_xsd11_namespace() {
     data(validation:jaxv-report($val:XML ,$val:XSD11_1)//message)
 };
 
-(: Good weather scenario : XML is valid:)
+(:~
+ : Good weather scenario: XML is valid against the XSD 1.1 schema and its assertion.
+ :)
 declare
     %test:assertEquals("valid")
 function val:xsd11_valid() {
     data(validation:jaxv-report($val:XML, $val:XSD11_1, "http://www.w3.org/XML/XMLSchema/v1.1")//status)
 };
 
-(: Good weather scenario : XML is invalid:)
+(:~
+ : Good weather scenario: XML fails the XSD 1.1 schema's xs:assert.
+ :)
 declare
     %test:assertEquals("cvc-assertion: Assertion evaluation ('value2 lt value1') for element 'root' on schema type '#AnonType_root' did not succeed. ")
 function val:xsd11_invalid() {
@@ -129,6 +142,9 @@ declare variable $val:CATALOG_VALID_XML :=
 declare variable $val:CATALOG_INVALID_XML :=
     <review xmlns="urn:jaxv-test:main"><rating>9</rating></review>;
 
+(:~
+ : Creates the test collection and stores the catalog document and the schema it imports.
+ :)
 declare
     %test:setUp
 function val:catalog_setup() {
@@ -137,21 +153,30 @@ function val:catalog_setup() {
     xmldb:store($val:CATALOG_COLLECTION, "imported.xsd", $val:CATALOG_IMPORTED_XSD)
 };
 
+(:~
+ : Removes the test collection.
+ :)
 declare
     %test:tearDown
 function val:catalog_cleanup() {
     xmldb:remove($val:CATALOG_COLLECTION)
 };
 
-(: Without a catalog, the import can't resolve at all (no schemaLocation hint) --
-   schema compilation itself fails, reported as an exception inside the report
-   rather than an XQuery-level error. Confirms the catalog argument isn't a no-op. :)
+(:~
+ : Without a catalog, the import can't resolve at all (no schemaLocation hint) --
+ : schema compilation itself fails, reported as an exception inside the report
+ : rather than an XQuery-level error. Confirms the catalog argument isn't a no-op.
+ :)
 declare
     %test:assertEquals("invalid")
 function val:catalog_without_catalog_fails() {
     data(validation:jaxv-report($val:CATALOG_VALID_XML, $val:CATALOG_MAIN_XSD, "http://www.w3.org/2001/XMLSchema")//status)
 };
 
+(:~
+ : With the stored catalog supplied as the fourth argument, the import resolves via
+ : the catalog's <uri> entry and a valid instance validates successfully.
+ :)
 declare
     %test:assertEquals("valid")
 function val:catalog_explicit_valid() {
@@ -159,6 +184,10 @@ function val:catalog_explicit_valid() {
         "http://www.w3.org/2001/XMLSchema", doc($val:CATALOG_COLLECTION || "/catalog.xml"))//status)
 };
 
+(:~
+ : With the stored catalog resolving the import, an instance that violates the
+ : imported type's restriction is still correctly reported as invalid.
+ :)
 declare
     %test:assertEquals("invalid")
 function val:catalog_explicit_invalid() {

--- a/exist-samples/src/main/resources/org/exist/samples/validation/parse/instance/searched-xsd11-invalid.xml
+++ b/exist-samples/src/main/resources/org/exist/samples/validation/parse/instance/searched-xsd11-invalid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<root xmlns="urn:jaxp-test:searched-xsd11"><value1>30</value1><value2>20</value2></root>

--- a/exist-samples/src/main/resources/org/exist/samples/validation/parse/instance/searched-xsd11-valid.xml
+++ b/exist-samples/src/main/resources/org/exist/samples/validation/parse/instance/searched-xsd11-valid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<root xmlns="urn:jaxp-test:searched-xsd11"><value1>20</value1><value2>30</value2></root>

--- a/exist-samples/src/main/resources/org/exist/samples/validation/parse/schemas/searched-xsd11.xsd
+++ b/exist-samples/src/main/resources/org/exist/samples/validation/parse/schemas/searched-xsd11.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           xmlns="urn:jaxp-test:searched-xsd11" targetNamespace="urn:jaxp-test:searched-xsd11"
+           elementFormDefault="qualified" xpathDefaultNamespace="##targetNamespace">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="value1" type="xs:integer"/>
+                <xs:element name="value2" type="xs:integer"/>
+            </xs:sequence>
+            <xs:assert test="value2 gt value1"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Stumbled across this while working on exist's native schemas which will be a follow-up PR.  🐇 🕳️ 

## Summary

- `validation:jaxp()` now validates XSD 1.1 schemas (`vc:minVersion="1.1"`), transparently routed through a dedicated `javax.xml.validation` pipeline since the bundled Xerces fork only wires XSD 1.1 support there, not into the dynamic-discovery SAX parser.
- `validation:jaxv()` gains a 4th, optional `$catalogs` argument, matching `jaxp()`'s existing catalog support (system catalog / explicit `.xml` catalog / directory-search collection catalog).
- Database-stored catalogs are streamed to the resolver via SAX instead of round-tripping through a `String`.
- Closes #1975, #2476 (regression tests added; underlying fixes already present).

## What changed

- `Jaxp.java` / `Jaxv.java`: XSD 1.1 detection + validator pipeline, shared catalog-argument `Shared.resolveCatalogArgument`, Subject-scoped and Caffeine-backed detection cache.
- `ResolverFactory.java` / `RecordingContentHandler.java`: SAX-streamed catalog loading without re-fetching from the database on xmlresolver's second pass.
- `SearchResourceResolver.java`: directory-search catalogs now work with both the SAX pipelineeline.
- Security: the XSD 1.1 detection peek only follows same-origin `schemaLocation` hints — covered by `JaxpSchemaLocationSecurityTest`.

## Test plan

- [x] Full `exist-core` suite: 7029 tests, 0 failures/errors
- [x] All CI checks green (Codacy, License check, container build, W3C XQTS, unit + integration
- [x] New/updated regression tests: `JaxpXsdCatalogTest`, `JaxvTest`, `JaxpSchemaLocationSecurityTest`, `JaxpXsd11DetectionCacheTest`, `IsMissingElementDeclarationTest`, `CatalogResolutionRegressionTest`,
`TournamentSchemaLanguageComparisonTest`
