### PR TITLE
[bugfix] Stop backup prolog stderr spam; fix DeadlockIT CI hang

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/DescriptorResourceCounter.java
+++ b/exist-core/src/main/java/org/exist/backup/DescriptorResourceCounter.java
@@ -56,6 +56,8 @@ public class DescriptorResourceCounter {
         this.counterHandler = new CounterHandler();
 
         xmlReader.setContentHandler(counterHandler);
+        // Suppress Xerces "[Fatal Error]" stderr noise; fatal errors still propagate via DefaultHandler.
+        xmlReader.setErrorHandler(counterHandler);
     }
 
     public long count(final InputStream descriptorInputStream) throws IOException, SAXException {

--- a/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
@@ -30,7 +30,6 @@ import org.exist.util.FileUtils;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -196,23 +195,26 @@ public class FileSystemBackupDescriptor extends AbstractBackupDescriptor {
         return null;
     }
 
+    /**
+     * Count resources declared in {@link BackupDescriptor#COLLECTION_DESCRIPTOR} files under this
+     * collection's subtree (same approach as {@link ZipArchiveBackupDescriptor}).
+     * {@link org.exist.backup.Restore} uses only the root descriptor's count for the progress total,
+     * so arbitrary subcollections (e.g. /db/apps, /db/foo/stuff) are included without double-counting
+     * the pre-queued /db/system hierarchy.
+     */
     private void countFileEntries(final Path descriptor) {
-
-        // Only count files from top level.
-        if (!descriptor.toString().endsWith("/db/" + COLLECTION_DESCRIPTOR)) {
+        final Path collectionDir = descriptor.getParent();
+        if (collectionDir == null) {
             return;
         }
-
         try {
             final DescriptorResourceCounter descriptorResourceCounter = new DescriptorResourceCounter();
-
-            try (final Stream<Path> walk = Files.walk(descriptor.getParent());
-                final Stream<Path> ds = walk
-                        .filter(f -> !Files.isDirectory(f))
-                        .filter(f -> !COLLECTION_DESCRIPTOR.equals(f.getFileName().toString()))) {
-
-                for (final Path d : ds.collect(Collectors.toList())) {
-                    try (final InputStream is = new BufferedInputStream(Files.newInputStream(d))) {
+            try (final Stream<Path> walk = Files.walk(collectionDir)) {
+                for (final Path contentsFile : walk
+                        .filter(p -> !Files.isDirectory(p))
+                        .filter(p -> COLLECTION_DESCRIPTOR.equals(p.getFileName().toString()))
+                        .toList()) {
+                    try (final InputStream is = Files.newInputStream(contentsFile)) {
                         numberOfFiles += descriptorResourceCounter.count(is);
                     }
                 }

--- a/exist-core/src/main/java/org/exist/backup/Restore.java
+++ b/exist-core/src/main/java/org/exist/backup/Restore.java
@@ -65,14 +65,17 @@ public class Restore {
         }
 
         //get the backup descriptors, can be more than one if it was an incremental backup
-        final Deque<BackupDescriptor> descriptors = getBackupDescriptors(f);
+        final BackupPlan plan = getBackupDescriptors(f);
+        final Deque<BackupDescriptor> descriptors = plan.restoreQueue();
 
         final Set<String> appsToSkip = overwriteApps ? Collections.emptySet() : AppRestoreUtils.checkApps(broker, descriptors);
 
-        // count all files
+        // Count from roots only: each root's getNumberOfFiles() recursively covers its entire subtree,
+        // so summing only roots avoids double-counting the pre-queued /db/system hierarchy while still
+        // including arbitrary collections like /db/apps that are not pre-queued.
         long totalNrOfFiles = 0;
-        for (BackupDescriptor backupDescriptor : descriptors) {
-            totalNrOfFiles += backupDescriptor.getNumberOfFiles();
+        for (final BackupDescriptor root : plan.roots()) {
+            totalNrOfFiles += root.getNumberOfFiles();
         }
 
         // continue restore
@@ -107,13 +110,17 @@ public class Restore {
         }
     }
     
-    private Deque<BackupDescriptor> getBackupDescriptors(Path contents) throws IOException {
+    private record BackupPlan(Deque<BackupDescriptor> restoreQueue, List<BackupDescriptor> roots) {}
+
+    private BackupPlan getBackupDescriptors(Path contents) throws IOException {
         final Deque<BackupDescriptor> descriptors = new ArrayDeque<>();
-        
+        final List<BackupDescriptor> roots = new ArrayList<>();
+
         do {
 
             final BackupDescriptor bd = getBackupDescriptor(contents);
             descriptors.push(bd);
+            roots.add(bd);
 
             // check if the /db/system collection is in the backup. This must be processed before other /db collections
             //TODO : find a way to make a correspondence with DBRoker's named constants
@@ -150,8 +157,8 @@ public class Restore {
                 }
             }
         } while(contents != null);
-        
-        return descriptors;
+
+        return new BackupPlan(descriptors, roots);
     }
     
     private BackupDescriptor getBackupDescriptor(final Path f) throws IOException {

--- a/exist-core/src/main/java/org/exist/util/XMLReaderObjectFactory.java
+++ b/exist-core/src/main/java/org/exist/util/XMLReaderObjectFactory.java
@@ -39,6 +39,7 @@ import org.exist.validation.GrammarPool;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
 import org.xmlresolver.Resolver;
 
 import java.util.Map;
@@ -50,6 +51,9 @@ import java.util.Map;
 public class XMLReaderObjectFactory extends BasePooledObjectFactory<XMLReader> implements BrokerPoolService {
 
     private static final Logger LOG = LogManager.getLogger(XMLReaderObjectFactory.class);
+
+    /** Shared handler: routes parse errors through SAX without Xerces stderr spam. */
+    static final DefaultHandler SILENT_SAX_ERROR_HANDLER = new DefaultHandler();
 
     public static final String CONFIGURATION_ENTITY_RESOLVER_ELEMENT_NAME = "entity-resolver";
     public static final String CONFIGURATION_CATALOG_ELEMENT_NAME = "catalog";
@@ -98,7 +102,7 @@ public class XMLReaderObjectFactory extends BasePooledObjectFactory<XMLReader> i
         final SAXParser saxParser = saxParserFactory.newSAXParser();
         final XMLReader xmlReader = saxParser.getXMLReader();
 
-        xmlReader.setErrorHandler(null);  // disable default Xerces Error Handler
+        xmlReader.setErrorHandler(SILENT_SAX_ERROR_HANDLER);
 
         return xmlReader;
     }
@@ -136,6 +140,8 @@ public class XMLReaderObjectFactory extends BasePooledObjectFactory<XMLReader> i
                 setReaderFeature(xmlReader, feature.getKey(), feature.getValue());
             }
         }
+
+        xmlReader.setErrorHandler(SILENT_SAX_ERROR_HANDLER);
     }
 
     @Override
@@ -143,7 +149,7 @@ public class XMLReaderObjectFactory extends BasePooledObjectFactory<XMLReader> i
         final XMLReader xmlReader = pooledXmlReader.getObject();
 
         xmlReader.setContentHandler(null);
-        xmlReader.setErrorHandler(null);
+        xmlReader.setErrorHandler(SILENT_SAX_ERROR_HANDLER);
         xmlReader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, null);
     }
 

--- a/exist-core/src/test/java/org/exist/backup/FileSystemBackupDescriptorTest.java
+++ b/exist-core/src/test/java/org/exist/backup/FileSystemBackupDescriptorTest.java
@@ -1,0 +1,159 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.backup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FileSystemBackupDescriptorTest {
+
+    private static final String CONTENTS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <exist:collection xmlns:exist="http://exist.sourceforge.net/NS/exist">
+                <exist:resource name="doc1.xml" type="XMLResource" filename="doc1.xml"/>
+                <exist:resource name="test.binary" type="BinaryResource" filename="test.binary"/>
+            </exist:collection>
+            """;
+
+    private static final String NESTED_CONTENTS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <exist:collection xmlns:exist="http://exist.sourceforge.net/NS/exist">
+                <exist:resource name="nested.xml" type="XMLResource" filename="nested.xml"/>
+            </exist:collection>
+            """;
+
+    @Test
+    void countsResourcesFromContentsXmlOnly(@TempDir final Path tempDir) throws Exception {
+        final Path backupRoot = tempDir.resolve("backup");
+        final Path dbDir = backupRoot.resolve("db");
+        Files.createDirectories(dbDir);
+
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
+        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>", UTF_8);
+        Files.write(dbDir.resolve("test.binary"), "test".getBytes(UTF_8));
+
+        final FileSystemBackupDescriptor descriptor = new FileSystemBackupDescriptor(
+                backupRoot,
+                dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR));
+
+        assertEquals(2, descriptor.getNumberOfFiles());
+    }
+
+    @Test
+    void rootDescriptorCountsAllDescendantResources(@TempDir final Path tempDir) throws Exception {
+        final Path backupRoot = tempDir.resolve("backup");
+        final Path dbDir = backupRoot.resolve("db");
+        final Path nestedDir = dbDir.resolve("nested");
+        Files.createDirectories(nestedDir);
+
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
+        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8);
+        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>", UTF_8);
+        Files.write(dbDir.resolve("test.binary"), "test".getBytes(UTF_8));
+        Files.writeString(nestedDir.resolve("nested.xml"), "<nested/>", UTF_8);
+
+        final FileSystemBackupDescriptor descriptor = new FileSystemBackupDescriptor(
+                backupRoot,
+                dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR));
+
+        // recursive: root counts its own 2 resources plus the nested collection's 1
+        assertEquals(3, descriptor.getNumberOfFiles());
+    }
+
+    @Test
+    void restoreProgressTotalIsRootDescriptorCount(@TempDir final Path tempDir) throws Exception {
+        // Restore.restore() uses only the root /db descriptor's count for totalNrOfFiles.
+        // The root must recursively include /db/system so that system resources are not
+        // excluded from the progress total.
+        final Path backupRoot = tempDir.resolve("backup");
+        final Path dbDir = Files.createDirectories(backupRoot.resolve("db"));
+        final Path systemDir = Files.createDirectories(dbDir.resolve("system"));
+
+        final String dbContents = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <exist:collection xmlns:exist="http://exist.sourceforge.net/NS/exist">
+                    <exist:resource name="r0.xml" type="XMLResource" filename="r0.xml"/>
+                    <exist:resource name="r1.xml" type="XMLResource" filename="r1.xml"/>
+                    <exist:resource name="r2.xml" type="XMLResource" filename="r2.xml"/>
+                </exist:collection>
+                """;
+        final String systemContents = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <exist:collection xmlns:exist="http://exist.sourceforge.net/NS/exist">
+                    <exist:resource name="s0.xml" type="XMLResource" filename="s0.xml"/>
+                    <exist:resource name="s1.xml" type="XMLResource" filename="s1.xml"/>
+                    <exist:resource name="s2.xml" type="XMLResource" filename="s2.xml"/>
+                    <exist:resource name="s3.xml" type="XMLResource" filename="s3.xml"/>
+                    <exist:resource name="s4.xml" type="XMLResource" filename="s4.xml"/>
+                </exist:collection>
+                """;
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), dbContents, UTF_8);
+        Files.writeString(systemDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), systemContents, UTF_8);
+
+        // root recursively includes /db/system: 3 + 5 = 8
+        assertEquals(8,
+                new FileSystemBackupDescriptor(backupRoot, dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR)).getNumberOfFiles(),
+                "root descriptor must recursively include all subcollections for accurate restore progress");
+    }
+
+    @Test
+    void rootDescriptorCountsNonSystemSubcollections(@TempDir final Path tempDir) throws Exception {
+        // Restore pre-queues only system/security/groups; arbitrary collections like /db/apps and
+        // /db/foo/stuff must be covered by the recursive root count or they are never counted.
+        final Path backupRoot = tempDir.resolve("backup");
+        final Path dbDir = Files.createDirectories(backupRoot.resolve("db"));
+        final Path appsDir = Files.createDirectories(dbDir.resolve("apps"));
+        final Path fooStuffDir = Files.createDirectories(dbDir.resolve("foo").resolve("stuff"));
+
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);         // 2 resources
+        Files.writeString(appsDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8); // 1 resource
+        Files.writeString(fooStuffDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8); // 1 resource
+
+        // 2 (db) + 1 (apps) + 1 (foo/stuff) = 4
+        assertEquals(4,
+                new FileSystemBackupDescriptor(backupRoot, dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR)).getNumberOfFiles(),
+                "root descriptor must count all subcollections, not only system/security/groups");
+    }
+
+    @Test
+    void collectionDescriptorCountsOwnSubtreeOnly(@TempDir final Path tempDir) throws Exception {
+        final Path backupRoot = tempDir.resolve("backup");
+        final Path dbDir = backupRoot.resolve("db");
+        final Path nestedDir = dbDir.resolve("nested");
+        Files.createDirectories(nestedDir);
+
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
+        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8);
+
+        final FileSystemBackupDescriptor nestedDescriptor = new FileSystemBackupDescriptor(
+                backupRoot,
+                nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR));
+
+        assertEquals(1, nestedDescriptor.getNumberOfFiles());
+    }
+}

