### PR TITLE
[bugfix] Function: report the actual argument count in arity-mismatch errors

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -217,7 +217,7 @@ public abstract class Function extends PathExpr {
     public void setArguments(final List<Expression> arguments) throws XPathException {
         if ((!mySignature.isVariadic()) && arguments.size() != mySignature.getArgumentCount()) {
             throw new XPathException(this, ErrorCodes.XPST0017,
-                    functionNotFoundErrorDescription(context, mySignature.getName(), mySignature.getArgumentCount()));
+                    functionNotFoundErrorDescription(context, mySignature.getName(), arguments.size()));
         }
         steps.clear();
 

--- a/exist-core/src/test/xquery/xquery3/function-arity-error.xqm
+++ b/exist-core/src/test/xquery/xquery3/function-arity-error.xqm
@@ -1,0 +1,57 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : When a function (item) is invoked with the wrong number of arguments,
+ : Function.setArguments raises XPST0017 with a message that must report the
+ : number of arguments ACTUALLY supplied, not the function's declared (expected)
+ : arity. Regression test: the message previously printed the expected arity in
+ : the "Unexpectedly received N parameter(s)" clause and dropped the real count.
+ :)
+module namespace fae = "http://exist-db.org/xquery/test/function-arity-error";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+(: a 1-arity function reference invoked with 2 arguments -> "received 2" :)
+declare
+    %test:assertError("Unexpectedly received 2 parameter")
+function fae:too-many-arguments() {
+    let $f := fn:abs#1
+    return $f(1, 2)
+};
+
+(: a 1-arity function reference invoked with 0 arguments -> "received 0" :)
+declare
+    %test:assertError("Unexpectedly received 0 parameter")
+function fae:zero-arguments() {
+    let $f := fn:abs#1
+    return $f()
+};
+
+(: a 2-arity function reference invoked with 1 argument -> "received 1" :)
+declare
+    %test:assertError("Unexpectedly received 1 parameter")
+function fae:too-few-arguments() {
+    let $f := fn:contains#2
+    return $f("abc")
+};


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

When a non-variadic function (item) is invoked with the wrong number of arguments, `Function.setArguments()` raises `XPST0017`. The error message reports the function's **expected** arity as if it were the count **received**, and drops the actual count:

```xquery
let $f := fn:abs#1 return $f(1, 2)
(: error: "Unexpectedly received 1 parameter(s) ..."  — says 1, but 2 were supplied :)
```

## Root cause

`setArguments()` passed `mySignature.getArgumentCount()` (the expected arity) as the `argumentCount` argument of `functionNotFoundErrorDescription()`, which renders that value in the `"Unexpectedly received %d parameter(s)"` clause. So the message printed the expected arity in the "received" slot and never showed the number actually supplied.

This was introduced by #6476, which consolidated this message onto the shared `functionNotFoundErrorDescription` helper but passed the wrong count. The pre-#6476 message reported both counts correctly: `"... doesn't match function signature (expected E, got A)"`.

## Fix

Pass `arguments.size()` — the count actually supplied — instead of the signature's expected arity. `functionNotFoundErrorDescription` uses this value only for the "received N" text; it lists the function's defined signatures separately, so the expected arity is still shown to the user. One-line change.

## Test plan

- [x] New XQSuite coverage (`exist-core/src/test/xquery/xquery3/function-arity-error.xqm`, run by `XQuery3Tests`): a 1-arity function reference invoked with 2 args reports "received 2"; with 0 args reports "received 0"; a 2-arity reference invoked with 1 arg reports "received 1". Each fails against the buggy code (which would print the expected arity) and passes with the fix.
- [x] `XQuery3Tests` green (1080 tests).
- [x] Codacy PMD clean on the changed file.
- [x] Confirmed the trigger path: `InternalFunctionCall.setArguments` / inherited `FunctionCall.setArguments` route through `Function.setArguments`, so invoking a function item with the wrong arity reaches this check.

## Notes

This is a follow-up to #6476 (merged). The `functionNotFoundErrorDescription` helper is also used for genuine not-found and wrong-arity resolution errors via `FunctionFactory`/`XQueryContext`; those call sites already pass the supplied count and are unaffected.
