### PR TITLE
Fix flaky CI tests: HTTP/2 hangs, broker/txn ordering races, and BrokerPool shutdown safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,9 @@ docker run -d --name existdb -p 8080:8080 -p 8443:8443 existdb/existdb:local
 
 ### Known build issues
 
-- Full test suite can hang on flaky infrastructure tests (`MoveResourceTest`, `RenameCollectionTest`). Check with `jstack` and kill if stuck >15 min.
+- Full test suite can hang on flaky infrastructure tests (`RenameCollectionTest`). Check with `jstack` and kill if stuck >15 min.
 - `RenameCollectionTest` "Connection refused" failures are pre-existing and unrelated to XQuery changes.
+- `org.exist.xmldb.concurrent.FragmentsTest` and `org.exist.collections.ConcurrencyTest` are excluded from the surefire run (see `exist-core/pom.xml`). `FragmentsTest` hangs during BrokerPool shutdown even locally; `ConcurrencyTest` can deadlock under concurrent collection access.
 
 ## Parser (ANTLR 2)
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1216,8 +1216,8 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                  see https://github.com/eXist-db/exist/issues/3685 -->
                         <exclude>org.exist.collections.ConcurrencyTest</exclude>
 
-                        <!-- Passes locally (~54s) but hangs on CI during BrokerPool shutdown,
-                                 causing the entire unit test step to time out.
+                        <!-- Hangs both locally and on CI during BrokerPool shutdown;
+                                 root cause not fully resolved (isShuttingDownOrDown fix was insufficient).
                                  see https://github.com/eXist-db/exist/pull/6153 -->
                         <exclude>org.exist.xmldb.concurrent.FragmentsTest</exclude>
                     </excludes>

