### PR TITLE
[bugfix] http-client: byte-safe multipart response parsing with nesting

### DIFF
--- a/extensions/modules/http-client/pom.xml
+++ b/extensions/modules/http-client/pom.xml
@@ -107,6 +107,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/ResponseHandler.java
+++ b/extensions/modules/http-client/src/main/java/org/exist/xquery/modules/httpclient/ResponseHandler.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -185,7 +186,10 @@ public class ResponseHandler {
 
     private static void addBody(final ValueSequence result, final byte[] bodyBytes,
                                  final String contentType, final BasicFunction callerFunc) throws XPathException {
-        if (ContentTypeHelper.isXml(contentType)) {
+        if (ContentTypeHelper.extractMediaType(contentType).startsWith("multipart/")) {
+            // a nested multipart part: recurse so its sub-parts are typed individually
+            addMultipartBodies(result, bodyBytes, contentType, callerFunc);
+        } else if (ContentTypeHelper.isXml(contentType)) {
             result.add(parseXml(bodyBytes, callerFunc));
         } else if (ContentTypeHelper.isHtml(contentType)) {
             result.add(parseHtml(bodyBytes, contentType, callerFunc));
@@ -271,26 +275,79 @@ public class ResponseHandler {
         return boundary.trim();
     }
 
+    /**
+     * Splits a multipart body into its parts, operating on the raw bytes so a binary part is not
+     * corrupted (a String round-trip through a charset would mangle non-text bytes). The CRLF that
+     * terminates each delimiter line, and the CRLF that precedes the next delimiter, belong to the
+     * boundary and are stripped; the preamble, the closing {@code --boundary--}, and the epilogue are
+     * discarded.
+     */
     private static byte[][] splitMultipart(final byte[] body, final String boundary) {
-        final String bodyStr = new String(body, StandardCharsets.UTF_8);
-        final String delimiter = "--" + boundary;
-        final String[] rawParts = bodyStr.split(delimiter);
+        final byte[] delim = ("--" + boundary).getBytes(StandardCharsets.US_ASCII);
         final List<byte[]> parts = new java.util.ArrayList<>();
-        for (final String part : rawParts) {
-            final String trimmed = part.trim();
-            if (trimmed.isEmpty() || trimmed.equals("--")) {
-                continue; // Skip preamble and closing delimiter
+        int pos = indexOf(body, delim, 0);
+        // a delimiter followed by "--" is the closing delimiter and ends the multipart
+        while (pos >= 0 && !isClosingDelimiter(body, pos + delim.length)) {
+            // the CRLF ending the delimiter line, and the CRLF before the next delimiter, belong
+            // to the boundary, not the part
+            final int partStart = skipLineEnding(body, pos + delim.length);
+            final int nextDelim = indexOf(body, delim, partStart);
+            final int partEnd = trimTrailingLineEnding(body, nextDelim < 0 ? body.length : nextDelim, partStart);
+            if (partEnd > partStart) {
+                parts.add(Arrays.copyOfRange(body, partStart, partEnd));
             }
-            parts.add(part.getBytes(StandardCharsets.UTF_8));
+            pos = nextDelim;
         }
         return parts.toArray(new byte[0][]);
     }
 
+    private static boolean isClosingDelimiter(final byte[] body, final int afterDelim) {
+        return afterDelim + 1 < body.length && body[afterDelim] == '-' && body[afterDelim + 1] == '-';
+    }
+
+    private static int skipLineEnding(final byte[] body, final int pos) {
+        int p = pos;
+        if (p < body.length && body[p] == '\r') {
+            p++;
+        }
+        if (p < body.length && body[p] == '\n') {
+            p++;
+        }
+        return p;
+    }
+
+    private static int trimTrailingLineEnding(final byte[] body, final int end, final int floor) {
+        int e = end;
+        if (e > floor && body[e - 1] == '\n') {
+            e--;
+        }
+        if (e > floor && body[e - 1] == '\r') {
+            e--;
+        }
+        return e;
+    }
+
+    /**
+     * The index of the first body byte in a part (just past the blank line separating the part
+     * headers from the part body), or 0 if the part has no header section.
+     */
+    private static int partHeaderEnd(final byte[] part) {
+        final int crlfcrlf = indexOf(part, new byte[]{'\r', '\n', '\r', '\n'}, 0);
+        if (crlfcrlf >= 0) {
+            return crlfcrlf + 4;
+        }
+        final int lflf = indexOf(part, new byte[]{'\n', '\n'}, 0);
+        if (lflf >= 0) {
+            return lflf + 2;
+        }
+        return 0;
+    }
+
     private static String extractPartContentType(final byte[] part) {
-        final String partStr = new String(part, StandardCharsets.UTF_8);
-        final String[] lines = partStr.split("\r?\n");
-        for (final String line : lines) {
-            if (line.toLowerCase().startsWith("content-type:")) {
+        // Part headers are ASCII; decode only the header region (ISO-8859-1 is a total byte->char map)
+        final String headers = new String(part, 0, partHeaderEnd(part), StandardCharsets.ISO_8859_1);
+        for (final String line : headers.split("\r?\n")) {
+            if (line.regionMatches(true, 0, "content-type:", 0, 13)) {
                 return line.substring(13).trim();
             }
         }
@@ -298,21 +355,28 @@ public class ResponseHandler {
     }
 
     private static byte[] extractPartBody(final byte[] part) {
-        final String partStr = new String(part, StandardCharsets.UTF_8);
-        // Body starts after the first blank line (double CRLF or double LF)
-        int bodyStart = partStr.indexOf("\r\n\r\n");
-        if (bodyStart >= 0) {
-            bodyStart += 4;
-        } else {
-            bodyStart = partStr.indexOf("\n\n");
-            if (bodyStart >= 0) {
-                bodyStart += 2;
-            } else {
-                return new byte[0];
+        return Arrays.copyOfRange(part, partHeaderEnd(part), part.length);
+    }
+
+    /**
+     * Finds the first occurrence of {@code target} in {@code data} at or after {@code from}.
+     */
+    private static int indexOf(final byte[] data, final byte[] target, final int from) {
+        for (int i = Math.max(from, 0); i <= data.length - target.length; i++) {
+            if (matchesAt(data, target, i)) {
+                return i;
             }
         }
-        final String bodyStr = partStr.substring(bodyStart);
-        return bodyStr.getBytes(StandardCharsets.UTF_8);
+        return -1;
+    }
+
+    private static boolean matchesAt(final byte[] data, final byte[] target, final int offset) {
+        for (int j = 0; j < target.length; j++) {
+            if (data[offset + j] != target[j]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -274,6 +274,9 @@ public class SendRequestFunctionTest {
             }
         });
 
+        // Multipart byte-safety + nesting endpoints (extracted to keep startHttpServer's complexity down)
+        registerMultipartTestEndpoints(httpServer);
+
         // OPTIONS endpoint
         httpServer.createContext("/options", exchange -> {
             exchange.getResponseHeaders().set("Allow", "GET, POST, OPTIONS");
@@ -302,6 +305,45 @@ public class SendRequestFunctionTest {
         if (httpServer != null) {
             httpServer.stop(0);
         }
+    }
+
+    /**
+     * Registers the multipart response endpoints used by the byte-safety and nesting tests, kept out
+     * of startHttpServer so that method's complexity is not inflated.
+     */
+    private static void registerMultipartTestEndpoints(final HttpServer server) {
+        // Multipart response with a binary part (bytes 0xFF 0xFE, base64 "//4=") that is not valid
+        // UTF-8 — corrupted by the old String-based splitter
+        server.createContext("/multipart-binary", exchange -> {
+            final String boundary = "bnd";
+            final java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            baos.writeBytes(("--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n")
+                    .getBytes(StandardCharsets.US_ASCII));
+            baos.writeBytes(new byte[]{(byte) 0xFF, (byte) 0xFE});
+            baos.writeBytes(("\r\n--" + boundary + "\r\nContent-Type: text/plain\r\n\r\nhello\r\n--"
+                    + boundary + "--\r\n").getBytes(StandardCharsets.US_ASCII));
+            final byte[] bodyBytes = baos.toByteArray();
+            exchange.getResponseHeaders().set("Content-Type", "multipart/mixed; boundary=" + boundary);
+            exchange.sendResponseHeaders(200, bodyBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bodyBytes);
+            }
+        });
+
+        // Nested multipart: outer multipart/mixed whose first part is itself a multipart/mixed
+        server.createContext("/multipart-nested", exchange -> {
+            final String inner = "--inner\r\nContent-Type: text/plain\r\n\r\nA\r\n"
+                    + "--inner\r\nContent-Type: text/plain\r\n\r\nB\r\n--inner--\r\n";
+            final String body = "--outer\r\nContent-Type: multipart/mixed; boundary=inner\r\n\r\n"
+                    + inner + "\r\n"
+                    + "--outer\r\nContent-Type: text/plain\r\n\r\nC\r\n--outer--\r\n";
+            exchange.getResponseHeaders().set("Content-Type", "multipart/mixed; boundary=outer");
+            final byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bodyBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bodyBytes);
+            }
+        });
     }
 
     private static void sendResponse(HttpExchange exchange, int status, String contentType,
@@ -1480,5 +1522,38 @@ public class SendRequestFunctionTest {
                 "return exists($response[1]/http:multipart)");
         assertEquals("Multipart response element should contain http:multipart",
                 "true", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * A binary multipart part is returned byte-for-byte (base64Binary), not corrupted by a UTF-8
+     * String round-trip. The first part is the two bytes 0xFF 0xFE (base64 "//4="); the second is text.
+     */
+    @Test
+    public void multipartBinaryPartIsByteSafe() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                HTTP_NS +
+                "let $r := http:send-request(\n" +
+                "  <http:request method='GET' href='" + baseUrl() + "/multipart-binary'/>)\n" +
+                "return $r[2] instance of xs:base64Binary\n" +
+                "  and string($r[2]) = '//4='\n" +
+                "  and $r[3] = 'hello'");
+        assertEquals("binary multipart part should round-trip byte-for-byte",
+                "true", result.getResource(0).getContent().toString());
+    }
+
+    /**
+     * A nested multipart part is parsed recursively, so its sub-parts surface as individual items:
+     * outer = [ multipart[ "A", "B" ], "C" ] yields the three leaf text items A, B, C.
+     */
+    @Test
+    public void multipartNestedIsParsedRecursively() throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery(
+                HTTP_NS +
+                "let $r := http:send-request(\n" +
+                "  <http:request method='GET' href='" + baseUrl() + "/multipart-nested'/>)\n" +
+                "let $bodies := $r[position() gt 1]\n" +
+                "return string-join($bodies, ',')");
+        assertEquals("nested multipart should yield the leaf parts A,B,C",
+                "A,B,C", result.getResource(0).getContent().toString());
     }
 }

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -36,6 +36,7 @@ import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.BinaryResource;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -239,7 +240,7 @@ public class SendRequestFunctionTest {
             byte[] bodyBytes = "gzipped content".getBytes(StandardCharsets.UTF_8);
 
             if (acceptEncoding != null && acceptEncoding.contains("gzip")) {
-                java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 try (java.util.zip.GZIPOutputStream gzip = new java.util.zip.GZIPOutputStream(baos)) {
                     gzip.write(bodyBytes);
                 }
@@ -316,7 +317,7 @@ public class SendRequestFunctionTest {
         // UTF-8 — corrupted by the old String-based splitter
         server.createContext("/multipart-binary", exchange -> {
             final String boundary = "bnd";
-            final java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             baos.writeBytes(("--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n")
                     .getBytes(StandardCharsets.US_ASCII));
             baos.writeBytes(new byte[]{(byte) 0xFF, (byte) 0xFE});

--- a/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
+++ b/extensions/modules/http-client/src/test/java/org/exist/xquery/modules/httpclient/SendRequestFunctionTest.java
@@ -24,6 +24,7 @@ package org.exist.xquery.modules.httpclient;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpExchange;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,7 +37,6 @@ import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.BinaryResource;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -240,7 +240,7 @@ public class SendRequestFunctionTest {
             byte[] bodyBytes = "gzipped content".getBytes(StandardCharsets.UTF_8);
 
             if (acceptEncoding != null && acceptEncoding.contains("gzip")) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get();
                 try (java.util.zip.GZIPOutputStream gzip = new java.util.zip.GZIPOutputStream(baos)) {
                     gzip.write(bodyBytes);
                 }
@@ -317,11 +317,11 @@ public class SendRequestFunctionTest {
         // UTF-8 — corrupted by the old String-based splitter
         server.createContext("/multipart-binary", exchange -> {
             final String boundary = "bnd";
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            baos.writeBytes(("--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n")
+            final UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get();
+            baos.write(("--" + boundary + "\r\nContent-Type: application/octet-stream\r\n\r\n")
                     .getBytes(StandardCharsets.US_ASCII));
-            baos.writeBytes(new byte[]{(byte) 0xFF, (byte) 0xFE});
-            baos.writeBytes(("\r\n--" + boundary + "\r\nContent-Type: text/plain\r\n\r\nhello\r\n--"
+            baos.write(new byte[]{(byte) 0xFF, (byte) 0xFE});
+            baos.write(("\r\n--" + boundary + "\r\nContent-Type: text/plain\r\n\r\nhello\r\n--"
                     + boundary + "--\r\n").getBytes(StandardCharsets.US_ASCII));
             final byte[] bodyBytes = baos.toByteArray();
             exchange.getResponseHeaders().set("Content-Type", "multipart/mixed; boundary=" + boundary);


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Makes multipart response parsing byte-safe and adds nested-multipart support in the native EXPath HTTP Client. Previously a multipart body was split with `String.split("--" + boundary)` over a **UTF-8 decode** of the whole body — so any binary part (a non-UTF-8 byte sequence) was corrupted by the String round-trip — and a part that was itself `multipart/*` was not parsed recursively. This is item 3 of the conformance-gap tracking issue #6512.

Part of #6512.

## What changed

In `ResponseHandler`:
- `splitMultipart`, `extractPartContentType`, and `extractPartBody` now operate on the **raw bytes**: the body is split at the boundary with a byte-level search, each part's header region is decoded as ISO-8859-1 (a total byte→char map) only to read the `Content-Type`, and the part body is sliced as bytes — so a binary part round-trips byte-for-byte. The leading/trailing CRLF that belong to the boundary are stripped; preamble, the closing `--boundary--`, and epilogue are discarded.
- `addBody` recurses into a part whose media type is `multipart/*`, so a **nested** multipart response surfaces its leaf parts.

## Test plan

- [x] `SendRequestFunctionTest.multipartBinaryPartIsByteSafe` — a part of bytes `0xFF 0xFE` round-trips as `xs:base64Binary` (`"//4="`), with the sibling text part intact.
- [x] `SendRequestFunctionTest.multipartNestedIsParsedRecursively` — `outer[ multipart[A,B], C ]` yields the leaf items `A, B, C`.
- [x] Existing multipart tests (`multipartResponseReturnsMultipleItems`, `multipartResponseContainsMultibodyElements`) still green.
- [x] Full `SendRequestFunctionTest` green (75/75).
- [x] Codacy/PMD clean on the changed code (the new test endpoints are registered in a helper so `startHttpServer`'s pre-existing complexity is not increased).

## Scope / follow-up (tracked in #6512)

Reproducing each part's headers (beyond `Content-Type`) in the `http:multipart` descriptor remains a follow-up.

## Note

This touches `ResponseHandler` (the response side), so it does not conflict with #6511 (`@src`) or #6513 (`@method`) in `RequestBuilder`. It does overlap #6514 (HTML response parsing), also in `ResponseHandler` — whichever merges later needs a small rebase.
