### PR TITLE
[bugfix] http-client: honor http:body/@method for inline body serialization

### DIFF
--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
@@ -361,8 +361,10 @@ public class RequestBuilder {
      * plain string (text), rather than XML-serialized.
      */
     private static boolean isRawContentMethod(final String method) {
-        return "binary".equals(method) || "base64".equals(method)
-                || "hex".equals(method) || "text".equals(method);
+        return switch (method) {
+            case "binary", "base64", "hex", "text" -> true;
+            case null, default -> false;
+        };
     }
 
     /**

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
@@ -433,19 +433,20 @@ public class RequestBuilder {
                 throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
                         "http:body with method='" + bodyMethod + "' requires base64-encoded content: " + e.getMessage());
             }
-        }
-        if ("hex".equals(bodyMethod)) {
+        } else if ("hex".equals(bodyMethod)) {
             try {
                 return HttpRequest.BodyPublishers.ofByteArray(HexFormat.of().parseHex(bodyContent.strip()));
             } catch (final IllegalArgumentException e) {
                 throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
                         "http:body with method='hex' requires hexadecimal content: " + e.getMessage());
             }
+        } else {
+            // text/xml/xhtml/html (or no @method): send as a string in the media-type's charset
+            final Charset charset = bodyMediaType != null
+                    ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
+                    : StandardCharsets.UTF_8;
+            return HttpRequest.BodyPublishers.ofString(bodyContent, charset);
         }
-        final Charset charset = bodyMediaType != null
-                ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
-                : StandardCharsets.UTF_8;
-        return HttpRequest.BodyPublishers.ofString(bodyContent, charset);
     }
 
     /**

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
@@ -426,27 +426,31 @@ public class RequestBuilder {
      * {@code html} (or no @method) are sent as a string in the media-type's charset (default UTF-8).
      */
     private HttpRequest.BodyPublisher bodyPublisherForMethod() throws XPathException {
-        if ("binary".equals(bodyMethod) || "base64".equals(bodyMethod)) {
-            try {
-                return HttpRequest.BodyPublishers.ofByteArray(Base64.getMimeDecoder().decode(bodyContent.strip()));
-            } catch (final IllegalArgumentException e) {
-                throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
-                        "http:body with method='" + bodyMethod + "' requires base64-encoded content: " + e.getMessage());
+        return switch (bodyMethod) {
+            case "binary", "base64" -> {
+                try {
+                    yield HttpRequest.BodyPublishers.ofByteArray(Base64.getMimeDecoder().decode(bodyContent.strip()));
+                } catch (final IllegalArgumentException e) {
+                    throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                            "http:body with method='" + bodyMethod + "' requires base64-encoded content: " + e.getMessage());
+                }
             }
-        } else if ("hex".equals(bodyMethod)) {
-            try {
-                return HttpRequest.BodyPublishers.ofByteArray(HexFormat.of().parseHex(bodyContent.strip()));
-            } catch (final IllegalArgumentException e) {
-                throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
-                        "http:body with method='hex' requires hexadecimal content: " + e.getMessage());
+            case "hex" -> {
+                try {
+                    yield HttpRequest.BodyPublishers.ofByteArray(HexFormat.of().parseHex(bodyContent.strip()));
+                } catch (final IllegalArgumentException e) {
+                    throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                            "http:body with method='hex' requires hexadecimal content: " + e.getMessage());
+                }
             }
-        } else {
             // text/xml/xhtml/html (or no @method): send as a string in the media-type's charset
-            final Charset charset = bodyMediaType != null
-                    ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
-                    : StandardCharsets.UTF_8;
-            return HttpRequest.BodyPublishers.ofString(bodyContent, charset);
-        }
+            case null, default -> {
+                final Charset charset = bodyMediaType != null
+                        ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
+                        : StandardCharsets.UTF_8;
+                yield HttpRequest.BodyPublishers.ofString(bodyContent, charset);
+            }
+        };
     }
 
     /**

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/RequestBuilder.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -84,6 +85,7 @@ public class RequestBuilder {
     private String bodyContent;
     private String bodySrc;
     private byte[] bodyResourceBytes;
+    private String bodyMethod;
     private String multipartMediaType;
     private final List<BodyPart> multipartBodies = new ArrayList<>();
 
@@ -143,8 +145,12 @@ public class RequestBuilder {
         bodyMediaType = bodyElem.getAttribute("media-type");
         bodySrc = getAttr(bodyElem, "src");
         if (bodySrc == null) {
-            // Body content is the text/XML content of the body element
-            bodyContent = getBodyContent(bodyElem);
+            bodyMethod = getAttr(bodyElem, "method");
+            // For binary/base64/hex/text the body is the string value of the content (the base64/hex
+            // lexical, or the text serialization; decoded as needed in applyBody); for xml/xhtml/html
+            // (or no @method) the child elements are XML-serialized.
+            bodyContent = isRawContentMethod(bodyMethod)
+                    ? stringValue(bodyElem) : getBodyContent(bodyElem);
             return;
         }
         if (hasNonWhitespaceContent(bodyElem)) {
@@ -326,7 +332,7 @@ public class RequestBuilder {
         }
     }
 
-    private void applyBody(final HttpRequest.Builder builder, final String upperMethod, final boolean isMultipart) {
+    private void applyBody(final HttpRequest.Builder builder, final String upperMethod, final boolean isMultipart) throws XPathException {
         if (isMultipart) {
             applyMultipartBody(builder, upperMethod);
         } else if (bodyResourceBytes != null) {
@@ -348,6 +354,35 @@ public class RequestBuilder {
             builder.header("Content-Type", bodyMediaType);
         }
         builder.method(upperMethod, HttpRequest.BodyPublishers.ofByteArray(bodyResourceBytes));
+    }
+
+    /**
+     * The http:body @method values whose content is sent as raw bytes (binary/base64/hex) or as a
+     * plain string (text), rather than XML-serialized.
+     */
+    private static boolean isRawContentMethod(final String method) {
+        return "binary".equals(method) || "base64".equals(method)
+                || "hex".equals(method) || "text".equals(method);
+    }
+
+    /**
+     * The string value of an element: the concatenation of all descendant text, computed explicitly
+     * because the in-memory DOM's getTextContent does not recurse into element children for a
+     * constructed http:body.
+     */
+    private static String stringValue(final Node node) {
+        final StringBuilder sb = new StringBuilder();
+        final NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node child = children.item(i);
+            final short type = child.getNodeType();
+            if (type == Node.TEXT_NODE || type == Node.CDATA_SECTION_NODE) {
+                sb.append(child.getNodeValue());
+            } else if (type == Node.ELEMENT_NODE) {
+                sb.append(stringValue(child));
+            }
+        }
+        return sb.toString();
     }
 
     /**
@@ -373,17 +408,42 @@ public class RequestBuilder {
         builder.method(upperMethod, publisher);
     }
 
-    private void applySingleBody(final HttpRequest.Builder builder, final String upperMethod) {
-        final Charset charset = bodyMediaType != null
-                ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
-                : StandardCharsets.UTF_8;
-        final HttpRequest.BodyPublisher bodyPublisher =
-                HttpRequest.BodyPublishers.ofString(bodyContent, charset);
+    private void applySingleBody(final HttpRequest.Builder builder, final String upperMethod) throws XPathException {
+        final HttpRequest.BodyPublisher bodyPublisher = bodyPublisherForMethod();
         // Set Content-Type if not already set via headers
         if (bodyMediaType != null && headers.stream().noneMatch(h -> "Content-Type".equalsIgnoreCase(h[0]))) {
             builder.header("Content-Type", bodyMediaType);
         }
         builder.method(upperMethod, bodyPublisher);
+    }
+
+    /**
+     * Builds the body publisher for a single (non-multipart) body, honoring http:body/@method (EXPath
+     * HTTP Client 3.1). {@code binary}/{@code base64} decode the body's text content from base64 and
+     * {@code hex} from hexadecimal -- both sent as raw bytes; {@code text}/{@code xml}/{@code xhtml}/
+     * {@code html} (or no @method) are sent as a string in the media-type's charset (default UTF-8).
+     */
+    private HttpRequest.BodyPublisher bodyPublisherForMethod() throws XPathException {
+        if ("binary".equals(bodyMethod) || "base64".equals(bodyMethod)) {
+            try {
+                return HttpRequest.BodyPublishers.ofByteArray(Base64.getMimeDecoder().decode(bodyContent.strip()));
+            } catch (final IllegalArgumentException e) {
+                throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                        "http:body with method='" + bodyMethod + "' requires base64-encoded content: " + e.getMessage());
+            }
+        }
+        if ("hex".equals(bodyMethod)) {
+            try {
+                return HttpRequest.BodyPublishers.ofByteArray(HexFormat.of().parseHex(bodyContent.strip()));
+            } catch (final IllegalArgumentException e) {
+                throw new XPathException((org.exist.xquery.Expression) null, HttpClientModule.HC005,
+                        "http:body with method='hex' requires hexadecimal content: " + e.getMessage());
+            }
+        }
+        final Charset charset = bodyMediaType != null
+                ? Charset.forName(ContentTypeHelper.extractCharset(bodyMediaType))
+                : StandardCharsets.UTF_8;
+        return HttpRequest.BodyPublishers.ofString(bodyContent, charset);
     }
 
     /**

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -822,13 +822,12 @@ public class SendRequestFunctionTest {
      */
     @Test
     public void bodyMethodBinarySendsDecodedBytes() throws XMLDBException {
-        final ResourceSet result = existEmbeddedServer.executeQuery(
-                HTTP_NS +
-                "let $response := http:send-request(\n" +
-                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                "    <http:body media-type='application/octet-stream' method='binary'>aGVsbG8=</http:body>\n" +
-                "  </http:request>)\n" +
-                "return parse-json($response[2])?body");
+        final ResourceSet result = existEmbeddedServer.executeQuery(HTTP_NS + """
+                let $response := http:send-request(
+                  <http:request method='POST' href='%s/echo'>
+                    <http:body media-type='application/octet-stream' method='binary'>aGVsbG8=</http:body>
+                  </http:request>)
+                return parse-json($response[2])?body""".formatted(baseUrl()));
         assertEquals("method='binary' should base64-decode the body to raw bytes",
                 "hello", result.getResource(0).getContent().toString());
     }
