### PR TITLE
[ignore] remove unused dependency plex from distribution

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -335,14 +335,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- needed for the AppAssembler booter approach -->
-        <dependency>
-            <groupId>org.codehaus.mojo.appassembler</groupId>
-            <artifactId>appassembler-booter</artifactId>
-            <version>${appassembler.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
remove plex from distribution. Forgot to remove when removing app assembler code.

xqts runner still depends on it.
