### PR TITLE
[feature] Resource-naming contract prototype: decisions 1, 2, 3, 5 (draft illustration for #6463)

### DIFF
--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -86,6 +86,7 @@ import org.exist.xmlrpc.function.XmlRpcDocumentFunction;
 import org.exist.xmlrpc.function.XmlRpcFunction;
 import org.exist.xquery.*;
 import org.exist.xquery.util.HTTPUtils;
+import org.exist.xquery.util.URIUtils;
 import org.exist.xquery.value.*;
 import org.exist.xupdate.Modification;
 import org.exist.xupdate.XUpdateProcessor;
@@ -468,7 +469,10 @@ public class RpcConnection implements RpcAPI {
                         final Permission perms = doc.getPermissions();
 
                         final Map<String, Object> hash = new HashMap<>(5);
-                        hash.put("name", doc.getFileURI().toString());
+                        // Resource-naming contract (eXist-db/exist#6463, decision 1): XML-RPC is a
+                        // decoded-string protocol, so names are returned in decoded display form,
+                        // not the percent-encoded stored form. See URIUtils.decodeForURI.
+                        hash.put("name", URIUtils.decodeForURI(doc.getFileURI().toString()));
                         hash.put("owner", perms.getOwner().getName());
                         hash.put("group", perms.getGroup().getName());
                         hash.put("permissions", perms.getMode());
@@ -477,14 +481,14 @@ public class RpcConnection implements RpcAPI {
                     }
                 }
                 for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-                    collections.add(i.next().toString());
+                    collections.add(URIUtils.decodeForURI(i.next().toString()));
                 }
             }
 
             final Permission perms = collection.getPermissionsNoLock();
             desc.put("collections", collections);
             desc.put("documents", docs);
-            desc.put("name", collection.getURI().toString());
+            desc.put("name", URIUtils.decodeForURI(collection.getURI().toString()));
             desc.put("created", Long.toString(collection.getCreated()));
             desc.put("owner", perms.getOwner().getName());
             desc.put("group", perms.getGroup().getName());