@@ -838,13 +837,12 @@ public class SendRequestFunctionTest {
      */
     @Test
     public void bodyMethodHexSendsDecodedBytes() throws XMLDBException {
-        final ResourceSet result = existEmbeddedServer.executeQuery(
-                HTTP_NS +
-                "let $response := http:send-request(\n" +
-                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                "    <http:body media-type='application/octet-stream' method='hex'>6869</http:body>\n" +
-                "  </http:request>)\n" +
-                "return parse-json($response[2])?body");
+        final ResourceSet result = existEmbeddedServer.executeQuery(HTTP_NS + """
+                let $response := http:send-request(
+                  <http:request method='POST' href='%s/echo'>
+                    <http:body media-type='application/octet-stream' method='hex'>6869</http:body>
+                  </http:request>)
+                return parse-json($response[2])?body""".formatted(baseUrl()));
         assertEquals("method='hex' should hex-decode the body to raw bytes",
                 "hi", result.getResource(0).getContent().toString());
     }
@@ -855,13 +853,12 @@ public class SendRequestFunctionTest {
      */
     @Test
     public void bodyMethodTextSerializesAsText() throws XMLDBException {
-        final ResourceSet result = existEmbeddedServer.executeQuery(
-                HTTP_NS +
-                "let $response := http:send-request(\n" +
-                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
-                "    <http:body media-type='text/plain' method='text'><a>x</a></http:body>\n" +
-                "  </http:request>)\n" +
-                "return parse-json($response[2])?body");
+        final ResourceSet result = existEmbeddedServer.executeQuery(HTTP_NS + """
+                let $response := http:send-request(
+                  <http:request method='POST' href='%s/echo'>
+                    <http:body media-type='text/plain' method='text'><a>x</a></http:body>
+                  </http:request>)
+                return parse-json($response[2])?body""".formatted(baseUrl()));
         assertEquals("method='text' should send the element's string value, not its markup",
                 "x", result.getResource(0).getContent().toString());
     }

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -816,6 +816,56 @@ public class SendRequestFunctionTest {
                 .withStackTraceContaining("HC005");
     }
 
+    /**
+     * http:body/@method='binary' decodes the body's base64 text content and sends the raw bytes
+     * (EXPath HTTP Client 3.1 serialization method). base64('hello') = 'aGVsbG8='.
+     */
+    @Test
+    public void bodyMethodBinarySendsDecodedBytes() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                HTTP_NS +
+                "let $response := http:send-request(\n" +
+                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                "    <http:body media-type='application/octet-stream' method='binary'>aGVsbG8=</http:body>\n" +
+                "  </http:request>)\n" +
+                "return parse-json($response[2])?body");
+        assertEquals("method='binary' should base64-decode the body to raw bytes",
+                "hello", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * http:body/@method='hex' decodes the body's hexadecimal text content. hex('hi') = '6869'.
+     */
+    @Test
+    public void bodyMethodHexSendsDecodedBytes() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                HTTP_NS +
+                "let $response := http:send-request(\n" +
+                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                "    <http:body media-type='application/octet-stream' method='hex'>6869</http:body>\n" +
+                "  </http:request>)\n" +
+                "return parse-json($response[2])?body");
+        assertEquals("method='hex' should hex-decode the body to raw bytes",
+                "hi", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * http:body/@method='text' serializes element content as text (its string value), not as XML --
+     * so a child element is sent as its text, not its markup.
+     */
+    @Test
+    public void bodyMethodTextSerializesAsText() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                HTTP_NS +
+                "let $response := http:send-request(\n" +
+                "  <http:request method='POST' href='" + baseUrl() + "/echo'>\n" +
+                "    <http:body media-type='text/plain' method='text'><a>x</a></http:body>\n" +
+                "  </http:request>)\n" +
+                "return parse-json($response[2])?body");
+        assertEquals("method='text' should send the element's string value, not its markup",
+                "x", result.getResource(0).getContent().toString());
+    }
+
     @Test
     public void putMethod() throws XMLDBException {
         final ResourceSet result = existEmbeddedServer.executeQuery(


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Honors the `@method` attribute on `http:body` in the native EXPath HTTP Client. Previously `@method` was ignored, so an inline body could only be XML-serialized or sent as text — a binary/base64/hex inline body could not be sent at all (only `http:body/@src`, added in #6511, delivered raw bytes). This is item 1 of the conformance-gap tracking issue #6512, found by auditing the native rewrite against the EXPath reference implementation and BaseX (whose `writeBase64`/`writeHex`/`writeText`/`writeMessage` tests pin this behavior).

Part of #6512.

## What changed

`RequestBuilder` now reads `http:body/@method` (EXPath HTTP Client 3.1) and serializes the inline body accordingly:

- **`binary` / `base64`** — the body's content is base64-decoded and sent as raw bytes.
- **`hex`** — the content is hex-decoded (`HexFormat`) and sent as raw bytes.
- **`text`** — the content's string value is sent (an element child is serialized as its text, not its markup).
- **`xml` / `xhtml` / `html`** (or no `@method`) — unchanged: child elements are XML-serialized as before.

Malformed base64/hex content raises `err:HC005`. The string value of body content is computed by an explicit recursive walk, because the in-memory DOM's `getTextContent` does not recurse into element children of a constructed `http:body` (which is why the previous text path lost element content).

## Spec / reference

- EXPath HTTP Client 3.1 — `http:body/@method` serialization.
- Matches the EXPath reference impl and BaseX, which write the decoded bytes for `binary`/`base64`/`hex` and the string value for `text`.

## Test plan

- [x] `SendRequestFunctionTest.bodyMethodBinarySendsDecodedBytes` — `method='binary'` with `aGVsbG8=` sends `hello`.
- [x] `SendRequestFunctionTest.bodyMethodHexSendsDecodedBytes` — `method='hex'` with `6869` sends `hi`.
- [x] `SendRequestFunctionTest.bodyMethodTextSerializesAsText` — `method='text'` sends an element child's string value, not its markup.
- [x] Full `SendRequestFunctionTest` green (76/76).
- [x] Codacy/PMD clean on the changed files.

## Scope / follow-ups (tracked in #6512)

Out of scope here and left as follow-ups: `@method` on multipart parts, JSON/adaptive serialization, and multiple external `$bodies`.

## Note

This touches `RequestBuilder`'s body handling, the same area as #6511 (`@src`) and #6503 (caching/JMX refactor). The three are independent in intent; whichever merges later will need a small rebase in `RequestBuilder`.
