### PR TITLE
[ci] Post XQTS result comparison as a PR comment

### DIFF
--- a/.github/workflows/ci-xqts-comment.yml
+++ b/.github/workflows/ci-xqts-comment.yml
@@ -1,0 +1,46 @@
+name: XQTS PR Comment
+# Posts the XQTS result comparison produced by ci-xqts.yml back onto the pull
+# request as a single, updating comment.
+#
+# This runs as a separate `workflow_run` workflow on purpose: the XQTS workflow
+# is triggered by `pull_request` and therefore receives a read-only GITHUB_TOKEN
+# for PRs opened from forks, so it cannot comment. A `workflow_run` workflow runs
+# in the context of the base repository and gets a write-enabled token, which is
+# what allows commenting on fork PRs as well. It never checks out or executes any
+# PR code — it only consumes the artifact uploaded by the trusted XQTS run.
+on:
+  workflow_run:
+    workflows: ["XQTS"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post XQTS comparison
+    runs-on: ubuntu-latest
+    # Only for PR-triggered XQTS runs that finished successfully and therefore
+    # uploaded the xqts-comparison artifact.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download XQTS Comparison
+        uses: actions/download-artifact@v7
+        with:
+          name: xqts-comparison
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: xqts-comparison
+      - name: Read PR Number
+        id: pr
+        run: echo "number=$(cat xqts-comparison/pr-number.txt)" >> "$GITHUB_OUTPUT"
+      - name: Post or Update Comparison Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: xqts-comparison
+          number: ${{ steps.pr.outputs.number }}
+          path: xqts-comparison/comparison-results.md

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -23,7 +23,9 @@ jobs:
         timeout-minutes: 25
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -V -B --no-transfer-progress clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
+        # `install` rather than `package` so that the xqts-compare goal below can
+        # resolve the exist-xqts dependencies from the local repository.
+        run: mvn -V -B --no-transfer-progress clean install -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
       - name: Run XQTS
         timeout-minutes: 60
         env:
@@ -73,17 +75,34 @@ jobs:
             "$(cat /tmp/previous_run_id.txt)" \
             --name xqts-logs \
             --dir /tmp/previous-xqts-output
-      - name: Compare Previous and Current XQTS Logs
+      - name: Compare Previous and Current XQTS Results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          java \
-          -jar ~/.m2/repository/net/sf/saxon/Saxon-HE/9.9.1-8/Saxon-HE-9.9.1-8.jar \
-          -xsl:exist-xqts/src/main/xslt/compare-results.xslt \
-          -it:compare-results \
-          -o:/tmp/comparison-results.xml \
-          xqts.previous.junit-data-path=/tmp/previous-xqts-output/junit/data \
-          xqts.current.junit-data-path=/tmp/xqts-output/junit/data
+          mvn -B --no-transfer-progress -pl exist-xqts exec:exec@xqts-compare \
+            -Dprevious-result=/tmp/previous-xqts-output \
+            -Dcurrent-result=/tmp/xqts-output \
+            -Dcomparison-output-dir=/tmp/xqts-comparison \
+            -Dprevious-label='`develop`' \
+            -Dcurrent-label='this run'
       - name: Show Comparison Results
-        run: cat /tmp/comparison-results.xml
+        run: cat /tmp/xqts-comparison/comparison-results.xml
+      - name: Publish Comparison Summary
+        # Surface the report on the run's Summary tab (works for fork PRs too)
+        run: cat /tmp/xqts-comparison/comparison-results.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Save PR Number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > /tmp/xqts-comparison/pr-number.txt
+      - name: Upload XQTS Comparison
+        # Consumed by the ci-xqts-comment.yml workflow_run, which posts the
+        # comparison as a PR comment with a write-enabled token (needed for
+        # PRs from forks, where this workflow's token is read-only).
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: xqts-comparison
+          retention-days: 3
+          path: /tmp/xqts-comparison
       - name: Archive XQTS Logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/exist-xqts/README.md
+++ b/exist-xqts/README.md
@@ -1,0 +1,58 @@
+# eXist-db W3C XQTS
+
+This module assembles the [exist-xqts-runner](https://github.com/eXist-db/exist-xqts-runner)
+together with the `exist-core` of this source tree, so that the W3C XQuery Test
+Suite can be executed against the current state of eXist-db.
+
+## Running the test suite
+
+Build the module, then run the generated script with the desired options:
+
+```bash
+mvn -pl exist-xqts --also-make clean package -DskipTests -Ddependency-check.skip=true
+find exist-xqts/target -name exist-xqts-runner.sh \
+    -exec {} --xqts-version HEAD --output-dir /tmp/xqts-output \;
+```
+
+The `--output-dir` folder is the runner's *result folder*: it contains the
+JUnit reports under `junit/data/*.xml` and the runner's build metadata in
+`runner-info.xml`.
+
+## Comparing two runs: the `xqts-compare` goal
+
+The `xqts-compare` goal compares the result folders of two runs — for example
+the run of a pull request against a baseline run of `develop`, or two local
+runs before and after a change. It is not bound to any lifecycle phase and only
+runs when invoked explicitly:
+
+```bash
+mvn -pl exist-xqts exec:exec@xqts-compare \
+    -Dprevious-result=/path/to/baseline-output \
+    -Dcurrent-result=/path/to/current-output
+```
+
+| Property | Required | Description |
+| :--- | :--- | :--- |
+| `previous-result` | yes | Result folder of the baseline run (absolute path) |
+| `current-result` | yes | Result folder of the run to compare against the baseline (absolute path) |
+| `comparison-output-dir` | no | Where to write the outputs; defaults to `exist-xqts/target/xqts-comparison` |
+| `previous-label` | no | Display name of the baseline run in the Markdown report; defaults to `previous` |
+| `current-label` | no | Display name of the compared run in the Markdown report; defaults to `current` |
+
+The goal makes no assumption about where the two result folders come from; any
+two folders produced by the runner's `--output-dir` can be compared. It fails
+with an actionable message if either parameter is missing or does not point to
+a comparable result folder.
+
+Two files are written to `comparison-output-dir`:
+
+- `comparison-results.xml` — the comparison data: totals, deltas, the newly
+  passing/failing/erroring/skipped test cases, and warnings when the two runs'
+  `runner-info.xml` metadata indicates environment drift
+  (see [#6326](https://github.com/eXist-db/exist/issues/6326));
+- `comparison-results.md` — the same information rendered as GitHub-flavoured
+  Markdown, as posted on pull requests by the `ci-xqts-comment.yml` workflow.
+
+The comparison needs this module's dependencies (Saxon, via `exist-core`) to be
+resolvable, so run `mvn -pl exist-xqts --also-make install ...` once before
+invoking the goal on a fresh clone.

--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -47,6 +47,13 @@
 
     <properties>
         <assemble.dir>${project.build.directory}/${project.artifactId}-dir</assemble.dir>
+
+        <!-- Defaults for the explicitly invoked xqts-compare goal (see README.md) -->
+        <previous-result/>
+        <current-result/>
+        <previous-label>previous</previous-label>
+        <current-label>current</current-label>
+        <comparison-output-dir>${project.build.directory}/xqts-comparison</comparison-output-dir>
     </properties>
 
     <dependencies>
@@ -130,6 +137,47 @@
                                     </platforms>
                                 </daemon>
                             </daemons>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Compares the results of two exist-xqts-runner runs and writes
+                        comparison-results.xml plus its GitHub-flavoured Markdown
+                        rendering comparison-results.md to ${comparison-output-dir}:
+
+                            mvn -pl exist-xqts exec:exec@xqts-compare \
+                                -Dprevious-result=<dir> -Dcurrent-result=<dir>
+
+                        phase=none is deliberate: the comparison must NOT run on an
+                        ordinary `mvn package`/`mvn install`, only when invoked
+                        directly. See README.md for the arguments.
+                    -->
+                    <execution>
+                        <id>xqts-compare</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${java.home}/bin/java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <!-- Saxon and its xmlresolver, provided via exist-core -->
+                                <classpath/>
+                                <argument>net.sf.saxon.Transform</argument>
+                                <argument>-xsl:${project.basedir}/src/main/xslt/compare.xslt</argument>
+                                <argument>-it:compare</argument>
+                                <argument>-o:${comparison-output-dir}/comparison-results.xml</argument>
+                                <argument>previous-result=${previous-result}</argument>
+                                <argument>current-result=${current-result}</argument>
+                                <argument>previous-label=${previous-label}</argument>
+                                <argument>current-label=${current-label}</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/exist-xqts/src/main/xslt/compare-results-md.xslt
+++ b/exist-xqts/src/main/xslt/compare-results-md.xslt
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<!--
+    Renders the XML produced by compare-results.xslt into a GitHub-flavoured
+    Markdown report suitable for posting as a pull-request comment.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:cr="http://exist-db.org/exist-xqts/compare-results"
+    exclude-result-prefixes="xs cr"
+    version="2.0">
+
+    <xsl:output method="text" encoding="UTF-8"/>
+
+    <!-- Maximum number of test cases listed per detail section -->
+    <xsl:param name="max-listed" as="xs:integer" select="50"/>
+
+    <!-- Display names for the two compared runs, e.g. "`develop`" and "this run" -->
+    <xsl:param name="previous-label" as="xs:string" select="'previous'"/>
+    <xsl:param name="current-label" as="xs:string" select="'current'"/>
+
+    <xsl:variable name="nl" as="xs:string" select="'&#10;'"/>
+
+    <!-- Format an integer with thousands separators, e.g. 24025 -> 24,025 -->
+    <xsl:function name="cr:int" as="xs:string">
+        <xsl:param name="n" as="xs:anyAtomicType?"/>
+        <xsl:sequence select="format-number(xs:double($n), '#,##0')"/>
+    </xsl:function>
+
+    <!-- Format an integer delta with an explicit sign, e.g. +15 / -3 / 0 -->
+    <xsl:function name="cr:signed-int" as="xs:string">
+        <xsl:param name="n" as="xs:anyAtomicType?"/>
+        <xsl:variable name="v" select="xs:double($n)"/>
+        <xsl:sequence select="if ($v gt 0) then concat('+', cr:int($v)) else cr:int($v)"/>
+    </xsl:function>
+
+    <!-- Format a decimal delta with an explicit sign and two fraction digits -->
+    <xsl:function name="cr:signed-dec" as="xs:string">
+        <xsl:param name="n" as="xs:anyAtomicType?"/>
+        <xsl:variable name="v" select="xs:double($n)"/>
+        <xsl:sequence select="if ($v gt 0)
+            then concat('+', format-number($v, '#,##0.00'))
+            else format-number($v, '#,##0.00')"/>
+    </xsl:function>
+
+    <!-- Directional emoji for a delta given whether an increase is good -->
+    <xsl:function name="cr:trend" as="xs:string">
+        <xsl:param name="delta" as="xs:anyAtomicType?"/>
+        <xsl:param name="increase-is-good" as="xs:boolean"/>
+        <xsl:variable name="v" select="xs:double($delta)"/>
+        <xsl:sequence select="
+            if ($v eq 0) then '➖'
+            else if (($v gt 0) eq $increase-is-good) then '🟢'
+            else '🔴'"/>
+    </xsl:function>
+
+    <xsl:template match="/cr:comparison">
+        <xsl:variable name="prev" select="cr:previous/cr:results" as="element(cr:results)"/>
+        <xsl:variable name="curr" select="cr:current/cr:results" as="element(cr:results)"/>
+        <xsl:variable name="chg" select="cr:change/cr:results" as="element(cr:results)"/>
+
+        <xsl:value-of select="concat('## 📊 XQTS result comparison', $nl, $nl)"/>
+        <xsl:value-of select="concat('Comparison of ', $current-label, ' against ', $previous-label, '.', $nl, $nl)"/>
+
+        <!-- Environment-drift warnings detected by compare-results.xslt -->
+        <xsl:for-each select="cr:warnings/cr:warning">
+            <xsl:value-of select="concat('> [!WARNING]', $nl, '> ', normalize-space(cr:summary), $nl, $nl)"/>
+        </xsl:for-each>
+
+        <!-- Top-level summary table -->
+        <xsl:value-of select="concat('| Metric | ', $previous-label, ' | ', $current-label, ' | Change |', $nl)"/>
+        <xsl:value-of select="concat('| :--- | ---: | ---: | ---: |', $nl)"/>
+
+        <!-- Passed (with percentage) -->
+        <xsl:value-of select="concat(
+            '| ', cr:trend($chg/@pass, true()), ' Passed ',
+            '| ', cr:int($prev/@pass), ' (', format-number(xs:double($prev/@pass-pct), '0.00'), '%) ',
+            '| ', cr:int($curr/@pass), ' (', format-number(xs:double($curr/@pass-pct), '0.00'), '%) ',
+            '| ', cr:signed-int($chg/@pass), ' (', cr:signed-dec($chg/@pass-pct-delta), ' pp) ',
+            '|', $nl)"/>
+
+        <!-- Failures -->
+        <xsl:value-of select="concat(
+            '| ', cr:trend($chg/@failures, false()), ' Failures ',
+            '| ', cr:int($prev/@failures),
+            ' | ', cr:int($curr/@failures),
+            ' | ', cr:signed-int($chg/@failures),
+            ' |', $nl)"/>
+
+        <!-- Errors -->
+        <xsl:value-of select="concat(
+            '| ', cr:trend($chg/@errors, false()), ' Errors ',
+            '| ', cr:int($prev/@errors),
+            ' | ', cr:int($curr/@errors),
+            ' | ', cr:signed-int($chg/@errors),
+            ' |', $nl)"/>
+
+        <!-- Skipped -->
+        <xsl:value-of select="concat(
+            '| ', cr:trend($chg/@skipped, false()), ' Skipped ',
+            '| ', cr:int($prev/@skipped),
+            ' | ', cr:int($curr/@skipped),
+            ' | ', cr:signed-int($chg/@skipped),
+            ' |', $nl)"/>
+
+        <!-- Total tests -->
+        <xsl:value-of select="concat(
+            '| 🧪 Total tests ',
+            '| ', cr:int($prev/@tests),
+            ' | ', cr:int($curr/@tests),
+            ' | ', cr:signed-int($chg/@tests),
+            ' |', $nl, $nl)"/>
+
+        <!-- Newly changed test cases relative to develop -->
+        <xsl:variable name="new-pass" select="cr:change/cr:new/cr:pass/testcase" as="element()*"/>
+        <xsl:variable name="new-failures" select="cr:change/cr:new/cr:failures/testcase" as="element()*"/>
+        <xsl:variable name="new-errors" select="cr:change/cr:new/cr:errors/testcase" as="element()*"/>
+        <xsl:variable name="new-skipped" select="cr:change/cr:new/cr:skipped/testcase" as="element()*"/>
+
+        <xsl:value-of select="concat(
+            'Relative to ', $previous-label, ': ',
+            '**', cr:int(count($new-pass)), '** newly passing, ',
+            '**', cr:int(count($new-failures)), '** newly failing, ',
+            '**', cr:int(count($new-errors)), '** new errors, ',
+            '**', cr:int(count($new-skipped)), '** newly skipped.', $nl, $nl)"/>
+
+        <xsl:call-template name="cr:detail-list">
+            <xsl:with-param name="heading" select="'🔴 Newly failing tests'"/>
+            <xsl:with-param name="cases" select="$new-failures"/>
+        </xsl:call-template>
+        <xsl:call-template name="cr:detail-list">
+            <xsl:with-param name="heading" select="'💥 New errors'"/>
+            <xsl:with-param name="cases" select="$new-errors"/>
+        </xsl:call-template>
+        <xsl:call-template name="cr:detail-list">
+            <xsl:with-param name="heading" select="'🟢 Newly passing tests'"/>
+            <xsl:with-param name="cases" select="$new-pass"/>
+        </xsl:call-template>
+
+        <xsl:value-of select="concat($nl, '&lt;sub>Runtime: ',
+            format-number(xs:double($curr/@time), '#,##0.0'), 's (',
+            cr:signed-dec($chg/@time), 's vs ', $previous-label, ').&lt;/sub>', $nl)"/>
+    </xsl:template>
+
+    <!-- Emit a collapsible <details> block listing test-case names -->
+    <xsl:template name="cr:detail-list">
+        <xsl:param name="heading" as="xs:string"/>
+        <xsl:param name="cases" as="element()*"/>
+        <xsl:if test="exists($cases)">
+            <xsl:value-of select="concat('&lt;details>', $nl,
+                '&lt;summary>', $heading, ' (', cr:int(count($cases)), ')&lt;/summary>', $nl, $nl)"/>
+            <xsl:for-each select="$cases[position() le $max-listed]">
+                <xsl:value-of select="concat('- `', @name, '`', $nl)"/>
+            </xsl:for-each>
+            <xsl:if test="count($cases) gt $max-listed">
+                <xsl:value-of select="concat('- … and ', cr:int(count($cases) - $max-listed), ' more', $nl)"/>
+            </xsl:if>
+            <xsl:value-of select="concat($nl, '&lt;/details>', $nl, $nl)"/>
+        </xsl:if>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -29,23 +29,21 @@
     exclude-result-prefixes="xs ri"
     version="2.0">
 