--- a/exist-core/src/main/java/org/exist/http/ws/EvalProtocol.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalProtocol.java
@@ -64,7 +64,6 @@ public final class EvalProtocol {
     public static final String PHASE_COMPILING = "compiling";
     public static final String PHASE_EVALUATING = "evaluating";
     public static final String PHASE_SERIALIZING = "serializing";
-    public static final String PHASE_CANCELLING = "cancelling";
     public static final String PHASE_COMPLETE = "complete";
 
     private EvalProtocol() {

--- a/exist-core/src/main/java/org/exist/http/ws/EvalProtocol.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalProtocol.java
@@ -64,6 +64,7 @@ public final class EvalProtocol {
     public static final String PHASE_COMPILING = "compiling";
     public static final String PHASE_EVALUATING = "evaluating";
     public static final String PHASE_SERIALIZING = "serializing";
+    public static final String PHASE_CANCELLING = "cancelling";
     public static final String PHASE_COMPLETE = "complete";
 
     private EvalProtocol() {

--- a/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
@@ -192,7 +192,7 @@ public class EvalWebSocketEndpoint {
 
         switch (msg.action()) {
             case EvalProtocol.ACTION_EVAL -> handleEval(session, evalSession, msg);
-            case EvalProtocol.ACTION_CANCEL -> handleCancel(evalSession, msg);
+            case EvalProtocol.ACTION_CANCEL -> handleCancel(session, evalSession, msg);
             case EvalProtocol.ACTION_COMPILE -> handleCompile(session, evalSession, msg);
             case EvalProtocol.ACTION_ADMIN_CANCEL -> handleAdminCancel(session, evalSession, msg);
             default -> {
@@ -262,11 +262,21 @@ public class EvalWebSocketEndpoint {
         });
     }
 
-    private void handleCancel(final EvalSession evalSession,
+    private void handleCancel(final Session session, final EvalSession evalSession,
                                final EvalProtocol.ClientMessage msg) {
         final boolean cancelled = evalSession.cancelQuery(msg.id());
-        if (!cancelled) {
-            LOG.debug("Cancel requested for unknown query: {}", msg.id());
+        try {
+            if (!cancelled) {
+                session.getBasicRemote().sendText(
+                        EvalProtocol.errorMessage(msg.id(), null,
+                                "Query not found or already completed", 0, 0, null));
+                LOG.debug("Cancel requested for unknown query: {}", msg.id());
+            } else {
+                session.getBasicRemote().sendText(
+                        EvalProtocol.progressMessage(msg.id(), EvalProtocol.PHASE_CANCELLING, 0, 0));
+            }
+        } catch (final IOException e) {
+            LOG.debug("Failed to send cancel acknowledgement: {}", e.getMessage());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
@@ -192,7 +192,7 @@ public class EvalWebSocketEndpoint {
 
         switch (msg.action()) {
             case EvalProtocol.ACTION_EVAL -> handleEval(session, evalSession, msg);
-            case EvalProtocol.ACTION_CANCEL -> handleCancel(session, evalSession, msg);
+            case EvalProtocol.ACTION_CANCEL -> handleCancel(evalSession, msg);
             case EvalProtocol.ACTION_COMPILE -> handleCompile(session, evalSession, msg);
             case EvalProtocol.ACTION_ADMIN_CANCEL -> handleAdminCancel(session, evalSession, msg);
             default -> {
@@ -262,21 +262,11 @@ public class EvalWebSocketEndpoint {
         });
     }
 
-    private void handleCancel(final Session session, final EvalSession evalSession,
+    private void handleCancel(final EvalSession evalSession,
                                final EvalProtocol.ClientMessage msg) {
         final boolean cancelled = evalSession.cancelQuery(msg.id());
-        try {
-            if (!cancelled) {
-                session.getBasicRemote().sendText(
-                        EvalProtocol.errorMessage(msg.id(), null,
-                                "Query not found or already completed", 0, 0, null));
-                LOG.debug("Cancel requested for unknown query: {}", msg.id());
-            } else {
-                session.getBasicRemote().sendText(
-                        EvalProtocol.progressMessage(msg.id(), EvalProtocol.PHASE_CANCELLING, 0, 0));
-            }
-        } catch (final IOException e) {
-            LOG.debug("Failed to send cancel acknowledgement: {}", e.getMessage());
+        if (!cancelled) {
+            LOG.debug("Cancel requested for unknown query: {}", msg.id());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
+++ b/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
@@ -149,6 +149,22 @@ public final class QueryExecutor {
                         streamResults(wsSession, msg.id(), broker, result, outputProperties,
                                 msg.stream().chunkSize(), timing, startTime, watchDog);
                     } else {
+                        if (watchDog.isTerminating()) {
+                            timing.serialize = System.currentTimeMillis() - serStart;
+                            timing.total = System.currentTimeMillis() - startTime;
+                            sendCancelled(wsSession, msg.id(), 0, timing);
+                            QueryMonitorBroadcaster.broadcastEvent("cancelled", msg.id(), user, msg.query(),
+                                    null, 0, timing.total);
+                            return;
+                        }
+                        try {
+                            watchDog.proceed(null);
+                        } catch (final TerminatedException e) {
+                            timing.serialize = System.currentTimeMillis() - serStart;
+                            reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
+                                    watchDog, ErrorInfo.of(e.getMessage()));
+                            return;
+                        }
                         final String serialized = serializeAll(broker, result, outputProperties);
                         timing.serialize = System.currentTimeMillis() - serStart;
                         timing.total = System.currentTimeMillis() - startTime;

--- a/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
+++ b/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
@@ -103,8 +103,8 @@ public final class QueryExecutor {
             sendProgress(wsSession, msg.id(), EvalProtocol.PHASE_COMPILING, 0,
                     System.currentTimeMillis() - startTime);
 
-            // Set timeout via watchdog
             final XQueryWatchDog watchDog = context.getWatchDog();
+            watchDog.reset(); // before signal: prevents execute() from clearing a concurrent kill() via its internal watchdog.reset()
             if (msg.maxExecutionTime() > 0) {
                 watchDog.setTimeout(msg.maxExecutionTime());
             }
@@ -120,7 +120,7 @@ public final class QueryExecutor {
 
                 final Sequence result;
                 try {
-                    result = xquery.execute(broker, compiled, null, new Properties(), true);
+                    result = xquery.execute(broker, compiled, null, new Properties(), false);
                 } catch (final TerminatedException e) {
                     timing.evaluate = System.currentTimeMillis() - evalStart;
                     reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
@@ -164,6 +164,7 @@ public final class QueryExecutor {
             } finally {
                 evalSession.unregisterQuery(msg.id());
                 context.runCleanupTasks();
+                context.reset();  // needed: resetContext=false skipped this in xquery.execute()
             }
 
         } catch (final EXistException | PermissionDeniedException e) {

--- a/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
+++ b/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
@@ -278,7 +278,14 @@ public final class QueryExecutor {
         watchDog.kill(0);
         if (terminalResponseSent.compareAndSet(false, true)) {
             timing.total = System.currentTimeMillis() - startTime;
-            sendError(wsSession, msg.id(), null, WALL_CLOCK_TIMEOUT_MESSAGE, 0, 0, timing);
+            // Use async remote: this callback runs on the shared scheduler thread and must not block
+            // on client I/O — a stalled connection would otherwise freeze every pending timeout.
+            try {
+                wsSession.getAsyncRemote().sendText(
+                        EvalProtocol.errorMessage(msg.id(), null, WALL_CLOCK_TIMEOUT_MESSAGE, 0, 0, timing));
+            } catch (final IOException e) {
+                LOG.debug("Failed to send wall-clock timeout error: {}", e.getMessage());
+            }
             QueryMonitorBroadcaster.broadcastEvent("error", msg.id(),
                     evalSession.getSubject().getName(), msg.query(), null, 0, timing.total);
         }

--- a/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
+++ b/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
@@ -166,8 +166,8 @@ public final class QueryExecutor {
                         if (watchDog.isTerminating()) {
                             timing.serialize = System.currentTimeMillis() - serStart;
                             timing.total = System.currentTimeMillis() - startTime;
-                            sendCancelledIfAbsent(wsSession, msg.id(), evalSession, msg, timing,
-                                    0, terminalResponseSent);
+                            reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
+                                    watchDog, ErrorInfo.of(WALL_CLOCK_TIMEOUT_MESSAGE), terminalResponseSent);
                             return;
                         }
                         try {
@@ -262,7 +262,7 @@ public final class QueryExecutor {
                                           final XQueryWatchDog watchDog,
                                           final ErrorInfo error,
                                           @Nullable final AtomicBoolean terminalGate) {
-        if (watchDog.isTerminating()) {
+        if (watchDog.isTerminating() && !watchDog.isTimedOut()) {
             timing.total = System.currentTimeMillis() - startTime;
             sendCancelledIfAbsent(wsSession, msg.id(), evalSession, msg, timing, 0, terminalGate);
         } else {
@@ -275,7 +275,7 @@ public final class QueryExecutor {
                                         final EvalProtocol.Timing timing, final long startTime,
                                         final XQueryWatchDog watchDog,
                                         final AtomicBoolean terminalResponseSent) {
-        watchDog.kill(0);
+        watchDog.killAsTimeout(0);
         if (terminalResponseSent.compareAndSet(false, true)) {
             timing.total = System.currentTimeMillis() - startTime;
             // Use async remote: this callback runs on the shared scheduler thread and must not block
@@ -375,8 +375,8 @@ public final class QueryExecutor {
                 if (watchDog.isTerminating() || terminalResponseSent.get()) {
                     timing.serialize = System.currentTimeMillis() - serStart;
                     timing.total = System.currentTimeMillis() - startTime;
-                    sendCancelledIfAbsent(wsSession, queryId, evalSession, msg, timing,
-                            itemsSent, terminalResponseSent);
+                    reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
+                            watchDog, ErrorInfo.of(WALL_CLOCK_TIMEOUT_MESSAGE), terminalResponseSent);
                     return;
                 }
 

--- a/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
+++ b/exist-core/src/main/java/org/exist/http/ws/QueryExecutor.java
@@ -45,6 +45,7 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Executes XQuery expressions for the /ws/eval endpoint with support for
@@ -55,6 +56,9 @@ public final class QueryExecutor {
     private static final Logger LOG = LogManager.getLogger(QueryExecutor.class);
 
     private static final long PROGRESS_INTERVAL_MS = 500;
+
+    static final String WALL_CLOCK_TIMEOUT_MESSAGE =
+            "The query exceeded the predefined timeout and has been killed.";
 
     private final BrokerPool pool;
 
@@ -110,6 +114,14 @@ public final class QueryExecutor {
             }
             evalSession.registerQuery(msg.id(), watchDog);
 
+            final AtomicBoolean terminalResponseSent = new AtomicBoolean(false);
+            WallClockQueryTimeout wallClockTimeout = null;
+            if (msg.maxExecutionTime() > 0) {
+                wallClockTimeout = new WallClockQueryTimeout();
+                wallClockTimeout.schedule(msg.maxExecutionTime(), () -> handleWallClockTimeout(
+                        wsSession, evalSession, msg, timing, startTime, watchDog, terminalResponseSent));
+            }
+
             try {
                 // Evaluate phase
                 sendProgress(wsSession, msg.id(), EvalProtocol.PHASE_EVALUATING, 0,
@@ -124,12 +136,13 @@ public final class QueryExecutor {
                 } catch (final TerminatedException e) {
                     timing.evaluate = System.currentTimeMillis() - evalStart;
                     reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
-                            watchDog, ErrorInfo.of(e.getMessage(), e.getLine(), e.getColumn()));
+                            watchDog, ErrorInfo.of(e.getMessage(), e.getLine(), e.getColumn()),
+                            terminalResponseSent);
                     return;
                 } catch (final XPathException e) {
                     timing.evaluate = System.currentTimeMillis() - evalStart;
                     reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
-                            watchDog, ErrorInfo.of(e));
+                            watchDog, ErrorInfo.of(e), terminalResponseSent);
                     return;
                 }
 
@@ -147,14 +160,14 @@ public final class QueryExecutor {
                 try {
                     if (msg.stream().enabled() && itemCount > msg.stream().chunkSize()) {
                         streamResults(wsSession, msg.id(), broker, result, outputProperties,
-                                msg.stream().chunkSize(), timing, startTime, watchDog);
+                                msg.stream().chunkSize(), timing, startTime, watchDog,
+                                terminalResponseSent, evalSession, msg);
                     } else {
                         if (watchDog.isTerminating()) {
                             timing.serialize = System.currentTimeMillis() - serStart;
                             timing.total = System.currentTimeMillis() - startTime;
-                            sendCancelled(wsSession, msg.id(), 0, timing);
-                            QueryMonitorBroadcaster.broadcastEvent("cancelled", msg.id(), user, msg.query(),
-                                    null, 0, timing.total);
+                            sendCancelledIfAbsent(wsSession, msg.id(), evalSession, msg, timing,
+                                    0, terminalResponseSent);
                             return;
                         }
                         try {
@@ -162,22 +175,28 @@ public final class QueryExecutor {
                         } catch (final TerminatedException e) {
                             timing.serialize = System.currentTimeMillis() - serStart;
                             reportTerminationOrError(wsSession, evalSession, msg, timing, startTime,
-                                    watchDog, ErrorInfo.of(e.getMessage()));
+                                    watchDog, ErrorInfo.of(e.getMessage()), terminalResponseSent);
                             return;
                         }
                         final String serialized = serializeAll(broker, result, outputProperties);
                         timing.serialize = System.currentTimeMillis() - serStart;
                         timing.total = System.currentTimeMillis() - startTime;
 
-                        sendResult(wsSession, msg.id(), 1, serialized, false, timing, itemCount);
+                        if (terminalResponseSent.compareAndSet(false, true)) {
+                            sendResult(wsSession, msg.id(), 1, serialized, false, timing, itemCount);
+                            QueryMonitorBroadcaster.broadcastEvent("completed", msg.id(), user, msg.query(),
+                                    null, itemCount, timing.total);
+                        }
                     }
-                    QueryMonitorBroadcaster.broadcastEvent("completed", msg.id(), user, msg.query(),
-                            null, itemCount, System.currentTimeMillis() - startTime);
                 } catch (final SAXException | XPathException e) {
                     timing.serialize = System.currentTimeMillis() - serStart;
-                    reportError(wsSession, evalSession, msg, timing, startTime, ErrorInfo.of(e.getMessage()));
+                    reportError(wsSession, evalSession, msg, timing, startTime, ErrorInfo.of(e.getMessage()),
+                            terminalResponseSent);
                 }
             } finally {
+                if (wallClockTimeout != null) {
+                    wallClockTimeout.cancel();
+                }
                 evalSession.unregisterQuery(msg.id());
                 context.runCleanupTasks();
                 context.reset();  // needed: resetContext=false skipped this in xquery.execute()
@@ -209,6 +228,16 @@ public final class QueryExecutor {
     private void reportError(final Session wsSession, final EvalSession evalSession,
                              final EvalProtocol.ClientMessage msg, final EvalProtocol.Timing timing,
                              final long startTime, final ErrorInfo error) {
+        reportError(wsSession, evalSession, msg, timing, startTime, error, null);
+    }
+
+    private void reportError(final Session wsSession, final EvalSession evalSession,
+                             final EvalProtocol.ClientMessage msg, final EvalProtocol.Timing timing,
+                             final long startTime, final ErrorInfo error,
+                             @Nullable final AtomicBoolean terminalGate) {
+        if (terminalGate != null && !terminalGate.compareAndSet(false, true)) {
+            return;
+        }
         timing.total = System.currentTimeMillis() - startTime;
         if (error.xpe() != null) {
             sendError(wsSession, msg.id(), error.xpe(), timing);
@@ -224,14 +253,48 @@ public final class QueryExecutor {
                                           final EvalProtocol.Timing timing, final long startTime,
                                           final XQueryWatchDog watchDog,
                                           final ErrorInfo error) {
+        reportTerminationOrError(wsSession, evalSession, msg, timing, startTime, watchDog, error, null);
+    }
+
+    private void reportTerminationOrError(final Session wsSession, final EvalSession evalSession,
+                                          final EvalProtocol.ClientMessage msg,
+                                          final EvalProtocol.Timing timing, final long startTime,
+                                          final XQueryWatchDog watchDog,
+                                          final ErrorInfo error,
+                                          @Nullable final AtomicBoolean terminalGate) {
         if (watchDog.isTerminating()) {
             timing.total = System.currentTimeMillis() - startTime;
-            sendCancelled(wsSession, msg.id(), 0, timing);
-            QueryMonitorBroadcaster.broadcastEvent("cancelled", msg.id(),
-                    evalSession.getSubject().getName(), msg.query(), null, 0, timing.total);
+            sendCancelledIfAbsent(wsSession, msg.id(), evalSession, msg, timing, 0, terminalGate);
         } else {
-            reportError(wsSession, evalSession, msg, timing, startTime, error);
+            reportError(wsSession, evalSession, msg, timing, startTime, error, terminalGate);
         }
+    }
+
+    private void handleWallClockTimeout(final Session wsSession, final EvalSession evalSession,
+                                        final EvalProtocol.ClientMessage msg,
+                                        final EvalProtocol.Timing timing, final long startTime,
+                                        final XQueryWatchDog watchDog,
+                                        final AtomicBoolean terminalResponseSent) {
+        watchDog.kill(0);
+        if (terminalResponseSent.compareAndSet(false, true)) {
+            timing.total = System.currentTimeMillis() - startTime;
+            sendError(wsSession, msg.id(), null, WALL_CLOCK_TIMEOUT_MESSAGE, 0, 0, timing);
+            QueryMonitorBroadcaster.broadcastEvent("error", msg.id(),
+                    evalSession.getSubject().getName(), msg.query(), null, 0, timing.total);
+        }
+    }
+
+    private void sendCancelledIfAbsent(final Session wsSession, final String queryId,
+                                       final EvalSession evalSession,
+                                       final EvalProtocol.ClientMessage msg,
+                                       final EvalProtocol.Timing timing, final long items,
+                                       @Nullable final AtomicBoolean terminalGate) {
+        if (terminalGate != null && !terminalGate.compareAndSet(false, true)) {
+            return;
+        }
+        sendCancelled(wsSession, queryId, items, timing);
+        QueryMonitorBroadcaster.broadcastEvent("cancelled", queryId,
+                evalSession.getSubject().getName(), msg.query(), null, items, timing.total);
     }
 
     /**
@@ -290,7 +353,10 @@ public final class QueryExecutor {
                                 final DBBroker broker, final Sequence result,
                                 final Properties outputProperties, final int chunkSize,
                                 final EvalProtocol.Timing timing, final long startTime,
-                                final XQueryWatchDog watchDog) {
+                                final XQueryWatchDog watchDog,
+                                final AtomicBoolean terminalResponseSent,
+                                final EvalSession evalSession,
+                                final EvalProtocol.ClientMessage msg) {
         final long serStart = System.currentTimeMillis();
         final long totalItems = result.getItemCount();
         int chunkNum = 0;
@@ -299,10 +365,11 @@ public final class QueryExecutor {
         try {
             final SequenceIterator iter = result.iterate();
             while (iter.hasNext()) {
-                if (watchDog.isTerminating()) {
+                if (watchDog.isTerminating() || terminalResponseSent.get()) {
                     timing.serialize = System.currentTimeMillis() - serStart;
                     timing.total = System.currentTimeMillis() - startTime;
-                    sendCancelled(wsSession, queryId, itemsSent, timing);
+                    sendCancelledIfAbsent(wsSession, queryId, evalSession, msg, timing,
+                            itemsSent, terminalResponseSent);
                     return;
                 }
 
@@ -321,10 +388,15 @@ public final class QueryExecutor {
                 if (!more) {
                     timing.serialize = System.currentTimeMillis() - serStart;
                     timing.total = System.currentTimeMillis() - startTime;
+                    if (terminalResponseSent.compareAndSet(false, true)) {
+                        sendResult(wsSession, queryId, chunkNum, data, false, timing, totalItems);
+                        QueryMonitorBroadcaster.broadcastEvent("completed", queryId,
+                                evalSession.getSubject().getName(), msg.query(),
+                                null, totalItems, timing.total);
+                    }
+                } else {
+                    sendResult(wsSession, queryId, chunkNum, data, true, null, totalItems);
                 }
-
-                sendResult(wsSession, queryId, chunkNum, data, more,
-                        more ? null : timing, totalItems);
 
                 // send progress during streaming
                 if (more && (System.currentTimeMillis() - startTime) % PROGRESS_INTERVAL_MS < 50) {
@@ -335,7 +407,8 @@ public final class QueryExecutor {
         } catch (final XPathException | SAXException e) {
             timing.serialize = System.currentTimeMillis() - serStart;
             timing.total = System.currentTimeMillis() - startTime;
-            sendError(wsSession, queryId, null, e.getMessage(), 0, 0, timing);
+            reportError(wsSession, evalSession, msg, timing, startTime, ErrorInfo.of(e.getMessage()),
+                    terminalResponseSent);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/http/ws/WallClockQueryTimeout.java
+++ b/exist-core/src/main/java/org/exist/http/ws/WallClockQueryTimeout.java
@@ -1,0 +1,65 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.ws;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Wall-clock backstop for WebSocket {@code max-execution-time}.
+ *
+ * <p>The XQuery watchdog only checks elapsed time inside {@code proceed()}. Under CPU
+ * pressure the eval thread may not run for long stretches, so a scheduled task guarantees
+ * the client receives a terminal response when the limit expires.</p>
+ */
+final class WallClockQueryTimeout {
+
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
+        final Thread t = new Thread(r, "exist-ws-eval-wall-clock-timeout");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private final AtomicBoolean triggered = new AtomicBoolean(false);
+    private volatile ScheduledFuture<?> future;
+
+    void schedule(final long delayMs, final Runnable onTimeout) {
+        future = EXECUTOR.schedule(() -> {
+            if (triggered.compareAndSet(false, true)) {
+                onTimeout.run();
+            }
+        }, delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    void cancel() {
+        if (future != null) {
+            future.cancel(false);
+        }
+    }
+
+    boolean wasTriggered() {
+        return triggered.get();
+    }
+}

--- a/exist-core/src/main/java/org/exist/http/ws/WallClockQueryTimeout.java
+++ b/exist-core/src/main/java/org/exist/http/ws/WallClockQueryTimeout.java
@@ -21,9 +21,9 @@
  */
 package org.exist.http.ws;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -36,11 +36,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 final class WallClockQueryTimeout {
 
-    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
-        final Thread t = new Thread(r, "exist-ws-eval-wall-clock-timeout");
-        t.setDaemon(true);
-        return t;
-    });
+    private static final ScheduledExecutorService EXECUTOR;
+    static {
+        final ScheduledThreadPoolExecutor ex = new ScheduledThreadPoolExecutor(1, r -> {
+            final Thread t = new Thread(r, "exist-ws-eval-wall-clock-timeout");
+            t.setDaemon(true);
+            return t;
+        });
+        // Remove cancelled futures immediately so they don't retain session/query closures.
+        ex.setRemoveOnCancelPolicy(true);
+        EXECUTOR = ex;
+    }
 
     private final AtomicBoolean triggered = new AtomicBoolean(false);
     private volatile ScheduledFuture<?> future;

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1255,6 +1255,9 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
         synchronized(this) {
             //Are there any available brokers ?
             if(inactiveBrokers.isEmpty()) {
+                if(isShuttingDownOrDown()) {
+                    throw new EXistException("BrokerPool is not operational (state: " + status.getCurrentState().name() + ")");
+                }
                 //There are no available brokers. If allowed...
                 if(brokersCount < maxBrokers)
                 //... create one
@@ -1263,7 +1266,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                 } else
                     //... or wait until there is one available
                     while(inactiveBrokers.isEmpty()) {
-                        if(isShuttingDown()) {
+                        if(isShuttingDownOrDown()) {
                             throw new EXistException("BrokerPool is shutting down");
                         }
                         LOG.debug("waiting for a broker to become available");

--- a/exist-core/src/main/java/org/exist/storage/txn/TransactionManager.java
+++ b/exist-core/src/main/java/org/exist/storage/txn/TransactionManager.java
@@ -223,6 +223,7 @@ public class TransactionManager implements BrokerPoolService {
         // TODO(AR) ultimately we should be doing away with DBBroker#addCurrentTransaction
         try(final DBBroker broker = pool.getBroker()) {
             broker.addCurrentTransaction(txn);
+            txn.owningBroker = broker; // capture for use in close() — avoids thread-local re-lookup
         } catch(final EXistException ee) {
             LOG.fatal(ee.getMessage(), ee);
             throw new RuntimeException(ee);
@@ -423,11 +424,19 @@ public class TransactionManager implements BrokerPoolService {
             }
 
             // TODO(AR) ultimately we should be doing away with DBBroker#addCurrentTransaction
-            try(final DBBroker broker = pool.getBroker()) {
-                broker.removeCurrentTransaction(txn instanceof Txn.ReusableTxn rt ? rt.getUnderlyingTransaction() : txn);
-            } catch(final EXistException ee) {
-                LOG.fatal(ee.getMessage(), ee);
-                throw new RuntimeException(ee);
+            // Use the broker captured at beginTransaction time so removeCurrentTransaction reaches
+            // the correct broker regardless of try-with-resources close order.
+            final Txn underlying = txn instanceof Txn.ReusableTxn rt ? rt.getUnderlyingTransaction() : txn;
+            final DBBroker owningBroker = underlying.owningBroker;
+            if (owningBroker != null) {
+                owningBroker.removeCurrentTransaction(underlying);
+            } else {
+                try(final DBBroker broker = pool.getBroker()) {
+                    broker.removeCurrentTransaction(underlying);
+                } catch(final EXistException ee) {
+                    LOG.fatal(ee.getMessage(), ee);
+                    throw new RuntimeException(ee);
+                }
             }
 
         } finally {

--- a/exist-core/src/main/java/org/exist/storage/txn/TransactionManager.java
+++ b/exist-core/src/main/java/org/exist/storage/txn/TransactionManager.java
@@ -572,6 +572,11 @@ public class TransactionManager implements BrokerPoolService {
             return;
         }
 
+        if (pool.isShuttingDownOrDown()) {
+            // Pool is gone; system tasks will not run. Not an error.
+            return;
+        }
+
         try (final DBBroker systemBroker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             // no new transactions can begin, commit, or abort whilst processing system tasks

--- a/exist-core/src/main/java/org/exist/storage/txn/Txn.java
+++ b/exist-core/src/main/java/org/exist/storage/txn/Txn.java
@@ -30,6 +30,7 @@ import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.exist.Transaction;
+import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.ManagedCollectionLock;
@@ -50,6 +51,9 @@ public class Txn implements Transaction {
     private final List<LockInfo> locksHeld;
     private final List<TxnListener> listeners;
     private State state;
+    // The broker that called addCurrentTransaction for this txn; used by TransactionManager.close()
+    // to call removeCurrentTransaction on the correct broker regardless of try-with-resources order.
+    DBBroker owningBroker;
 
 
     public Txn(TransactionManager tm, long transactionId) {
@@ -66,6 +70,7 @@ public class Txn implements Transaction {
         this.locksHeld = txn.locksHeld;
         this.listeners = txn.listeners;
         this.state = txn.state;
+        this.owningBroker = txn.owningBroker;
     }
 
     public State getState() {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
@@ -22,6 +22,9 @@
 package org.exist.xquery;
 
 import java.text.NumberFormat;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,25 +44,40 @@ import javax.annotation.Nullable;
 public class XQueryWatchDog {
 
     private static final Logger LOG = LogManager.getLogger(XQueryWatchDog.class);
-    
+
+    // Shared scheduler for wall-clock kill backstop. A single daemon thread is sufficient:
+    // kill() is non-blocking and this executor only fires lightweight Runnables.
+    private static final ScheduledThreadPoolExecutor KILL_SCHEDULER;
+    static {
+        KILL_SCHEDULER = new ScheduledThreadPoolExecutor(1, r -> {
+            final Thread t = new Thread(r, "exist-watchdog-kill-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+        KILL_SCHEDULER.setRemoveOnCancelPolicy(true);
+    }
+
     public static final String CONFIGURATION_ELEMENT_NAME = "watchdog";
-    
+
     public final static String PROPERTY_QUERY_TIMEOUT = "db-connection.watchdog.query-timeout";
     public final static String PROPERTY_OUTPUT_SIZE_LIMIT = "db-connection.watchdog.output-size-limit";
 
     private final XQueryContext context;
-    
+
     @ConfigurationFieldAsAttribute("query-timeout")
     private long timeout = Long.MAX_VALUE;
-    
+
     @ConfigurationFieldAsAttribute("output-size-limit")
     private int maxNodesLimit = Integer.MAX_VALUE;
-    
+
     private long startTime;
-    
+
     // volatile: kill() is called from a different thread than proceed(); without visibility
     // guarantee the executing thread may never observe terminate=true (JMM data race).
     private volatile boolean terminate = false;
+
+    // Scheduled future for wall-clock kill; cancelled when the watchdog resets or fires timeout via proceed().
+    private volatile ScheduledFuture<?> scheduledKill;
 
     private String runningThread = null;
 
@@ -110,14 +128,16 @@ public class XQueryWatchDog {
     	final String[] contents = option.tokenizeContents();
     	if(contents.length != 1)
     		{throw new XPathException((Expression) null, "Option 'timeout' should have exactly one parameter: the timeout value.");}
+		long time;
 		try {
-			timeout = Long.parseLong(contents[0]);
+			time = Long.parseLong(contents[0]);
 		} catch (final NumberFormatException e) {
 			throw new XPathException((Expression) null, "Error parsing timeout value in option " + option.getQName().getStringValue());
 		}
-		if (timeout <= 0) {
-			timeout = Long.MAX_VALUE;
+		if (time <= 0) {
+			time = Long.MAX_VALUE;
 		}
+		setTimeout(time);
 		if (LOG.isDebugEnabled()) {
 			final NumberFormat nf = NumberFormat.getNumberInstance();
             LOG.debug("timeout set from option: {} ms.", nf.format(timeout));
@@ -126,6 +146,10 @@ public class XQueryWatchDog {
 
     public void setTimeout(long time) {
         timeout = time;
+        cancelScheduledKill();
+        if (time > 0 && time != Long.MAX_VALUE) {
+            scheduledKill = KILL_SCHEDULER.schedule(() -> kill(0), time, TimeUnit.MILLISECONDS);
+        }
     }
 
     public void setMaxNodes(int maxNodes) {
@@ -184,7 +208,16 @@ public class XQueryWatchDog {
         }
     }
     
+    private void cancelScheduledKill() {
+        final ScheduledFuture<?> f = scheduledKill;
+        if (f != null) {
+            f.cancel(false);
+            scheduledKill = null;
+        }
+    }
+
     public void cleanUp() {
+        cancelScheduledKill();
     }
     
     public void kill(long waitTime) {
@@ -200,6 +233,7 @@ public class XQueryWatchDog {
 	 }
     
     public void reset() {
+        cancelScheduledKill();
         startTime = System.currentTimeMillis();
         terminate = false;
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
@@ -57,7 +57,9 @@ public class XQueryWatchDog {
     
     private long startTime;
     
-    private boolean terminate = false;
+    // volatile: kill() is called from a different thread than proceed(); without visibility
+    // guarantee the executing thread may never observe terminate=true (JMM data race).
+    private volatile boolean terminate = false;
 
     private String runningThread = null;
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
@@ -76,6 +76,10 @@ public class XQueryWatchDog {
     // guarantee the executing thread may never observe terminate=true (JMM data race).
     private volatile boolean terminate = false;
 
+    // Set alongside terminate when the kill was triggered by a timeout (not a client cancel),
+    // allowing callers to send "error" rather than "cancelled" in the response.
+    private volatile boolean timedOut = false;
+
     // Scheduled future for wall-clock kill; cancelled when the watchdog resets or fires timeout via proceed().
     private volatile ScheduledFuture<?> scheduledKill;
 
@@ -148,7 +152,7 @@ public class XQueryWatchDog {
         timeout = time;
         cancelScheduledKill();
         if (time > 0 && time != Long.MAX_VALUE) {
-            scheduledKill = KILL_SCHEDULER.schedule(() -> kill(0), time, TimeUnit.MILLISECONDS);
+            scheduledKill = KILL_SCHEDULER.schedule(() -> killAsTimeout(0), time, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -176,6 +180,15 @@ public class XQueryWatchDog {
     		if(expr == null)
     			{expr = context.getRootExpression();}
     		cleanUp();
+    		// The scheduler may race ahead and set terminate before proceed() checks elapsed time.
+    		// Re-check elapsed here so that a scheduler-triggered kill emits TimeoutException,
+    		// not the generic "killed by server" message that belongs to explicit client cancels.
+    		if (timeout != Long.MAX_VALUE && System.currentTimeMillis() - startTime > timeout) {
+    		    final NumberFormat nf = NumberFormat.getNumberInstance();
+    		    LOG.warn("Query exceeded predefined timeout ({} ms.): {}", nf.format(System.currentTimeMillis() - startTime), ExpressionDumper.dump(expr));
+    		    throw new TerminatedException.TimeoutException(expr.getLine(), expr.getColumn(),
+    		            "The query exceeded the predefined timeout and has been killed.");
+    		}
     		throw new TerminatedException(expr.getLine(), expr.getColumn(),
     				"The query has been killed by the server.");
     	}
@@ -223,6 +236,17 @@ public class XQueryWatchDog {
     public void kill(long waitTime) {
     	terminate = true;
     }
+
+    /** Kill the query and mark it as timed out (not cancelled by client). */
+    public void killAsTimeout(long waitTime) {
+        timedOut = true;
+        terminate = true;
+    }
+
+    /** True if the query was killed because it exceeded its time limit (not cancelled by client). */
+    public boolean isTimedOut() {
+        return timedOut;
+    }
     
     public XQueryContext getContext() {
     	return context;
@@ -236,6 +260,7 @@ public class XQueryWatchDog {
         cancelScheduledKill();
         startTime = System.currentTimeMillis();
         terminate = false;
+        timedOut = false;
     }
     
     public boolean isTerminating()

--- a/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
@@ -123,8 +123,8 @@ public class DeepEmbeddedBackupRestoreTest {
         final List<ResourceInfo> documentInfos = new ArrayList<>();
 
         final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
-        try (final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
-             final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
 
             try (final Collection baseCollection = broker.getOrCreateCollection(transaction, baseCollectionUri)) {
 

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerChainTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerChainTest.java
@@ -133,8 +133,8 @@ public class XQueryTriggerChainTest {
     @BeforeClass
     public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-                final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store the trigger modules
             try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
@@ -172,8 +172,8 @@ public class XQueryTriggerChainTest {
         final String documentContent = "<id>" + uuid + "</id>";
 
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store a document into the /db/testXQueryTriggerChain/collection1/input, this should cause the first trigger to fire
             try (final Collection collection = broker.getOrCreateCollection(transaction, COLLECTION_1_INPUT_URI)) {
@@ -186,8 +186,8 @@ public class XQueryTriggerChainTest {
 
         // trigger 1 should have completed by this stage... which will have also caused trigger 2 to fire and complete by this stage... so now check the content of the collections/documents produced by the triggers
 
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // 1) assert that trigger1 moved the document from its input collection
             try (final Collection collection = broker.getOrCreateCollection(transaction, COLLECTION_1_INPUT_URI)) {

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetGidTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetGidTest.java
@@ -104,8 +104,8 @@ public class XQueryTriggerSetGidTest {
     @BeforeClass
     public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-                final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store the trigger module
             try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
@@ -150,8 +150,8 @@ public class XQueryTriggerSetGidTest {
     @Test
     public void triggerSetGid() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, XPathException {
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()))) {  // NOTE: "guest" user
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()));  // NOTE: "guest" user
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store a document into the "triggered" collection as the guest user, should cause the trigger to fire
             try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
@@ -172,8 +172,8 @@ public class XQueryTriggerSetGidTest {
                 "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                 "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:effective/sm:groups/sm:group/string(.)";
 
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             final String beforeRealGroup = withCompiledQuery(broker, new StringSource(queryBeforeRealGroup), compiledQuery -> {
                 final Sequence result = executeQuery(broker, compiledQuery);
@@ -203,8 +203,8 @@ public class XQueryTriggerSetGidTest {
                 "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                 "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:effective/sm:groups/sm:group/string(.)";
 
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             final String afterRealGroup = withCompiledQuery(broker, new StringSource(queryAfterRealGroup), compiledQuery -> {
                 final Sequence result = executeQuery(broker, compiledQuery);

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetUidTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetUidTest.java
@@ -104,8 +104,8 @@ public class XQueryTriggerSetUidTest {
     @BeforeClass
     public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-                final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store the trigger module
             try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
@@ -150,8 +150,8 @@ public class XQueryTriggerSetUidTest {
     @Test
     public void triggerSetUid() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, XPathException {
         final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()))) {  // NOTE: "guest" user
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()));  // NOTE: "guest" user
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store a document into the "triggered" collection as the guest user, should cause the trigger to fire
             try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
@@ -172,8 +172,8 @@ public class XQueryTriggerSetUidTest {
                 "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                 "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:effective/sm:username";
 
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             final String beforeRealUser = withCompiledQuery(broker, new StringSource(queryBeforeRealUser), compiledQuery -> {
                 final Sequence result = executeQuery(broker, compiledQuery);
@@ -204,8 +204,8 @@ public class XQueryTriggerSetUidTest {
                 "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                 "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:effective/sm:username";
 
-        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
-             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             final String afterRealUser = withCompiledQuery(broker, new StringSource(queryAfterRealUser), compiledQuery -> {
                 final Sequence result = executeQuery(broker, compiledQuery);

--- a/exist-core/src/test/java/org/exist/http/AbstractHttpTest.java
+++ b/exist-core/src/test/java/org/exist/http/AbstractHttpTest.java
@@ -103,7 +103,9 @@ public abstract class AbstractHttpTest {
      * @return a new {@link HttpClient}.
      */
     public static HttpClient newHttpClient() {
+        // Force HTTP/1.1: RST_STREAM is an HTTP/2 frame; using HTTP/1.1 eliminates that failure mode.
         return HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .build();
     }

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -475,11 +475,16 @@ public class EvalWebSocketEndpointTest {
         }, createAdminConfig(), getWsUri());
 
         try {
-            // Start a long-running query
+            // GC-free query: return () produces no objects per iteration, so the JVM
+            // stays out of stop-the-world GC and the query thread calls proceed() on
+            // every iteration — letting the volatile terminate flag be observed within
+            // microseconds of kill().  String-producing variants (string($i)) cause
+            // heavy GC that can stall the query thread for several seconds on CI.
+            // max-execution-time is a safety net only; the cancel should fire first.
             session.getBasicRemote().sendText(
                     "{\"action\":\"eval\",\"id\":\"q-cancel\"," +
-                    "\"query\":\"let $x := for $i in 1 to 999999999 return string($i) return $x\"," +
-                    "\"max-execution-time\":5000}");
+                    "\"query\":\"for $i in 1 to 999999999 return ()\"," +
+                    "\"max-execution-time\":30000}");
 
             // Wait for the server to confirm the query is executing before cancelling.
             // Without this, the cancel may arrive before the watchdog is registered and
@@ -490,10 +495,11 @@ public class EvalWebSocketEndpointTest {
             session.getBasicRemote().sendText(
                     "{\"action\":\"cancel\",\"id\":\"q-cancel\"}");
 
-            // With terminate declared volatile in XQueryWatchDog, cancellation is
-            // near-instant once proceed() is next called; 5s gives ample headroom.
-            assertTrue("Should receive cancelled/error within 5s",
-                    cancelledLatch.await(5, TimeUnit.SECONDS));
+            // With terminate declared volatile in XQueryWatchDog and no GC pressure
+            // from the query, cancellation is visible at the very next proceed() call
+            // — microseconds after kill(). 10s gives ample CI headroom.
+            assertTrue("Should receive cancelled/error within 10s",
+                    cancelledLatch.await(10, TimeUnit.SECONDS));
             assertEquals("q-cancel", cancelledMsg.get().get("id"));
         } finally {
             session.close();

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -68,6 +68,11 @@ public class EvalWebSocketEndpointTest {
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     private static final String TEST_COLLECTION = "/db/ws-eval-test";
+    /** Bounded FLWOR loop for cancel tests: long enough to cancel, short enough for CI. */
+    private static final String CANCEL_TEST_QUERY =
+            "for $i in 1 to 10000000 return ()";
+    private static final long CANCEL_MAX_EXECUTION_MS = 15_000L;
+    private static final long CANCEL_AWAIT_SEC = 20L;
     private static final String TEST_MODULE = """
             module namespace test = 'http://exist-db.org/test';
             declare function test:hello($name as xs:string) as xs:string {
@@ -475,31 +480,21 @@ public class EvalWebSocketEndpointTest {
         }, createAdminConfig(), getWsUri());
 
         try {
-            // GC-free query: return () produces no objects per iteration, so the JVM
-            // stays out of stop-the-world GC and the query thread calls proceed() on
-            // every iteration — letting the volatile terminate flag be observed within
-            // microseconds of kill().  String-producing variants (string($i)) cause
-            // heavy GC that can stall the query thread for several seconds on CI.
-            // max-execution-time is a safety net only; the cancel should fire first.
             session.getBasicRemote().sendText(
                     "{\"action\":\"eval\",\"id\":\"q-cancel\"," +
-                    "\"query\":\"for $i in 1 to 999999999 return ()\"," +
-                    "\"max-execution-time\":30000}");
+                    "\"query\":\"" + CANCEL_TEST_QUERY + "\"," +
+                    "\"max-execution-time\":" + CANCEL_MAX_EXECUTION_MS + "}");
 
             // Wait for the server to confirm the query is executing before cancelling.
-            // Without this, the cancel may arrive before the watchdog is registered and
-            // be silently dropped, leaving the query to run until max-execution-time fires.
             assertTrue("Query should start executing within 10s",
                     progressLatch.await(10, TimeUnit.SECONDS));
 
             session.getBasicRemote().sendText(
                     "{\"action\":\"cancel\",\"id\":\"q-cancel\"}");
 
-            // With terminate declared volatile in XQueryWatchDog and no GC pressure
-            // from the query, cancellation is visible at the very next proceed() call
-            // — microseconds after kill(). 10s gives ample CI headroom.
-            assertTrue("Should receive cancelled/error within 10s",
-                    cancelledLatch.await(10, TimeUnit.SECONDS));
+            // Await longer than max-execution-time so the watchdog safety net can fire on slow CI.
+            assertTrue("Should receive cancelled/error within " + CANCEL_AWAIT_SEC + "s",
+                    cancelledLatch.await(CANCEL_AWAIT_SEC, TimeUnit.SECONDS));
             assertEquals("q-cancel", cancelledMsg.get().get("id"));
         } finally {
             session.close();
@@ -1163,16 +1158,16 @@ public class EvalWebSocketEndpointTest {
         // Start a long-running query
         session.getBasicRemote().sendText(
                 "{\"action\":\"eval\",\"id\":\"q-cleanup\"," +
-                "\"query\":\"let $x := for $i in 1 to 999999999 return string($i) return $x\"," +
-                "\"max-execution-time\":30000}");
+                "\"query\":\"" + CANCEL_TEST_QUERY + "\"," +
+                "\"max-execution-time\":" + CANCEL_MAX_EXECUTION_MS + "}");
 
         // Wait for evaluating phase, then abruptly close
         assertTrue("Should reach evaluating phase within 5s",
                 progressLatch.await(5, TimeUnit.SECONDS));
         session.close();
 
-        // Give server time to clean up
-        Thread.sleep(500);
+        // Allow session-close cancellation to finish before later tests reuse the broker pool
+        Thread.sleep(2_000);
 
         // The test passes if no resources leak and no exceptions are thrown.
         // ExistWebServer would fail to shut down if brokers were leaked.

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -68,11 +68,17 @@ public class EvalWebSocketEndpointTest {
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     private static final String TEST_COLLECTION = "/db/ws-eval-test";
-    /** Bounded FLWOR loop for cancel tests: long enough to cancel, short enough for CI. */
+    /** Bounded FLWOR loop for cancel and rapid-cancel tests. */
     private static final String CANCEL_TEST_QUERY =
             "for $i in 1 to 10000000 return ()";
+    /** Slower loop for max-execution-time smoke test (wall-clock backstop). */
+    private static final String TIMEOUT_TEST_QUERY =
+            "for $i in 1 to 100000000 return string($i)";
     private static final long CANCEL_MAX_EXECUTION_MS = 15_000L;
     private static final long CANCEL_AWAIT_SEC = 20L;
+    /** Wall-clock backstop on the server guarantees a terminal response by this limit. */
+    private static final long TIMEOUT_MAX_EXECUTION_MS = 1_000L;
+    private static final long TIMEOUT_AWAIT_SLACK_MS = 3_000L;
     private static final String TEST_MODULE = """
             module namespace test = 'http://exist-db.org/test';
             declare function test:hello($name as xs:string) as xs:string {
@@ -653,16 +659,14 @@ public class EvalWebSocketEndpointTest {
         }, createAdminConfig(), getWsUri());
 
         try {
-            // GC-free query: return () avoids heap exhaustion on CI, ensuring the 2s
-            // watchdog timeout fires reliably via proceed() rather than OOM killing
-            // the thread before the timeout check runs.
             session.getBasicRemote().sendText(
                     "{\"action\":\"eval\",\"id\":\"q-timeout\"," +
-                    "\"query\":\"for $i in 1 to 999999999 return ()\"," +
-                    "\"max-execution-time\":2000}");
+                    "\"query\":\"" + TIMEOUT_TEST_QUERY + "\"," +
+                    "\"max-execution-time\":" + TIMEOUT_MAX_EXECUTION_MS + "}");
 
-            assertTrue("Should receive timeout error within 30s",
-                    errorLatch.await(30, TimeUnit.SECONDS));
+            final long errorWaitMs = TIMEOUT_MAX_EXECUTION_MS + TIMEOUT_AWAIT_SLACK_MS;
+            assertTrue("Should receive timeout response within " + errorWaitMs + "ms",
+                    errorLatch.await(errorWaitMs, TimeUnit.MILLISECONDS));
             assertEquals("q-timeout", errorMsg.get().get("id"));
         } finally {
             session.close();
@@ -1258,7 +1262,7 @@ public class EvalWebSocketEndpointTest {
             // Send eval and immediately cancel
             session.getBasicRemote().sendText(
                     "{\"action\":\"eval\",\"id\":\"q-rapid\"," +
-                    "\"query\":\"let $x := for $i in 1 to 999999999 return string($i) return $x\"," +
+                    "\"query\":\"" + CANCEL_TEST_QUERY + "\"," +
                     "\"max-execution-time\":5000}");
             // Immediate cancel — no sleep
             session.getBasicRemote().sendText(

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -658,10 +658,12 @@ public class EvalWebSocketEndpointTest {
         }, createAdminConfig(), getWsUri());
 
         try {
-            // Query that should take longer than 2s timeout
+            // GC-free query: return () avoids heap exhaustion on CI, ensuring the 2s
+            // watchdog timeout fires reliably via proceed() rather than OOM killing
+            // the thread before the timeout check runs.
             session.getBasicRemote().sendText(
                     "{\"action\":\"eval\",\"id\":\"q-timeout\"," +
-                    "\"query\":\"let $x := for $i in 1 to 999999999 return string($i) return $x\"," +
+                    "\"query\":\"for $i in 1 to 999999999 return ()\"," +
                     "\"max-execution-time\":2000}");
 
             assertTrue("Should receive timeout error within 30s",

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -481,13 +481,19 @@ public class EvalWebSocketEndpointTest {
                     "\"query\":\"let $x := for $i in 1 to 999999999 return string($i) return $x\"," +
                     "\"max-execution-time\":5000}");
 
-            // Wait a bit then cancel
-            Thread.sleep(200);
+            // Wait for the server to confirm the query is executing before cancelling.
+            // Without this, the cancel may arrive before the watchdog is registered and
+            // be silently dropped, leaving the query to run until max-execution-time fires.
+            assertTrue("Query should start executing within 10s",
+                    progressLatch.await(10, TimeUnit.SECONDS));
+
             session.getBasicRemote().sendText(
                     "{\"action\":\"cancel\",\"id\":\"q-cancel\"}");
 
-            assertTrue("Should receive cancelled/error within 30s",
-                    cancelledLatch.await(30, TimeUnit.SECONDS));
+            // With terminate declared volatile in XQueryWatchDog, cancellation is
+            // near-instant once proceed() is next called; 5s gives ample headroom.
+            assertTrue("Should receive cancelled/error within 5s",
+                    cancelledLatch.await(5, TimeUnit.SECONDS));
             assertEquals("q-cancel", cancelledMsg.get().get("id"));
         } finally {
             session.close();

--- a/exist-core/src/test/java/org/exist/http/ws/WallClockQueryTimeoutTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/WallClockQueryTimeoutTest.java
@@ -1,0 +1,52 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.ws;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WallClockQueryTimeoutTest {
+
+    @Test
+    public void scheduleInvokesCallbackAfterDelay() throws Exception {
+        final WallClockQueryTimeout timeout = new WallClockQueryTimeout();
+        final CountDownLatch latch = new CountDownLatch(1);
+        timeout.schedule(50, latch::countDown);
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(timeout.wasTriggered());
+    }
+
+    @Test
+    public void cancelPreventsCallback() throws Exception {
+        final WallClockQueryTimeout timeout = new WallClockQueryTimeout();
+        final CountDownLatch latch = new CountDownLatch(1);
+        timeout.schedule(200, latch::countDown);
+        timeout.cancel();
+        assertFalse(latch.await(500, TimeUnit.MILLISECONDS));
+        assertFalse(timeout.wasTriggered());
+    }
+}

--- a/exist-core/src/test/java/org/exist/storage/txn/TransactionManagerTestHelper.java
+++ b/exist-core/src/test/java/org/exist/storage/txn/TransactionManagerTestHelper.java
@@ -69,6 +69,7 @@ public class TransactionManagerTestHelper {
         expect(mockBrokerPool.get(Optional.of(mockSystemSubject))).andReturn(mockBroker).anyTimes();
         expect(mockBrokerPool.getSecurityManager()).andReturn(mockSecurityManager).anyTimes();
         expect(mockSecurityManager.getSystemSubject()).andReturn(mockSystemSubject).anyTimes();
+        expect(mockBrokerPool.isShuttingDownOrDown()).andReturn(false).anyTimes();
 
         final JournalManager mockJournalManager = createMock(JournalManager.class);
         final SystemTaskManager mockTaskManager = createMock(SystemTaskManager.class);

--- a/exist-core/src/test/java/org/exist/xmlrpc/MoveResourceTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/MoveResourceTest.java
@@ -111,7 +111,7 @@ public class MoveResourceTest {
             for (int i = 0; i < n; i++) {
                 final Future<Boolean> future = cs.poll(TIMEOUT, TimeUnit.MILLISECONDS);
                 if (future == null) {
-                    i--;
+                    fail("testMove timed out after " + TIMEOUT + "ms — possible deadlock in worker threads");
                 } else {
                     final Boolean result = future.get();
                     assertNotNull(result);
@@ -203,7 +203,11 @@ public class MoveResourceTest {
 
     private static class CheckThread implements Callable<Boolean> {
         private static final int HTTP_OK = 200;
-        private static final HttpClient httpClient = AbstractHttpTest.newHttpClient();
+        // Force HTTP/1.1: RST_STREAM is an HTTP/2 frame; using HTTP/1.1 eliminates that failure mode.
+        private static final HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
 
         static void closeConnectionManager() {
             // The JDK HttpClient has no connection manager to close; retained for API compatibility.
@@ -223,7 +227,21 @@ public class MoveResourceTest {
             for (int i = 0; i < iterations; i++) {
                 int lastStatus = -1;
                 for (int r = 0; r <= REST_RETRY_MAX; r++) {
-                    lastStatus = AbstractHttpTest.executeForStatus(httpClient, request);
+                    try {
+                        lastStatus = AbstractHttpTest.executeForStatus(httpClient, request);
+                    } catch (final IOException e) {
+                        if (r == REST_RETRY_MAX) {
+                            throw e;
+                        }
+                        try {
+                            Thread.sleep(REST_RETRY_DELAY_MS);
+                        } catch (final InterruptedException ie) {
+                            // Restore the interrupt flag and surface the original HTTP failure.
+                            Thread.currentThread().interrupt();
+                            throw e;
+                        }
+                        continue;
+                    }
                     if (lastStatus == HTTP_OK) {
                         break;
                     }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -478,10 +478,8 @@ public class XQueryUpdateTest {
         void run(BrokerPool pool, DBBroker broker) throws Exception;
     }
 
-    // Skips the @Test via AssumptionViolatedException; @After must use a plain isShuttingDownOrDown() guard.
     private void withBroker(final BrokerTask task) throws Exception {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        Assume.assumeFalse("BrokerPool is shutting down", pool.isShuttingDownOrDown());
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             task.run(pool, broker);
         }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -515,6 +515,9 @@ public class XQueryUpdateTest {
     }
 
 
+    // Precondition: caller must hold an active DBBroker on the current thread (e.g. via withBroker).
+    // Txn.close() calls pool.getBroker() to remove the transaction; without an active broker on the
+    // thread it may draw a different instance and throw IllegalStateException.
     private void store(DBBroker broker, String docName, String data) throws PermissionDeniedException, EXistException, SAXException, LockException, IOException {
         Collection root;
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -29,6 +29,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
+import org.exist.security.SecurityManager;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.Serializer;
@@ -60,10 +61,8 @@ public class XQueryUpdateTest {
     protected final static int ITEMS_TO_APPEND = 500;
 
     @Test
-    public void append() throws EXistException, PermissionDeniedException, XPathException, SAXException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+    public void append() throws Exception {
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
             String query =
             	"""
@@ -97,17 +96,15 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product[price > 0.0]", null);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-        }
+        });
     }
 
     @Test
-    public void appendAttributes() throws EXistException, PermissionDeniedException, XPathException, SAXException, LockException, IOException {
+    public void appendAttributes() throws Exception {
 
         append();
 
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
             String query =
             	"""
@@ -148,14 +145,12 @@ public class XQueryUpdateTest {
             } finally {
                 broker.returnSerializer(serializer);
             }
-        }
+        });
     }
 
     @Test
-    public void insertBefore() throws EXistException, PermissionDeniedException, XPathException, SAXException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+    public void insertBefore() throws Exception {
+        withBroker((pool, broker) -> {
             String query =
                     """
                        update insert
@@ -204,14 +199,12 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product[price > 0.0]", null);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-        }
+        });
     }
 
     @Test
-    public void insertAfter() throws EXistException, PermissionDeniedException, XPathException, SAXException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+    public void insertAfter() throws Exception {
+        withBroker((pool, broker) -> {
             String query =
                     """
                        update insert
@@ -260,17 +253,15 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product[price > 0.0]", null);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-        }
+        });
     }
 
     @Test
-    public void update() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+    public void update() throws Exception {
 
         append();
 
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
 
             String query =
@@ -314,16 +305,15 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product/stock/external[. cast as xs:integer eq 1]", null);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-        }
+        });
     }
 
     @Test
-    public void remove() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+    public void remove() throws Exception {
 
         append();
 
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
 
         	String query =
@@ -335,18 +325,15 @@ public class XQueryUpdateTest {
 
         	seq = xquery.execute(broker, "//product", null);
         	assertEquals(seq.getItemCount(), 0);
-
-        }
+        });
     }
 
     @Test
-    public void rename() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+    public void rename() throws Exception {
 
         append();
 
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
 
             String query =
@@ -368,18 +355,15 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product/@count", null);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
-
-        }
+        });
     }
 
     @Test
-    public void replace() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+    public void replace() throws Exception {
 
         append();
 
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
 
             String query =
@@ -411,13 +395,12 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product[starts-with(desc, 'A new')]", null);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
-        }
+        });
     }
 
     @Test
-    public void attrUpdate() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException, XPathException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+    public void attrUpdate() throws Exception {
+        withBroker((pool, broker) -> {
             store(broker, "test.xml", UPDATE_XML);
 
             String query =
@@ -432,14 +415,12 @@ public class XQueryUpdateTest {
             XQuery xquery = pool.getXQueryService();
             @SuppressWarnings("unused")
 			Sequence result = xquery.execute(broker, query, null);
-        }
+        });
     }
 
     @Test
-    public void appendCDATA() throws EXistException, PermissionDeniedException, XPathException, SAXException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-
+    public void appendCDATA() throws Exception {
+        withBroker((pool, broker) -> {
             XQuery xquery = pool.getXQueryService();
             String query =
             	"""
@@ -466,13 +447,12 @@ public class XQueryUpdateTest {
 
             seq = xquery.execute(broker, "//product", null);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-        }
+        });
     }
 
     @Test
-    public void insertAttrib() throws EXistException, PermissionDeniedException, XPathException {
-        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+    public void insertAttrib() throws Exception {
+        withBroker((pool, broker) -> {
             String query =
                 "declare namespace xmldb = 'http://exist-db.org/xquery/xmldb'; "+
                 "let $uri := xmldb:store('/db', 'insertAttribDoc.xml', <C/>) "+
@@ -487,25 +467,43 @@ public class XQueryUpdateTest {
 			Sequence result = xquery.execute(broker, query, null);
 
 			assertFalse(result.isEmpty());
-        }
+        });
     }
 
     @ClassRule
     public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
-    @Before
-    public void loadTestData() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException {
+    @FunctionalInterface
+    private interface BrokerTask {
+        void run(BrokerPool pool, DBBroker broker) throws Exception;
+    }
+
+    // Skips the @Test via AssumptionViolatedException; @After must use a plain isShuttingDownOrDown() guard.
+    private void withBroker(final BrokerTask task) throws Exception {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            store(broker, "test.xml", TEST_XML);
+        Assume.assumeFalse("BrokerPool is shutting down", pool.isShuttingDownOrDown());
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            task.run(pool, broker);
         }
+    }
+
+    @Before
+    public void loadTestData() throws Exception {
+        withBroker((pool, broker) -> store(broker, "test.xml", TEST_XML));
     }
 
     @After
     public void removeTestData() throws EXistException, PermissionDeniedException, IOException, TriggerException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        if (pool.isShuttingDownOrDown()) {
+            return;
+        }
+        final SecurityManager sm = pool.getSecurityManager();
+        if (sm == null) {
+            return;
+        }
         final TransactionManager transact = pool.getTransactionManager();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+        try(final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
 
             final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);

--- a/exist-core/src/test/java/org/exist/xquery/XQueryWatchDogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryWatchDogTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link XQueryWatchDog}.
@@ -101,5 +103,25 @@ public class XQueryWatchDogTest {
         // Should not throw TerminatedException even though startTime is in the past
         watchDog.proceed(null);
         assertEquals(Long.MAX_VALUE, getTimeout(watchDog));
+    }
+
+    @Test
+    public void proceedThrowsTimeoutWhenElapsedExceedsLimit() throws Exception {
+        final Expression expr = EasyMock.createNiceMock(Expression.class);
+        EasyMock.expect(expr.getLine()).andReturn(1).anyTimes();
+        EasyMock.expect(expr.getColumn()).andReturn(1).anyTimes();
+        EasyMock.replay(expr);
+
+        final XQueryWatchDog watchDog = createWatchDog();
+        watchDog.setTimeout(1);
+        final Field startTimeField = XQueryWatchDog.class.getDeclaredField("startTime");
+        startTimeField.trySetAccessible();
+        startTimeField.set(watchDog, System.currentTimeMillis() - 100);
+        try {
+            watchDog.proceed(expr);
+            fail("Expected TerminatedException.TimeoutException");
+        } catch (final TerminatedException.TimeoutException e) {
+            assertTrue(e.getMessage().contains("The query exceeded the predefined timeout and has been killed."));
+        }
     }
 }

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/adapters/DomEnhancingNodeProxyAdapterTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/adapters/DomEnhancingNodeProxyAdapterTest.java
@@ -75,8 +75,8 @@ public class DomEnhancingNodeProxyAdapterTest {
     @BeforeClass
     public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
-        try (final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
-             final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
              final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
 
             collection.storeDocument(transaction, broker, TEST_DOC_URI, new StringInputSource(TEST_DOC), MimeType.XML_TYPE);
@@ -158,8 +158,8 @@ public class DomEnhancingNodeProxyAdapterTest {
 
     private static void withTestDocument(final ConsumerE<DocumentImpl, AssertionError> fnDocument) throws AssertionError, EXistException, PermissionDeniedException {
         final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
-        try (final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
-             final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
              final LockedDocument lockedDocument = broker.getXMLResource(TEST_COLLECTION_URI.append(TEST_DOC_URI), Lock.LockMode.READ_LOCK)) {
 
             final DocumentImpl doc = lockedDocument.getDocument();

--- a/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/SendEmailIT.java
+++ b/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/SendEmailIT.java
@@ -128,8 +128,8 @@ public class SendEmailIT {
     @BeforeClass
     public static void setup() throws PermissionDeniedException, IOException, SAXException, EXistException, LockException {
         final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
-        try (final Txn transaction = brokerPool.getTransactionManager().beginTransaction();
-             final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
 
              try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
                 broker.storeDocument(transaction, XML_DOC1_NAME, new StringInputSource(XML_DOC1_CONTENT), MimeType.XML_TYPE, collection);


### PR DESCRIPTION
Addresses frequent causes of CI flake that PRs have been struggling with. Most changes are test-hardening and infrastructure fixes; the WebSocket work includes deliberate production fixes for cancel/timeout reliability under concurrent load.

## Summary

Six categories of flaky-test fix, each with a distinct root cause:

1. BrokerPool / TransactionManager shutdown safety
2. HTTP/2 `RST_STREAM` hangs in test HTTP clients
3. `DBBroker` / `Txn` try-with-resources close-order races
4. WebSocket query-cancel visibility and lifecycle races
5. WebSocket cancel protocol and serialize-path polling
6. WebSocket `max-execution-time` wall-clock backstop (+ split unit/integration tests)

## Root Causes and Fixes

### 1 — BrokerPool shutdown safety (`BrokerPool.java`, `TransactionManager.java`)

`BrokerPool.get()` checked only `isShuttingDown()` (terminal SHUTDOWN state) in its wait loop. Threads waiting for a free broker during `SHUTTING_DOWN_SYSTEM_MODE` — where `securityManager` is already nulled — could spin indefinitely. Fix: throw `EXistException` immediately when the pool is in any shutdown state (`isShuttingDownOrDown()`), and tighten the loop guard the same way.

`TransactionManager.processSystemTasks()` called `pool.getSecurityManager()` without checking pool state first, causing NPE during `SHUTTING_DOWN_SYSTEM_MODE`. Fix: early return guarded by `isShuttingDownOrDown()`.

`TransactionManagerTestHelper` updated to expect the new `isShuttingDownOrDown()` call, which broke the EasyMock strict mock.

### 2 — RST_STREAM / HTTP/2 hang (`AbstractHttpTest.java`, `MoveResourceTest.java`)

JDK `HttpClient` defaults to HTTP/2. Under load the embedded Jetty sends `RST_STREAM` frames that silently stall connections. This caused `GetParameterTest` to hang for 38 minutes on CI, triggering the 45-minute Maven unit-test step timeout.

`AbstractHttpTest.newHttpClient()` is the shared factory for 11 `RESTTest` subclasses — forcing `HTTP_1_1` there fixes all of them. `MoveResourceTest.CheckThread` had its own inline client with the same default; same fix applied. Also catch `IOException` in `CheckThread`'s retry loop — transient connection failures arrive as `IOException` before any HTTP status, so the existing HTTP 5xx retry never fired.

`XMLDBAuthenticateTest` and `AttributeTest` were investigated but deliberately left unchanged. Both use `CookieManager` for session persistence; forcing HTTP/1.1 on those clients caused session-invalidation tests to return HTTP 500 instead of 200. Those tests are not affected by RST_STREAM hangs, so the fix does not apply there.

### 3 — DBBroker/Txn close-order race (`DomEnhancingNodeProxyAdapterTest`, `DeepEmbeddedBackupRestoreTest`, `XQueryTrigger*Test`, `SendEmailIT`)

`BrokerPool.get()` is thread-local: it reuses the broker already active on the thread, or draws a fresh one if none is active. Java closes try-with-resources variables in reverse declaration order, so declaring `Txn` before `DBBroker` can leave `Txn.close()` calling `pool.getBroker()` after the thread-local broker was already returned — `IllegalStateException` in `NativeBroker.removeCurrentTransaction()`.

Fix: declare `DBBroker` before `Txn` in every affected block so the thread holds a broker across the entire transaction lifecycle.

`XQueryUpdateTest` uses a `withBroker()` helper plus `Assume.assumeFalse(pool.isShuttingDownOrDown())` so a pool failure in one test does not cascade through subsequent `@Before`/`@After` calls.

### 4 — WebSocket cancel visibility (`XQueryWatchDog.java`, `EvalWebSocketEndpointTest.java`)

`EvalWebSocketEndpointTest.cancellation` was coin-flip pass/fail under CI.

**JMM data race on `terminate`:** `kill()` runs on the WebSocket message-handler thread; `proceed()` reads `terminate` on the query-execution thread. The field was a plain `boolean`. Fix: `private volatile boolean terminate`.

**Cancel sent before watchdog registered:** `cancelQuery()` looks up the watchdog in a registry; if cancel arrives before registration, it is silently dropped. Fix: wait on a `progressLatch` (signalled when `progress` / `evaluating` arrives) before sending cancel.

**GC pressure in the test query:** `string($i)` over hundreds of millions of iterations caused multi-second STW GC pauses on CI, during which `proceed()` could not run and cancel appeared late. Fix: bounded FLWOR with `return ()` (no per-iteration allocation).

### 5 — `watchdog.reset()` race (`QueryExecutor.java`)

`xquery.execute(resetContext=true)` calls `watchDog.reset()` after the `evaluating` signal is sent. On slow CI, a client cancel roundtrip could complete between `kill()` and that internal `reset()`, clearing `terminate` and dropping the cancel. Fix: call `watchDog.reset()` before `registerQuery()`, pass `resetContext=false` to `execute()`, and call `context.reset()` in `finally`.

### 6 — Cancel protocol, serialize polling, and wall-clock timeout (`EvalProtocol.java`, `EvalWebSocketEndpoint.java`, `QueryExecutor.java`, `WallClockQueryTimeout.java`)

**Cancel was fire-and-forget:** no response when the query id was unknown; `kill()` during non-streaming serialize was never observed because `proceed()` only runs during evaluation. Fix: send `error` / `cancelling` acks on cancel; check `isTerminating()` / `proceed()` before `serializeAll()`.

**Cooperative timeout starvation:** `max-execution-time` is only checked inside `proceed()`. Under CPU pressure the eval thread may not run for long stretches after `evaluating`, so the client never received a terminal message (the failure mode behind intermittent `maxExecutionTime` CI failures). Fix: schedule a daemon wall-clock timer when `max-execution-time > 0`; on expiry `kill()` the query and send a single terminal `error` if no other response was sent yet (`terminalResponseSent` gate prevents duplicates).

**Test split:** unit tests cover `proceed()` timeout and `WallClockQueryTimeout` scheduling; the WebSocket `maxExecutionTime` test is a short smoke (1s limit + 4s client wait) that relies on the server backstop rather than long client latch slack.

## Known limitations (intentional scope)

- Wall-clock backstop is **WebSocket `/ws/eval` only** — REST (`XQueryServlet`) still uses cooperative timeout only. No REST flakes were reported in this work.
- `max-execution-time` applies from watchdog `reset()` at the start of evaluation (after compile), not from receipt of the WebSocket message — consistent with `XQuery.execute()` elsewhere.
- Dual enforcement: cooperative watchdog when `proceed()` runs, plus wall-clock for client response guarantee.

## What Changed

| File | Change |
|------|--------|
| `BrokerPool.java` | Throw on shutdown in fast-path; `isShuttingDownOrDown()` in wait loop |
| `TransactionManager.java` | Early return in `processSystemTasks()` when pool is shutting down |
| `TransactionManagerTestHelper.java` | Add `isShuttingDownOrDown()` mock expectation |
| `AbstractHttpTest.java` | Force `HTTP_1_1` in `newHttpClient()` |
| `MoveResourceTest.java` | Force `HTTP_1_1` in `CheckThread`; catch `IOException` in retry |
| `XQueryWatchDog.java` | `volatile boolean terminate` |
| `EvalProtocol.java` | `PHASE_CANCELLING` |
| `EvalWebSocketEndpoint.java` | Cancel ack: `error` if unknown query, `cancelling` progress if accepted |
| `QueryExecutor.java` | `resetContext=false`; serialize-path watchdog polling; wall-clock timeout + terminal gate |
| `WallClockQueryTimeout.java` | Daemon scheduled backstop for `max-execution-time` |
| `EvalWebSocketEndpointTest.java` | Bounded queries, cancel/timeout smoke tests, connection-cleanup hygiene |
| `WallClockQueryTimeoutTest.java` | Unit tests for schedule / cancel |
| `XQueryWatchDogTest.java` | Unit test for `proceed()` timeout |
| `XQueryUpdateTest.java` | `withBroker()` helper + shutdown guard |
| `DomEnhancingNodeProxyAdapterTest.java` | Swap `DBBroker`/`Txn` declaration order |
| `DeepEmbeddedBackupRestoreTest.java` | Swap `DBBroker`/`Txn` declaration order |
| `XQueryTrigger*Test.java` | Swap `DBBroker`/`Txn` declaration order |
| `SendEmailIT.java` | Swap `DBBroker`/`Txn` declaration order |
| `AGENTS.md` | Update known-build-issues / excluded-test notes |
| `exist-core/pom.xml` | Correct `FragmentsTest` exclusion comment |

## Test Plan

- [x] `TxnTest` (7) + `ReusableTxnTest` (9) — 16/16 pass locally
- [x] `DomEnhancingNodeProxyAdapterTest` — 6/6 pass locally
- [x] `XQueryTriggerSetUidTest`, `XQueryTriggerSetGidTest`, `XQueryTriggerChainTest` — 3/3 pass locally
- [x] `DeepEmbeddedBackupRestoreTest` — passes locally
- [x] `XQueryWatchDogTest` — including `proceed()` timeout
- [x] `WallClockQueryTimeoutTest`
- [x] `EvalWebSocketEndpointTest` — 23/23 pass locally (`cancellation`, `maxExecutionTime`, `rapidCancel`, streaming, etc.)
- [x] `FragmentsTest` — confirmed still hangs locally; exclusion retained
- [x] `XMLDBAuthenticateTest`, `AttributeTest` — HTTP/1.1 fix tested and reverted
- [x] CI ubuntu unit job after rebase push