### PR TITLE
[bugfix] Bind context item for trailing function-call path step on stored docs

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -57,6 +57,17 @@ public class LocationStep extends Step {
     protected UpdateListener listener = null;
     protected Expression parent = null;
 
+    /**
+     * Whether this step is the initial (first) step of its parent expression,
+     * as determined during {@link #analyze(AnalyzeContextInfo)}. This is cached
+     * because the parent's child list may be rewritten after analysis (for
+     * example, {@link Function#checkArgument} wraps a function argument in a
+     * {@link DynamicCardinalityCheck} or type-check expression), which would
+     * otherwise make a lazy {@code parent.getSubExpression(0) == this} test in
+     * {@link #getDependencies()} report the wrong answer at evaluation time.
+     */
+    private boolean initialStep = false;
+
     //private int parentDeps = Dependency.UNKNOWN_DEPENDENCY;
     private boolean preloadedData = false;
     protected boolean optimized = false;
@@ -93,10 +104,12 @@ public class LocationStep extends Step {
         int deps = Dependency.CONTEXT_SET;
 
         // self axis has an obvious dependency on the context item
-        // likewise we depend on the context item if this is a single path step (outside a predicate)
+        // likewise we depend on the context item if this is the initial step of
+        // the enclosing expression (outside a predicate). initialStep is captured
+        // during analyze, before the parent's child list may be rewritten (e.g. a
+        // function argument being wrapped in a cardinality/type check). See #6521.
         if (!this.inPredicate &&
-                (this.axis == Constants.SELF_AXIS ||
-                        (parent != null && parent.getSubExpressionCount() > 0 && parent.getSubExpression(0) == this))) {
+                (this.axis == Constants.SELF_AXIS || this.initialStep)) {
             deps = deps | Dependency.CONTEXT_ITEM;
         }
 
@@ -324,6 +337,13 @@ public class LocationStep extends Step {
 
         // TODO : log somewhere ?
         super.analyze(contextInfo);
+
+        // Capture whether this step is the initial step of its parent expression
+        // now, while the parent's child list still reflects the source structure.
+        // It may be rewritten afterwards (e.g. Function.checkArgument wrapping the
+        // argument), so deferring this test to getDependencies() is unreliable.
+        this.initialStep = parent != null && parent.getSubExpressionCount() > 0
+                && parent.getSubExpression(0) == this;
     }
 
     @Override

--- a/exist-core/src/test/xquery/count.xql
+++ b/exist-core/src/test/xquery/count.xql
@@ -34,6 +34,15 @@ declare variable $cnt:COLLECTION1_NAME := "test-count-1";
 declare variable $cnt:COLLECTION2_NAME := "test-count-2";
 declare variable $cnt:COLLECTION1 := $cnt:TEST_COLLECTION || "/" || $cnt:COLLECTION1_NAME;
 declare variable $cnt:COLLECTION2 := $cnt:TEST_COLLECTION || "/" || $cnt:COLLECTION2_NAME;
+declare variable $cnt:AUTHORS_DOC := $cnt:TEST_COLLECTION || "/authors.xml";
+
+declare variable $cnt:AUTHORS :=
+    document {
+        <authors>
+            <author><places><place/><place/></places></author>
+            <author><places><place/><place/><place/></places></author>
+        </authors>
+    };
 
 declare
     %test:setUp
@@ -42,7 +51,8 @@ function cnt:setup() {
     xmldb:create-collection($cnt:TEST_COLLECTION, $cnt:COLLECTION1_NAME),
     xmldb:store($cnt:COLLECTION1, "test1.xml", <test/>),
     xmldb:create-collection($cnt:TEST_COLLECTION, $cnt:COLLECTION2_NAME),
-    xmldb:store($cnt:COLLECTION2, "test2xml", <test/>)
+    xmldb:store($cnt:COLLECTION2, "test2xml", <test/>),
+    xmldb:store($cnt:TEST_COLLECTION, "authors.xml", $cnt:AUTHORS)
 };
 
 declare 
@@ -57,8 +67,42 @@ function cnt:arg-self-on-stored() {
     (collection($cnt:COLLECTION1)/*, collection($cnt:COLLECTION2)/*)/count(.)
 };
 
-declare 
+declare
     %test:assertEquals(1, 1, 1)
 function cnt:arg-self-on-constructed() {
     (<a/>, <b/>, <c/>)/count(.)
+};
+
+(:~
+ : A trailing fn:count() step whose argument is a relative child step must be
+ : evaluated once per context item, even when the context is a *stored*
+ : (persistent) node set. Previously the persistent case collapsed to the
+ : whole-context branch and counted every descendant once (returning a single 5
+ : instead of (2, 3)). See https://github.com/eXist-db/exist/issues/6521
+ :)
+declare
+    %test:assertEquals(2, 3)
+function cnt:arg-child-on-stored() {
+    doc($cnt:AUTHORS_DOC)/authors/author/places/count(place)
+};
+
+(: the same query over an in-memory document was already correct; guard it :)
+declare
+    %test:assertEquals(2, 3)
+function cnt:arg-child-on-constructed() {
+    $cnt:AUTHORS/authors/author/places/count(place)
+};
+
+(: Martin's workaround with the simple map operator; locks the path that works :)
+declare
+    %test:assertEquals(2, 3)
+function cnt:arg-child-on-stored-simple-map() {
+    doc($cnt:AUTHORS_DOC)/authors/author/places ! count(place)
+};
+
+(: Martin's workaround copying the persistent tree into memory first :)
+declare
+    %test:assertEquals(2, 3)
+function cnt:arg-child-on-stored-wrapped() {
+    <a>{doc($cnt:AUTHORS_DOC)}</a>/authors/author/places/count(place)
 };


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Summary

Fixes eXist-db/exist#6521. A trailing path step that is a function call whose argument is a relative child step — for example `doc('/db/.../authors.xml')/authors/author/places/count(place)` — returned the wrong result against a **stored** (persistent) document: it counted every descendant once (a single `5`) instead of evaluating `count(place)` once per `places` element (`(2, 3)`). The identical query over an **in-memory** document was already correct, which is what made the bug surprising.

```xquery
let $doc := document {
  <authors>
    <author><places><place/><place/></places></author>
    <author><places><place/><place/><place/></places></author>
  </authors>
}
let $uri := xmldb:store("/db/apps", "tmp.xml", $doc)
return map {
  "raw":      $doc/authors/author/places/count(place),               (: (2, 3) — correct :)
  "from-doc": doc('/db/apps/tmp.xml')/authors/author/places/count(place)  (: was 5, now (2, 3) :)
}
```

## Root cause

`PathExpr.eval()` evaluates each path step in one of two branches: a per-item loop that passes each context item as the context item, or a single whole-context evaluation with a null context item. The per-item loop is the one that preserves correct multiplicity for a step that returns atomic values per context item (like `count(...)`). For persistent node sets, the branch is selected from the step's declared dependencies: a `CONTEXT_ITEM` dependency forces the per-item loop. (For in-memory nodes `PathExpr` always forces the per-item loop, which is why the memtree case was never affected.)

`LocationStep.getDependencies()` reports `CONTEXT_ITEM` when the step is the *initial* step of its enclosing expression. It detected that lazily with `parent.getSubExpression(0) == this`. That test is correct at analysis time but unreliable at evaluation time: `Function.checkArgument()` rewrites the function's child list **after** analysis, wrapping the argument in a `DynamicCardinalityCheck`. After that rewrite, the function's first sub-expression is the wrapper, not the `LocationStep`, so `parent.getSubExpression(0) == this` is `false`, the step drops its `CONTEXT_ITEM` dependency, and `PathExpr.eval()` falls through to the whole-context branch — which collapses the per-item multiplicity and counts all descendants at once.

The two workarounds reported in the issue corroborate this exactly: the simple map operator (`places ! count(place)`) re-binds a single-item context per left item and never relies on the context-item dependency, and copying the persistent tree into memory first (`<a>{doc(...)}</a>/...`) routes the query through the memtree branch that always iterates per item.

## What changed

`exist-core/.../LocationStep.java` — capture whether the step is the initial step of its parent **during `analyze()`**, while the parent's child list still reflects the source structure, and use the cached value in `getDependencies()` instead of recomputing it lazily after the child list may have been rewritten. The chosen `CONTEXT_ITEM` value is also correctness-safe in the limit: erring toward reporting it forces the always-correct per-item branch rather than the whole-context optimization.

`exist-core/src/test/xquery/count.xql` — XQSuite regression tests (per the `needs XQSuite test` label): the stored-doc case (the bug), the in-memory case (guards the path that already worked), and both issue workarounds (the simple map operator and the in-memory copy), all asserting `(2, 3)`.

## Test plan

- New XQSuite tests in `count.xql` pass (6/6 including the 2 pre-existing).
- `XPathQueryTest` (150), `OptimizerTests` (60), full `CoreTests` XQSuite (961) — all pass.
- Full `exist-core` unit suite — no code-related failures. The only errored classes are recovery/journal/backup/websocket/xmlrpc integration tests that fail with `DatabaseConfigurationException: Unable to read ... etc/conf.xml` under reactor contention; each passes in isolation on both this branch and clean `develop`, so they are a pre-existing environmental artifact of running the whole reactor, not a regression.
- Codacy PMD on the changed file: no new findings (the method's NPath is unchanged at 1296, identical to baseline).

## XQTS HEAD (no regression)

Before/after on the same in-repo runner JAR, across the path-expression and function-call test sets most likely to be affected by a path-step dependency change (30 sets: `prod-PathExpr`, `prod-StepExpr`, `prod-AxisStep[.*]`, `prod-FunctionCall`, `prod-ArrowPostfix`, `prod-CountClause`, `fn-count`, `fn-path`, `fn-string-join`, `fn-sum`, `fn-avg`, `fn-max`, `fn-min`, `fn-data`, `fn-exists`, `fn-empty`, `fn-name`, `fn-local-name`, `fn-string`, `fn-filter`, `fn-namespace-uri`):

| | passed | failures | errors | skipped |
|---|---|---|---|---|
| develop (baseline) | 2331 | 124 | 28 | 84 |
| with fix | 2331 | 124 | 28 | 84 |
| delta | 0 | 0 | 0 | 0 |

No set moved. The issue is an eXist-specific persistent-store behavior that the W3C suite does not exercise with stored documents, which is why the regression coverage is an XQSuite test rather than an XQTS gain.

## 6.4.1 applicability (finding only — no backport in this PR)

The reporter sees the bug on both 7.0 and 6.4.1. The root-cause code is byte-identical on the `eXist-6.4.1` tag: the `LocationStep.getDependencies()` heuristic, `LocationStep.analyze()`'s `parent = contextInfo.getParent()`, `Function.checkArgument()` wrapping the argument in `DynamicCardinalityCheck`, `DynamicCardinalityCheck.getDependencies()` delegating to its child, `FunCount` delegating its dependencies, and the `PathExpr` `inMemProcessing`/`isPersistentSet` two-branch logic all match `develop`. The defect is therefore the same, and this fix would apply to the 6.4.1 line essentially cleanly (only trivial line-offset adaptation; the insertion point at the end of `analyze()` and the `getDependencies()` condition are unchanged). This is recorded as a finding; no 6.4.1 backport is proposed here.

## Related issues

This sits in the broader family of "same query gives different results in-memory vs. stored in the database," but the issues in that family have distinct root causes:

- eXist-db/exist#4109 (open) is the closest relative: a per-item context-item failure on the `preceding`/`following` axes that appears only on stored documents, through a `for` clause or the simple map operator, with a context-selecting predicate such as `[exists(.)]`. Its regression tests already live in `exist-core/src/test/xquery/axes-persistent-nodes.xqm` (the `*-context-predicate-db-*` functions) and pass on current `develop`, so it appears already addressed in code and may be closeable; this PR does not change those tests' results. It is mentioned here only as related context, not fixed by this PR.
- eXist-db/exist#2817 (open) is a different layer: a FLWOR `where`-clause correlated join (`where $i/name = $j/name`) that fails only on stored inputs. Not touched by this change.

Only eXist-db/exist#6521 is fixed here.