-    <xsl:param name="xqts.previous.junit-data-path" as="xs:string" required="yes"/>
-    <xsl:param name="xqts.current.junit-data-path" as="xs:string" required="yes"/>
-
-
     <xsl:output method="xml" version="1.0" omit-xml-declaration="no" indent="yes" encoding="UTF-8"/>
 
 
     <xsl:template name="compare-results" as="document-node(element(cr:comparison))">
-        <xsl:variable name="previous-summary" select="cr:summarise-results($xqts.previous.junit-data-path)" as="document-node(element(cr:results))"/>
-        <xsl:variable name="current-summary" select="cr:summarise-results($xqts.current.junit-data-path)" as="document-node(element(cr:results))"/>
+        <xsl:param name="previous-junit-data-path" as="xs:string" required="yes"/>
+        <xsl:param name="current-junit-data-path" as="xs:string" required="yes"/>
+        <xsl:variable name="previous-summary" select="cr:summarise-results($previous-junit-data-path)" as="document-node(element(cr:results))"/>
+        <xsl:variable name="current-summary" select="cr:summarise-results($current-junit-data-path)" as="document-node(element(cr:results))"/>
         <xsl:variable name="new-changes" as="element()+">
             <xsl:for-each select="('pass', 'skipped', 'failures', 'errors')">
                 <xsl:sequence select="cr:new-changes($previous-summary/cr:results, $current-summary/cr:results, .)"/>
             </xsl:for-each>
         </xsl:variable>