@@ -510,7 +514,7 @@ public class RpcConnection implements RpcAPI {
             return this.<Map<String, Object>>readDocument(resourceUri).apply((document, broker, transaction) -> {
                 final Map<String, Object> hash = new HashMap<>(11);
                 final Permission perms = document.getPermissions();
-                hash.put("name", resourceUri.toString());
+                hash.put("name", URIUtils.decodeForURI(resourceUri.toString()));
                 hash.put("owner", perms.getOwner().getName());
                 hash.put("group", perms.getGroup().getName());
                 hash.put("permissions", perms.getMode());
@@ -576,12 +580,12 @@ public class RpcConnection implements RpcAPI {
             final List<String> collections = new ArrayList<>();
             if (collection.getPermissionsNoLock().validate(user, Permission.READ)) {
                 for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-                    collections.add(i.next().toString());
+                    collections.add(URIUtils.decodeForURI(i.next().toString()));
                 }
             }
             final Permission perms = collection.getPermissionsNoLock();
             desc.put("collections", collections);
-            desc.put("name", collection.getURI().toString());
+            desc.put("name", URIUtils.decodeForURI(collection.getURI().toString()));
             desc.put("created", Long.toString(collection.getCreated()));
             desc.put("owner", perms.getOwner().getName());
             desc.put("group", perms.getGroup().getName());
@@ -967,7 +971,7 @@ public class RpcConnection implements RpcAPI {
             return this.<List<String>>readCollection(collUri).apply((collection, broker, transaction) -> {
                 final List<String> list = new ArrayList<>();
                 for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-                    list.add(i.next().toString());
+                    list.add(URIUtils.decodeForURI(i.next().toString()));
                 }
                 return list;
             });
@@ -988,7 +992,7 @@ public class RpcConnection implements RpcAPI {
             return this.<List<String>>readCollection(collUri).apply((collection, broker, transaction) -> {
                 final List<String> list = new ArrayList<>();
                 for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
-                    list.add(i.next().getFileURI().toString());
+                    list.add(URIUtils.decodeForURI(i.next().getFileURI().toString()));
                 }
                 return list;
             });

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -34,6 +34,7 @@ import org.exist.storage.lock.LockManager;
 import org.exist.storage.lock.ManagedDocumentLock;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.util.URIUtils;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.xmldb.XMLDBModule;
 import org.exist.xquery.value.*;
@@ -81,7 +82,15 @@ public class ExtCollection extends BasicFunction {
         if (args.length == 0 || args[0].isEmpty()) {
             collectionUri = null;
         } else {
-            collectionUri = asUri(args[0].itemAt(0).getStringValue());
+            final String raw = args[0].itemAt(0).getStringValue();
+            // Resource-naming contract (eXist-db/exist#6463, decisions 1 + 2 + 5): canonicalize a bare
+            // db-path to its stored key by decode-then-encode, so collection("/db/x/café-col") and a
+            // literal '%' resolve, mirroring fn:doc. A scheme-ful URI (xmldb:, file:, ...) is left
+            // untouched so its scheme/authority are not rewritten.
+            final String effective = raw.startsWith(XmldbURI.ROOT_COLLECTION)
+                    ? URIUtils.encodePathForURILenient(URIUtils.decodePathForURI(raw))
+                    : raw;
+            collectionUri = asUri(effective);
         }
 
         return getCollectionItems(new URI[] { collectionUri });

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -122,7 +122,17 @@ public class ExtCollection extends BasicFunction {
 
         } else {
             final MutableDocumentSet ndocs = new DefaultDocumentSet();
-            final XmldbURI uri = XmldbURI.create(collectionUri);
+            final XmldbURI uri;
+            try {
+                // Resource-naming contract (eXist-db/exist#6463, decision 5): normalize the
+                // collection path the way xmldb:store/create-collection do, so
+                // collection("/db/café-col") resolves the stored key. escape=true encodes
+                // non-ASCII/space and leaves a literal '%' alone, so it is idempotent on an
+                // already-encoded path.
+                uri = XmldbURI.xmldbUriFor(collectionUri.toString(), true);
+            } catch (final URISyntaxException e) {
+                throw new XPathException(this, ErrorCodes.FODC0004, e);
+            }
             try (final Collection coll = context.getBroker().openCollection(uri, Lock.LockMode.READ_LOCK)) {
                 if (coll == null) {
                     if (context.isRaiseErrorOnFailedRetrieval()) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDocAvailable.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDocAvailable.java
@@ -96,7 +96,13 @@ public class FunDocAvailable extends Function {
             try {
                 new URI(path);
             } catch (final URISyntaxException e) {
-                throw new XPathException(this, ErrorCodes.FODC0005, e.getMessage(), arg, e);
+                // A bare db-path may contain a character (e.g. a raw space) that is a valid resource
+                // name under the resource-naming contract (eXist-db/exist#6463, decision 3) but not a
+                // valid java.net.URI; defer to DocUtils, which normalizes and resolves it. Any other
+                // malformed URI keeps the spec-mandated FODC0005.
+                if (!DocUtils.isDbPath(path)) {
+                    throw new XPathException(this, ErrorCodes.FODC0005, e.getMessage(), arg, e);
+                }
             }
 
             try {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.functions.xmldb;
 
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.StringTokenizer;
 
@@ -28,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.xmldb.LocalCollection;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xmldb.txn.bridge.InTxnLocalCollection;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Expression;
@@ -71,7 +73,22 @@ public abstract class XMLDBAbstractCollectionManipulator extends BasicFunction {
 
     public static LocalCollection getLocalCollection(final Expression callingExpression, final XQueryContext context, final String name) throws XMLDBException {
         try {
-            return new InTxnLocalCollection(context.getSubject(), context.getBroker().getBrokerPool(), null, execAndAddErrorIfMissing(callingExpression, () -> new AnyURIValue(name).toXmldbURI()));
+            return new InTxnLocalCollection(context.getSubject(), context.getBroker().getBrokerPool(), null, execAndAddErrorIfMissing(callingExpression, () -> {
+                try {
+                    // Resource-naming contract (eXist-db/exist#6463, decision 5): resolve the collection
+                    // path with escape=true -- the same codec XmldbURI.create / xmldb:store apply when a
+                    // collection is written -- so a caller's decoded or descriptor-derived literal path
+                    // (e.g. "/db/system/repo/badver-${app.version}") resolves the percent-encoded key that
+                    // was actually stored ("badver-$%7Bapp.version%7D"). AnyURIValue.toXmldbURI() resolved
+                    // with escape=false, so an awkward name either missed or threw on a raw illegal char.
+                    // escape=true leaves a literal '%' alone, so it is idempotent on an already-encoded
+                    // path (such as the internal collection URI passed by the node branch of eval()).
+                    return XmldbURI.xmldbUriFor(name, true);
+                } catch (final URISyntaxException e) {
+                    throw new XPathException(callingExpression, org.exist.xquery.ErrorCodes.FORG0001,
+                            "failed to convert '" + name + "' into an XmldbURI: " + e.getMessage(), e);
+                }
+            }));
         } catch (final XPathException e) {
             throw new XMLDBException(ErrorCodes.INVALID_URI, e);
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
@@ -34,6 +34,7 @@ import org.exist.xquery.Expression;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
+import org.exist.xquery.util.URIUtils;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.NodeValue;
@@ -192,7 +193,10 @@ public abstract class XMLDBAbstractCollectionManipulator extends BasicFunction {
 
     protected final Collection createCollectionPath(final Collection parentColl, final String relPath) throws XMLDBException, XPathException {
         Collection current = parentColl;
-        final StringTokenizer tok = new StringTokenizer(execAndAddErrorIfMissing(this, () -> new AnyURIValue(relPath).toXmldbURI().toString()), "/");
+        // Resource-naming contract (eXist-db/exist#6463): relPath is a decoded display path.
+        // Encode each segment once into its canonical stored form (escaping %, space, non-ASCII;
+        // sub-delimiters left literal) so a literal '%' round-trips and raw spaces are accepted.
+        final StringTokenizer tok = new StringTokenizer(URIUtils.encodePathForURILenient(relPath), "/");
         while (tok.hasMoreTokens()) {
             final String token = tok.nextToken();
             current = createCollection(current, token);

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
@@ -75,15 +75,16 @@ public abstract class XMLDBAbstractCollectionManipulator extends BasicFunction {
         try {
             return new InTxnLocalCollection(context.getSubject(), context.getBroker().getBrokerPool(), null, execAndAddErrorIfMissing(callingExpression, () -> {
                 try {
-                    // Resource-naming contract (eXist-db/exist#6463, decision 5): resolve the collection
-                    // path with escape=true -- the same codec XmldbURI.create / xmldb:store apply when a
-                    // collection is written -- so a caller's decoded or descriptor-derived literal path
-                    // (e.g. "/db/system/repo/badver-${app.version}") resolves the percent-encoded key that
-                    // was actually stored ("badver-$%7Bapp.version%7D"). AnyURIValue.toXmldbURI() resolved
-                    // with escape=false, so an awkward name either missed or threw on a raw illegal char.
-                    // escape=true leaves a literal '%' alone, so it is idempotent on an already-encoded
-                    // path (such as the internal collection URI passed by the node branch of eval()).
-                    return XmldbURI.xmldbUriFor(name, true);
+                    // Resource-naming contract (eXist-db/exist#6463, decisions 1 + 2 + 5): canonicalize
+                    // the collection path to its stored key by decode-then-encode -- the same mapping
+                    // fn:doc / fn:collection apply -- so a caller's decoded or descriptor-derived literal
+                    // path (e.g. "/db/system/repo/badver-${app.version}") resolves the percent-encoded key
+                    // that was actually stored ("badver-$%7Bapp.version%7D"), and a literal '%' resolves by
+                    // its decoded form. AnyURIValue.toXmldbURI() resolved with escape=false, so an awkward
+                    // name either missed or threw on a raw illegal char. decodeForURI is the exact inverse
+                    // of encodeForURILenient, so this is idempotent on an already-encoded path (such as the
+                    // internal collection URI passed by the node branch of eval()).
+                    return XmldbURI.xmldbUriFor(URIUtils.encodePathForURILenient(URIUtils.decodePathForURI(name)), false);
                 } catch (final URISyntaxException e) {
                     throw new XPathException(callingExpression, org.exist.xquery.ErrorCodes.FORG0001,
                             "failed to convert '" + name + "' into an XmldbURI: " + e.getMessage(), e);

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -42,11 +42,10 @@ import org.exist.util.MimeType;
 import org.exist.util.io.TemporaryFileManager;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xmldb.EXistResource;
-import org.exist.xquery.Expression;
+import org.exist.xquery.util.URIUtils;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
-import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.BinaryValue;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -64,7 +63,6 @@ import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.XMLResource;
 
 import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
 import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignature;
 import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignatures;
 
@@ -129,13 +127,15 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
     @Override
     public Sequence evalWithCollection(Collection collection, Sequence[] args, Sequence contextSequence) throws XPathException {
 
-        final Expression expression = this;
         String docName = args[1].isEmpty() ? null : args[1].getStringValue();
         if (docName != null && docName.isEmpty()) {
             docName = null;
         } else if (docName != null) {
-            final String localDocName = docName;
-            docName = execAndAddErrorIfMissing(this, () -> new AnyURIValue(expression, localDocName).toXmldbURI().toString());
+            // Resource-naming contract (eXist-db/exist#6463): the name argument is a decoded
+            // display name. Encode it exactly once into its canonical stored form -- escaping
+            // control characters, space, non-ASCII, and a literal '%' (to %25), while leaving
+            // sub-delimiters literal -- so a literal '%' round-trips and a raw space is accepted.
+            docName = URIUtils.encodeForURILenient(docName);
         }
 
         final Item item = args[2].itemAt(0);

--- a/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
@@ -136,10 +136,27 @@ public class DocUtils {
                 }
                 return new URI(baseStr).resolve(relativePath).toString();
             }
-        } catch (final URISyntaxException | XPathException e) {
-            // fall through
+        } catch (final URISyntaxException | IllegalArgumentException | XPathException e) {
+            // IllegalArgumentException: URI.create(relativePath) (called by URI.resolve) rejects a db
+            // resource name containing a raw space or similar -- a valid name under the resource-naming
+            // contract (eXist-db/exist#6463, decision 3). Fall through; the caller passes the original
+            // path (not this resolved form) to the DB branch, which normalizes and resolves it.
         }
         return null;
+    }
+
+    /**
+     * Whether {@code path} addresses a database resource (an absolute {@code /db} path or an
+     * {@code xmldb:} URI). Used to scope the resource-naming contract's read-side leniency
+     * (eXist-db/exist#6463, decision 3): a db resource name may contain a character that is not valid
+     * in a {@link URI} but is a valid name, so a parse failure on such a path should defer to the DB
+     * normalization rather than raise {@code FODC0005}; any other malformed URI is a genuine error.
+     *
+     * @param path the path argument to {@code fn:doc} / {@code fn:doc-available}
+     * @return true if the path targets the database
+     */
+    public static boolean isDbPath(final String path) {
+        return path.startsWith(XmldbURI.ROOT_COLLECTION) || path.startsWith(XmldbURI.XMLDB_URI_PREFIX);
     }
 
     private static @Nullable Sequence getFromDynamicallyAvailableDocuments(final XQueryContext context, final String path, @Nullable final Expression expression) throws XPathException {
@@ -157,6 +174,14 @@ public class DocUtils {
             }
             return context.getDynamicallyAvailableDocument(uri.toString());
         } catch (final URISyntaxException e) {
+            // A bare db-path may contain a character (e.g. a raw space) that is a valid resource name
+            // under the resource-naming contract (eXist-db/exist#6463, decision 3) but not a valid
+            // java.net.URI. Such a path cannot be a key in the dynamically-available-documents map
+            // (which is keyed by valid URIs), so skip that lookup and let the DB branch normalize
+            // (escape=true) and resolve it. Any other malformed URI keeps the spec-mandated FODC0005.
+            if (isDbPath(path)) {
+                return null;
+            }
             throw new XPathException(expression, ErrorCodes.FODC0005, e);
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
@@ -245,16 +245,20 @@ public class DocUtils {
         try {
             final XmldbURI baseURI = context.getBaseURI().toXmldbURI();
             final XmldbURI pathUri;
-            // Resource-naming contract (eXist-db/exist#6463, decision 5): normalize a bare db-path
-            // the way xmldb:store already normalizes a name, so doc("/db/x/café.xml") resolves the
-            // same key xmldb:store wrote. escape=true encodes non-ASCII/space and leaves a literal
-            // '%' alone -- so it is idempotent on an already-encoded path (e.g. one produced by
-            // xmldb:encode-uri), which still resolves as before.
+            // Resource-naming contract (eXist-db/exist#6463, decisions 1 + 2 + 5): canonicalize the
+            // db-path to the key xmldb:store wrote by treating it as decoded UTF-8 (decision 1) and
+            // re-encoding it leniently. decode-then-encode maps BOTH a decoded display name and an
+            // already-encoded path to the same stored key, so doc("/db/x/café.xml") and
+            // doc("/db/x/caf%C3%A9.xml") both resolve cafe.xml; and a literal '%' name resolves by its
+            // decoded form -- doc("/db/x/50%.xml") -> 50%25.xml (decision 2, read side). decodeForURI is
+            // the exact inverse of encodeForURILenient and never throws/truncates, so this is idempotent
+            // on the canonical stored form (the case a pre-encoding caller such as xmldb:encode-uri hits).
+            final String canonicalPath = URIUtils.encodePathForURILenient(URIUtils.decodePathForURI(path));
             if (baseURI != null && !(baseURI.equals("") || baseURI.equals("/db"))) {
                 // relative collection Path: add the current base URI
-                pathUri = baseURI.resolveCollectionPath(XmldbURI.xmldbUriFor(path, true));
+                pathUri = baseURI.resolveCollectionPath(XmldbURI.xmldbUriFor(canonicalPath, false));
             } else {
-                pathUri = XmldbURI.xmldbUriFor(path, true);
+                pathUri = XmldbURI.xmldbUriFor(canonicalPath, false);
             }
 
             // relative collection Path: add the current module call URI if applicable

--- a/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/DocUtils.java
@@ -220,11 +220,16 @@ public class DocUtils {
         try {
             final XmldbURI baseURI = context.getBaseURI().toXmldbURI();
             final XmldbURI pathUri;
+            // Resource-naming contract (eXist-db/exist#6463, decision 5): normalize a bare db-path
+            // the way xmldb:store already normalizes a name, so doc("/db/x/café.xml") resolves the
+            // same key xmldb:store wrote. escape=true encodes non-ASCII/space and leaves a literal
+            // '%' alone -- so it is idempotent on an already-encoded path (e.g. one produced by
+            // xmldb:encode-uri), which still resolves as before.
             if (baseURI != null && !(baseURI.equals("") || baseURI.equals("/db"))) {
                 // relative collection Path: add the current base URI
-                pathUri = baseURI.resolveCollectionPath(XmldbURI.xmldbUriFor(path, false));
+                pathUri = baseURI.resolveCollectionPath(XmldbURI.xmldbUriFor(path, true));
             } else {
-                pathUri = XmldbURI.xmldbUriFor(path, false);
+                pathUri = XmldbURI.xmldbUriFor(path, true);
             }
 
             // relative collection Path: add the current module call URI if applicable

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -286,15 +286,19 @@ public class URIUtils {
 	/**
 	 * Encodes a single resource/collection NAME segment into its canonical stored form under the
 	 * proposed resource-naming contract (see eXist-db/exist#6463, decision 2). This is the
-	 * "lenient" encoding: it percent-encodes only what storage requires to be unambiguous --
-	 * control characters, space, non-ASCII (as UTF-8 bytes), the path separator {@code '/'}
-	 * ({@code %2F}) and, crucially, a literal percent sign {@code '%'} ({@code %25}) -- while
-	 * leaving sub-delimiters and other printable ASCII (e.g. {@code & + ' ( ) @ , ; = $ [ ]})
-	 * literal. Leaving sub-delimiters literal keeps human-friendly names such as {@code it's.xml}
-	 * and {@code a+b.xml} readable in storage (the eXide#824 direction); always escaping
-	 * {@code '%'} as {@code %25} is what makes the encoding bijective, so a literal percent in a
-	 * name ({@code 50%.xml}, {@code a%20b.xml}) is distinguishable from a percent-escape and is
-	 * recovered exactly by {@link #decodeForURI(String)}.
+	 * "lenient" encoding: it keeps literal exactly the RFC 3986 "pchar" set that may appear
+	 * unescaped in a path segment -- unreserved ({@code - . _ ~}), sub-delimiters
+	 * ({@code ! $ & ' ( ) * + , ; =}), and {@code ':'} and {@code '@'} -- and percent-encodes
+	 * everything else: control characters, space, non-ASCII (as UTF-8 bytes), the path separator
+	 * {@code '/'} ({@code %2F}), the gen-delimiters {@code '#'} ({@code %23}), {@code '?'}
+	 * ({@code %3F}), {@code '['}/{@code ']'}, and, crucially, a literal percent sign {@code '%'}
+	 * ({@code %25}). Keeping sub-delimiters literal makes human-friendly names such as
+	 * {@code it's.xml} and {@code a+b.xml} readable in storage (the eXide#824 direction); encoding
+	 * {@code '#'} and {@code '?'} (which a URL path segment must escape) makes the stored form match
+	 * what the REST and WebDAV surfaces put on the wire, so all surfaces converge on one key; and
+	 * always escaping {@code '%'} as {@code %25} is what makes the encoding bijective, so a literal
+	 * percent in a name ({@code 50%.xml}, {@code a%20b.xml}) is distinguishable from a percent-escape
+	 * and is recovered exactly by {@link #decodeForURI(String)}.
 	 *
 	 * <p>This differs from {@link #iriToURI(String)} in exactly the two respects required for
 	 * bijectivity of a single name segment: {@code '/'} is NOT left literal (a slash inside a
@@ -317,27 +321,30 @@ public class URIUtils {
 		// space -> %20 and / -> %2F. We then restore to literal only the lenient "keep" set,
 		// deliberately leaving %25 (literal percent) and %2F (literal slash) escaped.
 		String result = urlEncodeUtf8(nameSegment);
-		result = result.replace("%23", "#");
+		// Restore to literal exactly the RFC 3986 "pchar" set that may appear unescaped in a path
+		// segment: unreserved (- . _ ~), sub-delimiters (! $ & ' ( ) * + , ; =), and ':' '@'.
+		// Everything else stays percent-encoded -- in particular %25 (literal percent), %2F (slash),
+		// %23 (#), %3F (?), %5B/%5D ([ ]) and space/non-ASCII. Keeping '#' and '?' encoded is what
+		// makes this match the form a standards-compliant HTTP client (and therefore the REST and
+		// WebDAV surfaces) put on the wire, so xmldb:store and the HTTP surfaces converge on one
+		// canonical stored key. See ResourceNamingConformanceTest (stored-form oracle).
 		result = result.replace("%2D", "-");
 		result = result.replace("%5F", "_");
 		result = result.replace("%2E", ".");
-		result = result.replace("%21", "!");
 		result = result.replace("%7E", "~");
-		result = result.replace("%2A", "*");
+		result = result.replace("%21", "!");
+		result = result.replace("%24", "$");
+		result = result.replace("%26", "&");
 		result = result.replace("%27", "'");
 		result = result.replace("%28", "(");
 		result = result.replace("%29", ")");
+		result = result.replace("%2A", "*");
+		result = result.replace("%2B", "+");
+		result = result.replace("%2C", ",");
 		result = result.replace("%3B", ";");
-		result = result.replace("%3F", "?");
+		result = result.replace("%3D", "=");
 		result = result.replace("%3A", ":");
 		result = result.replace("%40", "@");
-		result = result.replace("%26", "&");
-		result = result.replace("%3D", "=");
-		result = result.replace("%2B", "+");
-		result = result.replace("%24", "$");
-		result = result.replace("%2C", ",");
-		result = result.replace("%5B", "[");
-		result = result.replace("%5D", "]");
 		return result;
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -288,10 +288,12 @@ public class URIUtils {
 	 * proposed resource-naming contract (see eXist-db/exist#6463, decision 2). This is the
 	 * "lenient" encoding: it keeps literal exactly the RFC 3986 "pchar" set that may appear
 	 * unescaped in a path segment -- unreserved ({@code - . _ ~}), sub-delimiters
-	 * ({@code ! $ & ' ( ) * + , ; =}), and {@code ':'} and {@code '@'} -- and percent-encodes
-	 * everything else: control characters, space, non-ASCII (as UTF-8 bytes), the path separator
-	 * {@code '/'} ({@code %2F}), the gen-delimiters {@code '#'} ({@code %23}), {@code '?'}
-	 * ({@code %3F}), {@code '['}/{@code ']'}, and, crucially, a literal percent sign {@code '%'}
+	 * ({@code ! $ & ' ( ) * + , ; =}), and {@code '@'} -- and percent-encodes everything else:
+	 * control characters, space, non-ASCII (as UTF-8 bytes), the path separator {@code '/'}
+	 * ({@code %2F}), the gen-delimiters {@code '#'} ({@code %23}), {@code '?'} ({@code %3F}),
+	 * {@code '['}/{@code ']'}, {@code ':'} ({@code %3A}, which RFC 3986 permits in a segment but
+	 * eXist's {@code XmldbURI} cannot store literally -- {@code new URI("a:b")} reads {@code a} as a
+	 * scheme), and, crucially, a literal percent sign {@code '%'}
 	 * ({@code %25}). Keeping sub-delimiters literal makes human-friendly names such as
 	 * {@code it's.xml} and {@code a+b.xml} readable in storage (the eXide#824 direction); encoding
 	 * {@code '#'} and {@code '?'} (which a URL path segment must escape) makes the stored form match
@@ -321,10 +323,10 @@ public class URIUtils {
 		// space -> %20 and / -> %2F. We then restore to literal only the lenient "keep" set,
 		// deliberately leaving %25 (literal percent) and %2F (literal slash) escaped.
 		String result = urlEncodeUtf8(nameSegment);
-		// Restore to literal exactly the RFC 3986 "pchar" set that may appear unescaped in a path
-		// segment: unreserved (- . _ ~), sub-delimiters (! $ & ' ( ) * + , ; =), and ':' '@'.
+		// Restore to literal the RFC 3986 "pchar" set that may appear unescaped in a path segment,
+		// MINUS ':' (see below): unreserved (- . _ ~), sub-delimiters (! $ & ' ( ) * + , ; =), '@'.
 		// Everything else stays percent-encoded -- in particular %25 (literal percent), %2F (slash),
-		// %23 (#), %3F (?), %5B/%5D ([ ]) and space/non-ASCII. Keeping '#' and '?' encoded is what
+		// %23 (#), %3F (?), %3A (:), %5B/%5D ([ ]) and space/non-ASCII. Keeping '#' and '?' encoded is what
 		// makes this match the form a standards-compliant HTTP client (and therefore the REST and
 		// WebDAV surfaces) put on the wire, so xmldb:store and the HTTP surfaces converge on one
 		// canonical stored key. See ResourceNamingConformanceTest (stored-form oracle).
@@ -343,8 +345,11 @@ public class URIUtils {
 		result = result.replace("%2C", ",");
 		result = result.replace("%3B", ";");
 		result = result.replace("%3D", "=");
-		result = result.replace("%3A", ":");
 		result = result.replace("%40", "@");
+		// NOTE: ':' (%3A) is deliberately NOT restored. Although RFC 3986 permits ':' in a path
+		// segment, eXist's XmldbURI wraps java.net.URI, and a leading-segment ':' makes new URI
+		// parse the text before it as a scheme ("a:b" -> scheme "a") -- so a literal ':' is not
+		// storable. Encoding it as %3A is required for ':'-containing names to round-trip.
 		return result;
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -273,7 +273,186 @@ public class URIUtils {
 		result = result.replaceAll("%25", "%");
 		return result;
 	}
-	
+
+	// =========================================================================================
+	// Resource-naming contract prototype (eXist-db/exist#6463, decision 2: literal '%')
+	//
+	// The pair {encodeForURILenient, decodeForURI} below is the canonical store/display codec
+	// for a single resource or collection NAME segment under the proposed contract. It is the
+	// "Unicode-all-the-way, sub-delimiters-literal" direction, extended to be BIJECTIVE so that a
+	// literal percent sign in a name round-trips. The keystone test is ResourceNameCodecTest.
+	// =========================================================================================
+
+	/**
+	 * Encodes a single resource/collection NAME segment into its canonical stored form under the
+	 * proposed resource-naming contract (see eXist-db/exist#6463, decision 2). This is the
+	 * "lenient" encoding: it percent-encodes only what storage requires to be unambiguous --
+	 * control characters, space, non-ASCII (as UTF-8 bytes), the path separator {@code '/'}
+	 * ({@code %2F}) and, crucially, a literal percent sign {@code '%'} ({@code %25}) -- while
+	 * leaving sub-delimiters and other printable ASCII (e.g. {@code & + ' ( ) @ , ; = $ [ ]})
+	 * literal. Leaving sub-delimiters literal keeps human-friendly names such as {@code it's.xml}
+	 * and {@code a+b.xml} readable in storage (the eXide#824 direction); always escaping
+	 * {@code '%'} as {@code %25} is what makes the encoding bijective, so a literal percent in a
+	 * name ({@code 50%.xml}, {@code a%20b.xml}) is distinguishable from a percent-escape and is
+	 * recovered exactly by {@link #decodeForURI(String)}.
+	 *
+	 * <p>This differs from {@link #iriToURI(String)} in exactly the two respects required for
+	 * bijectivity of a single name segment: {@code '/'} is NOT left literal (a slash inside a
+	 * name is data, not a separator), and {@code '%'} is NOT un-escaped back from {@code %25}. It
+	 * differs from {@link #encodeForURI(String)} (the strict RFC 3986 path-component encoder) only
+	 * in that the strict encoder additionally escapes sub-delimiters ({@code it's -> it%27s});
+	 * both escape {@code '%'}.</p>
+	 *
+	 * <p>This encoding is deliberately NOT idempotent: {@code encodeForURILenient("50%")} is
+	 * {@code "50%25"} and encoding that again is {@code "50%2525"}. The contract therefore
+	 * requires it be applied EXACTLY ONCE, at the boundary where a decoded display name enters
+	 * storage.</p>
+	 *
+	 * @param nameSegment the literal (decoded) resource or collection name segment.
+	 *
+	 * @return the canonical percent-encoded stored form of the name segment.
+	 */
+	public static String encodeForURILenient(final String nameSegment) {
+		// urlEncodeUtf8 escapes EVERYTHING that is not unreserved, including % -> %25,
+		// space -> %20 and / -> %2F. We then restore to literal only the lenient "keep" set,
+		// deliberately leaving %25 (literal percent) and %2F (literal slash) escaped.
+		String result = urlEncodeUtf8(nameSegment);
+		result = result.replace("%23", "#");
+		result = result.replace("%2D", "-");
+		result = result.replace("%5F", "_");
+		result = result.replace("%2E", ".");
+		result = result.replace("%21", "!");
+		result = result.replace("%7E", "~");
+		result = result.replace("%2A", "*");
+		result = result.replace("%27", "'");
+		result = result.replace("%28", "(");
+		result = result.replace("%29", ")");
+		result = result.replace("%3B", ";");
+		result = result.replace("%3F", "?");
+		result = result.replace("%3A", ":");
+		result = result.replace("%40", "@");
+		result = result.replace("%26", "&");
+		result = result.replace("%3D", "=");
+		result = result.replace("%2B", "+");
+		result = result.replace("%24", "$");
+		result = result.replace("%2C", ",");
+		result = result.replace("%5B", "[");
+		result = result.replace("%5D", "]");
+		return result;
+	}
+
+	/**
+	 * Encodes a whole {@code '/'}-delimited resource PATH by applying {@link #encodeForURILenient}
+	 * to each segment and rejoining with {@code '/'}. Slashes are treated as separators; a literal
+	 * slash that is part of a name is not representable at the path level (it must be handled a
+	 * segment at a time via {@link #encodeForURILenient}).
+	 *
+	 * @param path the literal (decoded) resource path, e.g. {@code /db/data/café.xml}.
+	 *
+	 * @return the canonical stored form of the path, e.g. {@code /db/data/caf%C3%A9.xml}.
+	 */
+	public static String encodePathForURILenient(final String path) {
+		final String[] segments = path.split("/", -1);
+		final StringBuilder out = new StringBuilder(path.length());
+		for (int i = 0; i < segments.length; i++) {
+			out.append(encodeForURILenient(segments[i]));
+			if (i < segments.length - 1) {
+				out.append('/');
+			}
+		}
+		return out.toString();
+	}
+
+	/**
+	 * Decodes a whole {@code '/'}-delimited stored resource PATH back to its display form by
+	 * applying {@link #decodeForURI} to each segment and rejoining with {@code '/'}.
+	 *
+	 * @param path the percent-encoded stored path, e.g. {@code /db/data/caf%C3%A9.xml}.
+	 *
+	 * @return the display form of the path, e.g. {@code /db/data/café.xml}.
+	 */
+	public static String decodePathForURI(final String path) {
+		final String[] segments = path.split("/", -1);
+		final StringBuilder out = new StringBuilder(path.length());
+		for (int i = 0; i < segments.length; i++) {
+			out.append(decodeForURI(segments[i]));
+			if (i < segments.length - 1) {
+				out.append('/');
+			}
+		}
+		return out.toString();
+	}
+
+	/**
+	 * Decodes a percent-encoded URI path component back to its literal form, the inverse of
+	 * {@link #encodeForURI(String)} and of {@link #encodeForURILenient(String)}. Each
+	 * {@code %XX} escape is decoded to a byte; consecutive escapes are interpreted together as a
+	 * UTF-8 byte sequence. Every other character is left unchanged.
+	 *
+	 * <p>Unlike {@link #urlDecodeUtf8(String)} (which wraps {@link java.net.URLDecoder} and
+	 * therefore follows application/x-www-form-urlencoded rules), this method treats {@code '+'}
+	 * as a literal plus sign, per RFC 3986. This is required for round-tripping names (see
+	 * eXist-db/exist#1824): {@code decodeForURI(encodeForURI(s))} and
+	 * {@code decodeForURI(encodeForURILenient(s))} both equal {@code s} for every {@code s}.</p>
+	 *
+	 * <p>This is deliberately a standalone percent-decoder rather than a call to
+	 * {@link java.net.URI#getPath()}. {@code java.net.URI} is unsuitable as a general decoder for
+	 * the arbitrary strings that resource names may contain: it throws {@code URISyntaxException}
+	 * on inputs that are valid names here (a literal space, a trailing or malformed {@code %},
+	 * characters such as <code>{</code> or <code>}</code>), and worse, it <em>silently
+	 * truncates</em> at {@code '?'} and {@code '#'} -- losing data with no error. This decoder
+	 * never throws and never truncates: any {@code '%'} not followed by two hex digits is
+	 * preserved verbatim.</p>
+	 *
+	 * @param uriComponent the percent-encoded path component to decode.
+	 *
+	 * @return the decoded path component.
+	 */
+	public static String decodeForURI(final String uriComponent) {
+		if (uriComponent.indexOf('%') == -1) {
+			// fast path: nothing percent-encoded, nothing to decode
+			return uriComponent;
+		}
+
+		final int len = uriComponent.length();
+		final StringBuilder out = new StringBuilder(len);
+		final java.io.ByteArrayOutputStream pending = new java.io.ByteArrayOutputStream();
+
+		int i = 0;
+		while (i < len) {
+			final char c = uriComponent.charAt(i);
+			if (c == '%' && i + 2 < len && isHexDigit(uriComponent.charAt(i + 1)) && isHexDigit(uriComponent.charAt(i + 2))) {
+				pending.write((hexValue(uriComponent.charAt(i + 1)) << 4) | hexValue(uriComponent.charAt(i + 2)));
+				i += 3;
+			} else {
+				if (pending.size() > 0) {
+					out.append(pending.toString(UTF_8));
+					pending.reset();
+				}
+				out.append(c);
+				i++;
+			}
+		}
+		if (pending.size() > 0) {
+			out.append(pending.toString(UTF_8));
+		}
+		return out.toString();
+	}
+
+	private static boolean isHexDigit(final char c) {
+		return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+	}
+
+	private static int hexValue(final char c) {
+		if (c >= '0' && c <= '9') {
+			return c - '0';
+		}
+		if (c >= 'A' && c <= 'F') {
+			return c - 'A' + 10;
+		}
+		return c - 'a' + 10;
+	}
+
 	public static String escapeHtmlURI(String uri){
 		String result = urlEncodeUtf8(uri);
 		//TODO : to be continued

--- a/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/XmlRpcTest.java
@@ -31,6 +31,7 @@ import org.exist.security.MessageDigester;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.test.ExistWebServer;
 import org.exist.test.TestConstants;
+import org.exist.xquery.util.URIUtils;
 import org.exist.util.Compressor;
 import org.exist.util.MimeType;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
@@ -651,7 +652,9 @@ public class XmlRpcTest {
         HashMap collection = (HashMap) xmlrpc.execute("describeCollection", params);
         Object[] collections = (Object[]) collection.get("collections");
         boolean foundMatch = false;
-        String targetCollectionName = SPECIAL_COLLECTION.lastSegment().toString();
+        // Resource-naming contract (eXist-db/exist#6463, decision 1): XML-RPC now returns names in
+        // decoded display form, so compare against the decoded last segment, not the stored form.
+        String targetCollectionName = URIUtils.decodeForURI(SPECIAL_COLLECTION.lastSegment().toString());
         for (Object o : collections) {
             String childName = (String) o;
             if (childName.equals(targetCollectionName)) {

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
@@ -327,4 +327,37 @@ public class DocTest {
             assertTrue("expected FODC0005 for " + path + " but got: " + chain, chain.contains("FODC0005"));
         }
     }
+
+    /**
+     * Resource-naming contract (eXist-db/exist#6463, decision 2, read side): a resource whose name
+     * literally contains '%' is stored bijectively (the '%' is escaped to %25, so it never collides
+     * with a real percent-escape), and doc() resolves it by its decoded display name. doc() now
+     * canonicalizes a db-path by decode-then-encode, so doc("/db/test/50%.xml") reaches the 50%25.xml
+     * key; the encoded stored form resolves too (decode-then-encode is idempotent on it). The literal
+     * '%' is no longer deferred -- the write side never loses data, and the read side resolves the name.
+     */
+    @Test
+    public void doc_resolvesLiteralPercentNameByDecodedForm() throws XMLDBException {
+        existEmbeddedServer.executeQuery(
+                "declare variable $c external; declare variable $n external; "
+                        + "xmldb:store($c, $n, document { <pct/> })",
+                Map.of("c", new StringValue("/db/test"), "n", new StringValue("50%.xml")));
+
+        // the bijective lenient store escapes the literal '%' to %25 (no collision, no data loss)
+        final ResourceSet stored = existEmbeddedServer.executeQuery(
+                "xmldb:get-child-resources('/db/test')[contains(., '50%25')]");
+        assertEquals("50%25.xml", stored.getResource(0).getContent());
+
+        // resolve by the DECODED literal name (decision 2, read side, now closed)
+        final ResourceSet byDecoded = existEmbeddedServer.executeQuery(
+                "declare variable $p external; local-name(doc($p)/*)",
+                Map.of("p", new StringValue("/db/test/50%.xml")));
+        assertEquals("pct", byDecoded.getResource(0).getContent());
+
+        // and by the encoded stored form (idempotent)
+        final ResourceSet byEncoded = existEmbeddedServer.executeQuery(
+                "declare variable $p external; local-name(doc($p)/*)",
+                Map.of("p", new StringValue("/db/test/50%25.xml")));
+        assertEquals("pct", byEncoded.getResource(0).getContent());
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
@@ -34,6 +34,7 @@ import org.exist.util.ExistSAXParserFactory;
 import org.exist.xquery.*;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.StringValue;
 import org.junit.*;
 
 import static com.evolvedbinary.j8fu.Either.Left;
@@ -66,6 +67,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 /**
  *
@@ -275,6 +277,54 @@ public class DocTest {
             return Left(saxAdapter.getDocument());
         } catch (final ParserConfigurationException | SAXException | IOException e) {
             throw new XPathException((Expression) null, "Unable to parse document", e);
+        }
+    }
+
+    /**
+     * Resource-naming contract (eXist-db/exist#6463, decision 3, read side): a db resource whose
+     * decoded name contains a raw space is accepted at the write boundary; reading it back by the
+     * decoded absolute db-path must resolve too. Before the fix the read path raised FODC0005 in the
+     * dynamically-available-documents URI check (and IllegalArgumentException in base-uri resolution)
+     * before reaching the decision-5 normalization that escapes the space.
+     */
+    @Test
+    public void doc_resolvesRawSpaceDbPathOnRead() throws XMLDBException {
+        existEmbeddedServer.executeQuery(
+                "declare variable $c external; declare variable $n external; "
+                        + "xmldb:store($c, $n, document { <hit/> })",
+                Map.of("c", new StringValue("/db/test"), "n", new StringValue("with space.xml")));
+
+        final ResourceSet hit = existEmbeddedServer.executeQuery(
+                "declare variable $p external; local-name(doc($p)/*)",
+                Map.of("p", new StringValue("/db/test/with space.xml")));
+        assertEquals("hit", hit.getResource(0).getContent());
+
+        final ResourceSet avail = existEmbeddedServer.executeQuery(
+                "declare variable $p external; doc-available($p)",
+                Map.of("p", new StringValue("/db/test/with space.xml")));
+        assertEquals("true", avail.getResource(0).getContent());
+    }
+
+    /**
+     * The decision-3 read-side rescue must be scoped to db-paths: a genuinely malformed, non-db URI
+     * must still raise FODC0005 (qt3tests fn-doc-17 {@code "%gg"}, K2-SeqDocFunc-7/8/9 Windows
+     * backslash paths, K2-SeqDocFunc-14 {@code ":/"}), not silently fall through to an empty result.
+     */
+    @Test
+    public void doc_malformedNonDbUriStillRaisesFODC0005() {
+        for (final String bad : new String[] {"%gg", "%GG", ":/", "C:\\a\\b.xml", "\\a\\b.xml", "example.com\\x.xml"}) {
+            assertFODC0005(bad);
+        }
+    }
+
+    private static void assertFODC0005(final String path) {
+        try {
+            existEmbeddedServer.executeQuery(
+                    "declare variable $p external; doc($p)", Map.of("p", new StringValue(path)));
+            fail("expected FODC0005 for malformed non-db URI: " + path);
+        } catch (final XMLDBException e) {
+            final String chain = e.getMessage() + " | " + e.getCause();
+            assertTrue("expected FODC0005 for " + path + " but got: " + chain, chain.contains("FODC0005"));
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
@@ -1,0 +1,145 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.xmldb;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xquery.util.URIUtils;
+import org.exist.xquery.value.StringValue;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live round-trip test for surface 1 of the resource-naming contract prototype
+ * (eXist-db/exist#6463): the {@code xmldb:} write boundary. It stores an awkward-name corpus
+ * through the real {@code xmldb:store} / {@code xmldb:create-collection}, reads the stored keys
+ * back via {@code xmldb:get-child-resources} / {@code -collections}, and asserts each stored key is
+ * exactly the canonical lenient form {@link URIUtils#encodeForURILenient(String)} produces and that
+ * it decodes back to the original display name. Distinct names must not collide, and a raw space
+ * must now be accepted (decision 3).
+ *
+ * <p>This complements the pure-codec {@code ResourceNameCodecTest}: that proves the codec; this
+ * proves the {@code xmldb:} functions actually apply it against a real database.</p>
+ */
+public class ResourceNamingXmldbRoundTripTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
+
+    /**
+     * Decoded display names the user types. Each must round-trip; none may collide.
+     */
+    private static final String[] NAMES = {
+            "plain.xml",
+            "hello world.xml",       // raw space (decision 3)
+            "café.xml",
+            "naïve.xml",
+            "it's.xml",              // sub-delimiter, kept literal
+            "a+b.xml",
+            "Jack&Jill.xml",
+            "report(2026).xml",
+            "50%.xml",               // literal percent (decision 2)
+            "a%20b.xml",             // literal percent before hex
+            "%25.xml",
+            "100%done%.xml"
+    };
+
+    @Test
+    public void storeRoundTripsEveryName() throws XMLDBException {
+        final String col = "/db/naming-rt-resources";
+        existEmbeddedServer.executeQuery("xmldb:create-collection('/db', 'naming-rt-resources')");
+
+        for (final String name : NAMES) {
+            // pass the DECODED name; the store boundary must encode it exactly once
+            existEmbeddedServer.executeQuery(
+                    "declare variable $name external; declare variable $col external; "
+                            + "xmldb:store($col, $name, document { <doc/> })",
+                    // wrap in StringValue so the harness does not entity-expand '&' in the name
+                    Map.of("name", new StringValue(name), "col", col));
+        }
+
+        final Set<String> storedKeys = childNames(existEmbeddedServer.executeQuery(
+                "declare variable $col external; xmldb:get-child-resources($col)", Map.of("col", col)));
+
+        assertCorpusRoundTrips(storedKeys, "resource");
+    }
+
+    @Test
+    public void createCollectionRoundTripsEveryName() throws XMLDBException {
+        final String parent = "/db/naming-rt-collections";
+        existEmbeddedServer.executeQuery("xmldb:create-collection('/db', 'naming-rt-collections')");
+
+        for (final String name : NAMES) {
+            existEmbeddedServer.executeQuery(
+                    "declare variable $name external; declare variable $parent external; "
+                            + "xmldb:create-collection($parent, $name)",
+                    Map.of("name", new StringValue(name), "parent", parent));
+        }
+
+        final Set<String> storedKeys = childNames(existEmbeddedServer.executeQuery(
+                "declare variable $parent external; xmldb:get-child-collections($parent)", Map.of("parent", parent)));
+
+        assertCorpusRoundTrips(storedKeys, "collection");
+    }
+
+    private static void assertCorpusRoundTrips(final Set<String> storedKeys, final String kind) {
+        // every name produced exactly the canonical lenient stored form
+        for (final String name : NAMES) {
+            final String expectedStored = URIUtils.encodeForURILenient(name);
+            assertTrue("missing canonical stored " + kind + " " + expectedStored + " for name " + name,
+                    storedKeys.contains(expectedStored));
+        }
+        // no collisions: distinct names -> distinct stored keys
+        assertEquals("distinct " + kind + " names must not collide in storage", NAMES.length, storedKeys.size());
+        // every stored key decodes back to one of the original display names
+        for (final String key : storedKeys) {
+            final String display = URIUtils.decodeForURI(key);
+            assertTrue("stored " + kind + " key " + key + " did not decode to a known name (got " + display + ")",
+                    contains(display));
+        }
+    }
+
+    private static Set<String> childNames(final ResourceSet rs) throws XMLDBException {
+        final Set<String> names = new LinkedHashSet<>();
+        for (long i = 0; i < rs.getSize(); i++) {
+            names.add((String) rs.getResource(i).getContent());
+        }
+        return names;
+    }
+
+    private static boolean contains(final String display) {
+        for (final String name : NAMES) {
+            if (name.equals(display)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
@@ -180,6 +180,36 @@ public class ResourceNamingXmldbRoundTripTest {
                 rs.getResource(0).getContent());
     }
 
+    /**
+     * Characters that macOS/Windows reject in filenames but that the codec either encodes (`< | "`
+     * etc.) or keeps literal (`:` `*`, which are RFC 3986 pchar). eXist's native store is page-based,
+     * not one-file-per-resource, so it should accept all of them; FS-safety only matters at a
+     * backup/export boundary (flagged in the fallout report). This probes that the native store
+     * round-trips them, including the literal `:` and `*`.
+     */
+    @Test
+    public void filesystemHostileCharsRoundTripInNativeStore() throws XMLDBException {
+        final String col = "/db/naming-rt-fschars";
+        existEmbeddedServer.executeQuery("xmldb:create-collection('/db', 'naming-rt-fschars')");
+        final String[] fsNames = {"a:b.xml", "a*b.xml", "a<b.xml", "a|b.xml", "a\"b.xml"};
+        for (final String name : fsNames) {
+            store(col, name);
+        }
+        final Set<String> stored = childNames(existEmbeddedServer.executeQuery(
+                "declare variable $c external; xmldb:get-child-resources($c)", Map.of("c", col)));
+        final Set<String> expected = new LinkedHashSet<>();
+        for (final String name : fsNames) {
+            expected.add(name);
+            assertTrue("native store should accept " + name,
+                    stored.contains(URIUtils.encodeForURILenient(name)));
+        }
+        assertEquals("distinct FS-hostile names must not collide", fsNames.length, stored.size());
+        for (final String key : stored) {
+            assertTrue("stored key " + key + " did not decode to a known name",
+                    expected.contains(URIUtils.decodeForURI(key)));
+        }
+    }
+
     private static void store(final String col, final String name) throws XMLDBException {
         existEmbeddedServer.executeQuery(
                 "declare variable $name external; declare variable $col external; "

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
@@ -145,11 +145,14 @@ public class ResourceNamingXmldbRoundTripTest {
             assertTrue("doc() by stored form should resolve " + name,
                     docExists(col + "/" + URIUtils.encodeForURILenient(name)));
 
-            // A decoded name without a literal '%' resolves directly via the decision-5 normalization
-            // -- including a raw space, now that the read path is normalized on both the doc() and
-            // doc-available() URI checks (decision 3, read side). A literal-'%' name remains ambiguous
-            // (decision 2 boundary): its display form does not resolve and the stored form must be used.
-            final boolean resolvesByDecodedName = name.indexOf('%') < 0;
+            // doc() now canonicalizes a db-path by decode-then-encode (decisions 1 + 2 + 5), so a name
+            // resolves by its decoded display form exactly when decoding is a no-op on it -- i.e. the
+            // name does not itself contain a valid %XX escape. That covers every normal name plus a
+            // literal '%' that is not a valid escape (e.g. "50%.xml", "100%done%.xml"). The irreducible
+            // residual: a name that literally IS a valid escape ("a%20b.xml", "%25.xml") is read as its
+            // decoded meaning ("a b.xml", "%.xml"), so addressing it by that literal form does not reach
+            // its own stored key -- the single-decoded-wire ambiguity, addressable by the encoded form.
+            final boolean resolvesByDecodedName = URIUtils.decodeForURI(name).equals(name);
             assertEquals("doc() resolution by decoded name for " + name,
                     resolvesByDecodedName, docExists(col + "/" + name));
         }

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
@@ -126,6 +126,83 @@ public class ResourceNamingXmldbRoundTripTest {
         }
     }
 
+    /**
+     * Surface 2 (decision 5): doc() resolves a stored document by a bare db-path. A non-percent
+     * decoded name resolves directly (the asymmetry with xmldb:store is fixed); a literal-percent
+     * decoded name is ambiguous and is addressed by its %25 stored form instead (decision 2
+     * boundary). collection() over the collection enumerates every stored document.
+     */
+    @Test
+    public void docResolvesDecodedNames() throws XMLDBException {
+        final String col = "/db/naming-rt-doc";
+        existEmbeddedServer.executeQuery("xmldb:create-collection('/db', 'naming-rt-doc')");
+        for (final String name : NAMES) {
+            store(col, name);
+        }
+
+        for (final String name : NAMES) {
+            // addressing by the canonical stored form always resolves
+            assertTrue("doc() by stored form should resolve " + name,
+                    docExists(col + "/" + URIUtils.encodeForURILenient(name)));
+
+            // A "clean" decoded name (no literal '%', no raw space) resolves directly via the
+            // decision-5 normalization. A literal-'%' name is ambiguous (decision 2 boundary) and a
+            // raw space is rejected on the read path (decision 3, read side, a separate gap); in
+            // both cases the display form does not resolve and the stored form must be used.
+            final boolean clean = name.indexOf('%') < 0 && name.indexOf(' ') < 0;
+            assertEquals("doc() resolution by decoded name for " + name,
+                    clean, docExists(col + "/" + name));
+        }
+
+        final ResourceSet rs = existEmbeddedServer.executeQuery(
+                "declare variable $c external; count(collection($c))", Map.of("c", col));
+        assertEquals(String.valueOf(NAMES.length), rs.getResource(0).getContent());
+    }
+
+    /**
+     * Surface 2 (decision 5): collection() resolves a decoded non-ASCII collection PATH. The child
+     * collection is created and the document is stored via the canonical stored form; collection()
+     * is then asked for it by the decoded display path and must resolve the same key.
+     */
+    @Test
+    public void collectionResolvesDecodedCollectionPath() throws XMLDBException {
+        existEmbeddedServer.executeQuery("xmldb:create-collection('/db', 'rt-colnorm')");
+        existEmbeddedServer.executeQuery(
+                "declare variable $n external; xmldb:create-collection('/db/rt-colnorm', $n)",
+                Map.of("n", new StringValue("café-col")));
+        // store via the canonical stored collection path, isolating collection()'s own normalization
+        store("/db/rt-colnorm/" + URIUtils.encodeForURILenient("café-col"), "doc1.xml");
+
+        final ResourceSet rs = existEmbeddedServer.executeQuery(
+                "declare variable $c external; count(collection($c))",
+                Map.of("c", new StringValue("/db/rt-colnorm/café-col")));
+        assertEquals("collection() should resolve the decoded non-ASCII collection path", "1",
+                rs.getResource(0).getContent());
+    }
+
+    private static void store(final String col, final String name) throws XMLDBException {
+        existEmbeddedServer.executeQuery(
+                "declare variable $name external; declare variable $col external; "
+                        + "xmldb:store($col, $name, document { <doc/> })",
+                Map.of("name", new StringValue(name), "col", col));
+    }
+
+    /**
+     * Whether {@code doc($path)} resolves to a document. A path that doc() rejects as a malformed
+     * URI (a raw space, or a literal '%' not forming a valid escape) throws here; for the purpose
+     * of "does the display form resolve to the intended document?" that counts as "did not
+     * resolve", so the throw is mapped to {@code false}.
+     */
+    private static boolean docExists(final String path) {
+        try {
+            final ResourceSet rs = existEmbeddedServer.executeQuery(
+                    "declare variable $p external; exists(doc($p))", Map.of("p", new StringValue(path)));
+            return Boolean.parseBoolean((String) rs.getResource(0).getContent());
+        } catch (final XMLDBException e) {
+            return false;
+        }
+    }
+
     private static Set<String> childNames(final ResourceSet rs) throws XMLDBException {
         final Set<String> names = new LinkedHashSet<>();
         for (long i = 0; i < rs.getSize(); i++) {

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/ResourceNamingXmldbRoundTripTest.java
@@ -145,13 +145,13 @@ public class ResourceNamingXmldbRoundTripTest {
             assertTrue("doc() by stored form should resolve " + name,
                     docExists(col + "/" + URIUtils.encodeForURILenient(name)));
 
-            // A "clean" decoded name (no literal '%', no raw space) resolves directly via the
-            // decision-5 normalization. A literal-'%' name is ambiguous (decision 2 boundary) and a
-            // raw space is rejected on the read path (decision 3, read side, a separate gap); in
-            // both cases the display form does not resolve and the stored form must be used.
-            final boolean clean = name.indexOf('%') < 0 && name.indexOf(' ') < 0;
+            // A decoded name without a literal '%' resolves directly via the decision-5 normalization
+            // -- including a raw space, now that the read path is normalized on both the doc() and
+            // doc-available() URI checks (decision 3, read side). A literal-'%' name remains ambiguous
+            // (decision 2 boundary): its display form does not resolve and the stored form must be used.
+            final boolean resolvesByDecodedName = name.indexOf('%') < 0;
             assertEquals("doc() resolution by decoded name for " + name,
-                    clean, docExists(col + "/" + name));
+                    resolvesByDecodedName, docExists(col + "/" + name));
         }
 
         final ResourceSet rs = existEmbeddedServer.executeQuery(

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XmldbCollectionAddressByDecodedNameTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XmldbCollectionAddressByDecodedNameTest.java
@@ -91,6 +91,37 @@ public class XmldbCollectionAddressByDecodedNameTest {
         assertEquals("1", rs.getResource(0).getContent());
     }
 
+    /**
+     * Decision 2, read side, across the xmldb: and fn:collection surfaces: a collection whose name
+     * literally contains '%' is stored bijectively (the '%' is escaped to %25) and is resolvable by
+     * its decoded literal name via xmldb:collection-available and fn:collection -- the same
+     * decode-then-encode canonicalization fn:doc applies. (The '%' here is not a valid escape, so
+     * decoding is a no-op and the decoded form round-trips to its own stored key.)
+     */
+    @Test
+    public void literalPercentCollectionResolvesByDecodedName() throws XMLDBException {
+        final String name = "pctcol-50%done";
+        existEmbeddedServer.executeQuery(
+                "declare variable $n external; xmldb:create-collection('/db', $n)",
+                Map.of("n", new StringValue(name)));
+
+        // bijective lenient store escapes the literal '%' to %25 (no collision)
+        assertTrue("precondition: the name must encode to a %25 stored key",
+                URIUtils.encodeForURILenient(name).contains("%25"));
+
+        // xmldb:collection-available by the decoded literal name
+        assertEquals("xmldb:collection-available by decoded literal-% name", "true", available("/db/" + name));
+
+        // fn:collection over the decoded literal path resolves the same collection
+        existEmbeddedServer.executeQuery(
+                "declare variable $c external; xmldb:store($c, 'd.xml', document { <d/> })",
+                Map.of("c", new StringValue("/db/" + name)));
+        final ResourceSet count = existEmbeddedServer.executeQuery(
+                "declare variable $c external; count(collection($c))",
+                Map.of("c", new StringValue("/db/" + name)));
+        assertEquals("collection() by decoded literal-% path", "1", count.getResource(0).getContent());
+    }
+
     private static String available(final String path) throws XMLDBException {
         final ResourceSet rs = existEmbeddedServer.executeQuery(
                 "declare variable $p external; xmldb:collection-available($p)", Map.of("p", new StringValue(path)));

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XmldbCollectionAddressByDecodedNameTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XmldbCollectionAddressByDecodedNameTest.java
@@ -1,0 +1,99 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.xmldb;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xquery.util.URIUtils;
+import org.exist.xquery.value.StringValue;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Surface 2 of the resource-naming contract (eXist-db/exist#6463, decision 5), address side: the
+ * {@code xmldb:} collection lookup and listing functions must resolve a caller-supplied DECODED or
+ * descriptor-derived literal collection path to the percent-encoded key that was actually stored --
+ * the same normalization {@code fn:doc()}/{@code fn:collection()} already apply.
+ *
+ * <p>Regression for the EXPath repo collection naming reported against #6463: {@code Deployment}
+ * mints a package's repo collection as {@code abbrev + "-" + version} via {@code XmldbURI.create}
+ * (escape=true), so a package whose version contains {@code '{'}/{@code '}'} -- e.g. an unsubstituted
+ * {@code "${app.version}"} -- installs under {@code /db/system/repo/<abbrev>-$%7B...%7D}. Before this
+ * fix the address-side {@code xmldb:} functions resolved with escape=false
+ * ({@code AnyURIValue.toXmldbURI()}), so {@code xmldb:collection-available} returned false and
+ * {@code xmldb:get-child-resources} threw for the descriptor-derived literal
+ * {@code /db/system/repo/<abbrev>-${app.version}} -- the collection was reachable only by its encoded
+ * form. The shared {@code getLocalCollection} now normalizes with escape=true, matching the write
+ * codec.</p>
+ */
+public class XmldbCollectionAddressByDecodedNameTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
+
+    /** A collection name whose '{'/'}' get percent-encoded at the write boundary, like an unsubstituted ${...} version. */
+    private static final String AWKWARD = "addr-probe-${ver}";
+
+    @Test
+    public void collectionAvailableResolvesDecodedLiteralPath() throws XMLDBException {
+        existEmbeddedServer.executeQuery(
+                "declare variable $n external; xmldb:create-collection('/db', $n)",
+                Map.of("n", new StringValue(AWKWARD)));
+
+        // the stored key is percent-encoded ('{' -> %7B, '}' -> %7D, '$' kept literal)
+        final String storedKey = URIUtils.encodeForURILenient(AWKWARD);
+        assertTrue("precondition: the awkward name must encode to a distinct stored key", storedKey.contains("%7B"));
+
+        // addressing by the encoded stored form always worked
+        assertEquals("collection-available by the encoded stored form", "true", available("/db/" + storedKey));
+        // addressing by the DECODED, descriptor-derived literal is what this fix restores
+        assertEquals("collection-available by the decoded literal path", "true", available("/db/" + AWKWARD));
+    }
+
+    @Test
+    public void getChildResourcesResolvesDecodedLiteralPath() throws XMLDBException {
+        existEmbeddedServer.executeQuery(
+                "declare variable $n external; xmldb:create-collection('/db', $n)",
+                Map.of("n", new StringValue(AWKWARD)));
+        existEmbeddedServer.executeQuery(
+                "declare variable $c external; xmldb:store($c, 'doc.xml', document { <d/> })",
+                Map.of("c", new StringValue("/db/" + AWKWARD)));
+
+        // list children by the decoded literal path; before the fix this threw an XMLDBException
+        final ResourceSet rs = existEmbeddedServer.executeQuery(
+                "declare variable $c external; count(xmldb:get-child-resources($c))",
+                Map.of("c", new StringValue("/db/" + AWKWARD)));
+        assertEquals("1", rs.getResource(0).getContent());
+    }
+
+    private static String available(final String path) throws XMLDBException {
+        final ResourceSet rs = existEmbeddedServer.executeQuery(
+                "declare variable $p external; xmldb:collection-available($p)", Map.of("p", new StringValue(path)));
+        return (String) rs.getResource(0).getContent();
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
@@ -99,6 +99,19 @@ class ResourceNameCodecTest {
         c.put("q?x.xml", "q%3Fx.xml");
         c.put("[draft].xml", "%5Bdraft%5D.xml");
 
+        // --- characters that macOS/Windows reject in FILENAMES. Most are not RFC 3986 pchar, so
+        //     the codec already percent-encodes them (the encoded stored form is filesystem-safe).
+        //     NOTE: ':' and '*' ARE pchar, so the codec keeps them LITERAL -- safe in eXist's native
+        //     page store, but hostile if a name becomes a host filename (backup/export). Flagged in
+        //     the fallout report as a contract question (encode ':'/'*' for cross-OS file safety?). ---
+        c.put("a<b.xml", "a%3Cb.xml");
+        c.put("a>b.xml", "a%3Eb.xml");
+        c.put("a\"b.xml", "a%22b.xml");
+        c.put("a\\b.xml", "a%5Cb.xml");
+        c.put("a|b.xml", "a%7Cb.xml");
+        c.put("a:b.xml", "a%3Ab.xml");   // pchar, but eXist's XmldbURI can't store a literal ':' -> encode
+        c.put("a*b.xml", "a*b.xml");     // pchar -> kept literal (FS-hostile on Windows, but storable)
+
         // --- literal percent: the hard case decision 2 is about (ALWAYS escaped to %25) ---
         c.put("50%.xml", "50%25.xml");
         c.put("a%20b.xml", "a%2520b.xml");

--- a/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
@@ -93,6 +93,12 @@ class ResourceNameCodecTest {
         c.put("a,b;c=d.xml", "a,b;c=d.xml");
         c.put("@home.xml", "@home.xml");
 
+        // --- gen-delimiters that a URL path segment must escape (so REST/WebDAV escape them too,
+        //     and we match, for cross-surface convergence): # ? [ ] ---
+        c.put("a#b.xml", "a%23b.xml");
+        c.put("q?x.xml", "q%3Fx.xml");
+        c.put("[draft].xml", "%5Bdraft%5D.xml");
+
         // --- literal percent: the hard case decision 2 is about (ALWAYS escaped to %25) ---
         c.put("50%.xml", "50%25.xml");
         c.put("a%20b.xml", "a%2520b.xml");

--- a/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/ResourceNameCodecTest.java
@@ -1,0 +1,231 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.util;
+
+import org.exist.xquery.functions.fn.FunEscapeURI;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Keystone proof for the resource-naming contract prototype (eXist-db/exist#6463, decision 2:
+ * literal {@code '%'}).
+ *
+ * <p>This test validates the proposed END-STATE codec for a single resource/collection name:
+ * {@link URIUtils#encodeForURILenient(String)} on store and {@link URIUtils#decodeForURI(String)}
+ * on display. It proves three things the team needs in order to choose the contract direction with
+ * full information:</p>
+ *
+ * <ol>
+ *   <li><b>Bijectivity</b> -- the codec round-trips every name in the corpus, INCLUDING names that
+ *       contain a literal percent sign ({@code 50%.xml}, {@code a%20b.xml}, {@code %25.xml}), which
+ *       is the hard case decision 2 is about.</li>
+ *   <li><b>The exact canonical stored form</b> -- each assertion pins the stored bytes, so the
+ *       contract is documented by executable example. Sub-delimiters stay literal
+ *       ({@code it's.xml}, {@code a+b.xml}) -- the eXide#824 direction -- while {@code '%'} is
+ *       always escaped to {@code %25}, which is the single change that buys bijectivity.</li>
+ *   <li><b>Why today's store path fails</b> -- the legacy boundary
+ *       ({@code xmldbUriFor(escape=true)} == {@link FunEscapeURI#escape(CharSequence, boolean)} then
+ *       {@code new URI(...)}) keeps {@code '%'} literal, so a literal-percent name is either
+ *       silently corrupted ({@code a%20b} -&gt; {@code a b}, a space) or rejected outright
+ *       ({@code 5%done} throws). The new codec fixes both.</li>
+ * </ol>
+ *
+ * <p>The headline finding for #6463: a literal {@code '%'} is fully representable WITHIN the lenient
+ * (sub-delimiters-literal) contract -- it needs only that {@code '%'} always be escaped to
+ * {@code %25}. It does NOT force adopting the strict full-encode scheme ({@code it's -> it%27s}),
+ * so supporting {@code '%'} does not imply a second migration of stored names away from the lenient
+ * direction.</p>
+ */
+class ResourceNameCodecTest {
+
+    /**
+     * The round-trip corpus from the tasking: spaces, Unicode, sub-delimiters, and -- the hard
+     * case -- literal percent. Key = the literal (display) name the user types; value = its
+     * canonical stored form under the proposed lenient-bijective contract.
+     */
+    private static Map<String, String> corpus() {
+        final Map<String, String> c = new LinkedHashMap<>();
+
+        // --- plain ASCII (unchanged) ---
+        c.put("plain.xml", "plain.xml");
+
+        // --- space ---
+        c.put("hello world.xml", "hello%20world.xml");
+
+        // --- Unicode (percent-encoded as UTF-8 bytes) ---
+        c.put("café.xml", "caf%C3%A9.xml");
+        c.put("naïve.xml", "na%C3%AFve.xml");
+        c.put("Москва.xml", "%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0.xml");
+        c.put("日本.xml", "%E6%97%A5%E6%9C%AC.xml");
+
+        // --- sub-delimiters: LEFT LITERAL (the eXide#824 / openapi#54 direction) ---
+        c.put("it's.xml", "it's.xml");
+        c.put("a+b.xml", "a+b.xml");
+        c.put("Jack&Jill.xml", "Jack&Jill.xml");
+        c.put("report(final).xml", "report(final).xml");
+        c.put("a,b;c=d.xml", "a,b;c=d.xml");
+        c.put("@home.xml", "@home.xml");
+
+        // --- literal percent: the hard case decision 2 is about (ALWAYS escaped to %25) ---
+        c.put("50%.xml", "50%25.xml");
+        c.put("a%20b.xml", "a%2520b.xml");
+        c.put("%25.xml", "%2525.xml");
+        c.put("100%done%.xml", "100%25done%25.xml");
+
+        // --- literal slash inside a NAME (data, not a separator) ---
+        c.put("a/b.xml", "a%2Fb.xml");
+
+        return c;
+    }
+
+    /**
+     * (1) Bijectivity: {@code decodeForURI(encodeForURILenient(name)) == name} for every name,
+     * including the literal-percent cases. This is the property decision 2 hinges on.
+     */
+    @Test
+    void lenientCodecRoundTripsEveryName() {
+        for (final String name : corpus().keySet()) {
+            final String stored = URIUtils.encodeForURILenient(name);
+            final String display = URIUtils.decodeForURI(stored);
+            assertEquals(name, display, "round-trip failed for: " + name);
+        }
+    }
+
+    /**
+     * (2) The exact canonical stored form for every name -- the contract, documented by example.
+     */
+    @Test
+    void lenientCodecProducesCanonicalStoredForm() {
+        for (final Map.Entry<String, String> e : corpus().entrySet()) {
+            assertEquals(e.getValue(), URIUtils.encodeForURILenient(e.getKey()),
+                    "wrong stored form for: " + e.getKey());
+        }
+    }
+
+    /**
+     * (2b) Path-level round-trip: the same property holds across a whole {@code '/'}-delimited
+     * collection path, segment by segment.
+     */
+    @Test
+    void lenientCodecRoundTripsWholePath() {
+        final String path = "/db/data/Reports 2026/café & crème/50%.xml";
+        final String stored = URIUtils.encodePathForURILenient(path);
+        assertEquals("/db/data/Reports%202026/caf%C3%A9%20&%20cr%C3%A8me/50%25.xml", stored);
+        assertEquals(path, URIUtils.decodePathForURI(stored));
+    }
+
+    /**
+     * (3a) Why today's store path SILENTLY CORRUPTS a literal-percent name when the percent
+     * happens to be followed by two hex digits: the legacy boundary keeps {@code '%'} literal, so
+     * {@code a%20b.xml} is misread as an already-encoded space and comes back as {@code "a b.xml"}.
+     */
+    @Test
+    void legacyStorePathCorruptsLiteralPercentBeforeHex() throws URISyntaxException {
+        final String name = "a%20b.xml";
+
+        // legacy store boundary: xmldbUriFor(escape=true) == FunEscapeURI.escape(.., false) then new URI(..)
+        final String legacyStored = new URI(FunEscapeURI.escape(name, false)).getRawPath();
+        // '%' was kept literal, so the %20 is preserved verbatim as if it were an escape
+        assertEquals("a%20b.xml", legacyStored);
+        // legacy display (decode on read) then turns it into a space -- data loss
+        final String legacyDisplay = URIUtils.decodeForURI(legacyStored);
+        assertEquals("a b.xml", legacyDisplay);
+        assertNotEquals(name, legacyDisplay, "legacy path must be shown to corrupt this name");
+
+        // the new codec round-trips it exactly
+        assertEquals(name, URIUtils.decodeForURI(URIUtils.encodeForURILenient(name)));
+    }
+
+    /**
+     * (3b) Why today's store path REJECTS a literal-percent name when the percent is not followed
+     * by two hex digits: {@code FunEscapeURI.escape} keeps {@code '%'} literal and
+     * {@code new URI("5%done.xml")} throws on the malformed escape. The new codec stores it fine.
+     */
+    @Test
+    void legacyStorePathRejectsBareLiteralPercent() {
+        final String name = "5%done.xml";
+
+        assertThrows(URISyntaxException.class,
+                () -> new URI(FunEscapeURI.escape(name, false)),
+                "legacy boundary must be shown to reject a bare literal '%'");
+
+        // the new codec stores and recovers it
+        final String stored = URIUtils.encodeForURILenient(name);
+        assertEquals("5%25done.xml", stored);
+        assertEquals(name, URIUtils.decodeForURI(stored));
+    }
+
+    /**
+     * (4a) The strict-vs-lenient fork: {@link URIUtils#encodeForURI(String)} (strict RFC 3986) is
+     * ALSO bijective with {@code decodeForURI}; it differs from the lenient encoder only in that it
+     * escapes sub-delimiters too ({@code it's -> it%27s}). Both handle literal {@code '%'}
+     * identically. This documents that decision 2 is orthogonal to the sub-delimiter choice.
+     */
+    @Test
+    void strictCodecIsAlsoBijectiveAndDiffersOnlyOnSubDelimiters() {
+        for (final String name : corpus().keySet()) {
+            assertEquals(name, URIUtils.decodeForURI(URIUtils.encodeForURI(name)),
+                    "strict codec round-trip failed for: " + name);
+        }
+        // the one visible difference: sub-delimiters
+        assertEquals("it%27s.xml", URIUtils.encodeForURI("it's.xml"));
+        assertEquals("it's.xml", URIUtils.encodeForURILenient("it's.xml"));
+        // literal percent is handled the same way by both
+        assertEquals("50%25.xml", URIUtils.encodeForURI("50%.xml"));
+        assertEquals("50%25.xml", URIUtils.encodeForURILenient("50%.xml"));
+    }
+
+    /**
+     * (4b) The encoding is intentionally NOT idempotent -- it must be applied EXACTLY ONCE at the
+     * storage boundary. Encoding an already-encoded name double-escapes the percent signs, which is
+     * why the contract has to nail down a single encode point per surface.
+     */
+    @Test
+    void lenientEncodingIsNotIdempotent() {
+        final String once = URIUtils.encodeForURILenient("50%.xml");
+        final String twice = URIUtils.encodeForURILenient(once);
+        assertEquals("50%25.xml", once);
+        assertEquals("50%2525.xml", twice);
+        assertNotEquals(once, twice, "encoding must be applied exactly once");
+    }
+
+    /**
+     * (5) The decoder never throws and never truncates, even on inputs that {@code java.net.URI}
+     * would reject or silently cut at {@code '?'}/{@code '#'}. Resource names can contain anything.
+     */
+    @Test
+    void decoderNeverThrowsOrTruncates() {
+        // a trailing or malformed percent is preserved verbatim
+        assertEquals("trailing%", URIUtils.decodeForURI("trailing%"));
+        assertEquals("bad%zz", URIUtils.decodeForURI("bad%zz"));
+        // '?' and '#' are ordinary characters here, not query/fragment delimiters
+        assertEquals("a?b#c.xml", URIUtils.decodeForURI("a?b#c.xml"));
+    }
+}

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -1,0 +1,454 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.webdav;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.exist.xquery.util.URIUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.fail;
+
+/**
+ * Cross-surface resource-naming conformance harness (PR A).
+ *
+ * For a corpus of "awkward" resource names, this stores each name through one API surface and probes
+ * how it round-trips and what name actually lands in storage, across eXist's remote surfaces. It
+ * prints a matrix of the current behavior (visible in the CI log) and enforces a <b>ratchet</b>:
+ * the set of names that fail to round-trip cross-surface must exactly equal {@link #KNOWN_FAILURES}.
+ * So merging this guards every already-correct name against regression immediately, and as the naming
+ * fixes land you remove entries from {@code KNOWN_FAILURES} to lock in each improvement — the test
+ * tells you exactly which ones when they start passing.
+ *
+ * Surfaces covered in this first increment:
+ * <ul>
+ *   <li><b>WebDAV</b> (Apache Jackrabbit server since PR #6364) — probed via {@link HttpClient}.</li>
+ *   <li><b>REST</b> — via {@link HttpClient}.</li>
+ *   <li>an <b>oracle</b> for the stored name — eXist's native REST collection listing (no XQuery module
+ *       needed; the WebDAV module's test conf.xml registers no XQuery builtin-modules), reporting what
+ *       name actually got stored under the test collection.</li>
+ * </ul>
+ *
+ * <p>The harness is module- and WebDAV-client-independent: the test collection is created by a REST PUT
+ * (which auto-creates it), and all probes go over {@link HttpClient}. Request URLs are built with the
+ * multi-argument {@link URI} constructor, which percent-encodes the path; note this leaves RFC 3986
+ * sub-delimiters ({@code + @ & ( ) '}) literal on the wire, which is itself part of the encoding
+ * behavior this harness characterizes. Probe content is valid XML because the corpus names end in
+ * {@code .xml} and eXist parses {@code .xml} resources on store.</p>
+ *
+ * TODO (follow-up increments, see the resource-naming tasking):
+ * <ul>
+ *   <li>XML-RPC surface (create/read via {@code org.apache.xmlrpc} client against {@code /xmlrpc}).</li>
+ *   <li>Full N×N cross-surface matrix (create-via-X then read-via-every-Y).</li>
+ *   <li>existdb-openapi lives in a separate repo; its special-char suite is PR F there.</li>
+ * </ul>
+ */
+public class ResourceNamingConformanceTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    private static final String TEST_COLLECTION = "/db/naming-conformance-test";
+    // valid XML, because the corpus names end in .xml and eXist parses .xml resources on store
+    private static final String MARKER = "naming-probe-content";
+    private static final String CONTENT = "<probe>" + MARKER + "</probe>";
+
+    private static HttpClient http;
+
+    /**
+     * The corpus of "awkward" leaf resource names. Each is the human-intended name the user
+     * believes they are creating. {@code /} is excluded (path separator); a {@code .xml}/{@code .bin}
+     * suffix is kept so MIME detection behaves normally.
+     */
+    private static final Map<String, String> CORPUS = new LinkedHashMap<>();
+    static {
+        CORPUS.put("ascii-control",   "plain.xml");        // control: must always work
+        CORPUS.put("space",           "with space.xml");
+        CORPUS.put("plus",            "a+b.xml");
+        CORPUS.put("literal-percent", "a%b.xml");
+        CORPUS.put("encoded-space",   "a%20b.xml");        // literal "%20" in the name
+        CORPUS.put("hash",            "a#b.xml");
+        CORPUS.put("at",              "a@b.xml");
+        CORPUS.put("ampersand",       "a&b.xml");
+        CORPUS.put("parens",          "report(2024).xml");
+        CORPUS.put("apostrophe",      "o'brien.xml");
+        CORPUS.put("non-ascii",       "café.xml");
+        CORPUS.put("cyrillic",        "Привет.xml");
+        CORPUS.put("cjk",             "文書.xml");
+    }
+
+    /**
+     * The ratchet allowlist: corpus labels that do NOT round-trip cross-surface (stored via WebDAV,
+     * then read back by the requested name via both WebDAV and REST). The set of names that currently
+     * fail must equal this set exactly.
+     *
+     * <p>It is <b>empty</b>: with request URLs built the standard way (the multi-argument
+     * {@link URI} constructor, which leaves RFC 3986 sub-delimiters such as {@code + @ & ( ) '} literal
+     * in the path, exactly as a browser or {@code curl} sends them), every corpus name — including
+     * those with sub-delimiters and non-ASCII characters — round-trips between WebDAV and REST. eXist
+     * may store a percent-encoded form (e.g. a space as {@code %20}; see the {@code (≠)} markers in the
+     * printed matrix), but both surfaces agree on read, so the content is reachable by the requested
+     * name. An earlier revision of this harness percent-encoded sub-delimiters in the request URL and
+     * saw five "failures" ({@code + @ & ( ) '}); those were artifacts of that encoding choice, not of
+     * eXist's storage, and disappear once the URL is encoded conventionally.</p>
+     *
+     * <p>The ratchet therefore guards the <em>good</em> state: if any corpus name ever stops
+     * round-tripping cross-surface, the test fails as a regression. If a future change makes a new,
+     * not-yet-covered name fail, add it here with a comment. See the resource-naming tasking
+     * (issues #3795, #3665, #1824, #5299, #1612).</p>
+     */
+    private static final Set<String> KNOWN_FAILURES = Set.of();
+
+    @BeforeClass
+    public static void createTestCollection() {
+        // HttpClient is AutoCloseable (Java 21); created here and closed in @AfterClass below.
+        http = HttpClient.newHttpClient();
+        freshCollection();
+    }
+
+    @AfterClass
+    public static void removeTestCollection() {
+        restDelete(TEST_COLLECTION);
+        http.close();
+    }
+
+    /**
+     * Resets the test collection to empty: delete it, then recreate it by REST-PUTting a seed
+     * document (which auto-creates the collection) and removing the seed. Wiping the whole
+     * collection avoids depending on the stored name, which is what this test characterizes.
+     */
+    private static void freshCollection() {
+        restDelete(TEST_COLLECTION);
+        restPut(TEST_COLLECTION + "/__seed.xml", CONTENT);
+        restDelete(TEST_COLLECTION + "/__seed.xml");
+    }
+
+    @Test
+    public void crossSurfaceNamingConformance() throws Exception {
+        final List<Row> rows = new ArrayList<>();
+
+        for (final Map.Entry<String, String> probe : CORPUS.entrySet()) {
+            final String label = probe.getKey();
+            final String name = probe.getValue();
+            final Row row = new Row(label, name);
+
+            // start each probe from an empty collection (deleting by the requested name is unreliable,
+            // since the stored name may differ — which is exactly what this test characterizes)
+            freshCollection();
+
+            try {
+                // CREATE via WebDAV — HTTP PUT with the URI constructor encoding the path
+                final StringBuilder putBody = new StringBuilder();
+                final int putCode = webdavPut(TEST_COLLECTION + "/" + name, CONTENT, putBody);
+                row.created = putCode == 200 || putCode == 201 || putCode == 204;
+                if (!row.created) {
+                    row.error = "PUT " + putCode + ": " + putBody.toString().replaceAll("\\s+", " ").trim();
+                }
+
+                // ORACLE: what name actually landed in storage?
+                row.storedName = soleStoredName();
+
+                // READ-BACK via WebDAV (self round-trip, HTTP GET) — by the name the user PUT
+                row.webdavReadBack = webdavGet(TEST_COLLECTION + "/" + name);
+
+                // READ via REST by the name the user PUT (cross-surface WebDAV -> REST): can a REST
+                // client retrieve, by the requested name, what a WebDAV client just stored?
+                row.restReadBack = restGet(TEST_COLLECTION + "/" + name);
+            } catch (final Throwable t) {
+                row.error = t.getClass().getSimpleName() + ": " + String.valueOf(t.getMessage());
+            }
+            rows.add(row);
+        }
+
+        final String matrix = renderMatrix("WebDAV create -> {oracle, WebDAV read, REST read}", rows);
+        System.out.println(matrix);
+
+        // Cross-surface storage convergence (eXist-db/exist#6463): the form REST/WebDAV actually
+        // store must equal the canonical lenient codec URIUtils.encodeForURILenient(requestedName)
+        // -- the same encoder xmldb:store/create-collection now apply. This proves the HTTP surfaces
+        // and the xmldb: layer agree on one stored key for every name, including the literal-percent
+        // cases (a%b -> a%25b, a%20b -> a%2520b) which must stay distinct.
+        final StringBuilder storeMismatch = new StringBuilder();
+        for (final Row r : rows) {
+            if (r.created && r.storedName != null) {
+                final String canonical = URIUtils.encodeForURILenient(r.requestedName);
+                if (!canonical.equals(r.storedName)) {
+                    storeMismatch.append("\n    - ").append(r.label)
+                            .append(": stored '").append(r.storedName)
+                            .append("' but canonical lenient codec is '").append(canonical).append('\'');
+                }
+            }
+        }
+        if (storeMismatch.length() > 0) {
+            fail("REST/WebDAV stored form diverges from the canonical lenient codec "
+                    + "(URIUtils.encodeForURILenient):" + storeMismatch
+                    + "\n--- current matrix ---\n" + matrix);
+        }
+
+        // A name is "conformant" when it stores and its content round-trips by the requested name
+        // via BOTH WebDAV and REST.
+        final Set<String> failing = new LinkedHashSet<>();
+        for (final Row r : rows) {
+            final boolean conformant = r.created
+                    && Boolean.TRUE.equals(r.webdavReadBack)
+                    && Boolean.TRUE.equals(r.restReadBack);
+            if (!conformant) {
+                failing.add(r.label);
+            }
+        }
+
+        // Ratchet: the set of failing names must match KNOWN_FAILURES exactly.
+        final Set<String> regressions = new LinkedHashSet<>(failing);
+        regressions.removeAll(KNOWN_FAILURES);              // failing but expected to pass -> regression
+        final Set<String> nowFixed = new LinkedHashSet<>(KNOWN_FAILURES);
+        nowFixed.removeAll(failing);                        // listed as broken but now passing -> tighten the list
+
+        final StringBuilder msg = new StringBuilder();
+        if (!regressions.isEmpty()) {
+            msg.append(regressions.size())
+                    .append(" name(s) regressed — expected to round-trip cross-surface but failed:")
+                    .append(describe(regressions, rows)).append('\n');
+        }
+        if (!nowFixed.isEmpty()) {
+            msg.append(nowFixed.size())
+                    .append(" name(s) now round-trip cross-surface but are still listed as known failures.\n")
+                    .append("Remove them from KNOWN_FAILURES so they become regression-guarded:")
+                    .append(describe(nowFixed, rows)).append('\n');
+        }
+        if (msg.length() > 0) {
+            fail(msg.append("--- current matrix ---\n").append(matrix).toString());
+        }
+    }
+
+    /** Render a set of corpus labels as "    - label (requested-name)" lines for failure messages. */
+    private static String describe(final Set<String> labels, final List<Row> rows) {
+        final StringBuilder sb = new StringBuilder();
+        for (final Row r : rows) {
+            if (labels.contains(r.label)) {
+                sb.append("\n    - ").append(r.label).append(" (").append(r.requestedName).append(')');
+            }
+        }
+        return sb.toString();
+    }
+
+    // ---- WebDAV helpers (java.net.http.HttpClient; the multi-arg URI constructor encodes the path) ----
+
+    /** HTTP PUT to the WebDAV endpoint; returns the HTTP status (or -1), appending any body. */
+    private static int webdavPut(final String dbPath, final String content, final StringBuilder bodyOut) {
+        try {
+            final HttpRequest req = authed(endpointUri("/webdav", dbPath))
+                    .header("Content-Type", "application/xml")
+                    .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
+                    .build();
+            final HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
+            if (bodyOut != null) {
+                bodyOut.append(resp.body());
+            }
+            return resp.statusCode();
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            if (bodyOut != null) {
+                bodyOut.append(e);
+            }
+            return -1;
+        }
+    }
+
+    /** HTTP GET from the WebDAV endpoint; true if 200 and content matches. */
+    private static Boolean webdavGet(final String dbPath) {
+        return getMatchesMarker(endpointUri("/webdav", dbPath));
+    }
+
+    // ---- REST helpers ----
+
+    /** GET a db path via the REST interface; returns true if 200 and content matches. */
+    private Boolean restGet(final String dbPath) {
+        return getMatchesMarker(endpointUri("/rest", dbPath));
+    }
+
+    /** HTTP PUT to the REST endpoint (auto-creates parent collections); returns the HTTP status. */
+    private static int restPut(final String dbPath, final String content) {
+        try {
+            final HttpRequest req = authed(endpointUri("/rest", dbPath))
+                    .header("Content-Type", "application/xml")
+                    .PUT(HttpRequest.BodyPublishers.ofString(content, UTF_8))
+                    .build();
+            return http.send(req, HttpResponse.BodyHandlers.discarding()).statusCode();
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            return -1;
+        }
+    }
+
+
+    /**
+     * The single stored child resource name under the test collection (null if zero, "?multiple:..." if >1).
+     *
+     * Uses eXist's native REST collection listing (a built-in of the REST servlet) rather than an
+     * {@code xmldb:*} query, because the WebDAV module's test {@code conf.xml} registers no XQuery
+     * builtin-modules — so this harness must not depend on any XQuery module.
+     */
+    private String soleStoredName() {
+        final List<String> names = restListChildResources(TEST_COLLECTION);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.size() == 1 ? names.get(0) : "?multiple:" + String.join(",", names);
+    }
+
+    /** GET a collection via REST and extract the child {@code <exist:resource name="..."/>} names. */
+    private List<String> restListChildResources(final String collection) {
+        final List<String> names = new ArrayList<>();
+        try {
+            final HttpRequest req = authed(endpointUri("/rest", collection)).GET().build();
+            final String body = http.send(req, HttpResponse.BodyHandlers.ofString(UTF_8)).body();
+            final Matcher m = Pattern.compile("<exist:resource[^>]*\\sname=\"([^\"]*)\"").matcher(body);
+            while (m.find()) {
+                names.add(unescapeXml(m.group(1)));
+            }
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            // treat as empty listing
+        }
+        return names;
+    }
+
+    /** HTTP DELETE against the REST endpoint (built-in; needs no XQuery module). */
+    private static void restDelete(final String dbPath) {
+        try {
+            final HttpRequest req = authed(endpointUri("/rest", dbPath)).DELETE().build();
+            http.send(req, HttpResponse.BodyHandlers.discarding());
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            // best-effort cleanup
+        }
+    }
+
+    /** Send a GET and report whether the response is 200 and its body contains the probe marker. */
+    private static Boolean getMatchesMarker(final URI uri) {
+        try {
+            final HttpResponse<String> resp = http.send(authed(uri).GET().build(),
+                    HttpResponse.BodyHandlers.ofString(UTF_8));
+            return resp.statusCode() == 200 && resp.body().contains(MARKER);
+        } catch (final Exception e) {
+            restoreInterrupt(e);
+            return false;
+        }
+    }
+
+    /**
+     * Build the request URI for an endpoint and db path. The multi-argument {@link URI} constructor
+     * percent-encodes the path component (and, per RFC 3986, leaves sub-delimiters such as
+     * {@code + @ & ( ) '} literal — which is itself part of what this harness characterizes).
+     */
+    private static URI endpointUri(final String endpoint, final String dbPath) {
+        try {
+            return new URI("http", null, "localhost", existWebServer.getPort(), endpoint + dbPath, null, null);
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException("cannot build URI for " + endpoint + dbPath, e);
+        }
+    }
+
+    private static HttpRequest.Builder authed(final URI uri) {
+        return HttpRequest.newBuilder(uri).header("Authorization", basicAuth());
+    }
+
+    /** Re-assert the interrupt flag if a blocking HttpClient call was interrupted. */
+    private static void restoreInterrupt(final Exception e) {
+        if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static String unescapeXml(final String s) {
+        return s.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+                .replace("&quot;", "\"").replace("&apos;", "'");
+    }
+
+    private static String basicAuth() {
+        return "Basic " + java.util.Base64.getEncoder().encodeToString(
+                (TestUtils.ADMIN_DB_USER + ":" + TestUtils.ADMIN_DB_PWD).getBytes(UTF_8));
+    }
+
+    // ---- matrix rendering ----
+
+    private static final class Row {
+        final String label;
+        final String requestedName;
+        boolean created;
+        String storedName;
+        Boolean webdavReadBack;
+        Boolean restReadBack;
+        String error;
+
+        Row(final String label, final String requestedName) {
+            this.label = label;
+            this.requestedName = requestedName;
+        }
+    }
+
+    private static String renderMatrix(final String title, final List<Row> rows) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("\n=== Resource-naming conformance: ").append(title).append(" ===\n");
+        sb.append(String.format("%-16s %-18s %-8s %-22s %-10s %-9s %s%n",
+                "probe", "requested", "created", "stored-as", "dav-read", "rest-read", "error"));
+        for (final Row r : rows) {
+            final boolean stored = r.storedName != null && r.storedName.equals(r.requestedName);
+            sb.append(String.format("%-16s %-18s %-8s %-22s %-10s %-9s %s%n",
+                    r.label,
+                    r.requestedName,
+                    r.created ? "ok" : "FAIL",
+                    r.storedName == null ? "-" : (r.storedName + (stored ? "" : " (≠)")),
+                    cell(r.webdavReadBack),
+                    cell(r.restReadBack),
+                    r.error == null ? "" : r.error));
+        }
+        sb.append("Legend: stored-as '(≠)' = stored name differs from requested; ")
+                .append("dav-read/rest-read = content round-tripped via that surface.\n");
+        return sb.toString();
+    }
+
+    private static String cell(final Boolean b) {
+        if (b == null) {
+            return "-";
+        }
+        return b ? "PASS" : "FAIL";
+    }
+}

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -112,6 +112,14 @@ public class ResourceNamingConformanceTest {
         CORPUS.put("non-ascii",       "café.xml");
         CORPUS.put("cyrillic",        "Привет.xml");
         CORPUS.put("cjk",             "文書.xml");
+        // characters macOS/Windows reject in filenames (eXist-db/exist#6463 follow-up): ':' and '*'
+        // are RFC 3986 pchar; the rest are not. Probes whether REST/WebDAV agree with the canonical
+        // codec on these (the stored-form oracle), and whether they store at all.
+        CORPUS.put("colon",           "a:b.xml");
+        CORPUS.put("asterisk",        "a*b.xml");
+        CORPUS.put("angle-brackets",  "a<b>.xml");
+        CORPUS.put("pipe",            "a|b.xml");
+        CORPUS.put("dquote",          "a\"b.xml");
     }
 
     /**
@@ -134,7 +142,14 @@ public class ResourceNamingConformanceTest {
      * not-yet-covered name fail, add it here with a comment. See the resource-naming tasking
      * (issues #3795, #3665, #1824, #5299, #1612).</p>
      */
-    private static final Set<String> KNOWN_FAILURES = Set.of();
+    private static final Set<String> KNOWN_FAILURES = Set.of(
+            // A literal ':' cannot round-trip on any surface. eXist's XmldbURI wraps java.net.URI,
+            // and a ':' makes the segment look like it carries a scheme -- xmldb:store rejects it,
+            // and a WebDAV PUT of ".../a:b.xml" returns HTTP 500 (verified). The canonical codec
+            // therefore encodes ':' to %3A (URIUtils.encodeForURILenient); a client must likewise
+            // send %3A to address such a name. Tracked under eXist-db/exist#6463. (Separately, the
+            // 500 should arguably be a 4xx -- a pre-existing WebDAV error-mapping nit.)
+            "colon");
 
     @BeforeClass
     public static void createTestCollection() {

--- a/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/ResourceNamingConformanceTest.java
@@ -220,18 +220,8 @@ public class ResourceNamingConformanceTest {
         // -- the same encoder xmldb:store/create-collection now apply. This proves the HTTP surfaces
         // and the xmldb: layer agree on one stored key for every name, including the literal-percent
         // cases (a%b -> a%25b, a%20b -> a%2520b) which must stay distinct.
-        final StringBuilder storeMismatch = new StringBuilder();
-        for (final Row r : rows) {
-            if (r.created && r.storedName != null) {
-                final String canonical = URIUtils.encodeForURILenient(r.requestedName);
-                if (!canonical.equals(r.storedName)) {
-                    storeMismatch.append("\n    - ").append(r.label)
-                            .append(": stored '").append(r.storedName)
-                            .append("' but canonical lenient codec is '").append(canonical).append('\'');
-                }
-            }
-        }
-        if (storeMismatch.length() > 0) {
+        final String storeMismatch = storedFormMismatches(rows);
+        if (!storeMismatch.isEmpty()) {
             fail("REST/WebDAV stored form diverges from the canonical lenient codec "
                     + "(URIUtils.encodeForURILenient):" + storeMismatch
                     + "\n--- current matrix ---\n" + matrix);
@@ -270,6 +260,26 @@ public class ResourceNamingConformanceTest {
         if (msg.length() > 0) {
             fail(msg.append("--- current matrix ---\n").append(matrix).toString());
         }
+    }
+
+    /**
+     * For each created row, compare the form actually stored against the canonical lenient codec
+     * {@link URIUtils#encodeForURILenient(String)}. Returns a (possibly empty) description of the
+     * mismatches.
+     */
+    private static String storedFormMismatches(final List<Row> rows) {
+        final StringBuilder mismatch = new StringBuilder();
+        for (final Row r : rows) {
+            if (r.created && r.storedName != null) {
+                final String canonical = URIUtils.encodeForURILenient(r.requestedName);
+                if (!canonical.equals(r.storedName)) {
+                    mismatch.append("\n    - ").append(r.label)
+                            .append(": stored '").append(r.storedName)
+                            .append("' but canonical lenient codec is '").append(canonical).append('\'');
+                }
+            }
+        }
+        return mismatch.toString();
     }
 
     /** Render a set of corpus labels as "    - label (requested-name)" lines for failure messages. */


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Why this is a draft

This PR is **an illustration, not a merge request**. It implements the recommended answers in #6463 as running, tested code so that the contract discussion (which @dizzzz rightly flagged as complex, and worth a community call or workshop) has a concrete artifact to react to: you can see exactly what each decision costs, what it changes, and where the boundaries are. It is intentionally a **draft**; if the discussion wants it as a real merge candidate, we can un-draft it and add the remaining pre-merge gate (a full XQTS run).

It merges cleanly onto current `develop` today (no conflicts).

## Which decisions of #6463 it reflects

| #6463 decision | This PR | Where |
|---|---|---|
| **1 — apps speak raw decoded UTF-8; REST/WebDAV keep wire encoding but must round-trip** | XML-RPC now **decodes** resource/collection names on read; REST/WebDAV verified to already converge (Jackrabbit), aligned the codec to RFC 3986 pchar to keep them in lockstep | `RpcConnection.java`, conformance test |
| **2 — literal `%` (the non-injective / silent-collision defect)** | **fully handled, not postponed** (per @duncdrum's request to see the `%` fallout in one branch). A **bijective lenient codec** (`encodeForURILenient`/`decodeForURI`) escapes `%`→`%25` at the store boundary, so `café.xml` and the literal `caf%C3%A9.xml` no longer collide; and the **read path resolves a literal-`%` name by its decoded form** (`doc("/db/x/50%.xml")` → `50%25.xml`) across `doc()`, `collection()`, and the `xmldb:` reads | `URIUtils.java`, `DocUtils.java`, `ExtCollection.java`, `XMLDBAbstractCollectionManipulator.java`, codec test |
| **3 — allow full Unicode; reject only `/` and control/NUL** | `xmldb:store`/`create-collection` **accept a raw space** (and other Unicode) instead of throwing `FORG0001` — and the **read path** now resolves a raw-space db-path too (`doc()` / `doc-available()`), closing the write-accepts/read-rejects gap | `XMLDBStore.java`, `URIUtils.java`, `DocUtils.java`, `FunDocAvailable.java` |
| **5 — `doc()`/`collection()` normalize a bare db-path the way `store` does** | `doc()` and `collection()` canonicalize a bare db-path to its stored key (decode-then-encode, idempotent on already-encoded paths); **extended to the `xmldb:` collection read functions**, so a decoded or descriptor-derived literal path resolves the stored key | `DocUtils.java`, `ExtCollection.java`, `XMLDBAbstractCollectionManipulator.java` |

**Decision 4** (guard non-`/db` paths at the API surface, leave core alone) is deliberately **not** in this PR — it lives at the application-API layer (e.g., existdb-openapi), per the issue.

The codec is proven to **converge across surfaces**: a stored-form oracle asserts every surface stores exactly `encodeForURILenient(name)` and decodes back to the original, over an awkward-name corpus (space, non-ASCII, sub-delimiters, parentheses, apostrophe, literal `%`, and filesystem-hostile chars).

## Benefits

- **Ends the `store`-normalizes / `doc`-doesn't asymmetry.** `doc($col || "/" || $name)` after `xmldb:store($col, $name, …)` now resolves for any name — no more `doc(xmldb:encode-uri($n))` dance.
- **Fixes silent data loss.** The non-injective encoding (`café.xml` vs literal `caf%C3%A9.xml` → same key, one destroyed) becomes bijective; distinct names get distinct keys.
- **One canonical codec** across `xmldb:store`/`create-collection`, `doc()`, `collection()`, the `xmldb:` read functions, and XML-RPC — verified converging, not asserted.
- **Raw spaces and full Unicode just work** end to end — accepted at the write boundary (no `FORG0001` surprise) and resolvable on the read path (`doc("/db/x/with space.xml")` after `xmldb:store("/db/x", "with space.xml", …)` now hits).
- **Literal `%` is fully handled** — stored without data loss *and* resolvable by its decoded name on read (`doc()`, `collection()`, `xmldb:` reads), not postponed.
- A package's EXPath repo collection is **addressable by its own descriptor-derived name** (the manifestation written up in #6463's latest comment).

## Is it a breaking change? What would a developer need to adjust?

**No data migration.** The stored form of every name that is creatable on `develop` today is **unchanged** — existing databases are unaffected. The only names whose stored form differs are ones that previously could not be stored at all (a raw space → `FORG0001`) or that were silently colliding (literal `%`).

The behavior changes a developer might notice, and how to adjust:

1. **XML-RPC listings now return decoded UTF-8 names** (decision 1). A client that consumed `RpcConnection` listing results and decoded them itself, or compared them against the percent-encoded form, will see the already-decoded name. **Adjust:** treat XML-RPC resource/collection names as raw decoded UTF-8 (the same contract REST clients follow after decoding the wire form).
2. **`xmldb:store` / `xmldb:create-collection` no longer throw `FORG0001` on a raw space** (decision 3) and now store a literal-`%` name bijectively (decision 2). Code that *relied on the throw* to reject such names will no longer get the exception. **Adjust:** if rejection is intended, validate the name explicitly instead of depending on the codec to throw.
3. **Literal-`%` names store and resolve distinctly.** `a%20b.xml` now stores as `a%2520b.xml` instead of colliding with `a b.xml`, and a literal-`%` name resolves by its decoded form on read (see the full-fallout section). This affects only names that were previously unsafe or data-losing — no correctly-stored data moves. The one caveat is the residual ambiguity above: a name that literally *is* a valid escape is addressed by its encoded form.
4. **`doc()` / `collection()` / `xmldb:` reads may now resolve a decoded path that previously missed.** This is strictly additive for callers that currently get an empty result and want a hit; the honest risk is code that *branched on the miss* (treated empty as "absent"). **Adjust:** none expected, but the full XQTS run is the gate to confirm nothing leaned on the old miss.

**On read-path validity:** the `doc()` / `doc-available()` read path previously threw `FODC0005` on a raw-space db-path (three separate `java.net.URI` parse points). All three now defer to the DB normalization **for db-paths** (`/db` or `xmldb:`), so a raw-space name resolves — while any genuinely malformed **non-db** URI (`%gg`, `:/`, a Windows backslash path) still raises `FODC0005`, exactly as the qt3tests `fn/doc` cases require.

## Literal `%` — the full fallout (per @duncdrum's request)

The branch handles `%` rather than postponing it, so the trade-off is visible in one place rather than deferred to a Phase 2.

- **Write — solved, no data loss.** `encodeForURILenient` escapes a literal `%`→`%25`, so a name *containing* `%` and a name that *is* a percent-escape get distinct stored keys. The old non-injective encoding silently overwrote one with the other; that is gone.
- **Read — resolved by decoded name, via decode-then-encode.** The read path canonicalizes a db-path by `decodeForURI` then `encodeForURILenient` — treating it as decoded UTF-8 (decision 1) and re-encoding to the stored key. Because `decodeForURI` is the exact inverse of `encodeForURILenient`, this maps **both** a decoded display name **and** an already-encoded path to the same key, so pre-encoding callers (`doc(xmldb:encode-uri($n))`, TEI Publisher) keep working unchanged.
- **The one irreducible residual.** A name that *literally is a valid escape* (`a%20b.xml`, `%25.xml`) is read as its decoded meaning (`a b.xml`, `%.xml`), so it is addressed by its encoded form, not that literal string. This is inherent to a single decoded-wire contract (you cannot have `a%20b.xml` mean both "the literal name" and "a b.xml" on the same wire). It is pinned exactly by the round-trip oracle: a name resolves by its decoded form **iff `decodeForURI(name) == name`** — i.e. every normal name, plus a literal `%` that is not itself a valid escape (`50%.xml`, `100%done%.xml` resolve; `a%20b.xml` is reached by its encoded form).

No stored data migrates: the only names whose stored form is *new* are ones that previously could not be stored without collision (a literal `%`) — there was no correct prior form to migrate from.

## Tests

- `ResourceNameCodecTest` — the codec in isolation: bijective round-trip of the full corpus incl. `50%.xml` / `a%20b.xml` / `%25.xml`, pins canonical stored forms, demonstrates the legacy collision/rejection.
- `ResourceNamingXmldbRoundTripTest` — the `xmldb:` write boundary against a real database: every stored key equals `encodeForURILenient(name)` and decodes back.
- `XmldbCollectionAddressByDecodedNameTest` — the `xmldb:` read boundary: an `${…}`-style awkward-named collection is addressable by its decoded literal (fails on the pre-fix baseline, passes here), plus `literalPercentCollectionResolvesByDecodedName` (a literal-`%` collection resolves via `xmldb:collection-available` and `fn:collection`).
- `DocTest` — read-path raw space and literal `%`: `doc_resolvesRawSpaceDbPathOnRead`, `doc_resolvesLiteralPercentNameByDecodedForm` (store `50%.xml` → `50%25.xml` with no data loss, then resolve by both the decoded and the encoded form), and `doc_malformedNonDbUriStillRaisesFODC0005` (the qt3tests garbage cases stay `FODC0005`).
- `XPathQueryTest` (150) — regression guard for the shared `collection()` / `getLocalCollection` changes: stays green.
- `ResourceNamingConformanceTest` (webdav module, cross-surface) — the stored-form oracle: REST/WebDAV/XML-RPC converge on one key; documents the remaining `KNOWN_FAILURES` (`:` colon, etc.) with rationale.
- `XmlRpcTest` — XML-RPC read decode.

**Pre-merge gate not yet run:** a full XQTS pass (the issue's stated condition for the decision-5 core change). This is why it's a draft.

## What this deliberately leaves for follow-up

Nothing in decisions 2, 3, or 5 is deferred. What this branch intentionally does *not* include, so the scope stays reviewable:

- **Decoded `xmldb:get-child-resources` / `-collections` return.** These now *resolve* a decoded path, but still *return* the encoded stored names (`caf%C3%A9.xml`, not `café.xml`) — the long-standing `//TODO: decode names?`. Changing the default return would break every caller that expects the encoded form, so the right shape is an **opt-in `$decode` argument** (already prototyped on a separate branch). Until then, callers decode the result themselves, exactly as eXide does (`xmldb:decode-uri`).
- **XML-RPC write-side decode.** XML-RPC read/listing methods decode names (decision 1, surface 3); the write methods (`storeResource`, `createCollection`, …) accepting decoded names is the symmetric follow-up.
- **Colon (`:`) and the other `KNOWN_FAILURES`.** `a:b.xml` still does not round-trip cross-surface — `XmldbURI` wraps `java.net.URI`, where `a:` parses as a scheme. This is recorded in the conformance ratchet, not silently broken; a real fix needs the storage-layer change below.
- **The `%`-that-is-a-valid-escape residual.** `a%20b.xml` is read as its decoded meaning (`a b.xml`); see the full-fallout section. Inherent to a single decoded-wire contract, not a TODO.
- **Decision 4** (validate/400 a non-`/db` path) — by design this lives at the application-API layer (existdb-openapi), not core.
- **The application-API half of decision 1** (existdb-openapi returning/accepting decoded UTF-8) — a separate PR in that repo.
- **Phase 3** — storing names as raw UTF-8 in `collections.dbx` (no encoding at the persistence layer at all), which would also retire the colon residual. Large; captured for direction only, per the issue.
- **The normative contract document** — to be written once the decisions are ratified.