--- a/exist-core/src/test/java/org/exist/storage/lock/DeadlockIT.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/DeadlockIT.java
@@ -26,9 +26,11 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,6 +59,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
+import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.base.Resource;
@@ -90,6 +93,38 @@ public class DeadlockIT {
 
     /** Max time to wait for executor to finish (fail fast instead of hanging CI). */
     private static final int AWAIT_TERMINATION_MINUTES = 5;
+
+    /** Max attempts to find and remove an existing document before failing. */
+    private static final int MAX_REMOVE_ATTEMPTS = 100;
+
+    private final AtomicReference<Throwable> taskFailure = new AtomicReference<>();
+
+    private void recordTaskFailure(final Throwable t) {
+        taskFailure.compareAndSet(null, t);
+    }
+
+    private void rethrowTaskFailure() {
+        final Throwable failure = taskFailure.get();
+        if (failure != null) {
+            if (failure instanceof RuntimeException re) {
+                throw re;
+            }
+            if (failure instanceof Error err) {
+                throw err;
+            }
+            throw new AssertionError(failure.getMessage(), failure);
+        }
+    }
+
+    /** Matches {@link StoreTask} global document numbering. */
+    private static String documentName(final int collectionId, final int indexInCollection) {
+        return "test" + (collectionId * DOC_COUNT + indexInCollection) + ".xml";
+    }
+
+    private static boolean isConcurrentRemoveRace(final XMLDBException e) {
+        return e.errorCode == ErrorCodes.INVALID_RESOURCE
+                || e.errorCode == ErrorCodes.NO_SUCH_RESOURCE;
+    }
 
     /** Use 4 test runs, querying different collections */
     @Parameters(name = "{0}")
@@ -185,8 +220,10 @@ public class DeadlockIT {
 
 	@Test(timeout = (AWAIT_TERMINATION_MINUTES + 1) * 60 * 1000)
 	public void runTasks() {
+		taskFailure.set(null);
 		final ExecutorService executor = Executors.newFixedThreadPool(N_THREADS);
-        executor.submit(new StoreTask("store", COLL_COUNT, DOC_COUNT));
+        final CountDownLatch storeComplete = new CountDownLatch(1);
+        executor.submit(new StoreTask(COLL_COUNT, DOC_COUNT, storeComplete, taskFailure));
         synchronized (this) {
             try {
                 wait(DELAY);
@@ -200,6 +237,15 @@ public class DeadlockIT {
 			executor.submit(new QueryTask(COLL_COUNT));
 		}
         if (mode == TEST_REMOVE) {
+            try {
+                assertTrue("Store task did not finish before document removals started",
+                        storeComplete.await(AWAIT_TERMINATION_MINUTES, TimeUnit.MINUTES));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.error(e.getMessage(), e);
+                fail(e.getMessage());
+            }
+            rethrowTaskFailure();
             for (int i = 0; i < REMOVE_COUNT; i++) {
                 executor.submit(new RemoveDocumentTask(COLL_COUNT, DOC_COUNT));
             }
@@ -217,20 +263,11 @@ public class DeadlockIT {
 			executor.shutdownNow();
 			assertTrue("Executor did not terminate within " + AWAIT_TERMINATION_MINUTES + " minutes; possible deadlock or hang", terminated);
 		}
+		rethrowTaskFailure();
 	}
 
-	private static class StoreTask implements Runnable {
-
-		@SuppressWarnings("unused")
-		private final String id;
-		private final int docCount;
-		private final int collectionCount;
-
-		public StoreTask(final String id, final int collectionCount, final int docCount) {
-			this.id = id;
-			this.collectionCount = collectionCount;
-			this.docCount = docCount;
-		}
+	private record StoreTask(int collectionCount, int docCount, CountDownLatch storeComplete,
+			AtomicReference<Throwable> taskFailure) implements Runnable {
 
 		@Override
 		public void run() {
@@ -240,7 +277,6 @@ public class DeadlockIT {
 
 				final TestDataGenerator generator = new TestDataGenerator("xdb", docCount);
 				Collection coll;
-				int fileCount = 0;
 				for (int i = 0; i < collectionCount; i++) {
                     try(final Txn transaction = transact.beginTransaction()) {
                         coll = broker.getOrCreateCollection(transaction,
@@ -252,12 +288,12 @@ public class DeadlockIT {
                     }
 
                     final Path[] files = generator.generate(broker, coll, generateXQ);
-                    for (int j = 0; j < files.length; j++, fileCount++) {
+                    for (int j = 0; j < files.length; j++) {
                         try(final Txn transaction = transact.beginTransaction()) {
                             final InputSource is = new InputSource(files[j].toUri()
                                     .toASCIIString());
 
-							broker.storeDocument(transaction, XmldbURI.create("test" + fileCount + ".xml"), is, MimeType.XML_TYPE, coll);
+							broker.storeDocument(transaction, XmldbURI.create(documentName(i, j)), is, MimeType.XML_TYPE, coll);
                             transact.commit(transaction);
                         }
                     }
@@ -265,8 +301,10 @@ public class DeadlockIT {
 				}
 			} catch (Exception e) {
 				LOG.error(e.getMessage(), e);
-//				fail(e.getMessage());
-			}
+				taskFailure.compareAndSet(null, e);
+			} finally {
+                storeComplete.countDown();
+            }
 		}
 	}
 
@@ -331,7 +369,7 @@ public class DeadlockIT {
 				}
 			} catch (Exception e) {
 				LOG.error(e.getMessage(), e);
-				fail(e.getMessage());
+				recordTaskFailure(e);
 			}
 		}
 	}
@@ -348,11 +386,10 @@ public class DeadlockIT {
         @Override
         public void run() {
             boolean removed = false;
-            do {
+            for (int attempt = 0; !removed && attempt < MAX_REMOVE_ATTEMPTS; attempt++) {
                 final int collectionId = random.nextInt(collectionCount);
                 final String collection = "/db/test/" + collectionId;
-                final int docId = random.nextInt(documentCount) * collectionId;
-                final String document = "test" + docId + ".xml";
+                final String document = documentName(collectionId, random.nextInt(documentCount));
                 try {
                     final org.xmldb.api.base.Collection testCollection = DatabaseManager.getCollection("xmldb:exist://" + collection, "admin", "");
                     final Resource resource = testCollection.getResource(document);
@@ -361,10 +398,18 @@ public class DeadlockIT {
                         removed = true;
                     }
                 } catch (final XMLDBException e) {
+                    if (isConcurrentRemoveRace(e)) {
+                        continue;
+                    }
 					LOG.error(e.getMessage(), e);
-                    fail(e.getMessage());
+                    recordTaskFailure(e);
+                    return;
                 }
-            } while (!removed);
+            }
+            if (!removed) {
+                recordTaskFailure(new AssertionError(
+                        "Could not remove a document after " + MAX_REMOVE_ATTEMPTS + " attempts"));
+            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/util/XMLReaderPoolTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderPoolTest.java
@@ -348,7 +348,7 @@ public class XMLReaderPoolTest {
     }
 
     @Test
-    public void xmlReaderHasNoErrorHandler()  {
+    public void xmlReaderHasSilentErrorHandler()  {
         final Configuration mockConfiguration = createMock(Configuration.class);
         expect(mockConfiguration.getProperty(GrammarPool.GRAMMAR_POOL_ELEMENT)).andReturn(null);
         expect(mockConfiguration.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER)).andReturn(null);
@@ -366,7 +366,7 @@ public class XMLReaderPoolTest {
         final XMLReader xmlreader = xmlReaderPool.borrowXMLReader();
         assertNotNull(xmlreader);
         try {
-            assertNull(xmlreader.getErrorHandler());
+            assertSame(XMLReaderObjectFactory.SILENT_SAX_ERROR_HANDLER, xmlreader.getErrorHandler());
         } finally {
             xmlReaderPool.returnXMLReader(xmlreader);
         }
@@ -800,7 +800,7 @@ public class XMLReaderPoolTest {
     }
 
     @Test
-    public void reusedXmlReaderStillHasNoErrorHandler()  {
+    public void reusedXmlReaderStillHasSilentErrorHandler()  {
         final Configuration mockConfiguration = createMock(Configuration.class);
         expect(mockConfiguration.getProperty(GrammarPool.GRAMMAR_POOL_ELEMENT)).andReturn(null);
         expect(mockConfiguration.getProperty(XMLReaderObjectFactory.CATALOG_RESOLVER)).andReturn(null);
@@ -830,7 +830,7 @@ public class XMLReaderPoolTest {
         xmlreader = xmlReaderPool.borrowXMLReader();
         assertNotNull(xmlreader);
         try {
-            assertNull(xmlreader.getErrorHandler());
+            assertSame(XMLReaderObjectFactory.SILENT_SAX_ERROR_HANDLER, xmlreader.getErrorHandler());
         } finally {
             xmlReaderPool.returnXMLReader(xmlreader);
         }


### PR DESCRIPTION
### Description:

Two CI reliability fixes:

1. **Filesystem backup resource counting** — `FileSystemBackupDescriptor` no longer parses every payload file as XML when counting resources. Binary entries (e.g. `test.binary`) were triggering Xerces `[Fatal Error] :1:1: Content is not allowed in prolog.` on stderr. Counting now follows the zip-backup path: only `__contents__.xml` descriptors under each collection subtree. SAX errors are routed through a silent `DefaultHandler` on the pooled reader factory (and `XMLReaderPoolTest` updated accordingly). `FileSystemBackupDescriptorTest` covers nested collections and per-descriptor subtrees.

2. **DeadlockIT** — `RemoveDocumentTask` used the wrong document ID formula (`collectionId * random` instead of `collectionId * documentCount + random`), causing an infinite retry loop in `testRemoved` when `collectionId > 0`. Fix the ID calculation, cap remove retries, propagate worker failures, wait for store completion before removals, and retry on benign concurrent-remove races.

### Reference:

CI log noise and Windows integration timeouts observed while running the test suite on GitHub Actions.

### Type of tests:

- New unit tests: `FileSystemBackupDescriptorTest` (3 cases)
- Updated integration test: `DeadlockIT` (Failsafe)
- Updated unit test: `XMLReaderPoolTest`

### Test plan

- [x] `FileSystemBackupDescriptorTest` passes locally
- [x] `DeadlockIT` passes locally (6/6)
- [x] Fork CI green (unit + integration on Ubuntu/macOS/Windows, XQTS)

Made with [Cursor](https://cursor.com)