-        <xsl:variable name="previous-runner-info" as="document-node()?" select="cr:load-runner-info($xqts.previous.junit-data-path)"/>
-        <xsl:variable name="current-runner-info" as="document-node()?" select="cr:load-runner-info($xqts.current.junit-data-path)"/>
+        <xsl:variable name="previous-runner-info" as="document-node()?" select="cr:load-runner-info($previous-junit-data-path)"/>
+        <xsl:variable name="current-runner-info" as="document-node()?" select="cr:load-runner-info($current-junit-data-path)"/>
         <xsl:document>
             <cr:comparison>
                 <xsl:variable name="warnings" as="element(cr:warning)*" select="cr:drift-warnings($previous-runner-info, $current-runner-info)"/>

--- a/exist-xqts/src/main/xslt/compare.xslt
+++ b/exist-xqts/src/main/xslt/compare.xslt
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db Open Source Native XML Database
+    Copyright (C) 2001 The eXist-db Authors
+
+    info@exist-db.org
+    http://www.exist-db.org
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<!--
+    Entry point of the `xqts-compare` Maven goal (see the README):
+
+        mvn -pl exist-xqts exec:exec@xqts-compare \
+            -Dprevious-result=<dir> -Dcurrent-result=<dir>
+
+    Compares two exist-xqts-runner result folders and writes
+    `comparison-results.xml` (the primary output) plus the GitHub-flavoured
+    Markdown rendering `comparison-results.md` next to it. Terminates with an
+    actionable message when a parameter is missing or does not point to a
+    comparable result folder.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:err="http://www.w3.org/2005/xqt-errors"
+    xmlns:cr="http://exist-db.org/exist-xqts/compare-results"
+    exclude-result-prefixes="xs err"
+    version="3.0">
+
+    <xsl:import href="compare-results.xslt"/>
+    <xsl:import href="compare-results-md.xslt"/>
+
+    <!-- Paths to two result folders written by `exist-xqts-runner ... - -output-dir <dir>` -->
+    <xsl:param name="previous-result" as="xs:string" select="''"/>
+    <xsl:param name="current-result" as="xs:string" select="''"/>
+
+    <xsl:output method="xml" version="1.0" omit-xml-declaration="no" indent="yes" encoding="UTF-8"/>
+    <xsl:output name="cr:markdown" method="text" encoding="UTF-8"/>
+
+    <xsl:variable name="cr:usage" as="xs:string" select="'Usage: mvn -pl exist-xqts exec:exec@xqts-compare -Dprevious-result=/path/to/previous -Dcurrent-result=/path/to/current'"/>
+    <xsl:variable name="cr:expectation" as="xs:string" select="'It must point to a result folder written by exist-xqts-runner (its --output-dir), which contains the JUnit reports under junit/data/*.xml. Relative paths are resolved against this stylesheet, so prefer absolute paths.'"/>
+
+    <xsl:template name="compare" as="document-node(element(cr:comparison))">
+        <xsl:variable name="previous-junit-data-path" select="cr:validated-junit-data-path('previous-result', $previous-result)" as="xs:string"/>
+        <xsl:variable name="current-junit-data-path" select="cr:validated-junit-data-path('current-result', $current-result)" as="xs:string"/>
+        <xsl:variable name="comparison" as="document-node(element(cr:comparison))">
+            <xsl:call-template name="compare-results">
+                <xsl:with-param name="previous-junit-data-path" select="$previous-junit-data-path"/>
+                <xsl:with-param name="current-junit-data-path" select="$current-junit-data-path"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:result-document href="comparison-results.md" format="cr:markdown">
+            <xsl:apply-templates select="$comparison/cr:comparison"/>
+        </xsl:result-document>
+        <xsl:sequence select="$comparison"/>
+    </xsl:template>
+
+    <!--
+        Validate that $result-dir denotes a comparable runner result folder and
+        return the path of the JUnit data directory within it, terminating the
+        transformation with an actionable message otherwise.
+    -->
+    <xsl:function name="cr:validated-junit-data-path" as="xs:string">
+        <xsl:param name="parameter-name" as="xs:string"/>
+        <xsl:param name="result-dir" as="xs:string"/>
+        <xsl:if test="$result-dir eq ''">
+            <xsl:message terminate="yes" select="concat('Missing required parameter -D', $parameter-name, '. ', $cr:usage)"/>
+        </xsl:if>
+        <xsl:variable name="junit-data-path" select="concat($result-dir, '/junit/data')" as="xs:string"/>
+        <xsl:variable name="testsuites" as="element(testsuite)*">
+            <xsl:try>
+                <xsl:sequence select="collection(concat($junit-data-path, '?select=*.xml'))/testsuite"/>
+                <xsl:catch>
+                    <xsl:message terminate="yes" select="concat('Cannot read -D', $parameter-name, '=', $result-dir, ': ', $err:description, ' ', $cr:expectation)"/>
+                </xsl:catch>
+            </xsl:try>
+        </xsl:variable>
+        <xsl:if test="empty($testsuites)">
+            <xsl:message terminate="yes" select="concat('No JUnit test-suite reports found in ', $junit-data-path, ', so -D', $parameter-name, '=', $result-dir, ' cannot be compared. ', $cr:expectation)"/>
+        </xsl:if>
+        <xsl:sequence select="$junit-data-path"/>
+    </xsl:function>
+
+</xsl:stylesheet>


