### PR TITLE
[bugfix] http-client: support the src attribute on http:body (#6510)

### DIFF
--- a/extensions/modules/http-client/pom.xml
+++ b/extensions/modules/http-client/pom.xml
@@ -102,6 +102,11 @@
             <version>3.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
@@ -23,7 +23,11 @@ package org.exist.xquery.modules.httpclient;
 
 import com.github.mizosoft.methanol.MediaType;
 import com.github.mizosoft.methanol.MultipartBodyPublisher;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.Source;
+import org.exist.source.SourceFactory;
 import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
 import org.exist.xquery.modules.httpclient.config.RequestOptions;
 import org.exist.xquery.modules.httpclient.config.HttpClientOptions;
 import org.exist.xquery.modules.httpclient.config.ResponseOptions;
@@ -31,8 +35,12 @@ import org.exist.xquery.modules.httpclient.config.UserCredentials;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
 import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import java.io.StringWriter;
 import java.net.URI;
@@ -74,6 +82,8 @@ public class RequestBuilder {
     private final List<String[]> headers = new ArrayList<>();
     private String bodyMediaType;
     private String bodyContent;
+    private String bodySrc;
+    private byte[] bodyResourceBytes;
     private String multipartMediaType;
     private final List<BodyPart> multipartBodies = new ArrayList<>();
 
@@ -103,7 +113,7 @@ public class RequestBuilder {
         return this;
     }
 
-    private void parseChildren(final Element reqElem) {
+    private void parseChildren(final Element reqElem) throws XPathException {
         final NodeList children = reqElem.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             final Node child = children.item(i);
@@ -114,14 +124,100 @@ public class RequestBuilder {
             if ("header".equals(localName)) {
                 addHeader((Element) child);
             } else if ("body".equals(localName)) {
-                final Element bodyElem = (Element) child;
-                bodyMediaType = bodyElem.getAttribute("media-type");
-                bodyContent = getBodyContent(bodyElem);
+                parseBody((Element) child);
             } else if ("multipart".equals(localName)) {
                 final Element multipartElem = (Element) child;
                 multipartMediaType = getAttr(multipartElem, "media-type");
                 parseMultipart(multipartElem);
             }
+        }
+    }
+
+    /**
+     * Parses an {@code http:body} element. When a {@code @src} attribute is present the body content
+     * is the linked resource (resolved later in {@link #resolveBodySource(XQueryContext)}); per the
+     * EXPath HTTP Client spec (3.1) the body must then have no content and no attribute other than
+     * {@code media-type}, which is required -- otherwise {@code err:HC004}.
+     */
+    private void parseBody(final Element bodyElem) throws XPathException {
+        bodyMediaType = bodyElem.getAttribute("media-type");
+        bodySrc = getAttr(bodyElem, "src");
+        if (bodySrc == null) {
+            // Body content is the text/XML content of the body element
+            bodyContent = getBodyContent(bodyElem);
+            return;
+        }
+        if (hasNonWhitespaceContent(bodyElem)) {
+            throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC004,
+                    "http:body with a src attribute must not also contain body content");
+        }
+        if (hasDisallowedSrcAttribute(bodyElem)) {
+            throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC004,
+                    "http:body with a src attribute may only carry the media-type attribute");
+        }
+        // media-type is mandatory on http:body (HC005, a request-validity error -- HC004 is reserved
+        // for the src/content conflict above). Matches the EXPath reference behavior (BaseX).
+        if (bodyMediaType.isEmpty()) {
+            throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                    "http:body with a src attribute requires the media-type attribute");
+        }
+    }
+
+    private static boolean hasNonWhitespaceContent(final Element bodyElem) {
+        final NodeList children = bodyElem.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                return true;
+            }
+            if (node.getNodeType() == Node.TEXT_NODE && node.getNodeValue() != null && !node.getNodeValue().isBlank()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasDisallowedSrcAttribute(final Element bodyElem) {
+        final NamedNodeMap attrs = bodyElem.getAttributes();
+        for (int i = 0; i < attrs.getLength(); i++) {
+            final Node attr = attrs.item(i);
+            // ignore namespace declarations
+            if ("xmlns".equals(attr.getPrefix()) || "xmlns".equals(attr.getNodeName())) {
+                continue;
+            }
+            final String name = attr.getLocalName() != null ? attr.getLocalName() : attr.getNodeName();
+            if (!"media-type".equals(name) && !"src".equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolves an {@code http:body/@src} resource to the bytes used as the request body. {@code @src}
+     * is a URI reference resolved like {@code fn:doc}: a database path ({@code /db/...} or
+     * {@code xmldb:}), a {@code file:} URI, or an {@code http:}/classpath location. No-op when there is
+     * no {@code @src}.
+     *
+     * @param context the query context (supplies the broker used to read the resource)
+     * @throws XPathException err:HC005 if the resource cannot be resolved or read
+     */
+    public void resolveBodySource(final XQueryContext context) throws XPathException {
+        if (bodySrc == null) {
+            return;
+        }
+        try {
+            final Source source = SourceFactory.getSource(context.getBroker(), null, bodySrc, false);
+            if (source == null) {
+                throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                        "Could not resolve http:body/@src: " + bodySrc);
+            }
+            try (final InputStream is = source.getInputStream()) {
+                bodyResourceBytes = is.readAllBytes();
+            }
+        } catch (final IOException | PermissionDeniedException e) {
+            throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                    "Failed to read http:body/@src '" + bodySrc + "': " + e.getMessage(), e);
         }
     }
 
@@ -233,11 +329,25 @@ public class RequestBuilder {
     private void applyBody(final HttpRequest.Builder builder, final String upperMethod, final boolean isMultipart) {
         if (isMultipart) {
             applyMultipartBody(builder, upperMethod);
+        } else if (bodyResourceBytes != null) {
+            applyResourceBody(builder, upperMethod);
         } else if (bodyContent != null && !bodyContent.isEmpty()) {
             applySingleBody(builder, upperMethod);
         } else {
             builder.method(upperMethod, HttpRequest.BodyPublishers.noBody());
         }
+    }
+
+    /**
+     * Body sourced from {@code http:body/@src} (resolved by {@link #resolveBodySource(XQueryContext)}):
+     * the linked resource's raw bytes are sent verbatim, with {@code @media-type} as the Content-Type
+     * (required by HC004, so it is always present here) unless a Content-Type header was set explicitly.
+     */
+    private void applyResourceBody(final HttpRequest.Builder builder, final String upperMethod) {
+        if (!bodyMediaType.isEmpty() && headers.stream().noneMatch(h -> "Content-Type".equalsIgnoreCase(h[0]))) {
+            builder.header("Content-Type", bodyMediaType);
+        }
+        builder.method(upperMethod, HttpRequest.BodyPublishers.ofByteArray(bodyResourceBytes));
     }
 
     /**

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/SendRequestFunction.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/SendRequestFunction.java
@@ -97,6 +97,8 @@ public class SendRequestFunction extends BasicFunction {
         // Parse request element
         final RequestBuilder requestBuilder = new RequestBuilder();
         requestBuilder.parse(requestNode, hrefParam, bodiesParam);
+        // Resolve an http:body/@src resource (if any) to the body bytes; needs the broker
+        requestBuilder.resolveBodySource(context);
         final HttpRequest httpRequest = requestBuilder.build();
 
         final RequestOptions allOptions = requestBuilder.getOptions();

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -46,6 +46,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.*;
 
 /**
@@ -758,13 +759,12 @@ public class SendRequestFunctionTest {
     public void bodySrcSendsResourceContent() throws XMLDBException {
         storeBinaryResource("http-src-body.txt", "abracadabra");
         try {
-            final ResourceSet result = existEmbeddedServer.executeQuery(
-                    HTTP_NS +
-                    "let $response := http:send-request(\n" +
-                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                    "    <http:body media-type='text/plain' src='/db/http-src-body.txt'/>\n" +
-                    "  </http:request>)\n" +
-                    "return parse-json($response[2])?body");
+            final ResourceSet result = existEmbeddedServer.executeQuery(HTTP_NS + """
+                    let $response := http:send-request(
+                      <http:request method='POST' href='%s/echo'>
+                        <http:body media-type='text/plain' src='/db/http-src-body.txt'/>
+                      </http:request>)
+                    return parse-json($response[2])?body""".formatted(baseUrl()));
             assertEquals("http:body/@src content should be sent as the request body",
                     "abracadabra", result.getResource(0).getContent().toString());
         } finally {
@@ -793,18 +793,13 @@ public class SendRequestFunctionTest {
      */
     @Test
     public void bodySrcWithContentThrowsHC004() {
-        try {
-            existEmbeddedServer.executeQuery(
-                    HTTP_NS +
-                    "http:send-request(\n" +
-                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                    "    <http:body media-type='text/plain' src='/db/http-src-body.txt'>inline</http:body>\n" +
-                    "  </http:request>)");
-            fail("expected err:HC004 for http:body with both @src and content");
-        } catch (final XMLDBException e) {
-            final String chain = e.getMessage() + " | " + e.getCause();
-            assertTrue("expected HC004 but got: " + chain, chain.contains("HC004"));
-        }
+        assertThatExceptionOfType(XMLDBException.class)
+                .isThrownBy(() -> existEmbeddedServer.executeQuery(HTTP_NS + """
+                        http:send-request(
+                          <http:request method='POST' href='%s/echo'>
+                            <http:body media-type='text/plain' src='/db/http-src-body.txt'>inline</http:body>
+                          </http:request>)""".formatted(baseUrl())))
+                .withStackTraceContaining("HC004");
     }
 
     /**
@@ -812,18 +807,13 @@ public class SendRequestFunctionTest {
      */
     @Test
     public void bodySrcWithoutMediaTypeThrowsHC005() {
-        try {
-            existEmbeddedServer.executeQuery(
-                    HTTP_NS +
-                    "http:send-request(\n" +
-                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                    "    <http:body src='/db/http-src-body.txt'/>\n" +
-                    "  </http:request>)");
-            fail("expected err:HC005 for http:body with @src but no media-type");
-        } catch (final XMLDBException e) {
-            final String chain = e.getMessage() + " | " + e.getCause();
-            assertTrue("expected HC005 but got: " + chain, chain.contains("HC005"));
-        }
+        assertThatExceptionOfType(XMLDBException.class)
+                .isThrownBy(() -> existEmbeddedServer.executeQuery(HTTP_NS + """
+                        http:send-request(
+                          <http:request method='POST' href='%s/echo'>
+                            <http:body src='/db/http-src-body.txt'/>
+                          </http:request>)""".formatted(baseUrl())))
+                .withStackTraceContaining("HC005");
     }
 
     @Test

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -29,8 +29,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.exist.xmldb.EXistResource;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.BinaryResource;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -743,6 +747,83 @@ public class SendRequestFunctionTest {
                 "return contains(parse-json($response[2])?body, 'hello server')");
         assertEquals("POST body should be transmitted",
                 "true", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * The http:body @src attribute (EXPath HTTP Client 3.1) sends the linked database resource as the
+     * request body. Regression for eXist-db/exist#6510, where @src was silently ignored and an empty
+     * body was sent.
+     */
+    @Test
+    public void bodySrcSendsResourceContent() throws XMLDBException {
+        storeBinaryResource("http-src-body.txt", "abracadabra");
+        try {
+            final ResourceSet result = existEmbeddedServer.executeQuery(
+                    HTTP_NS +
+                    "let $response := http:send-request(\n" +
+                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                    "    <http:body media-type='text/plain' src='/db/http-src-body.txt'/>\n" +
+                    "  </http:request>)\n" +
+                    "return parse-json($response[2])?body");
+            assertEquals("http:body/@src content should be sent as the request body",
+                    "abracadabra", result.getResource(0).getContent().toString());
+        } finally {
+            removeResource("http-src-body.txt");
+        }
+    }
+
+    private static void storeBinaryResource(final String name, final String content) throws XMLDBException {
+        final Collection root = existEmbeddedServer.getRoot();
+        final BinaryResource res = root.createResource(name, BinaryResource.class);
+        ((EXistResource) res).setMimeType("text/plain");
+        res.setContent(content.getBytes(StandardCharsets.UTF_8));
+        root.storeResource(res);
+    }
+
+    private static void removeResource(final String name) throws XMLDBException {
+        final Collection root = existEmbeddedServer.getRoot();
+        final Resource res = root.getResource(name);
+        if (res != null) {
+            root.removeResource(res);
+        }
+    }
+
+    /**
+     * Per EXPath HTTP Client 3.1, combining @src with body content is err:HC004.
+     */
+    @Test
+    public void bodySrcWithContentThrowsHC004() {
+        try {
+            existEmbeddedServer.executeQuery(
+                    HTTP_NS +
+                    "http:send-request(\n" +
+                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                    "    <http:body media-type='text/plain' src='/db/http-src-body.txt'>inline</http:body>\n" +
+                    "  </http:request>)");
+            fail("expected err:HC004 for http:body with both @src and content");
+        } catch (final XMLDBException e) {
+            final String chain = e.getMessage() + " | " + e.getCause();
+            assertTrue("expected HC004 but got: " + chain, chain.contains("HC004"));
+        }
+    }
+
+    /**
+     * media-type is mandatory on an http:body that uses @src (request-validity error err:HC005).
+     */
+    @Test
+    public void bodySrcWithoutMediaTypeThrowsHC005() {
+        try {
+            existEmbeddedServer.executeQuery(
+                    HTTP_NS +
+                    "http:send-request(\n" +
+                    "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                    "    <http:body src='/db/http-src-body.txt'/>\n" +
+                    "  </http:request>)");
+            fail("expected err:HC005 for http:body with @src but no media-type");
+        } catch (final XMLDBException e) {
+            final String chain = e.getMessage() + " | " + e.getCause();
+            assertTrue("expected HC005 but got: " + chain, chain.contains("HC005"));
+        }
     }
 
     @Test


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Implements the `src` attribute on `http:body` in the native EXPath HTTP Client, fixing #6510. Previously `@src` was parsed away and an empty body was sent with no error — so e.g. a `PUT` with `<http:body media-type='text/plain' src='/db/tmp/test.txt'/>` stored an empty resource.

Closes https://github.com/eXist-db/exist/issues/6510

## What changed

- **`RequestBuilder`** — `http:body` parsing now reads `@src`. When present, the body is the linked resource rather than the element's content. `resolveBodySource(XQueryContext)` resolves `@src` to the request-body bytes, and `applyBody` sends them with `@media-type` as the `Content-Type`.
- **`SendRequestFunction`** — calls `resolveBodySource(context)` between `parse` and `build` (resolution needs the broker from the query context), so the built `HttpRequest` carries the resolved bytes.

## Spec conformance (EXPath HTTP Client 3.1)

> The `src` attribute can be used in a request to set the body content as the content of the linked resource… When this attribute is used, only the `media-type` attribute must also be present, and there can be neither content in the `http:body` element, nor any other attribute, or this is an error [err:HC004].

- `@src` is resolved like `fn:doc`, via `SourceFactory`: a database path (`/db/…` or `xmldb:`), a `file:` URI, or an `http:`/classpath location all work; the resource bytes are sent verbatim. This matches the EXPath reference implementation (BaseX), which writes the `src` resource's raw bytes.
- `err:HC004` (the code was already defined in `HttpClientModule` but never thrown) is raised for the spec's conflict conditions: `@src` combined with body content, or `@src` with any attribute other than `media-type`.
- `media-type` is mandatory on the body, raised as `err:HC005` (a request-validity error — HC004 is reserved for the src/content conflict, matching eXist's own HC004 description and BaseX's "media-type is mandatory" behavior).

## Test plan

- [x] `SendRequestFunctionTest.bodySrcSendsResourceContent` — stores a db resource, sends it via `@src` to an echo endpoint, and asserts the body was transmitted (uses the existing embedded `HttpServer` harness; no external service).
- [x] `SendRequestFunctionTest.bodySrcWithContentThrowsHC004` — `@src` plus inline content raises `err:HC004`.
- [x] `SendRequestFunctionTest.bodySrcWithoutMediaTypeThrowsHC005` — `@src` without `media-type` raises `err:HC005`.
- [x] Full `SendRequestFunctionTest` green (76/76).
- [x] Codacy/PMD clean on the changed files.

## Note

This touches `RequestBuilder`, which #6503 (the HttpClient caching/JMX refactor) is also revising. The two are independent in intent — #6503 is a refactor, this is a missing-feature fix — but whichever merges second will need a small rebase in `RequestBuilder`.
