### PR TITLE
[ignore] override jackson-databind dep version

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -616,6 +616,12 @@
                 <version>${objenesis.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- provide project-specific version of jackson-databind version (overrides tika dependency) -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.22.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/extensions/contentextraction/pom.xml
+++ b/extensions/contentextraction/pom.xml
@@ -95,7 +95,6 @@
             <artifactId>j8fu</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/extensions/vector/pom.xml
+++ b/extensions/vector/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Tika parser depends on an older version of jackson-databind 2.21.3 This version has a CVE which is fixed in 2.21.4
But in another subproject we are already depending on 2.22.0 so this seems to be a good common ground.

So in order to better control which version of jackson-databind we are depending on throughout the project it is now
declared in parent POM and then consumed by both extension projects with the `provided` scope.

```
mvn dependency:tree | grep jackson-databind:jar:2.22
```
returns 3 hits

```
mvn dependency:tree | grep jackson-databind:jar:2.21
```

returns no hits

Merging this PR will give us docker images with 0 fixable critical or high severity CVEs (`latest`)