### PR DESCRIPTION
### Description:

Lifts the XQTS result comparison into an explicitly invoked maven goal in `exist-xqts` and posts its output back onto the pull request as a single, updating comment — implementing what was [agreed with @duncdrum](https://github.com/eXist-db/exist/pull/6564#issuecomment-5067294838).

**The `xqts-compare` goal**

```bash
mvn -pl exist-xqts exec:exec@xqts-compare \
    -Dprevious-result=/path/to/previous -Dcurrent-result=/path/to/current
```

- Not bound to any lifecycle phase (`phase=none`, the same pattern as the existing `xml:transform@schema-governance` goal) — it only runs when invoked explicitly, in CI or locally.
- Takes two result folders as written by `exist-xqts-runner --output-dir`, with no assumption about where they come from. In CI that is the current run and the last successful `develop` run downloaded from the artifact store.
- Fails with an actionable message when an argument is missing or does not point to a comparable result folder.
- Runs Saxon from the module's own classpath (via `exist-core`), so the Saxon version can never drift from the build.
- Writes `comparison-results.xml` plus a GitHub-flavoured Markdown rendering `comparison-results.md` in one pass (default output: `exist-xqts/target/xqts-comparison`, overridable with `-Dcomparison-output-dir`).

**What changed**

- **`exist-xqts/src/main/xslt/compare.xslt`** (new) — entry point of the goal: validates the arguments, runs the comparison, emits XML + Markdown via `xsl:result-document`.
- **`exist-xqts/src/main/xslt/compare-results.xslt`** — required global params become template parameters so the entry point can drive it; comparison logic unchanged.
- **`exist-xqts/src/main/xslt/compare-results-md.xslt`** (new) — Markdown renderer: summary table with pass-% and trend markers, collapsible lists of newly failing/erroring/passing test cases, run labels as parameters instead of a hard-coded `develop`, and the runner-drift warnings from #6326 rendered as `> [!WARNING]` alerts.
- **`exist-xqts/pom.xml` / `exist-xqts/README.md`** — the exec-maven-plugin execution and its documentation.
- **`.github/workflows/ci-xqts.yml`** — replaces the raw Saxon invocations with the goal, appends the report to the run **Summary** tab (works for fork PRs), and uploads it with the PR number as the `xqts-comparison` artifact (PR events only). The build step installs the modules so the goal can resolve its dependencies.
- **`.github/workflows/ci-xqts-comment.yml`** (new) — a `workflow_run` companion that downloads the artifact and posts/updates a sticky comment.

**Why a separate `workflow_run` workflow?**

The XQTS workflow is triggered by `pull_request`, so for PRs opened from forks its `GITHUB_TOKEN` is read-only and cannot comment. A `workflow_run` workflow runs in the base-repository context with a write-enabled token, so the comment works for fork PRs too. It never checks out or executes any PR code — it only consumes the artifact produced by the trusted XQTS run, and is guarded to `workflow_run.event == 'pull_request'` && `conclusion == 'success'`. The main XQTS workflow keeps its `contents: read` permissions.

The comment uses `marocchino/sticky-pull-request-comment` with a fixed `header`, so re-runs update the existing comment in place rather than adding new ones.

### Reference:

https://github.com/eXist-db/exist/pull/6564#issuecomment-5067294838, #6326

### Type of tests:

CI-only change, verified locally against the project's Saxon-HE 12.5: the goal produces correct XML and Markdown (including drift warnings) from representative runner result folders, and all three failure modes (missing argument, unreadable path, folder without JUnit reports) fail the build with actionable messages. Both workflow YAML files validate, `license:check` passes. End-to-end behaviour (artifact hand-off and comment posting) exercises only on GitHub Actions once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
