### PR TITLE
[ignore] only ignore the contents of .moderne/ (allows negations)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ work/
 # Claude planning files
 plans/
 .codacy/
-.moderne/
+.moderne/*
 !.moderne/context/
 !.moderne/moderne.yml
 .github/instructions/


### PR DESCRIPTION
`.moderne/` excludes the directory, and git never descends into an excluded directory, so the negations beneath it can never fire ([gitignore(5)](https://git-scm.com/docs/gitignore): *"It is not possible to re-include a file if a parent directory of that file is excluded."*). This hides new files under `.moderne/context/` from `git status` and makes `git add .moderne/context/` exit 1, even for tracked files. The contents form `.moderne/*` excludes the children individually, freeing the negations to re-include; `build/`, `run/`, `git-apply.log` and loose files under `.moderne/` stay ignored.

The prethink workflow is not broken — it has been committing new context files all along (79b280b08, 4ab5ba6a3) — so this fixes local use, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
