### PR TITLE
[bugfix] xmldb:store: parse binary content stored under an XML mime type

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Properties;
 
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,6 +40,7 @@ import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.util.FileUtils;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.TemporaryFileManager;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xmldb.EXistResource;
@@ -185,18 +187,40 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                     if (Type.subTypeOf(item.getType(), Type.STRING)) {
                         resource.setContent(item.getStringValue());
                     } else if (item.getType() == Type.BASE64_BINARY) {
-                        // Pass the BinaryValue through rather than .toJavaObject(), which reads the
-                        // whole value into a heap byte[] (a multi-GB upload would OOM). The local
-                        // resource keeps the BinaryValue and the store streams it via the
-                        // (disk-backed by default) binary cache instead of materializing it.
                         final BinaryValue binaryValue = (BinaryValue) item;
-                        // The resource is only lent the value: closing the resource (on exit from
-                        // this try-with-resources) closes the value it was given, but the query
-                        // that produced the value may still need to read it afterwards. Take a
-                        // shared reference on the resource's behalf so its close() releases only
-                        // that reference.
-                        binaryValue.incrementSharedReferences();
-                        resource.setContent(binaryValue);
+                        if (mimeType.isXMLType()) {
+                            // The content is binary but the target mime type is an XML type: parse the
+                            // binary's bytes as an XML document. Setting the BinaryValue directly would
+                            // leave the (XML) resource with no character/byte stream, and the store would
+                            // later fail with an NPE when it tried to parse a null string as XML. Buffer
+                            // the bytes into a re-readable StringInputSource: the xmldb:store route parses
+                            // the source twice (validate, then store) and does not reset it between passes,
+                            // so a single-shot stream would be drained on the second pass. Buffering costs
+                            // nothing asymptotically here — storing XML parses the whole document into a
+                            // DOM anyway — and StringInputSource yields a fresh (unsynchronized) stream on
+                            // each read, letting the parser detect the encoding from the bytes.
+                            final byte[] xmlBytes;
+                            try (final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream()) {
+                                binaryValue.streamBinaryTo(baos);
+                                xmlBytes = baos.toByteArray();
+                            } catch (final IOException e) {
+                                throw new XPathException(this, "Unable to read binary content to store as XML: " + e.getMessage(), e);
+                            }
+                            resource.setContent(new StringInputSource(xmlBytes));
+                        } else {
+                            // Pass the BinaryValue through rather than .toJavaObject(), which reads the
+                            // whole value into a heap byte[] (a multi-GB upload would OOM). The local
+                            // resource keeps the BinaryValue and the store streams it via the
+                            // (disk-backed by default) binary cache instead of materializing it.
+                            //
+                            // The resource is only lent the value: closing the resource (on exit from
+                            // this try-with-resources) closes the value it was given, but the query
+                            // that produced the value may still need to read it afterwards. Take a
+                            // shared reference on the resource's behalf so its close() releases only
+                            // that reference.
+                            binaryValue.incrementSharedReferences();
+                            resource.setContent(binaryValue);
+                        }
                     } else if (Type.subTypeOf(item.getType(), Type.NODE)) {
                         if (mimeType.isXMLType()) {
                             final ContentHandler handler = ((XMLResource) resource).setContentAsSAX();

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -115,7 +115,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
         } catch (InstantiationException ex) {
             LOG.error(ex.getMessage(), ex);
         }
-        return null;
+        return InputStream.nullInputStream();
     }
 
     @Override

