### PR TITLE
[bugfix] Silence Log4j StatusLogger noise in Maven test forks

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1206,7 +1206,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
                         <exist.jetty.portal.dir>${project.basedir}/../exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/portal</exist.jetty.portal.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
 
                     <excludes>
@@ -1233,7 +1233,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
                         <exist.jetty.portal.dir>${project.basedir}/../exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/portal</exist.jetty.portal.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>

--- a/exist-parent/log4j2-test.xml
+++ b/exist-parent/log4j2-test.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<!-- Shared Log4j 2 configuration for Maven Surefire/Failsafe across all modules. -->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.exist.jetty" level="WARN"/>
+        <Root level="OFF">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -151,6 +151,9 @@
         <!-- CI: skip unit tests when running integration-only (e.g. -DskipUnitTests=true) -->
         <skipUnitTests>false</skipUnitTests>
 
+        <!-- Shared by Surefire/Failsafe: must exist on disk for every module (not only test-classes). -->
+        <exist.log4j.testConfigurationFile>${project.parent.basedir}/log4j2-test.xml</exist.log4j.testConfigurationFile>
+
         <!-- needed just for the license-maven-plugin in this module! -->
         <project.parent.relativePath>.</project.parent.relativePath>
 
@@ -1083,7 +1086,7 @@
                             <user.language>en</user.language>
                             <user.timezone>Europe/Berlin</user.timezone>
                             <java.locale.providers>CLDR,SPI</java.locale.providers>
-                            <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                            <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                             <log4j2.disableJmx>false</log4j2.disableJmx>
                             <xml.catalog.alwaysResolve>false</xml.catalog.alwaysResolve>
                         </systemPropertyVariables>

--- a/extensions/debuggee/pom.xml
+++ b/extensions/debuggee/pom.xml
@@ -98,7 +98,7 @@
                     <argLine>@{jacocoArgLine}</argLine>
                     <systemPropertyVariables>
                         <java.locale.providers>CLDR,SPI</java.locale.providers>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
                     </systemPropertyVariables>
                 </configuration>

--- a/extensions/exquery/restxq/pom.xml
+++ b/extensions/exquery/restxq/pom.xml
@@ -260,7 +260,7 @@
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -188,7 +188,7 @@
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/modules/persistentlogin/pom.xml
+++ b/extensions/modules/persistentlogin/pom.xml
@@ -147,7 +147,7 @@
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -159,7 +159,7 @@
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/vector/pom.xml
+++ b/extensions/vector/pom.xml
@@ -102,7 +102,7 @@
                     <argLine>--add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                     <systemPropertyVariables>
                         <exist.home>${project.basedir}/../../exist-core/target/test-classes</exist.home>
-                        <log4j.configurationFile>${project.basedir}/../../exist-core/target/test-classes/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -175,7 +175,7 @@
                         <jetty.home>${project.basedir}/../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
-                        <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
+                        <log4j.configurationFile>${exist.log4j.testConfigurationFile}</log4j.configurationFile>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Description:

Surefire inherited `log4j.configurationFile=${project.build.testOutputDirectory}/log4j2.xml` from the parent POM. Many modules run tests without copying `log4j2.xml` into `target/test-classes`, so Log4j 2 logged this on stderr for every fork:

`ERROR Reconfiguration failed: No configuration found for '…' at 'null' in 'null'`

This adds a shared `exist-parent/log4j2-test.xml` and points Surefire/Failsafe at it via a new `exist.log4j.testConfigurationFile` property. Module-specific overrides (exist-core, vector, webdav, etc.) now use the same property.

### Reference:

Observed while investigating CI test log noise during DeadlockIT/prolog work.

### Type of tests:

- Maven build / Surefire configuration only (no new test classes)
- Verified locally: `mvn test -pl extensions/modules/http-client -Dsurefire.useFile=false` no longer emits `Reconfiguration failed`

### Test plan

- [x] `extensions/modules/http-client` tests pass without Log4j reconfiguration errors
- [ ] Upstream CI (unit + integration + Codacy)

Made with [Cursor](https://cursor.com)