### PR TITLE
[bugfix] Sequence.containsReference: recurse into nested map/array items

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/ArrayListValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ArrayListValueSequence.java
@@ -242,7 +242,9 @@ public class ArrayListValueSequence extends AbstractSequence implements MemoryNo
     @Override
     public boolean containsReference(final Item item) {
         for (final Item value : values) {
-            if (value == item) {
+            // recurse into container items (maps/arrays) so a value nested inside a map or array held
+            // by this sequence is detected, mirroring MapType/ArrayType.containsReference
+            if (value == item || (value instanceof Sequence seq && seq.containsReference(item))) {
                 return true;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
@@ -387,7 +387,9 @@ public class OrderedValueSequence extends AbstractSequence {
     public boolean containsReference(final Item item) {
         for (final SequenceIterator it = iterate(); it.hasNext(); ) {
             final Item i = it.nextItem();
-            if (i == item) {
+            // recurse into container items (maps/arrays) so a value nested inside a map or array held
+            // by this sequence is detected, mirroring MapType/ArrayType.containsReference
+            if (i == item || (i instanceof Sequence seq && seq.containsReference(item))) {
                 return true;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/PreorderedValueSequence.java
@@ -142,7 +142,9 @@ public class PreorderedValueSequence extends AbstractSequence {
     public boolean containsReference(final Item item) {
         for (final SequenceIterator it = iterate(); it.hasNext(); ) {
             final Item i = it.nextItem();
-            if (i == item) {
+            // recurse into container items (maps/arrays) so a value nested inside a map or array held
+            // by this sequence is detected, mirroring MapType/ArrayType.containsReference
+            if (i == item || (i instanceof Sequence seq && seq.containsReference(item))) {
                 return true;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
@@ -445,7 +445,9 @@ public class SubSequence extends AbstractSequence {
         try {
             for (final SequenceIterator it = iterate(); it.hasNext(); ) {
                 final Item i = it.nextItem();
-                if (i == item) {
+                // recurse into container items (maps/arrays) so a value nested inside a map or array held
+                // by this sequence is detected, mirroring MapType/ArrayType.containsReference
+                if (i == item || (i instanceof Sequence seq && seq.containsReference(item))) {
                     return true;
                 }
             }

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -395,7 +395,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     @Override
     public boolean containsReference(final Item item) {
         for (int i = 0; i <= size; i++) {
-            if (values[i] == item) {
+            // recurse into container items (maps/arrays) so a value nested inside a map or array held
+            // by this sequence is detected, mirroring MapType/ArrayType.containsReference
+            if (values[i] == item || (values[i] instanceof Sequence seq && seq.containsReference(item))) {
                 return true;
             }
         }

--- a/exist-core/src/test/java/org/exist/xquery/value/ContainsReferenceNestedTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/ContainsReferenceNestedTest.java
@@ -1,0 +1,107 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.value;
+
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.functions.map.MapType;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@code Sequence.containsReference} must detect an item that is nested inside a map (or array) held by
+ * the sequence, not only items held directly. This is the guard that {@code XQueryContext.popLocalVariables}
+ * uses (via {@code destroy(context, contextSequence)}) to avoid closing a value that is still part of a
+ * result; for a value nested in a returned map it must report {@code true}.
+ *
+ * <p>Regression for the file-backed binary premature-close bug: the general-purpose value sequences
+ * checked only direct reference equality and did not recurse into container items, unlike
+ * {@code MapType}/{@code ArrayType}. Each method below fails (the nested item is not detected) without the
+ * fix. {@code OrderedValueSequence} and {@code PreorderedValueSequence} receive the same one-line fix; they
+ * are not constructed directly here (they require {@code OrderSpec} scaffolding) but share the identical
+ * recursion.</p>
+ */
+public class ContainsReferenceNestedTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer SERVER = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void valueSequenceDetectsItemNestedInMap() throws Exception {
+        withMapNesting((map, nested, notNested) -> {
+            final ValueSequence vs = new ValueSequence();
+            vs.add(map);
+            assertTrue(vs.containsReference(nested));
+            assertFalse(vs.containsReference(notNested));
+        });
+    }
+
+    @Test
+    public void arrayListValueSequenceDetectsItemNestedInMap() throws Exception {
+        withMapNesting((map, nested, notNested) -> {
+            final ArrayListValueSequence als = new ArrayListValueSequence();
+            als.add(map);
+            assertTrue(als.containsReference(nested));
+            assertFalse(als.containsReference(notNested));
+        });
+    }
+
+    @Test
+    public void subSequenceDetectsItemNestedInMap() throws Exception {
+        withMapNesting((map, nested, notNested) -> {
+            final ValueSequence backing = new ValueSequence();
+            backing.add(map);
+            final SubSequence sub = new SubSequence(1, backing);
+            assertTrue(sub.containsReference(nested));
+            assertFalse(sub.containsReference(notNested));
+        });
+    }
+
+    @FunctionalInterface
+    private interface MapNestingTest {
+        void test(MapType map, StringValue nested, StringValue notNested) throws XPathException;
+    }
+
+    /**
+     * Builds a {@code map { "data": $nested }} in a fresh context and runs {@code test} with it, plus a
+     * sibling {@code notNested} item that the sequence must NOT report as referenced.
+     */
+    private void withMapNesting(final MapNestingTest test) throws Exception {
+        final BrokerPool pool = SERVER.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            final StringValue nested = new StringValue("nested-marker");
+            final StringValue notNested = new StringValue("not-nested");
+            final MapType map = new MapType(context);
+            map.add(new StringValue("data"), nested);
+            test.test(map, nested, notNested);
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/value/ContainsReferenceNestedTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/ContainsReferenceNestedTest.java
@@ -24,7 +24,6 @@ package org.exist.xquery.value;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.functions.map.MapType;
 import org.junit.ClassRule;
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  *
  * <p>Regression for the file-backed binary premature-close bug: the general-purpose value sequences
  * checked only direct reference equality and did not recurse into container items, unlike
- * {@code MapType}/{@code ArrayType}. Each method below fails (the nested item is not detected) without the
+ * {@code MapType}/{@code ArrayType}. Each test below fails (the nested item is not detected) without the
  * fix. {@code OrderedValueSequence} and {@code PreorderedValueSequence} receive the same one-line fix; they
  * are not constructed directly here (they require {@code OrderSpec} scaffolding) but share the identical
  * recursion.</p>
@@ -55,53 +54,60 @@ public class ContainsReferenceNestedTest {
 
     @Test
     public void valueSequenceDetectsItemNestedInMap() throws Exception {
-        withMapNesting((map, nested, notNested) -> {
-            final ValueSequence vs = new ValueSequence();
-            vs.add(map);
-            assertTrue(vs.containsReference(nested));
-            assertFalse(vs.containsReference(notNested));
-        });
-    }
-
-    @Test
-    public void arrayListValueSequenceDetectsItemNestedInMap() throws Exception {
-        withMapNesting((map, nested, notNested) -> {
-            final ArrayListValueSequence als = new ArrayListValueSequence();
-            als.add(map);
-            assertTrue(als.containsReference(nested));
-            assertFalse(als.containsReference(notNested));
-        });
-    }
-
-    @Test
-    public void subSequenceDetectsItemNestedInMap() throws Exception {
-        withMapNesting((map, nested, notNested) -> {
-            final ValueSequence backing = new ValueSequence();
-            backing.add(map);
-            final SubSequence sub = new SubSequence(1, backing);
-            assertTrue(sub.containsReference(nested));
-            assertFalse(sub.containsReference(notNested));
-        });
-    }
-
-    @FunctionalInterface
-    private interface MapNestingTest {
-        void test(MapType map, StringValue nested, StringValue notNested) throws XPathException;
-    }
-
-    /**
-     * Builds a {@code map { "data": $nested }} in a fresh context and runs {@code test} with it, plus a
-     * sibling {@code notNested} item that the sequence must NOT report as referenced.
-     */
-    private void withMapNesting(final MapNestingTest test) throws Exception {
         final BrokerPool pool = SERVER.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQueryContext context = new XQueryContext(broker.getBrokerPool());
             final StringValue nested = new StringValue("nested-marker");
             final StringValue notNested = new StringValue("not-nested");
+
             final MapType map = new MapType(context);
             map.add(new StringValue("data"), nested);
-            test.test(map, nested, notNested);
+
+            final ValueSequence sequence = new ValueSequence();
+            sequence.add(map);
+
+            assertTrue(sequence.containsReference(nested));
+            assertFalse(sequence.containsReference(notNested));
+        }
+    }
+
+    @Test
+    public void arrayListValueSequenceDetectsItemNestedInMap() throws Exception {
+        final BrokerPool pool = SERVER.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            final StringValue nested = new StringValue("nested-marker");
+            final StringValue notNested = new StringValue("not-nested");
+
+            final MapType map = new MapType(context);
+            map.add(new StringValue("data"), nested);
+
+            final ArrayListValueSequence sequence = new ArrayListValueSequence();
+            sequence.add(map);
+
+            assertTrue(sequence.containsReference(nested));
+            assertFalse(sequence.containsReference(notNested));
+        }
+    }
+
+    @Test
+    public void subSequenceDetectsItemNestedInMap() throws Exception {
+        final BrokerPool pool = SERVER.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            final StringValue nested = new StringValue("nested-marker");
+            final StringValue notNested = new StringValue("not-nested");
+
+            final MapType map = new MapType(context);
+            map.add(new StringValue("data"), nested);
+
+            // SubSequence over a one-element backing sequence whose only item (at index 1) is the map.
+            final ValueSequence backing = new ValueSequence();
+            backing.add(map);
+            final SubSequence sequence = new SubSequence(1, backing);
+
+            assertTrue(sequence.containsReference(nested));
+            assertFalse(sequence.containsReference(notNested));
         }
     }
 }

--- a/extensions/modules/file/src/test/xquery/modules/file/binary-nested-in-map.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/binary-nested-in-map.xqm
@@ -1,0 +1,67 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : A file-backed binary value (file:read-binary -> BinaryValueFromFile) returned nested in a map held by
+ : a sequence must remain readable after the function that produced it returns.
+ :
+ : Regression for the premature-close bug where the general-purpose value sequences' containsReference did
+ : not recurse into container items, so the variable-cleanup guard (popLocalVariables -> destroy) failed to
+ : see a binary nested in a map inside a sequence and closed its channel while it was still referenced. This
+ : is the path the Roaster / existdb-openapi multipart upload tripped (request:get-uploaded-file-data carried
+ : as $request?body?file?data, Roaster's form-data binary shape, then stored with xmldb:store).
+ :)
+module namespace bnm="http://exist-db.org/testsuite/modules/file/binary-nested-in-map";
+
+import module namespace file="http://exist-db.org/xquery/file";
+import module namespace util="http://exist-db.org/xquery/util";
+import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $bnm:suite := "binary-nested-in-map";
+
+declare
+    %test:tearDown
+function bnm:tear-down() as empty-sequence() {
+    helper:clear-suite-fs($bnm:suite)
+};
+
+(:~
+ : The inner one-iteration FLWOR is load-bearing: it wraps the map in a ValueSequence -- the
+ : contextSequence type whose containsReference was buggy. Returning a bare map { ... } yields a MapType,
+ : whose containsReference already recurses, so it would NOT exercise the bug.
+ :)
+declare %private
+function bnm:make-nested($path as xs:string) {
+    let $b := file:read-binary($path)
+    return (for $i in 1 to 1 return map { "data": $b })
+};
+
+declare
+    %test:assertEquals("SERVER_SECRET=123!")
+function bnm:binary-nested-in-map-survives-function-return() {
+    let $directory := helper:get-test-directory($bnm:suite)
+    let $_ := helper:setup-fs-extra($directory)
+    return util:binary-to-string(bnm:make-nested(concat($directory, "/.env"))[1]?data)
+};

--- a/extensions/modules/file/src/test/xquery/modules/file/binary-nested-in-map.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/binary-nested-in-map.xqm
@@ -41,6 +41,17 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare variable $bnm:suite := "binary-nested-in-map";
 
+(: One directory per run, shared by setUp and the test (helper:get-test-directory embeds a fresh uuid
+ : on each call, so it must be computed once here rather than recomputed in each function). :)
+declare variable $bnm:directory := helper:get-test-directory($bnm:suite);
+
+declare
+    %test:setUp
+function bnm:set-up() as empty-sequence() {
+    let $_ := helper:setup-fs-extra($bnm:directory)
+    return ()
+};
+
 declare
     %test:tearDown
 function bnm:tear-down() as empty-sequence() {
@@ -61,7 +72,5 @@ function bnm:make-nested($path as xs:string) {
 declare
     %test:assertEquals("SERVER_SECRET=123!")
 function bnm:binary-nested-in-map-survives-function-return() {
-    let $directory := helper:get-test-directory($bnm:suite)
-    let $_ := helper:setup-fs-extra($directory)
-    return util:binary-to-string(bnm:make-nested(concat($directory, "/.env"))[1]?data)
+    util:binary-to-string(bnm:make-nested(concat($bnm:directory, "/.env"))[1]?data)
 };


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

A file-backed binary value (`BinaryValueFromFile`, e.g. from `request:get-uploaded-file-data` or `file:read-binary`) that is nested inside a map (or array) held by a sequence could have its file channel closed while it was still referenced — after which any read failed with *"Underlying channel has been closed"*. The most visible symptom: a multipart upload stored through a routing framework (Roaster / existdb-openapi `POST /api/db/.../install`) failed at `xmldb:store` with:

```
error while obtaining length of binary value <filename>
```

## Root cause

The general-purpose value sequences checked only direct reference equality and did **not** recurse into items that are themselves containers — unlike `MapType.containsReference` and `ArrayType.containsReference`, which both do `value == item || value.containsReference(item)`:

```java
// e.g. ValueSequence (before)
public boolean containsReference(final Item item) {
    for (int i = 0; i <= size; i++) {
        if (values[i] == item) {       // direct items only
            return true;
        }
    }
    return false;
}
```

`containsReference` is the guard eXist uses to avoid destroying a value that is part of a result. When a `let`/function scope pops, `XQueryContext.popLocalVariables` → `VariableImpl.destroy` → `<sequence>.destroy` → `<value>.destroy(context, contextSequence)`, and `BinaryValueFromFile.destroy` only skips closing when `contextSequence.containsReference(this)`. For a binary returned **nested in a map inside a sequence**, that check returned `false`, so the channel was closed even though the value was still reachable through the returned map.

**Five general-purpose sequence types** had this gap: `ValueSequence`, `ArrayListValueSequence`, `OrderedValueSequence`, `PreorderedValueSequence`, and `SubSequence` — any of which can be the `contextSequence` while holding a map/array. (`MapType`/`ArrayType` already recurse correctly; `RangeSequence` holds only integers and every `NodeSet` holds only nodes, so none of those can nest a map/array.)

This is precisely the path the Roaster / existdb-openapi multipart upload tripped: `request:get-uploaded-file-data` is carried as `$request?body?file?data` (Roaster's form-data binary shape, `map { name, data, size }` produced by `for ... return map { "data": $data[$index] }`), and the deferred handler's `xmldb:store` then read a value whose channel had already been closed by the enclosing function's variable cleanup.

## Fix

Make each affected sequence's `containsReference` recurse into container items, mirroring `MapType`/`ArrayType`:

```java
if (i == item || (i instanceof Sequence seq && seq.containsReference(item))) {
```

## How it was found

Reproduced end-to-end against the **real Roaster `body:parse`** deployed into a local eXist, instrumenting `BinaryValueFromFile` to capture the close-site. The close fired from `popLocalVariables → destroy` with `containsReference` returning `false` on a `ValueSequence` of maps; the fix flips it to `true` and the upload stores cleanly. Reduced to a pure-XQuery / direct unit-test case, then a `containsReference` audit of every `Sequence` implementation found the four sibling types with the identical gap.

## What changed

- `exist-core/.../xquery/value/{ValueSequence, ArrayListValueSequence, OrderedValueSequence, PreorderedValueSequence, SubSequence}.java` — `containsReference` recurses into nested container items.

## Test plan

- [x] `ContainsReferenceNestedTest` (unit): asserts `ValueSequence`, `ArrayListValueSequence` and `SubSequence` detect an item nested in a map (and don't report an unrelated item). Each fails without the fix. `OrderedValueSequence`/`PreorderedValueSequence` take the identical one-line change (their `OrderSpec` construction is not exercised directly).
- [x] `FileBinaryNestedInMapTest` (file module): a `file:read-binary` value returned nested in a map inside a sequence from a function, then read. Fails with *"Underlying channel has been closed"* before the fix, passes after.
- [x] Verified end-to-end against the real Roaster multipart route (stores byte-identical, no error).
- [x] Codacy/PMD clean on the changed methods (pre-existing findings elsewhere in those files are untouched).

## Notes

- Sibling of #6506 (`BinaryValueFromFile` shared-reference refcounting, the *enclosed-expression* premature-close path). Both are "file-backed binary closed while still referenced", but distinct root causes in different files; this one is the multipart/`xmldb:store` symptom. Neither fixes the other; both are needed.