--- a/exist-core/src/test/xquery/xmldb/store-binary-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/store-binary-tests.xql
@@ -1,0 +1,107 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for xmldb:store() with a binary (xs:base64Binary) content value.
+ :
+ : Regression for the case where a binary content value is stored under an XML-type
+ : mime (explicit mime="application/xml" or inferred from an .xml resource name):
+ : the store used to fail with java.lang.NullPointerException
+ : ("Cannot invoke \"String.length()\" because \"<parameter1>\" is null") because the
+ : binary was bound to an XML resource that had no character/byte stream to parse.
+ : The bytes should instead be parsed as an XML document.
+ :)
+module namespace sbt = "http://exist-db.org/xquery/test/xmldb-store-binary";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace util = "http://exist-db.org/xquery/util";
+
+declare variable $sbt:collection-name := "xmldb-store-binary-test";
+declare variable $sbt:collection := "/db/" || $sbt:collection-name;
+
+declare
+    %test:setUp
+function sbt:setup() as empty-sequence() {
+    let $_ := xmldb:create-collection("/db", $sbt:collection-name)
+    return ()
+};
+
+declare
+    %test:tearDown
+function sbt:tear-down() as empty-sequence() {
+    let $_ := xmldb:remove($sbt:collection)
+    return ()
+};
+
+(: binary content + explicit application/xml mime -> parsed and stored as XML :)
+declare
+    %test:assertEquals("1")
+function sbt:binary-with-xml-mime-is-parsed() {
+    let $bin := util:string-to-binary("<doc><a>1</a></doc>")
+    let $stored := xmldb:store($sbt:collection, "explicit.xml", $bin, "application/xml")
+    return doc($stored)/doc/a/string()
+};
+
+(: binary content, mime inferred from the .xml resource name -> parsed and stored as XML :)
+declare
+    %test:assertEquals("1")
+function sbt:binary-with-inferred-xml-mime-is-parsed() {
+    let $bin := util:string-to-binary("<doc><a>1</a></doc>")
+    let $stored := xmldb:store($sbt:collection, "inferred.xml", $bin)
+    return doc($stored)/doc/a/string()
+};
+
+(: the parsed document is a real XML document, not a binary resource :)
+declare
+    %test:assertEquals("false")
+function sbt:binary-with-xml-mime-is-not-binary() {
+    let $bin := util:string-to-binary("<doc><a>1</a></doc>")
+    let $stored := xmldb:store($sbt:collection, "as-xml.xml", $bin, "application/xml")
+    return string(util:binary-doc-available($stored))
+};
+
+(: XML encoding declaration in the bytes is honored (parser reads it from the stream) :)
+declare
+    %test:assertEquals("ä")
+function sbt:binary-with-xml-mime-honors-encoding() {
+    let $bin := util:string-to-binary("<?xml version='1.0' encoding='UTF-8'?><doc>&#xE4;</doc>")
+    let $stored := xmldb:store($sbt:collection, "encoded.xml", $bin, "application/xml")
+    return doc($stored)/doc/string()
+};
+
+(: control: binary content + a binary mime is still stored byte-for-byte as a binary resource :)
+declare
+    %test:assertEquals("true")
+function sbt:binary-with-binary-mime-stays-binary() {
+    let $bin := util:string-to-binary("<doc><a>1</a></doc>")
+    let $stored := xmldb:store($sbt:collection, "raw.bin", $bin, "application/octet-stream")
+    return string(util:binary-doc-available($stored))
+};
+
+(: malformed XML bytes under an XML mime fail with a clean store/parse error, NOT an NPE :)
+declare
+    %test:assertError("storing document")
+function sbt:binary-malformed-xml-mime-reports-parse-error() {
+    let $bin := util:string-to-binary("not well-formed <")
+    return xmldb:store($sbt:collection, "broken.xml", $bin, "application/xml")
+};


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

`xmldb:store($collection, $name, $content, $mime)` threw a `NullPointerException` — `Cannot invoke "String.length()" because "<parameter1>" is null` — whenever `$content` was an `xs:base64Binary` value **and** the target mime type was an XML type (an explicit `mime="application/xml"`, or one inferred from an `.xml` resource name). The store failed for every binary-content + XML-mime combination, regardless of how the binary value was produced.

Minimal repro:

```xquery
xmldb:store("/db", "x.xml", xs:base64Binary("PHByb2JlPmhpPC9wcm9iZT4="), "application/xml")
(: -> NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null :)
```

## Root cause

`getResource(mimeType, …)` creates an **`XMLResource`** for an XML mime type. The binary was then bound to it with `resource.setContent((BinaryValue) item)`. A `BinaryValue` is an `AtomicValue`, so `LocalXMLResource.setContent` routed it into the resource's `value` slot, leaving the XML resource with **no character or byte stream**. The store path then built the parse source as `Objects.requireNonNullElseGet(res.inputSource, () -> new StringInputSource(res.content))` (`LocalCollection.storeXMLResource`); with both `inputSource` and `content` null, this produced `new StringInputSource(null)`, and parsing failed at `new StringReader(null)` → the NPE.

## What changed

`XMLDBStore` now branches on the mime type for binary content:

- **Binary content + XML mime type** → read the bytes and set them on the resource as a re-readable `StringInputSource(byte[])`, so the parser reads the bytes and detects the encoding from the XML declaration (the bytes are parsed and stored as an XML document). `StringInputSource` is used because the store may open the source stream more than once — a plain `InputSource` over a single `ByteArrayInputStream` would be drained on the first read.
- **Binary content + non-XML mime type** → unchanged; the `BinaryValue` is still streamed straight to a binary resource without materializing it.

Malformed bytes under an XML mime now produce a clean parse error instead of an NPE. Reading the bytes into a buffer for the XML case adds no asymptotic memory cost, since storing XML parses the whole document into a DOM anyway.

## How it surfaced

This was found via existdb-openapi's binary-safe `PUT /api/db/resource`. roaster hands the raw request body straight through, and `request:get-data()` returns it as an `xs:base64Binary` for an `application/octet-stream` upload; the handler then calls `xmldb:store` with the resource's natural (XML) mime, hitting the untested binary-content + XML-mime pairing. `request:get-data()` itself was never at fault — it delivers the octet-stream body correctly through the controller-forward path; the bug is entirely in `xmldb:store`.

## Test plan

- [x] New XQSuite coverage (`exist-core/src/test/xquery/xmldb/store-binary-tests.xql`, run by `XMLDBTests`): binary stored under an explicit `application/xml` mime and under an inferred `.xml` mime is parsed and re-readable as XML; the stored doc is a real XML document (not a binary resource); the XML encoding declaration in the bytes is honored; binary + a binary mime still stores byte-for-byte (control); malformed bytes under an XML mime produce a clean store/parse error, not an NPE.
- [x] `XMLDBTests` green (36/36, including the 30 pre-existing xmldb tests).
- [x] Codacy PMD clean on the changed file.
- [x] Verified the NPE before the fix and its absence after, via a direct `xmldb:store` call on a running instance.
