### PR TITLE
[bugfix] Fix premature closing of still-referenced binary values

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -189,7 +189,14 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                         // whole value into a heap byte[] (a multi-GB upload would OOM). The local
                         // resource keeps the BinaryValue and the store streams it via the
                         // (disk-backed by default) binary cache instead of materializing it.
-                        resource.setContent((BinaryValue) item);
+                        final BinaryValue binaryValue = (BinaryValue) item;
+                        // The resource is only lent the value: closing the resource (on exit from
+                        // this try-with-resources) closes the value it was given, but the query
+                        // that produced the value may still need to read it afterwards. Take a
+                        // shared reference on the resource's behalf so its close() releases only
+                        // that reference.
+                        binaryValue.incrementSharedReferences();
+                        resource.setContent(binaryValue);
                     } else if (Type.subTypeOf(item.getType(), Type.NODE)) {
                         if (mimeType.isXMLType()) {
                             final ContentHandler handler = ((XMLResource) resource).setContentAsSAX();

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
@@ -54,6 +54,14 @@ public class BinaryValueFromFile extends BinaryValue {
     private final MappedByteBuffer buf;
     private final Optional<BiConsumer<Boolean, Path>> closeListener;
 
+    // Number of outstanding references. Starts at 1 (the value itself); incremented when the value is
+    // shared out of an enclosed expression and decremented by each close(). The underlying channel is
+    // released only once it reaches zero, mirroring the reference counting in
+    // AbstractFilterInputStreamCache (used by BinaryValueFromInputStream). Without this, exitEnclosedExpr
+    // would close a still-referenced value -- e.g. an uploaded file's value (request:get-uploaded-file-data)
+    // closed before a deferred xmldb:store could read it.
+    private int sharedReferences = 1;
+
     protected BinaryValueFromFile(final BinaryValueManager manager, final BinaryValueType binaryValueType, final Path file, final Optional<BiConsumer<Boolean, Path>> closeListener) throws XPathException {
         this(null, manager, binaryValueType, file, closeListener);
     }
@@ -128,6 +136,11 @@ public class BinaryValueFromFile extends BinaryValue {
 
     @Override
     public void close() throws IOException {
+        sharedReferences--;
+        if (sharedReferences > 0 || !channel.isOpen()) {
+            // still referenced (e.g. shared out of an enclosed expression), or already released
+            return;
+        }
         boolean closed = false;
         try {
             channel.close();
@@ -176,6 +189,6 @@ public class BinaryValueFromFile extends BinaryValue {
 
     @Override
     public void incrementSharedReferences() {
-        // we don't need reference counting, as there is nothing to cleanup when all references are returned
+        sharedReferences++;
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/value/BinaryValueFromFileSharedReferenceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/BinaryValueFromFileSharedReferenceTest.java
@@ -1,0 +1,102 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.value;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A file-backed binary value must honor the shared-reference contract that
+ * {@link org.exist.xquery.XQueryContext}'s {@code enterEnclosedExpr()} / {@code exitEnclosedExpr()}
+ * rely on: {@code incrementSharedReferences()} protects the value while it is shared out of an enclosed
+ * expression, and {@code close()} must only release the underlying channel once the shared references
+ * are exhausted (mirroring {@link org.exist.xquery.value.BinaryValueFromInputStream}).
+ *
+ * <p>Regression for the multipart-upload failure: an uploaded file's {@link BinaryValueFromFile} (from
+ * {@code request:get-uploaded-file-data}) had its channel closed by {@code exitEnclosedExpr()} before a
+ * deferred {@code xmldb:store} could read it, surfacing as
+ * "error while obtaining length of binary value ..." caused by "Underlying channel has been closed".</p>
+ */
+public class BinaryValueFromFileSharedReferenceTest {
+
+    /**
+     * Models {@code enterEnclosedExpr()} (incrementSharedReferences) followed by {@code exitEnclosedExpr()}
+     * (close) on a value that escapes the enclosed expression: it must remain open and readable, and only
+     * be released by the final cleanup {@code close()}.
+     */
+    @Test
+    public void survivesEnclosedExpressionWhenShared() throws Exception {
+        final byte[] content = "multipart upload payload".getBytes(UTF_8);
+        final Path file = Files.createTempFile("bvff-shared", ".bin");
+        try {
+            Files.write(file, content);
+            final MockBinaryValueManager manager = new MockBinaryValueManager();
+            final BinaryValue bin = BinaryValueFromFile.getInstance(manager, new Base64BinaryValueType(), file);
+
+            // enterEnclosedExpr(): the value is referenced from outside the enclosed expression
+            bin.incrementSharedReferences();
+            // exitEnclosedExpr(): closes (decrements a reference on) each registered binary value
+            bin.close();
+
+            // having escaped the enclosed expression, the value must still be readable
+            assertFalse("a binary value shared out of an enclosed expression must not be closed", bin.isClosed());
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                bin.streamBinaryTo(baos);
+                assertArrayEquals(content, baos.toByteArray());
+            }
+
+            // the final cleanup releases it for real
+            bin.close();
+            assertTrue("once the last reference is released the value is closed", bin.isClosed());
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    /**
+     * A value that is never shared out of an enclosed expression is released by a single {@code close()},
+     * preserving the eager-cleanup behavior of {@code exitEnclosedExpr()}.
+     */
+    @Test
+    public void closesWhenNotShared() throws Exception {
+        final Path file = Files.createTempFile("bvff-unshared", ".bin");
+        try {
+            Files.write(file, "payload".getBytes(UTF_8));
+            final MockBinaryValueManager manager = new MockBinaryValueManager();
+            final BinaryValue bin = BinaryValueFromFile.getInstance(manager, new Base64BinaryValueType(), file);
+
+            assertFalse(bin.isClosed());
+            bin.close();
+            assertTrue("a single owner's close() releases the value", bin.isClosed());
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+}

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/AbstractBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/AbstractBinariesTest.java
@@ -86,6 +86,42 @@ public abstract class AbstractBinariesTest<T, U, E extends Exception> {
     }
 
     /**
+     * A file-backed binary (file:read-binary -&gt; BinaryValueFromFile) used in an element constructor and
+     * then read again must remain readable. Without BinaryValueFromFile's shared-reference reference
+     * counting, XQueryContext.exitEnclosedExpr() closed the channel immediately after the constructor and
+     * the second read failed with "Underlying channel has been closed". {@code count($w)} forces the
+     * constructor to be evaluated before {@code $b} is read again.
+     *
+     * <p>This must run as a <em>root-context main module</em> to reproduce, which is why it is a Java
+     * (executeXQuery) test rather than an XQSuite function: in a {@code ModuleContext} (an XQSuite test
+     * function, or {@code util:eval}) {@code registerBinaryValueInstance()} delegates to the parent/root
+     * context while {@code enterEnclosedExpr()}/{@code exitEnclosedExpr()} act on the {@code ModuleContext}'s
+     * own (empty) deque, so the constructor's {@code exitEnclosedExpr()} never sees the binary there and the
+     * premature close does not occur (it defers harmlessly to {@code popLocalVariables} after the read).
+     * Both {@code executeXQuery()} implementations here run the query as a main module (embedded and REST),
+     * so {@code exitEnclosedExpr()} and the binary share one context and the bug is exercised.</p>
+     */
+    @Test
+    public void readBinaryUsedInElementConstructorThenReadAgain() throws Exception {
+        final byte[] data = randomData(1024);
+        final Path tmpFile = createTemporaryFile(data);
+
+        final String query = """
+                import module namespace file = "http://exist-db.org/xquery/file";
+                let $b := file:read-binary('%s')
+                let $w := <a>{$b}</a>
+                return (count($w), $b)[2]""".formatted(tmpFile.toAbsolutePath());
+
+        final QueryResultAccessor<T, E> resultsAccessor = executeXQuery(query);
+        resultsAccessor.accept(results -> {
+            assertEquals(1, size(results));
+            final U item = item(results, 0);
+            assertTrue(isBinaryType(item));
+            assertArrayEquals(data, getBytes(item));
+        });
+    }
+
+    /**
      * {@see https://github.com/eXist-db/exist/issues/790#error-case-4}
      */
     @Test

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/AbstractBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/AbstractBinariesTest.java
@@ -122,6 +122,89 @@ public abstract class AbstractBinariesTest<T, U, E extends Exception> {
     }
 
     /**
+     * A file-backed binary (file:read-binary -&gt; BinaryValueFromFile) stored with xmldb:store and then
+     * read again must remain readable. xmldb:store wraps its Resource in try-with-resources, and
+     * LocalBinaryResource.doClose() close()s the binary value it was given; without XMLDBStore taking a
+     * shared reference on the value it lends to the resource, that close() released the <em>caller's</em>
+     * value and the second read failed with "Underlying channel has been closed".
+     *
+     * <p>Like {@link #readBinaryUsedInElementConstructorThenReadAgain()}, this must run as a root-context
+     * main module (see that test's javadoc for the ModuleContext rationale).</p>
+     *
+     * @see <a href="https://github.com/eXist-db/exist/issues/6552">Regression when storing an uploaded binary</a>
+     */
+    @Test
+    public void readBinaryStoreThenReadAgain() throws Exception {
+        final byte[] data = randomData(1024);
+        final Path tmpFile = createTemporaryFile(data);
+
+        final String query = """
+                import module namespace file = "http://exist-db.org/xquery/file";
+                let $b := file:read-binary('%s')
+                return (xmldb:store('%s', 'stored-file-backed.bin', $b, 'application/octet-stream'), $b)[2]""".formatted(tmpFile.toAbsolutePath(), TEST_COLLECTION);
+
+        final QueryResultAccessor<T, E> resultsAccessor = executeXQuery(query);
+        resultsAccessor.accept(results -> {
+            assertEquals(1, size(results));
+            final U item = item(results, 0);
+            assertTrue(isBinaryType(item));
+            assertArrayEquals(data, getBytes(item));
+        });
+    }
+
+    /**
+     * The same premature close as {@link #readBinaryStoreThenReadAgain()}, but for a database-backed
+     * binary (util:binary-doc -&gt; BinaryValueFromInputStream): without the shared reference taken by
+     * XMLDBStore, the second read failed with "The underlying InputStream has been closed".
+     *
+     * @see <a href="https://github.com/eXist-db/exist/issues/6552">Regression when storing an uploaded binary</a>
+     */
+    @Test
+    public void binaryDocStoreThenReadAgain() throws Exception {
+        final String query = """
+                let $b := util:binary-doc('%s')
+                return (xmldb:store('%s', 'stored-db-backed.bin', $b, 'application/octet-stream'), $b)[2]""".formatted(TEST_COLLECTION.append(BIN1_FILENAME), TEST_COLLECTION);
+
+        final QueryResultAccessor<T, E> resultsAccessor = executeXQuery(query);
+        resultsAccessor.accept(results -> {
+            assertEquals(1, size(results));
+            final U item = item(results, 0);
+            assertTrue(isBinaryType(item));
+            assertArrayEquals(BIN1_CONTENT, getBytes(item));
+        });
+    }
+
+    /**
+     * Storing the same binary value twice (e.g. a staging copy and a final copy) must work: without the
+     * shared reference taken by XMLDBStore, the first xmldb:store closed the value and the second failed
+     * in LocalBinaryResource.getStreamLength() with "error while obtaining length of binary value".
+     *
+     * @see <a href="https://github.com/eXist-db/exist/issues/6552">Regression when storing an uploaded binary</a>
+     */
+    @Test
+    public void readBinaryStoredTwice() throws Exception {
+        final byte[] data = randomData(1024);
+        final Path tmpFile = createTemporaryFile(data);
+
+        final String query = """
+                import module namespace file = "http://exist-db.org/xquery/file";
+                let $b := file:read-binary('%1$s')
+                return (
+                    xmldb:store('%2$s', 'stored-twice-1.bin', $b, 'application/octet-stream'),
+                    xmldb:store('%2$s', 'stored-twice-2.bin', $b, 'application/octet-stream'),
+                    $b
+                )[3]""".formatted(tmpFile.toAbsolutePath(), TEST_COLLECTION);
+
+        final QueryResultAccessor<T, E> resultsAccessor = executeXQuery(query);
+        resultsAccessor.accept(results -> {
+            assertEquals(1, size(results));
+            final U item = item(results, 0);
+            assertTrue(isBinaryType(item));
+            assertArrayEquals(data, getBytes(item));
+        });
+    }
+
+    /**
      * {@see https://github.com/eXist-db/exist/issues/790#error-case-4}
      */
     @Test


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

This PR now fixes **two** distinct premature-close bugs in the binary-value lifecycle. Per @duncdrum's request in https://github.com/eXist-db/exist/issues/6552#issuecomment-4900791885, the fix for #6552 has been folded into this PR as a second commit, so this one PR closes that issue.

Closes https://github.com/eXist-db/exist/issues/6552

## Bug 1 — enclosed expressions close a file-backed binary (commit 1)

A file-backed binary value (`BinaryValueFromFile`, e.g. from `file:read-binary` or `request:get-uploaded-file-data`) that is **used in an element or document constructor** (an enclosed expression) and then read again could have its file channel closed underneath it, after which the second read failed with *"Underlying channel has been closed"*:

```xquery
let $b := file:read-binary($path)
let $w := <a>{$b}</a>
return (count($w), $b)[2]   (: count($w) forces the constructor; -> "Underlying channel has been closed" without the fix :)
```

### Root cause

`BinaryValueFromFile` did not honor the shared-reference reference counting that `XQueryContext.enterEnclosedExpr()` / `exitEnclosedExpr()` rely on:

- `incrementSharedReferences()` was a no-op (`"we don't need reference counting…"`), and
- `close()` released the `FileChannel`/`RandomAccessFile` unconditionally.

`enterEnclosedExpr()` increments the shared-reference count of each live binary value so a value that escapes an enclosed expression survives; the matching `exitEnclosedExpr()` then `close()`s each, intending only to decrement a reference. For `BinaryValueFromFile` the increment did nothing and the `close()` actually tore down the channel — so a value used in a constructor was closed immediately after the constructor, while it was still referenced. `BinaryValueFromInputStream` was unaffected because it already reference-counts through `AbstractFilterInputStreamCache`.

### Fix

Give `BinaryValueFromFile` the same reference counting as its input-stream sibling: a counter starting at 1, incremented by `incrementSharedReferences()` and decremented by `close()`, releasing the channel/file handle only when it reaches zero. Eager cleanup of values not shared out of a scope is preserved (their count goes 1 → 0 on cleanup).

## Bug 2 — `xmldb:store` closes the caller's binary value (commit 2; #6552)

The regression reported in https://github.com/eXist-db/exist/issues/6552: since #6467, storing a binary value with `xmldb:store` and then reading it again in the same query fails. Root-cause analysis is in https://github.com/eXist-db/exist/issues/6552#issuecomment-4899882837.

```xquery
let $file := request:get-uploaded-file-data("file")
return (xmldb:store($collection, $filename, $file), util:binary-to-string($file))[2]
(: -> "Underlying channel has been closed" without the fix :)
```

### Root cause

`XMLDBStore.evalWithCollection()` wraps its `Resource` in try-with-resources. Since #6467 the `xs:base64Binary` branch passes the caller's actual `BinaryValue` to `LocalBinaryResource.setContent()` (before #6467 it was copied to a `byte[]`), and on try-exit `AbstractEXistResource.close()` → `LocalBinaryResource.doClose()` calls `binaryValue.close()` — closing the **caller's** value, which the query may still need. This breaks file-backed *and* database-backed (`util:binary-doc`) values, and also breaks storing the same value twice.

### Fix

`XMLDBStore` now takes a **shared reference on the value's behalf** (`incrementSharedReferences()`) before lending it to the resource, so the resource's `close()` releases only that reference and the value remains readable by the caller. The reference is taken by the lender rather than inside `LocalBinaryResource.setContent()` because `setContent` has two kinds of callers with opposite ownership semantics: a query-result resource **owns** its value — closing the resource must release it, the contract pinned by `FilterInputStreamCacheMonitorTest.binaryResult` — while `xmldb:store` only **lends** the caller's value. For file-backed values this depends on Bug 1's reference counting — which is why the two fixes belong in one PR: commit 2 without commit 1 would still fail for file-backed values.

Verification matrix from the #6552 investigation (three reproducers, per build):

| Build | file-backed reuse | db-backed reuse | stored twice |
|---|---|---|---|
| develop | fail | fail | fail |
| + commit 1 only | fail | fail | fail |
| + commit 2 only | fail | pass | fail |
| + both (this PR) | pass | pass | pass |

## What changed

- `exist-core/.../xquery/value/BinaryValueFromFile.java` — add the `sharedReferences` counter; `incrementSharedReferences()` increments it; `close()` decrements and releases the channel only at zero (idempotent once released).
- `exist-core/.../xquery/functions/xmldb/XMLDBStore.java` — takes a shared reference on the binary value before lending it to the resource, so the resource's `close()` no longer closes the caller's value.
- `exist-core/.../xquery/value/BinaryValueFromFileSharedReferenceTest.java` — new unit test for the reference-counting contract.
- `extensions/modules/file/.../AbstractBinariesTest.java` — four new regression tests (see below), inherited by the embedded, XML:DB (local + remote), and REST harnesses.

## Test plan

- [x] `BinaryValueFromFileSharedReferenceTest` (unit): models `enterEnclosedExpr()`/`exitEnclosedExpr()` on a shared file-backed value; it must stay open and readable, then be released by the final `close`. Fails before the fix, passes after.
- [x] `AbstractBinariesTest#readBinaryUsedInElementConstructorThenReadAgain`: the Bug 1 query. Fails with *"Underlying channel has been closed"* before commit 1, passes after.
- [x] `AbstractBinariesTest#readBinaryStoreThenReadAgain`: Bug 2, file-backed (`file:read-binary` → `xmldb:store` → read again).
- [x] `AbstractBinariesTest#binaryDocStoreThenReadAgain`: Bug 2, database-backed (`util:binary-doc` → `xmldb:store` → read again; failed with *"The underlying InputStream has been closed"*).
- [x] `AbstractBinariesTest#readBinaryStoredTwice`: Bug 2, same value stored twice (failed with *"error while obtaining length of binary value"* — the failure signature from the CI of eXist-db/public-repo, which currently carries a workaround for this).
- [x] All `AbstractBinariesTest` tests were run against a build **without** the `XMLDBStore` change first: 12 failures with exactly the #6552 error signatures across all harnesses (embedded, XML:DB local + remote, REST); with the change, all 26 pass.
- [x] `FilterInputStreamCacheMonitorTest` passes (3/3) — in particular `binaryResult`, which pins the query-result resource-ownership contract that ruled out placing the reference-taking inside `LocalBinaryResource.setContent()`.
- [x] Codacy/PMD clean on the changed files (two pre-existing findings in `XMLDBStore.java` — method NPath complexity and a parameter reassignment in an untouched method — left as-is to keep the diff minimal).

The regression tests run **main-module queries** (not XQSuite test functions) on purpose: inside a module function Bug 1 is masked, because `ModuleContext.registerBinaryValueInstance()` delegates registration to the parent/root context, while `enterEnclosedExpr()`/`exitEnclosedExpr()` operate on the `ModuleContext`'s own (empty) deque — so the constructor's `exitEnclosedExpr()` never sees the binary there and the close happens later via `popLocalVariables` (after the read), harmlessly. The bug surfaces only where the binary and the enclosed expression share a context, i.e., in a main-module query. (That asymmetry in `ModuleContext` is pre-existing and merely masks this bug; this PR does not change it.)

## Notes

- This PR was originally described as fixing a multipart-upload bug. Upon further research, that claim was misplaced. The multipart `xmldb:store` failure actually has a **distinct** root cause (`Sequence.containsReference` not recursing into nested map/array items, across five sequence types), now fixed separately in #6507. This PR fixes two sibling "binary value closed while still referenced" bugs: the *enclosed-expression* path (Bug 1) and the *`xmldb:store` resource-close* path (Bug 2, #6552).
- Rebased onto current develop per @duncdrum's request (the single original commit was reapplied unchanged).
