### PR TITLE
[feature] Unix-style execute-without-read for stored XQuery

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -558,6 +558,24 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
             throws LockException, PermissionDeniedException;
 
     /**
+     * Retrieve a child resource after putting a lock on it, validating the given
+     * access mode instead of {@link Permission#READ}.
+     *
+     * With this method, access to the received document object is safe.
+     *
+     * @param broker   The database broker
+     * @param name     The name of the document (without collection path)
+     * @param lockMode The mode of the lock to acquire
+     * @param requiredMode The access mode which the current subject must hold on the
+     *     document, e.g. {@link Permission#READ} or {@link Permission#EXECUTE}
+     * @return The locked document or null if it doesn't exist
+     * @throws PermissionDeniedException if the current subject does not hold {@code requiredMode}
+     * @throws LockException if broker is locked
+     */
+    @Nullable LockedDocument getDocumentWithLock(DBBroker broker, XmldbURI name, LockMode lockMode, int requiredMode)
+            throws LockException, PermissionDeniedException;
+
+    /**
      * Get a child resource as identified by path. This method doesn't put
      * a lock on the document nor does it recognize locks held by other threads.
      * There's no guarantee that the document still exists when accessing it.

--- a/exist-core/src/main/java/org/exist/collections/LockedCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/LockedCollection.java
@@ -327,6 +327,11 @@ public class LockedCollection implements Collection {
     }
 
     @Override
+    public LockedDocument getDocumentWithLock(final DBBroker broker, final XmldbURI name, final Lock.LockMode lockMode, final int requiredMode) throws LockException, PermissionDeniedException {
+        return collection.getDocumentWithLock(broker, name, lockMode, requiredMode);
+    }
+
+    @Override
     @Deprecated
     public DocumentImpl getDocumentNoLock(final DBBroker broker, final String rawPath) throws PermissionDeniedException {
         return collection.getDocumentNoLock(broker, rawPath);

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -46,6 +46,7 @@ import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.PermissionFactory;
 import org.exist.security.Subject;
+import org.exist.security.internal.aider.UnixStylePermissionAider;
 import org.exist.storage.*;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
@@ -692,6 +693,11 @@ public class MutableCollection implements Collection {
 
     @Override
     public LockedDocument getDocumentWithLock(final DBBroker broker, final XmldbURI name, final LockMode lockMode) throws LockException, PermissionDeniedException {
+        return getDocumentWithLock(broker, name, lockMode, Permission.READ);
+    }
+
+    @Override
+    public LockedDocument getDocumentWithLock(final DBBroker broker, final XmldbURI name, final LockMode lockMode, final int requiredMode) throws LockException, PermissionDeniedException {
         try(final ManagedCollectionLock collectionLock = lockManager.acquireCollectionReadLock(path)) {
 
             // lock the document
@@ -722,9 +728,10 @@ public class MutableCollection implements Collection {
                 unlockFn.run();
                 return null;
             } else {
-                if(!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
+                if(!doc.getPermissions().validate(broker.getCurrentSubject(), requiredMode)) {
                     unlockFn.run();
-                    throw new PermissionDeniedException("Permission denied to read + document: " + name);
+                    throw new PermissionDeniedException("Permission denied, '" + broker.getCurrentSubject().getName()
+                            + "' does not have '" + new UnixStylePermissionAider(requiredMode) + "' access to document: " + name);
                 }
 
                 return new LockedDocument(documentLock, doc);

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1563,7 +1563,7 @@ public class RESTServer {
      * Get the document a request addresses.
      *
      * A regular resource requires READ, as it always did. A stored XQuery is additionally resolved
-     * on EXECUTE via {@link DBBroker#getResourceForExecution(XmldbURI, LockMode)}, so that a caller
+     * on EXECUTE via {@link DBBroker#getResourceForExecution(XmldbURI)}, so that a caller
      * which may run it but not read it gets to run it. Reading a query as data — the {@code ?_source}
      * view — is unaffected and still validates READ separately.
      *
@@ -1578,7 +1578,7 @@ public class RESTServer {
         } catch (final PermissionDeniedException readDenied) {
             final ExecutableResource executable;
             try {
-                executable = broker.getResourceForExecution(uri, LockMode.READ_LOCK);
+                executable = broker.getResourceForExecution(uri);
             } catch (final PermissionDeniedException executeDenied) {
                 // neither readable nor executable, so report the failure to read it
                 throw readDenied;

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -48,6 +48,7 @@ import org.exist.source.StringSource;
 import org.exist.source.URLSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.ExecutableResource;
 import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.ManagedCollectionLock;
@@ -86,6 +87,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
@@ -456,7 +458,7 @@ public class RESTServer {
             // check if path leads to an XQuery resource
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
             final String xproc_mime_type = MimeType.XPROC_TYPE.getName();
-            lockedDocument = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
+            lockedDocument = getResourceForRequest(broker, pathUri);
             resource = lockedDocument == null ? null : lockedDocument.getDocument();
 
             if (null != resource && !isExecutableType(resource)) {
@@ -504,7 +506,7 @@ public class RESTServer {
                     break;
                 }
 
-                lockedDocument = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
+                lockedDocument = getResourceForRequest(broker, servletPath);
                 resource = lockedDocument == null ? null : lockedDocument.getDocument();
                 if (null != resource && isExecutableType(resource)) {
                     break;
@@ -697,7 +699,7 @@ public class RESTServer {
             // if yes, the resource is loaded and the XQuery executed.
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
             final String xproc_mime_type = MimeType.XPROC_TYPE.getName();
-            lockedDocument = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
+            lockedDocument = getResourceForRequest(broker, pathUri);
             resource = lockedDocument == null ? null : lockedDocument.getDocument();
 
             XmldbURI servletPath = pathUri;
@@ -711,7 +713,7 @@ public class RESTServer {
                     break;
                 }
 
-                lockedDocument = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
+                lockedDocument = getResourceForRequest(broker, servletPath);
                 resource = lockedDocument == null ? null : lockedDocument.getDocument();
                 if (null != resource
                         && (resource.getResourceType() == DocumentImpl.BINARY_FILE
@@ -1267,7 +1269,7 @@ public class RESTServer {
         // xquery resource
         while (resource == null) {
             // traverse up the path looking for xquery objects
-            lockedDocument = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
+            lockedDocument = getResourceForRequest(broker, servletPath);
             resource = lockedDocument == null ? null : lockedDocument.getDocument();
             if (resource != null
                     && (resource.getResourceType() == DocumentImpl.BINARY_FILE
@@ -1558,6 +1560,45 @@ public class RESTServer {
     }
 
     /**
+     * Get the document a request addresses.
+     *
+     * A regular resource requires READ, as it always did. A stored XQuery is additionally resolved
+     * on EXECUTE via {@link DBBroker#getResourceForExecution(XmldbURI, LockMode)}, so that a caller
+     * which may run it but not read it gets to run it. Reading a query as data — the {@code ?_source}
+     * view — is unaffected and still validates READ separately.
+     *
+     * @return the locked document, or null if there is none at that path
+     *
+     * @throws PermissionDeniedException if the caller may neither read the resource nor, when it is a
+     *     stored query, execute it
+     */
+    private @Nullable LockedDocument getResourceForRequest(final DBBroker broker, final XmldbURI uri) throws PermissionDeniedException {
+        try {
+            return broker.getXMLResource(uri, LockMode.READ_LOCK);
+        } catch (final PermissionDeniedException readDenied) {
+            final ExecutableResource executable;
+            try {
+                executable = broker.getResourceForExecution(uri, LockMode.READ_LOCK);
+            } catch (final PermissionDeniedException executeDenied) {
+                // neither readable nor executable, so report the failure to read it
+                throw readDenied;
+            }
+
+            if (executable == null) {
+                return null;
+            }
+
+            // only a stored query may be reached without READ; anything else is a data read
+            if (!MimeType.XQUERY_TYPE.getName().equals(executable.document().getDocument().getMimeType())) {
+                executable.close();
+                throw readDenied;
+            }
+
+            return executable.document();
+        }
+    }
+
+    /**
      * Directly execute an XQuery stored as a binary document in the database.
      *
      * @throws PermissionDeniedException
@@ -1586,6 +1627,12 @@ public class RESTServer {
                 context.prepareForReuse();
             }
 
+            // a caller which may execute but not read the query must not learn anything about its
+            // source from a failure. Recomputed per request from the current subject, as the compiled
+            // query is pooled and shared between users, and set before the query is compiled, since a
+            // compile error never reaches XQuery#execute (which computes the level for runtime errors)
+            context.setErrorDisclosure(ErrorDisclosure.of(source, broker.getCurrentSubject()));
+
             // TODO: don't hardcode this?
             context.setModuleLoadPath(
                     XmldbURI.EMBEDDED_SERVER_URI.append(
@@ -1598,31 +1645,37 @@ public class RESTServer {
             reqw.setServletPath(servletPath);
             reqw.setPathInfo(pathInfo);
 
-            final long compilationTime;
-            if (compiled == null) {
-                try {
-                    final long compilationStart = System.currentTimeMillis();
-                    compiled = xquery.compile(context, source);
-                    compilationTime = System.currentTimeMillis() - compilationStart;
-                } catch (final IOException e) {
-                    throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
-                }
-            } else {
-                compilationTime = 0;
-            }
-
-            DebuggeeFactory.checkForDebugRequest(request, context);
-
-            boolean wrap = outputProperties.getProperty("_wrap") != null
-                    && "yes".equals(outputProperties.getProperty("_wrap"));
-
             try {
-                final long executeStart = System.currentTimeMillis();
-                final Sequence result = xquery.execute(broker, compiled, null, outputProperties);
-                writeResults(response, broker, transaction, result, -1, 1, false, outputProperties, wrap, compilationTime, System.currentTimeMillis() - executeStart);
+                final long compilationTime;
+                if (compiled == null) {
+                    try {
+                        final long compilationStart = System.currentTimeMillis();
+                        compiled = xquery.compile(context, source);
+                        compilationTime = System.currentTimeMillis() - compilationStart;
+                    } catch (final IOException e) {
+                        throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
+                    }
+                } else {
+                    compilationTime = 0;
+                }
 
-            } finally {
-                context.runCleanupTasks();
+                DebuggeeFactory.checkForDebugRequest(request, context);
+
+                boolean wrap = outputProperties.getProperty("_wrap") != null
+                        && "yes".equals(outputProperties.getProperty("_wrap"));
+
+                try {
+                    final long executeStart = System.currentTimeMillis();
+                    final Sequence result = xquery.execute(broker, compiled, null, outputProperties);
+                    writeResults(response, broker, transaction, result, -1, 1, false, outputProperties, wrap, compilationTime, System.currentTimeMillis() - executeStart);
+
+                } finally {
+                    context.runCleanupTasks();
+                }
+            } catch (final XPathException e) {
+                // compile and runtime failures alike are filtered: a read-blind caller learns only
+                // that the execution failed, the real error is logged with a correlation id
+                throw ErrorDisclosure.disclose(context, e);
             }
         } finally {
             if (compiled != null) {

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1619,7 +1619,6 @@ public class RESTServer {
             final XQuery xquery = broker.getBrokerPool().getXQueryService();
             compiled = pool.borrowCompiledXQuery(broker, source);
 
-            final boolean cached = compiled != null;
             final XQueryContext context;
             if (compiled == null) {
                 context = new XQueryContext(broker.getBrokerPool());
@@ -1638,7 +1637,7 @@ public class RESTServer {
             // X-XQuery-Cached reveals whether another user recently executed this shared query; do not
             // disclose it to a read-blind caller (plan §4.6 — suppress X-XQuery-* for GENERIC)
             if (disclosure == ErrorDisclosure.FULL) {
-                response.setHeader("X-XQuery-Cached", Boolean.toString(cached));
+                response.setHeader("X-XQuery-Cached", Boolean.toString(compiled != null));
             }
 
             // TODO: don't hardcode this?

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1588,8 +1588,12 @@ public class RESTServer {
                 return null;
             }
 
-            // only a stored query may be reached without READ; anything else is a data read
-            if (!MimeType.XQUERY_TYPE.getName().equals(executable.document().getDocument().getMimeType())) {
+            // only a stored XQuery may be reached without READ; anything else is a data read. Require
+            // the binary resource type as well as the mime type, so an XML resource merely labelled
+            // application/xquery is not admitted (it would fail the BinaryDocument cast downstream)
+            final DocumentImpl document = executable.document().getDocument();
+            if (document.getResourceType() != DocumentImpl.BINARY_FILE
+                    || !MimeType.XQUERY_TYPE.getName().equals(document.getMimeType())) {
                 executable.close();
                 throw readDenied;
             }
@@ -1615,14 +1619,11 @@ public class RESTServer {
             final XQuery xquery = broker.getBrokerPool().getXQueryService();
             compiled = pool.borrowCompiledXQuery(broker, source);
 
-            XQueryContext context;
+            final boolean cached = compiled != null;
+            final XQueryContext context;
             if (compiled == null) {
-                // special header to indicate that the query is not returned from
-                // cache
-                response.setHeader("X-XQuery-Cached", "false");
                 context = new XQueryContext(broker.getBrokerPool());
             } else {
-                response.setHeader("X-XQuery-Cached", "true");
                 context = compiled.getContext();
                 context.prepareForReuse();
             }
@@ -1631,7 +1632,14 @@ public class RESTServer {
             // source from a failure. Recomputed per request from the current subject, as the compiled
             // query is pooled and shared between users, and set before the query is compiled, since a
             // compile error never reaches XQuery#execute (which computes the level for runtime errors)
-            context.setErrorDisclosure(ErrorDisclosure.of(source, broker.getCurrentSubject()));
+            final ErrorDisclosure disclosure = ErrorDisclosure.of(source, broker.getCurrentSubject());
+            context.setErrorDisclosure(disclosure);
+
+            // X-XQuery-Cached reveals whether another user recently executed this shared query; do not
+            // disclose it to a read-blind caller (plan §4.6 — suppress X-XQuery-* for GENERIC)
+            if (disclosure == ErrorDisclosure.FULL) {
+                response.setHeader("X-XQuery-Cached", Boolean.toString(cached));
+            }
 
             // TODO: don't hardcode this?
             context.setModuleLoadPath(
@@ -1676,6 +1684,15 @@ public class RESTServer {
                 // compile and runtime failures alike are filtered: a read-blind caller learns only
                 // that the execution failed, the real error is logged with a correlation id
                 throw ErrorDisclosure.disclose(context, e);
+            } catch (final BadRequestException | PermissionDeniedException | RuntimeException e) {
+                // a failure of an authorized query which is not an XPathException — serialization
+                // (BadRequestException), a runtime permission failure, or any RuntimeException — still
+                // carries source-derived detail, so branch on the disclosure level, not the Java type
+                final XPathException generic = ErrorDisclosure.discloseGeneric(context, e);
+                if (generic != null) {
+                    throw generic;
+                }
+                throw e;
             }
         } finally {
             if (compiled != null) {

--- a/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
@@ -39,6 +39,7 @@ import org.exist.util.MimeTable;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
+import org.xml.sax.SAXException;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
@@ -534,10 +535,22 @@ public class XQueryServlet extends AbstractExistHttpServlet {
             
             if (requestAttr != null && (XmldbURI.API_LOCAL.equals(collectionURI.getApiName())) ) {
                 request.setAttribute(requestAttr, resultSequence);
-                
+
             } else {
-                XQuerySerializer serializer = new XQuerySerializer(broker, outputProperties, output);
-                serializer.serialize(resultSequence);
+                final XQuerySerializer serializer = new XQuerySerializer(broker, outputProperties, output);
+                try {
+                    // serialization runs the tail of a lazily-evaluated query, so a runtime failure can
+                    // surface here rather than in execute() above; it must be filtered just the same
+                    serializer.serialize(resultSequence);
+                } catch (final XPathException e) {
+                    throw ErrorDisclosure.disclose(context, e);
+                } catch (final SAXException e) {
+                    final XPathException generic = ErrorDisclosure.discloseGeneric(context, e);
+                    if (generic != null) {
+                        throw generic;
+                    }
+                    throw e;
+                }
             }
             
 		} catch (final PermissionDeniedException e) {

--- a/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
@@ -342,7 +342,9 @@ public class XQueryServlet extends AbstractExistHttpServlet {
             
         } else if (urlAttrib != null) {
             try(final DBBroker broker = getPool().get(Optional.ofNullable(user))) {
-                source = SourceFactory.getSource(broker, moduleLoadPath, urlAttrib.toString(), true);
+                // resolved for execution: a stored query needs EXECUTE, not READ. The ?_source view
+                // below still validates READ, so an unreadable query can be run but not viewed
+                source = SourceFactory.getSourceForExecution(broker, moduleLoadPath, urlAttrib.toString(), true);
                 if (source == null) {
                     final String msg = "Could not read source: context=" + moduleLoadPath + ", location=" + urlAttrib;
                     getLog().error(msg);
@@ -433,23 +435,32 @@ public class XQueryServlet extends AbstractExistHttpServlet {
             CompiledXQuery query = getPool().getXQueryPool().borrowCompiledXQuery(broker, source);
 
             XQueryContext context;
-            if (query==null) {
+            if (query == null) {
                context = new XQueryContext(getPool());
                context.setModuleLoadPath(moduleLoadPath);
-               try {
-            	   query = xquery.compile(context, source);
-                   
-               } catch (final XPathException ex) {
-                  throw new EXistException("Cannot compile xquery: "+ ex.getMessage(), ex);
-                  
-               } catch (final IOException ex) {
-                  throw new EXistException("I/O exception while compiling xquery: " + ex.getMessage() ,ex);
-               }
-               
             } else {
                context = query.getContext();
                context.setModuleLoadPath(moduleLoadPath);
                context.prepareForReuse();
+            }
+
+            // a caller which may execute but not read the query must not learn anything about its
+            // source from a failure. Recomputed per request, as the compiled query is pooled and
+            // shared between users, and set before compiling: a compile error never reaches
+            // XQuery#execute, which computes the level for a runtime failure
+            context.setErrorDisclosure(ErrorDisclosure.of(source, user));
+
+            if (query == null) {
+               try {
+            	   query = xquery.compile(context, source);
+
+               } catch (final XPathException ex) {
+                  final XPathException disclosed = ErrorDisclosure.disclose(context, ex);
+                  throw new EXistException("Cannot compile xquery: "+ disclosed.getMessage(), disclosed);
+
+               } catch (final IOException ex) {
+                  throw new EXistException("I/O exception while compiling xquery: " + ex.getMessage() ,ex);
+               }
             }
 
             final Properties outputProperties = new Properties();
@@ -484,7 +495,12 @@ public class XQueryServlet extends AbstractExistHttpServlet {
             Sequence resultSequence;
             try {
                 resultSequence = xquery.execute(broker, query, null, outputProperties);
-                
+
+            } catch (final XPathException e) {
+                // a read-blind caller learns only that the execution failed; the real error is
+                // logged server-side with a correlation id
+                throw ErrorDisclosure.disclose(context, e);
+
             } finally {
                 context.runCleanupTasks();
                 getPool().getXQueryPool().returnCompiledXQuery(source, query);

--- a/exist-core/src/main/java/org/exist/source/SourceFactory.java
+++ b/exist-core/src/main/java/org/exist/source/SourceFactory.java
@@ -138,7 +138,7 @@ public class SourceFactory {
             }
 
             if (pathUri != null) {
-                source = getSource_fromDb(broker, pathUri, forExecution);
+                source = getSourceFromDb(broker, pathUri, forExecution);
             }
         }
 
@@ -152,7 +152,7 @@ public class SourceFactory {
             } else {
                 pathUri = XmldbURI.create(contextPath).append(location);
             }
-            source = getSource_fromDb(broker, pathUri, forExecution);
+            source = getSourceFromDb(broker, pathUri, forExecution);
         }
 
         /* file:// or location without scheme (:/) is assumed to be a file */
@@ -223,7 +223,7 @@ public class SourceFactory {
      *
      * @return the source, or null if there is no such resource in the db indicated by {@code path}.
      */
-    private static @Nullable Source getSource_fromDb(final DBBroker broker, final XmldbURI path, final boolean forExecution) throws PermissionDeniedException, IOException {
+    private static @Nullable Source getSourceFromDb(final DBBroker broker, final XmldbURI path, final boolean forExecution) throws PermissionDeniedException, IOException {
         if (forExecution) {
             // gate on EXECUTE, not READ: the source is compiled on the caller's behalf
             try (final ExecutableResource executable = broker.getResourceForExecution(path)) {

--- a/exist-core/src/main/java/org/exist/source/SourceFactory.java
+++ b/exist-core/src/main/java/org/exist/source/SourceFactory.java
@@ -226,7 +226,7 @@ public class SourceFactory {
     private static @Nullable Source getSource_fromDb(final DBBroker broker, final XmldbURI path, final boolean forExecution) throws PermissionDeniedException, IOException {
         if (forExecution) {
             // gate on EXECUTE, not READ: the source is compiled on the caller's behalf
-            try (final ExecutableResource executable = broker.getResourceForExecution(path, LockMode.READ_LOCK)) {
+            try (final ExecutableResource executable = broker.getResourceForExecution(path)) {
                 if (executable == null) {
                     return null;
                 }

--- a/exist-core/src/main/java/org/exist/source/SourceFactory.java
+++ b/exist-core/src/main/java/org/exist/source/SourceFactory.java
@@ -39,6 +39,7 @@ import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.ExecutableResource;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.FileUtils;
@@ -75,6 +76,37 @@ public class SourceFactory {
      * @throws IOException if a general I/O error occurs whilst accessing the resource.
      */
     public static @Nullable Source getSource(final DBBroker broker, @Nullable final String contextPath, final String location, final boolean checkXQEncoding) throws IOException, PermissionDeniedException {
+        return getSource(broker, contextPath, location, checkXQEncoding, false);
+    }
+
+    /**
+     * Create a {@link Source} object for a resource which is about to be COMPILED AND EXECUTED as an
+     * XQuery, rather than read as data.
+     *
+     * A resource in the database is resolved on {@link org.exist.security.Permission#EXECUTE} instead
+     * of {@link org.exist.security.Permission#READ}, so that a caller which may run a stored query but
+     * not read it gets its source — the database reads it on their behalf, as a kernel reads a
+     * {@code --x} binary. Resources outside the database are unaffected.
+     *
+     * The caller must derive the error disclosure level from the returned source before it compiles,
+     * see {@link org.exist.xquery.ErrorDisclosure#of(Source, org.exist.security.Subject)}.
+     *
+     * @param broker the eXist-db DBBroker
+     * @param contextPath the context path of the resource.
+     * @param location the location of the resource (relative to the {@code contextPath}).
+     * @param checkXQEncoding where we need to check the encoding of the XQuery.
+     *
+     * @return The Source of the resource, or null if the resource cannot be found.
+     *
+     * @throws PermissionDeniedException if the resource resides in the database and the calling user
+     *     may not execute it.
+     * @throws IOException if a general I/O error occurs whilst accessing the resource.
+     */
+    public static @Nullable Source getSourceForExecution(final DBBroker broker, @Nullable final String contextPath, final String location, final boolean checkXQEncoding) throws IOException, PermissionDeniedException {
+        return getSource(broker, contextPath, location, checkXQEncoding, true);
+    }
+
+    private static @Nullable Source getSource(final DBBroker broker, @Nullable final String contextPath, final String location, final boolean checkXQEncoding, final boolean forExecution) throws IOException, PermissionDeniedException {
         Source source = null;
 
         /* resource: */
@@ -105,7 +137,7 @@ public class SourceFactory {
             }
 
             if (pathUri != null) {
-                source = getSource_fromDb(broker, pathUri);
+                source = getSource_fromDb(broker, pathUri, forExecution);
             }
         }
 
@@ -119,7 +151,7 @@ public class SourceFactory {
             } else {
                 pathUri = XmldbURI.create(contextPath).append(location);
             }
-            source = getSource_fromDb(broker, pathUri);
+            source = getSource_fromDb(broker, pathUri, forExecution);
         }
 
         /* file:// or location without scheme (:/) is assumed to be a file */
@@ -190,7 +222,24 @@ public class SourceFactory {
      *
      * @return the source, or null if there is no such resource in the db indicated by {@code path}.
      */
-    private static @Nullable Source getSource_fromDb(final DBBroker broker, final XmldbURI path) throws PermissionDeniedException, IOException {
+    private static @Nullable Source getSource_fromDb(final DBBroker broker, final XmldbURI path, final boolean forExecution) throws PermissionDeniedException, IOException {
+        if (forExecution) {
+            // gate on EXECUTE, not READ: the source is compiled on the caller's behalf
+            try (final ExecutableResource executable = broker.getResourceForExecution(path, LockMode.READ_LOCK)) {
+                if (executable == null) {
+                    return null;
+                }
+
+                final DocumentImpl resource = executable.document().getDocument();
+                if (resource.getResourceType() == DocumentImpl.BINARY_FILE) {
+                    return new DBSource(broker.getBrokerPool(), (BinaryDocument) resource, true);
+                }
+
+                // an XML resource is not a stored query: serializing it is a data read, so fall
+                // through to the READ-gated path below
+            }
+        }
+
         Source source = null;
         try(final LockedDocument lockedResource = broker.getXMLResource(path, LockMode.READ_LOCK)) {
             if (lockedResource != null) {

--- a/exist-core/src/main/java/org/exist/source/SourceFactory.java
+++ b/exist-core/src/main/java/org/exist/source/SourceFactory.java
@@ -43,6 +43,7 @@ import org.exist.storage.ExecutableResource;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.FileUtils;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.SAXException;
 
@@ -230,13 +231,15 @@ public class SourceFactory {
                     return null;
                 }
 
+                // resolve on EXECUTE only for something that is actually a stored query: a binary
+                // resource with the xquery mime type. Anything else (an XML resource, or a binary of
+                // another type merely labelled otherwise) is not an execution target, so fall through
+                // to the READ-gated path — matching RESTServer.getResourceForRequest
                 final DocumentImpl resource = executable.document().getDocument();
-                if (resource.getResourceType() == DocumentImpl.BINARY_FILE) {
+                if (resource.getResourceType() == DocumentImpl.BINARY_FILE
+                        && MimeType.XQUERY_TYPE.getName().equals(resource.getMimeType())) {
                     return new DBSource(broker.getBrokerPool(), (BinaryDocument) resource, true);
                 }
-
-                // an XML resource is not a stored query: serializing it is a data read, so fall
-                // through to the READ-gated path below
             }
         }
 

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -431,6 +431,32 @@ public interface DBBroker extends AutoCloseable {
         throws PermissionDeniedException;
 
     /**
+     * Resolve a stored resource for the purpose of EXECUTING it, i.e. compiling and
+     * running it as an XQuery.
+     *
+     * Requires {@link org.exist.security.Permission#EXECUTE} on the resource, and — unlike
+     * {@link #getXMLResource(XmldbURI, LockMode)} and {@link #getResource(XmldbURI, int)} —
+     * does not require {@link org.exist.security.Permission#READ}. This mirrors Unix, where
+     * the kernel reads a {@code --x} binary on behalf of a process which cannot read it.
+     * The getters used for data access keep their READ semantics, so reading a query as data
+     * (download, {@code fn:unparsed-text}, {@code util:binary-doc}, …) still requires READ.
+     *
+     * The returned handle also reports whether the current subject may read the source
+     * ({@link ExecutableResource#callerCanRead()}), which callers use to decide how much of
+     * an execution failure they may disclose.
+     *
+     * @param docURI absolute path to the resource in the database
+     * @param lockMode the mode of the lock to acquire on the document
+     *
+     * @return the executable resource, or null if no document could be found at the specified
+     *     location. The caller must {@link ExecutableResource#close()} it to release the lock.
+     *
+     * @throws PermissionDeniedException if the current subject does not have EXECUTE on the resource
+     */
+    @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI, LockMode lockMode)
+        throws PermissionDeniedException;
+
+    /**
      * Get a new document id that does not yet exist within the collection.
      *
      * @param transaction the transaction

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -445,15 +445,17 @@ public interface DBBroker extends AutoCloseable {
      * ({@link ExecutableResource#callerCanRead()}), which callers use to decide how much of
      * an execution failure they may disclose.
      *
+     * The document is always resolved with a read lock: execution never writes to the resource
+     * being executed, so there is no write-lock variant to choose.
+     *
      * @param docURI absolute path to the resource in the database
-     * @param lockMode the mode of the lock to acquire on the document
      *
      * @return the executable resource, or null if no document could be found at the specified
      *     location. The caller must {@link ExecutableResource#close()} it to release the lock.
      *
      * @throws PermissionDeniedException if the current subject does not have EXECUTE on the resource
      */
-    @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI, LockMode lockMode)
+    @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI)
         throws PermissionDeniedException;
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/ExecutableResource.java
+++ b/exist-core/src/main/java/org/exist/storage/ExecutableResource.java
@@ -26,7 +26,7 @@ import org.exist.security.Permission;
 
 /**
  * A resource which the current subject is allowed to EXECUTE, as resolved by
- * {@link DBBroker#getResourceForExecution(org.exist.xmldb.XmldbURI, org.exist.storage.lock.Lock.LockMode)}.
+ * {@link DBBroker#getResourceForExecution(org.exist.xmldb.XmldbURI)}.
  *
  * Holding this handle means the subject has {@link Permission#EXECUTE} on the document;
  * it does not imply {@link Permission#READ}. {@link #callerCanRead()} reports whether the

--- a/exist-core/src/main/java/org/exist/storage/ExecutableResource.java
+++ b/exist-core/src/main/java/org/exist/storage/ExecutableResource.java
@@ -1,0 +1,48 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.Permission;
+
+/**
+ * A resource which the current subject is allowed to EXECUTE, as resolved by
+ * {@link DBBroker#getResourceForExecution(org.exist.xmldb.XmldbURI, org.exist.storage.lock.Lock.LockMode)}.
+ *
+ * Holding this handle means the subject has {@link Permission#EXECUTE} on the document;
+ * it does not imply {@link Permission#READ}. {@link #callerCanRead()} reports whether the
+ * subject may also read the source, which callers use to decide how much of a failure they
+ * may disclose (see {@link org.exist.xquery.ErrorDisclosure}).
+ *
+ * @param document the locked document
+ * @param callerCanRead whether the subject which resolved this resource also holds READ on it
+ */
+public record ExecutableResource(LockedDocument document, boolean callerCanRead) implements AutoCloseable {
+
+    /**
+     * Releases the lock held on the document.
+     */
+    @Override
+    public void close() {
+        document.close();
+    }
+}

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2534,6 +2534,40 @@ public class NativeBroker implements DBBroker {
     }
 
     @Override
+    public @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI, final LockMode lockMode) throws PermissionDeniedException {
+        if (docURI == null) {
+            return null;
+        }
+        docURI = prepend(docURI.toCollectionPathURI());
+        final XmldbURI collUri = docURI.removeLastSegment();
+        final XmldbURI docUri = docURI.lastSegment();
+        final LockMode collectionLockMode = lockManager.relativeCollectionLockMode(LockMode.READ_LOCK, lockMode);
+        try (final Collection collection = openCollection(collUri, collectionLockMode)) {
+            if (collection == null) {
+                LOG.debug("Collection '{}' not found!", collUri);
+                return null;
+            }
+
+            try {
+                // gate on EXECUTE, not READ: the database reads the source on the caller's behalf
+                final LockedDocument lockedDocument = collection.getDocumentWithLock(this, docUri, lockMode, Permission.EXECUTE);
+
+                // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
+                collection.close();
+
+                if (lockedDocument == null) {
+                    return null;
+                }
+
+                final boolean callerCanRead = lockedDocument.getDocument().getPermissions().validate(getCurrentSubject(), Permission.READ);
+                return new ExecutableResource(lockedDocument, callerCanRead);
+            } catch (final LockException e) {
+                throw new PermissionDeniedException(e);
+            }
+        }
+    }
+
+    @Override
     public void readBinaryResource(final BinaryDocument blob, final OutputStream os)
             throws IOException {
         try (final Txn transaction = continueOrBeginTransaction()) {

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2534,15 +2534,17 @@ public class NativeBroker implements DBBroker {
     }
 
     @Override
-    public @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI, final LockMode lockMode) throws PermissionDeniedException {
+    public @Nullable ExecutableResource getResourceForExecution(XmldbURI docURI) throws PermissionDeniedException {
         if (docURI == null) {
             return null;
         }
         docURI = prepend(docURI.toCollectionPathURI());
         final XmldbURI collUri = docURI.removeLastSegment();
         final XmldbURI docUri = docURI.lastSegment();
-        final LockMode collectionLockMode = lockManager.relativeCollectionLockMode(LockMode.READ_LOCK, lockMode);
-        try (final Collection collection = openCollection(collUri, collectionLockMode)) {
+        // a document is only ever resolved for execution, never for writing, so both the collection and
+        // document locks are always read locks (relativeCollectionLockMode(READ_LOCK, READ_LOCK) can only
+        // ever answer READ_LOCK)
+        try (final Collection collection = openCollection(collUri, LockMode.READ_LOCK)) {
             if (collection == null) {
                 LOG.debug("Collection '{}' not found!", collUri);
                 return null;
@@ -2550,7 +2552,7 @@ public class NativeBroker implements DBBroker {
 
             try {
                 // gate on EXECUTE, not READ: the database reads the source on the caller's behalf
-                final LockedDocument lockedDocument = collection.getDocumentWithLock(this, docUri, lockMode, Permission.EXECUTE);
+                final LockedDocument lockedDocument = collection.getDocumentWithLock(this, docUri, LockMode.READ_LOCK, Permission.EXECUTE);
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
                 collection.close();

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2559,7 +2559,10 @@ public class NativeBroker implements DBBroker {
                     return null;
                 }
 
-                final boolean callerCanRead = lockedDocument.getDocument().getPermissions().validate(getCurrentSubject(), Permission.READ);
+                // fail closed: an unknown subject is treated as unable to read the source
+                final Subject currentSubject = getCurrentSubject();
+                final boolean callerCanRead = currentSubject != null
+                        && lockedDocument.getDocument().getPermissions().validate(currentSubject, Permission.READ);
                 return new ExecutableResource(lockedDocument, callerCanRead);
             } catch (final LockException e) {
                 throw new PermissionDeniedException(e);

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -287,6 +287,12 @@ public class ErrorCodes {
     public static final ErrorCode EXXQDY0008 = new EXistErrorCode("EXXQDY0008", "Invalid argument.");
     public static final ErrorCode EXXQDY0009 = new EXistErrorCode("EXXQDY0009", "Permission denied.");
 
+    // --- Execute-without-read confidentiality error codes ---
+    // The single error reported to a caller which may EXECUTE but not READ a query: it carries
+    // nothing derived from the source, only a correlation id for the error logged server-side.
+    // See {@link ErrorDisclosure}.
+    public static final ErrorCode EXXQDY0010 = new EXistErrorCode("EXXQDY0010", "Query execution failed.");
+
     public static final ErrorCode ERROR = new EXistErrorCode("ERROR", "Error.");
 
     public static class ErrorCode {

--- a/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
@@ -23,7 +23,9 @@ package org.exist.xquery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.security.Permission;
 import org.exist.security.Subject;
+import org.exist.source.DBSource;
 import org.exist.source.Source;
 
 import javax.annotation.Nullable;
@@ -57,6 +59,28 @@ public enum ErrorDisclosure {
     GENERIC;
 
     private static final Logger LOG = LogManager.getLogger(ErrorDisclosure.class);
+
+    /**
+     * The level which applies to a subject executing a query from the given source.
+     *
+     * A stored query which the subject cannot read is {@link #GENERIC}; everything else — a query
+     * typed in by the caller, a query from the file system or the classpath, a stored query the
+     * subject can read — is {@link #FULL}, as its source is not confidential from that caller.
+     *
+     * Entry points must apply this to the context BEFORE compiling: a compile error never reaches
+     * {@link XQuery#execute}, which can only recompute the level for a runtime failure.
+     *
+     * @param source the source of the query, or null if it is unknown
+     * @param subject the subject executing the query, or null if it is unknown
+     *
+     * @return the level which may be disclosed to that subject
+     */
+    public static ErrorDisclosure of(@Nullable final Source source, @Nullable final Subject subject) {
+        if (!(source instanceof DBSource dbSource) || subject == null) {
+            return FULL;
+        }
+        return dbSource.getPermissions().validate(subject, Permission.READ) ? FULL : GENERIC;
+    }
 
     /**
      * Filter an error according to the disclosure level of the context it was raised in.

--- a/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
@@ -1,0 +1,104 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.security.Subject;
+import org.exist.source.Source;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * How much of a failed query execution may be disclosed to the caller.
+ *
+ * A caller which may EXECUTE a stored query but not READ it must not learn anything about the
+ * source: not the query text, nor the message, error code, line/column or cause of a failure —
+ * exactly as {@code execve} of a {@code --x} binary reports a generic errno rather than the
+ * contents of the file. The full error is logged server-side with a correlation id so that the
+ * owner or a DBA can still diagnose it.
+ *
+ * The disclosure level is recomputed from the current subject on every execution
+ * (see {@link XQuery#execute}) and is never cached with the compiled query, so the same pooled
+ * query yields full errors to a read-capable caller and generic errors to a read-blind one.
+ *
+ * @author <a href="mailto:info@exist-db.org">The eXist-db Authors</a>
+ */
+public enum ErrorDisclosure {
+
+    /**
+     * The caller may read the source, so it may see the error in full.
+     */
+    FULL,
+
+    /**
+     * The caller may execute but not read the source, so it learns only that the execution failed.
+     */
+    GENERIC;
+
+    private static final Logger LOG = LogManager.getLogger(ErrorDisclosure.class);
+
+    /**
+     * Filter an error according to the disclosure level of the context it was raised in.
+     *
+     * For {@link #FULL} the original error is returned unchanged. For {@link #GENERIC} the original
+     * is logged at WARN with a correlation id, the resource, and the real and effective subjects,
+     * and a sanitized error is returned which carries nothing but {@link ErrorCodes#EXXQDY0010}
+     * and that same correlation id.
+     *
+     * @param context the context the query executed in, or null if it is unknown
+     * @param original the error raised by the query
+     *
+     * @return the error which may be disclosed to the caller
+     */
+    public static XPathException disclose(@Nullable final XQueryContext context, final XPathException original) {
+        if (context == null || context.getErrorDisclosure() == FULL) {
+            return original;
+        }
+
+        final String correlationId = UUID.randomUUID().toString();
+        LOG.warn("Read-blind query execution failed [{}] resource={} realUser={} effectiveUser={}",
+                correlationId, sourceOf(context), realUserOf(context), effectiveUserOf(context), original);
+
+        return new XPathException((Expression) null, ErrorCodes.EXXQDY0010,
+                "Query execution failed (ref " + correlationId + ").");
+    }
+
+    private static String sourceOf(final XQueryContext context) {
+        final Source source = context.getSource();
+        return source == null ? "unknown" : source.path();
+    }
+
+    private static String realUserOf(final XQueryContext context) {
+        return nameOf(context.getRealUser());
+    }
+
+    private static String effectiveUserOf(final XQueryContext context) {
+        // the effective user is read through the broker, which may already be gone when the error is filtered
+        return context.getBroker() == null ? "unknown" : nameOf(context.getEffectiveUser());
+    }
+
+    private static String nameOf(@Nullable final Subject subject) {
+        return subject == null ? "unknown" : subject.getName();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
@@ -101,7 +101,34 @@ public enum ErrorDisclosure {
         if (context == null || context.getErrorDisclosure() == FULL) {
             return original;
         }
+        return sanitize(context, original);
+    }
 
+    /**
+     * Filter an arbitrary failure of an authorized query, for the transports which catch more than
+     * {@link XPathException}.
+     *
+     * A query which was allowed to run can fail in ways that are not an {@link XPathException} — a
+     * serialization {@code BadRequestException} or {@code SAXException}, a runtime
+     * {@link org.exist.security.PermissionDeniedException}, a {@link RuntimeException} — and every one
+     * of those carries source-derived detail that must not reach a read-blind caller. The transport
+     * must branch on the disclosure level (this method), never on the Java type of the failure.
+     *
+     * @param context the context the query executed in, or null if it is unknown
+     * @param original the failure raised by the query
+     *
+     * @return the sanitized generic error to throw instead when {@link #GENERIC}, or {@code null} when
+     *     {@link #FULL}, which signals the caller to rethrow {@code original} unchanged so its own type
+     *     and HTTP status are preserved
+     */
+    public static @Nullable XPathException discloseGeneric(@Nullable final XQueryContext context, final Throwable original) {
+        if (context == null || context.getErrorDisclosure() == FULL) {
+            return null;
+        }
+        return sanitize(context, original);
+    }
+
+    private static XPathException sanitize(final XQueryContext context, final Throwable original) {
         final String correlationId = UUID.randomUUID().toString();
         LOG.warn("Read-blind query execution failed [{}] resource={} realUser={} effectiveUser={}",
                 correlationId, sourceOf(context), realUserOf(context), effectiveUserOf(context), original);

--- a/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorDisclosure.java
@@ -76,10 +76,12 @@ public enum ErrorDisclosure {
      * @return the level which may be disclosed to that subject
      */
     public static ErrorDisclosure of(@Nullable final Source source, @Nullable final Subject subject) {
-        if (!(source instanceof DBSource dbSource) || subject == null) {
+        if (!(source instanceof DBSource dbSource)) {
+            // not a stored query, so its source is not confidential from the caller
             return FULL;
         }
-        return dbSource.getPermissions().validate(subject, Permission.READ) ? FULL : GENERIC;
+        // fail closed: a stored query whose reader we cannot determine is treated as unreadable
+        return subject != null && dbSource.getPermissions().validate(subject, Permission.READ) ? FULL : GENERIC;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -197,12 +197,14 @@ public class XQuery {
      */
     private CompiledXQuery compile(final XQueryContext context, final Reader reader, final boolean xpointer) throws XPathException, PermissionDeniedException {
 
-        //check read permission
-        if (context.getSource() instanceof DBSource) {
-            ((DBSource) context.getSource()).validate(Permission.READ);
+        //check execute permission: the source is compiled on the caller's behalf, so it needs
+        //EXECUTE and not READ, exactly as a kernel reads a --x binary for a process which cannot
+        //read it. Reading a query as data still requires READ, see DBBroker#getResourceForExecution
+        if (context.getSource() instanceof DBSource dbSource) {
+            dbSource.validate(Permission.EXECUTE);
         }
-        
-        
+
+
     	//TODO: move XQueryContext.getUserFromHttpSession() here, have to check if servlet.jar is in the classpath
     	//before compiling/executing that code though to avoid a dependency on servlet.jar - reflection? - deliriumsky
     	

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -365,10 +365,11 @@ public class XQuery {
 
             // a caller which may execute but not read the query must not learn anything about its
             // source from a failure. Recomputed here on every execution, as the compiled query is
-            // pooled and shared between users.
+            // pooled and shared between users. Fail closed: an unknown subject is treated as
+            // unable to read.
             final Subject currentSubject = broker.getCurrentSubject();
-            final boolean callerCanRead = currentSubject == null
-                    || dbSource.getPermissions().validate(currentSubject, Permission.READ);
+            final boolean callerCanRead = currentSubject != null
+                    && dbSource.getPermissions().validate(currentSubject, Permission.READ);
             expression.getContext().setErrorDisclosure(callerCanRead ? ErrorDisclosure.FULL : ErrorDisclosure.GENERIC);
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -358,10 +358,18 @@ public class XQuery {
     public Sequence execute(final DBBroker broker, final CompiledXQuery expression, @Nullable final Tuple3<QName, List<Expression>, Optional<ErrorCodes.ErrorCode>> functionCall, @Nullable Sequence contextSequence, final Properties outputProperties, final boolean resetContext) throws XPathException, PermissionDeniedException {
     	
         //check execute permissions
-        if (expression.getContext().getSource() instanceof DBSource) {
-            ((DBSource) expression.getContext().getSource()).validate(Permission.EXECUTE);
+        if (expression.getContext().getSource() instanceof DBSource dbSource) {
+            dbSource.validate(Permission.EXECUTE);
+
+            // a caller which may execute but not read the query must not learn anything about its
+            // source from a failure. Recomputed here on every execution, as the compiled query is
+            // pooled and shared between users.
+            final Subject currentSubject = broker.getCurrentSubject();
+            final boolean callerCanRead = currentSubject == null
+                    || dbSource.getPermissions().validate(currentSubject, Permission.READ);
+            expression.getContext().setErrorDisclosure(callerCanRead ? ErrorDisclosure.FULL : ErrorDisclosure.GENERIC);
         }
-        
+
         final long start = System.currentTimeMillis();
     	
         final XQueryContext context = expression.getContext();

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -400,6 +400,12 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     private Source source = null;
 
+    /**
+     * How much of a failed execution may be disclosed to the caller. Recomputed from the current
+     * subject on every execution and never cached with the compiled query, see {@link ErrorDisclosure}.
+     */
+    private ErrorDisclosure errorDisclosure = ErrorDisclosure.FULL;
+
     private DebuggeeJoint debuggeeJoint = null;
 
     private int xqueryVersion = 31;
@@ -3647,6 +3653,27 @@ public class XQueryContext implements BinaryValueManager, Context {
     @Override
     public void setSource(final Source source) {
         this.source = source;
+    }
+
+    /**
+     * Get how much of a failed execution may be disclosed to the caller.
+     *
+     * @return the error disclosure level, never null
+     */
+    public ErrorDisclosure getErrorDisclosure() {
+        return errorDisclosure;
+    }
+
+    /**
+     * Set how much of a failed execution may be disclosed to the caller.
+     *
+     * This must be recomputed from the current subject on every execution — a compiled query is
+     * pooled and shared between users, so the level of a previous execution must never be reused.
+     *
+     * @param errorDisclosure the error disclosure level
+     */
+    public void setErrorDisclosure(final ErrorDisclosure errorDisclosure) {
+        this.errorDisclosure = errorDisclosure;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -1,0 +1,258 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http;
+
+import org.apache.commons.codec.binary.Base64;
+import org.eclipse.jetty.http.HttpStatus;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.EXistSchemaType;
+import org.exist.security.Group;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.PermissionFactory;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.test.ExistWebServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.util.SyntaxException;
+import org.exist.xmldb.XmldbURI;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Executing a stored query over REST requires EXECUTE, not READ. A caller which may execute but not
+ * read a query gets its results, but learns only that it failed when it fails — the query text, the
+ * message, the spec error code and the location all stay server-side.
+ *
+ * The same queries are served to a caller which may also read them, and must come back with the real
+ * error, which is what proves the disclosure level is per-request rather than baked into the pooled
+ * compiled query.
+ */
+public class RESTExecuteWithoutReadTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private static final String TEST_USER = "restExecUser";
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("restExecuteWithoutRead");
+
+    /** rwx--x--x — runnable by anybody, readable by nobody but the owner */
+    private static final XmldbURI EXEC_ONLY_VALID = TEST_COLLECTION.append("exec-only-valid.xq");
+    private static final XmldbURI EXEC_ONLY_BROKEN = TEST_COLLECTION.append("exec-only-broken.xq");
+
+    /** rwxr-xr-x — the usual mode */
+    private static final XmldbURI READABLE_VALID = TEST_COLLECTION.append("readable-valid.xq");
+    private static final XmldbURI READABLE_BROKEN = TEST_COLLECTION.append("readable-broken.xq");
+
+    /** rw-r--r-- — the default mode of a stored resource: readable, but NOT executable */
+    private static final XmldbURI NOT_EXECUTABLE = TEST_COLLECTION.append("not-executable.xq");
+
+    private static final String VALID_QUERY = "xquery version \"3.1\";\n<result>{ sum(1 to 3) }</result>";
+    private static final String BROKEN_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn $secret +";
+
+    private static String credentials;
+
+    @BeforeClass
+    public static void setup() throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, TriggerException, SyntaxException {
+        credentials = Base64.encodeBase64String((TEST_USER + ":" + TEST_USER).getBytes(UTF_8));
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final SecurityManager securityManager = pool.getSecurityManager();
+
+        try (final DBBroker broker = pool.get(Optional.of(securityManager.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            createUser(securityManager, broker, TEST_USER);
+
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
+                collection.getPermissions().setMode("rwxr-xr-x");
+                broker.saveCollection(transaction, collection);
+            }
+
+            storeQuery(broker, transaction, EXEC_ONLY_VALID, VALID_QUERY, "rwx--x--x");
+            storeQuery(broker, transaction, EXEC_ONLY_BROKEN, BROKEN_QUERY, "rwx--x--x");
+            storeQuery(broker, transaction, READABLE_VALID, VALID_QUERY, "rwxr-xr-x");
+            storeQuery(broker, transaction, READABLE_BROKEN, BROKEN_QUERY, "rwxr-xr-x");
+            storeQuery(broker, transaction, NOT_EXECUTABLE, VALID_QUERY, "rw-r--r--");
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void executeOnlyQueryRuns() throws IOException {
+        final Response response = get(EXEC_ONLY_VALID, null);
+
+        assertEquals(HttpStatus.OK_200, response.status);
+        assertTrue("the query the caller cannot read still returns its results: " + response.body,
+                response.body.contains("<result>6</result>"));
+    }
+
+    @Test
+    public void executeOnlyQueryFailsGenerically() throws IOException {
+        final Response response = get(EXEC_ONLY_BROKEN, null);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.status);
+        assertTrue("the caller learns only that it failed: " + response.body,
+                response.body.contains("Query execution failed"));
+        assertTrue("and is given a correlation id to quote: " + response.body,
+                response.body.matches("(?s).*\\(ref [0-9a-f-]+\\).*"));
+
+        assertNoLeak(response.body);
+    }
+
+    @Test
+    public void readableQueryFailsWithTheRealError() throws IOException {
+        final Response response = get(READABLE_BROKEN, null);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.status);
+        assertTrue("a caller which may read the query sees the real error: " + response.body,
+                response.body.contains("XPST0003"));
+        assertFalse("and is not fobbed off with the generic error: " + response.body,
+                response.body.contains("Query execution failed"));
+    }
+
+    /**
+     * The pooled compiled query is shared between users, so the disclosure level must be recomputed on
+     * every request. Running the readable copy first primes the pool with a FULL context; the
+     * execute-only copy must still come back generic, and vice versa.
+     */
+    @Test
+    public void theDisclosureLevelIsNotCachedWithTheCompiledQuery() throws IOException {
+        final Response readable = get(READABLE_BROKEN, null);
+        assertTrue(readable.body.contains("XPST0003"));
+
+        final Response readBlind = get(EXEC_ONLY_BROKEN, null);
+        assertTrue("a read-blind caller must not inherit the verbosity of a read-capable one: " + readBlind.body,
+                readBlind.body.contains("Query execution failed"));
+        assertNoLeak(readBlind.body);
+
+        final Response readableAgain = get(READABLE_BROKEN, null);
+        assertTrue("nor must a read-capable caller be starved of detail: " + readableAgain.body,
+                readableAgain.body.contains("XPST0003"));
+    }
+
+    /**
+     * Relaxing the execution gate must not open a way to fetch the source as data.
+     */
+    @Test
+    public void theSourceOfAnExecuteOnlyQueryCannotBeViewed() throws IOException {
+        final Response response = get(EXEC_ONLY_VALID, "_source=yes");
+
+        assertEquals(HttpStatus.FORBIDDEN_403, response.status);
+        assertFalse("the source must not leak through the ?_source view: " + response.body,
+                response.body.contains("sum(1 to 3)"));
+    }
+
+    /**
+     * A query stored with the default resource mode (0666 → rw-r--r-- here) has no execute bit, so it
+     * cannot be run — being able to read it is not enough.
+     */
+    @Test
+    public void aReadableButNonExecutableQueryIsDenied() throws IOException {
+        final Response response = get(NOT_EXECUTABLE, null);
+
+        assertEquals(HttpStatus.FORBIDDEN_403, response.status);
+    }
+
+    private static void assertNoLeak(final String body) {
+        assertFalse("the source must not leak: " + body, body.contains("$secret"));
+        assertFalse("the spec error code must not leak: " + body, body.contains("XPST0003"));
+        assertFalse("the location must not leak: " + body, body.contains("at line"));
+    }
+
+    private static Response get(final XmldbURI uri, final String queryString) throws IOException {
+        final String path = "http://localhost:" + existWebServer.getPort() + "/rest" + uri
+                + (queryString == null ? "" : "?" + queryString);
+
+        final HttpURLConnection connection = (HttpURLConnection) new URL(path).openConnection();
+        try {
+            connection.setRequestProperty("Authorization", "Basic " + credentials);
+            connection.setRequestMethod("GET");
+            connection.connect();
+
+            final int status = connection.getResponseCode();
+            final InputStream is = status < 400 ? connection.getInputStream() : connection.getErrorStream();
+            final String body = is == null ? "" : new String(is.readAllBytes(), UTF_8);
+
+            return new Response(status, body);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private record Response(int status, String body) {
+    }
+
+    private static void storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final String query, final String modeStr)
+            throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, SyntaxException {
+        try (final Collection collection = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK)) {
+            broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(query.getBytes(UTF_8)),
+                    MimeType.XQUERY_TYPE, collection);
+        }
+        PermissionFactory.chmod_str(broker, transaction, uri, Optional.of(modeStr), Optional.empty());
+    }
+
+    private static void createUser(final SecurityManager securityManager, final DBBroker broker, final String username)
+            throws PermissionDeniedException, EXistException {
+        final UserAider user = new UserAider(username);
+        user.setPassword(username);
+
+        Group group = new GroupAider(username);
+        group.setMetadataValue(EXistSchemaType.DESCRIPTION, "Personal group for " + username);
+        group.addManager(user);
+        securityManager.addGroup(broker, group);
+
+        user.addGroup(username);
+        securityManager.addAccount(user);
+
+        group = securityManager.getGroup(username);
+        group.addManager(securityManager.getAccount(username));
+        securityManager.updateGroup(group);
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -53,6 +53,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -92,8 +94,15 @@ public class RESTExecuteWithoutReadTest {
     /** rw-r--r-- — the default mode of a stored resource: readable, but NOT executable */
     private static final XmldbURI NOT_EXECUTABLE = TEST_COLLECTION.append("not-executable.xq");
 
+    /** compiles and runs, then fails when the result is serialized (a function item is not serializable) */
+    private static final XmldbURI EXEC_ONLY_SERIALIZE_FAIL = TEST_COLLECTION.append("exec-only-serialize-fail.xq");
+    private static final XmldbURI READABLE_SERIALIZE_FAIL = TEST_COLLECTION.append("readable-serialize-fail.xq");
+
     private static final String VALID_QUERY = "xquery version \"3.1\";\n<result>{ sum(1 to 3) }</result>";
     private static final String BROKEN_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn $secret +";
+    // returns a function item; execute() succeeds but serialization of the result fails with SENR0001,
+    // which is the path that escaped ErrorDisclosure before the fix
+    private static final String SERIALIZE_FAIL_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn function() { $secret }";
 
     private static String credentials;
 
@@ -119,6 +128,8 @@ public class RESTExecuteWithoutReadTest {
             storeQuery(broker, transaction, READABLE_VALID, VALID_QUERY, "rwxr-xr-x");
             storeQuery(broker, transaction, READABLE_BROKEN, BROKEN_QUERY, "rwxr-xr-x");
             storeQuery(broker, transaction, NOT_EXECUTABLE, VALID_QUERY, "rw-r--r--");
+            storeQuery(broker, transaction, EXEC_ONLY_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwx--x--x");
+            storeQuery(broker, transaction, READABLE_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwxr-xr-x");
 
             transaction.commit();
         }
@@ -155,6 +166,53 @@ public class RESTExecuteWithoutReadTest {
                 response.body.contains("XPST0003"));
         assertFalse("and is not fobbed off with the generic error: " + response.body,
                 response.body.contains("Query execution failed"));
+    }
+
+    /**
+     * A failure that surfaces while the result is being serialized — not during execute() — must be
+     * sanitized just the same. Before the fix this escaped the disclosure filter, because it is
+     * raised outside the narrow try that caught XPathException from execute().
+     */
+    @Test
+    public void executeOnlySerializationFailureIsGeneric() throws IOException {
+        final Response response = get(EXEC_ONLY_SERIALIZE_FAIL, null);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, response.status);
+        assertTrue("a serialization failure of an unreadable query must also be generic: " + response.body,
+                response.body.contains("Query execution failed"));
+        assertFalse("the serialization error code must not leak: " + response.body,
+                response.body.contains("SENR0001"));
+        assertNoLeak(response.body);
+    }
+
+    @Test
+    public void readableSerializationFailureShowsTheRealError() throws IOException {
+        final Response response = get(READABLE_SERIALIZE_FAIL, null);
+
+        // a readable caller keeps the original failure's status and detail — here a serialization
+        // BadRequestException, which the servlet maps to 400. Only the read-blind path is normalized
+        // to a uniform 500 + generic message (executeOnlySerializationFailureIsGeneric)
+        assertTrue("a readable caller gets a real error status, not 200: " + response.status,
+                response.status >= 400);
+        assertFalse("a caller which may read the query is not fobbed off with the generic error: " + response.body,
+                response.body.contains("Query execution failed"));
+    }
+
+    /**
+     * X-XQuery-Cached reveals whether another user recently ran the shared query, so it must not be
+     * sent to a read-blind caller (plan §4.6). A read-capable caller still gets it.
+     */
+    @Test
+    public void theCacheHeaderIsSuppressedForAReadBlindCaller() throws IOException {
+        final Response readBlind = get(EXEC_ONLY_VALID, null);
+        assertEquals(HttpStatus.OK_200, readBlind.status);
+        assertFalse("the shared-pool activity oracle must not reach a read-blind caller",
+                readBlind.headers.containsKey("X-XQuery-Cached"));
+
+        final Response readable = get(READABLE_VALID, null);
+        assertEquals(HttpStatus.OK_200, readable.status);
+        assertTrue("a read-capable caller still gets the cache header",
+                readable.headers.containsKey("X-XQuery-Cached"));
     }
 
     /**
@@ -220,13 +278,13 @@ public class RESTExecuteWithoutReadTest {
             final InputStream is = status < 400 ? connection.getInputStream() : connection.getErrorStream();
             final String body = is == null ? "" : new String(is.readAllBytes(), UTF_8);
 
-            return new Response(status, body);
+            return new Response(status, body, connection.getHeaderFields());
         } finally {
             connection.disconnect();
         }
     }
 
-    private record Response(int status, String body) {
+    private record Response(int status, String body, Map<String, List<String>> headers) {
     }
 
     private static void storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final String query, final String modeStr)

--- a/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
@@ -127,7 +127,7 @@ public class ExecuteWithoutReadTest {
     // --- 1. the caller may read AND execute the query: failures are disclosed in full ---
 
     @Test
-    public void readAndExecute_validQueryReturnsItsResult() throws Exception {
+    public void readAndExecuteValidQueryReturnsItsResult() throws Exception {
         chmodAll(READ_AND_EXECUTE);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -139,7 +139,7 @@ public class ExecuteWithoutReadTest {
     }
 
     @Test
-    public void readAndExecute_syntaxErrorIsDisclosedInFull() throws Exception {
+    public void readAndExecuteSyntaxErrorIsDisclosedInFull() throws Exception {
         chmodAll(READ_AND_EXECUTE);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -153,7 +153,7 @@ public class ExecuteWithoutReadTest {
     }
 
     @Test
-    public void readAndExecute_runtimeErrorIsDisclosedInFull() throws Exception {
+    public void readAndExecuteRuntimeErrorIsDisclosedInFull() throws Exception {
         chmodAll(READ_AND_EXECUTE);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -167,7 +167,7 @@ public class ExecuteWithoutReadTest {
     // --- 2. the caller may only execute the query: it runs, but failures are generic ---
 
     @Test
-    public void executeOnly_validQueryReturnsTheSameResult() throws Exception {
+    public void executeOnlyValidQueryReturnsTheSameResult() throws Exception {
         chmodAll(EXECUTE_ONLY);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -180,7 +180,7 @@ public class ExecuteWithoutReadTest {
     }
 
     @Test
-    public void executeOnly_syntaxErrorIsGeneric() throws Exception {
+    public void executeOnlySyntaxErrorIsGeneric() throws Exception {
         chmodAll(EXECUTE_ONLY);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -192,7 +192,7 @@ public class ExecuteWithoutReadTest {
     }
 
     @Test
-    public void executeOnly_runtimeErrorIsGeneric() throws Exception {
+    public void executeOnlyRuntimeErrorIsGeneric() throws Exception {
         chmodAll(EXECUTE_ONLY);
 
         try (final DBBroker broker = testUserBroker()) {
@@ -211,7 +211,7 @@ public class ExecuteWithoutReadTest {
      * protects a query served from the XQuery pool, whose context was primed by another user.
      */
     @Test
-    public void executeOnly_runtimeErrorIsGenericEvenWhenOnlyXQueryExecuteSetsTheLevel() throws Exception {
+    public void executeOnlyRuntimeErrorIsGenericEvenWhenOnlyXQueryExecuteSetsTheLevel() throws Exception {
         chmodAll(EXECUTE_ONLY);
 
         try (final DBBroker broker = testUserBroker()) {

--- a/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
@@ -1,0 +1,332 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.security;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.source.DBSource;
+import org.exist.source.Source;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.ExecutableResource;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.util.SyntaxException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.ErrorDisclosure;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Executing a stored query requires EXECUTE, and a caller which may execute but not read it must
+ * learn only that the execution failed. Both stored modules below are run twice — once by a caller
+ * which may read them and once by a caller which may not — and the difference must be visible in
+ * the failures only, never in the results.
+ *
+ * NOTE: no execution entry point (REST, RESTXQ, XQueryServlet, …) is wired to this mechanism yet,
+ * that is Phase 1b/1c of eXist-db/exist#6568. {@link #executeStoredQuery} therefore stands in for
+ * what those loaders will do: resolve the query on EXECUTE, take the disclosure level from the
+ * resolved handle, compile, execute, and filter any failure through {@link ErrorDisclosure}.
+ */
+public class ExecuteWithoutReadTest {
+
+    private static final String TEST_USER = "executeWithoutReadUser";
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/executeWithoutRead");
+    private static final XmldbURI VALID_QUERY = TEST_COLLECTION.append("valid.xq");
+    private static final XmldbURI SYNTAX_ERROR_QUERY = TEST_COLLECTION.append("syntax-error.xq");
+    private static final XmldbURI RUNTIME_ERROR_QUERY = TEST_COLLECTION.append("runtime-error.xq");
+
+    private static final String VALID_MODULE =
+            "xquery version \"3.1\";\n<result>{ sum(1 to 3) }</result>";
+
+    /** the trailing operand is missing, so this fails to compile with XPST0003 */
+    private static final String SYNTAX_ERROR_MODULE =
+            "xquery version \"3.1\";\nlet $secret := 1\nreturn $secret +";
+
+    /** this compiles, and fails with FOAR0001 once it runs */
+    private static final String RUNTIME_ERROR_MODULE =
+            "xquery version \"3.1\";\nlet $secret := 0\nreturn 1 idiv $secret";
+
+    private static final String READ_AND_EXECUTE = "rwxr-xr-x";
+    private static final String EXECUTE_ONLY = "rwx--x--x";
+
+    @ClassRule
+    public static final ExistEmbeddedServer server = new ExistEmbeddedServer(true, true);
+
+    @BeforeClass
+    public static void setup() throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, TriggerException {
+        final BrokerPool pool = server.getBrokerPool();
+        final SecurityManager securityManager = pool.getSecurityManager();
+
+        try (final DBBroker broker = pool.get(Optional.of(securityManager.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            createUser(securityManager, broker, TEST_USER);
+
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
+                collection.getPermissions().setMode("rwxr-xr-x");
+                broker.saveCollection(transaction, collection);
+            }
+
+            storeQuery(broker, transaction, VALID_QUERY, VALID_MODULE);
+            storeQuery(broker, transaction, SYNTAX_ERROR_QUERY, SYNTAX_ERROR_MODULE);
+            storeQuery(broker, transaction, RUNTIME_ERROR_QUERY, RUNTIME_ERROR_MODULE);
+
+            transaction.commit();
+        } catch (final SyntaxException e) {
+            throw new EXistException(e);
+        }
+    }
+
+    // --- 1. the caller may read AND execute the query: failures are disclosed in full ---
+
+    @Test
+    public void readAndExecute_validQueryReturnsItsResult() throws Exception {
+        chmodAll(READ_AND_EXECUTE);
+
+        try (final DBBroker broker = testUserBroker()) {
+            final Sequence result = executeStoredQuery(broker, VALID_QUERY, true);
+
+            assertEquals(1, result.getItemCount());
+            assertEquals("6", result.itemAt(0).getStringValue());
+        }
+    }
+
+    @Test
+    public void readAndExecute_syntaxErrorIsDisclosedInFull() throws Exception {
+        chmodAll(READ_AND_EXECUTE);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, SYNTAX_ERROR_QUERY, true);
+            fail("the query does not compile, so it must fail");
+        } catch (final XPathException e) {
+            assertEquals("a read-capable caller sees the real error", ErrorCodes.XPST0003, e.getErrorCode());
+            assertFalse("a read-capable caller is not fobbed off with the generic error",
+                    e.getMessage().contains("Query execution failed"));
+        }
+    }
+
+    @Test
+    public void readAndExecute_runtimeErrorIsDisclosedInFull() throws Exception {
+        chmodAll(READ_AND_EXECUTE);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, RUNTIME_ERROR_QUERY, true);
+            fail("the query divides by zero, so it must fail");
+        } catch (final XPathException e) {
+            assertEquals("a read-capable caller sees the real error", ErrorCodes.FOAR0001, e.getErrorCode());
+        }
+    }
+
+    // --- 2. the caller may only execute the query: it runs, but failures are generic ---
+
+    @Test
+    public void executeOnly_validQueryReturnsTheSameResult() throws Exception {
+        chmodAll(EXECUTE_ONLY);
+
+        try (final DBBroker broker = testUserBroker()) {
+            final Sequence result = executeStoredQuery(broker, VALID_QUERY, true);
+
+            assertEquals("a query which succeeds returns its results, being unreadable changes nothing",
+                    1, result.getItemCount());
+            assertEquals("6", result.itemAt(0).getStringValue());
+        }
+    }
+
+    @Test
+    public void executeOnly_syntaxErrorIsGeneric() throws Exception {
+        chmodAll(EXECUTE_ONLY);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, SYNTAX_ERROR_QUERY, true);
+            fail("the query does not compile, so it must fail");
+        } catch (final XPathException e) {
+            assertGeneric(e);
+        }
+    }
+
+    @Test
+    public void executeOnly_runtimeErrorIsGeneric() throws Exception {
+        chmodAll(EXECUTE_ONLY);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, RUNTIME_ERROR_QUERY, true);
+            fail("the query divides by zero, so it must fail");
+        } catch (final XPathException e) {
+            assertGeneric(e);
+        }
+    }
+
+    // --- what each half of the mechanism is responsible for ---
+
+    /**
+     * XQuery.execute recomputes the disclosure level from the current subject on every execution, so
+     * a runtime failure is sanitized even for a loader which never set the level itself. This is what
+     * protects a query served from the XQuery pool, whose context was primed by another user.
+     */
+    @Test
+    public void executeOnly_runtimeErrorIsGenericEvenWhenOnlyXQueryExecuteSetsTheLevel() throws Exception {
+        chmodAll(EXECUTE_ONLY);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, RUNTIME_ERROR_QUERY, false);
+            fail("the query divides by zero, so it must fail");
+        } catch (final XPathException e) {
+            assertGeneric(e);
+        }
+    }
+
+    /**
+     * A compile error never reaches XQuery.execute, so XQuery.execute cannot sanitize it: the loader
+     * MUST take the level from {@link ExecutableResource#callerCanRead()} before it compiles. This
+     * pins that requirement — if a Phase 1b entry point forgets, a read-blind caller is handed the
+     * syntax error of a query it cannot read, which is exactly the leak this mechanism exists to stop.
+     */
+    @Test
+    public void aLoaderWhichDoesNotSetTheLevelBeforeCompilingLeaksTheSyntaxError() throws Exception {
+        chmodAll(EXECUTE_ONLY);
+
+        try (final DBBroker broker = testUserBroker()) {
+            executeStoredQuery(broker, SYNTAX_ERROR_QUERY, false);
+            fail("the query does not compile, so it must fail");
+        } catch (final XPathException e) {
+            assertEquals("compile errors bypass XQuery.execute entirely, so the loader has to set the"
+                            + " disclosure level itself before compiling",
+                    ErrorCodes.XPST0003, e.getErrorCode());
+        }
+    }
+
+    /**
+     * Stands in for the execution entry points until Phase 1b wires them up.
+     *
+     * @param loaderSetsDisclosure whether the loader takes the disclosure level from the resolved
+     *     handle before compiling, as a Phase 1b entry point must. When false, only the level which
+     *     {@link XQuery#execute} computes for itself applies.
+     */
+    private static Sequence executeStoredQuery(final DBBroker broker, final XmldbURI uri, final boolean loaderSetsDisclosure)
+            throws PermissionDeniedException, XPathException, IOException {
+        final BrokerPool pool = broker.getBrokerPool();
+
+        try (final ExecutableResource resource = broker.getResourceForExecution(uri, LockMode.READ_LOCK)) {
+            assertNotNull("the caller holds EXECUTE, so the query must resolve", resource);
+
+            final XQueryContext context = new XQueryContext(pool);
+            if (loaderSetsDisclosure) {
+                context.setErrorDisclosure(resource.callerCanRead() ? ErrorDisclosure.FULL : ErrorDisclosure.GENERIC);
+            }
+
+            final Source source = new DBSource(pool, (BinaryDocument) resource.document().getDocument(), true);
+            final XQuery xquery = pool.getXQueryService();
+            try {
+                final CompiledXQuery compiled = xquery.compile(broker, context, source);
+                return xquery.execute(broker, compiled, null);
+            } catch (final XPathException e) {
+                throw ErrorDisclosure.disclose(context, e);
+            }
+        }
+    }
+
+    private static void assertGeneric(final XPathException e) {
+        assertEquals("a read-blind caller learns only that the execution failed",
+                ErrorCodes.EXXQDY0010, e.getErrorCode());
+
+        final String message = e.getMessage();
+        assertTrue("the caller is given a correlation id to quote to the owner/DBA",
+                message.matches(".*\\(ref [0-9a-f-]+\\)\\.?$"));
+        assertFalse("the source must not leak", message.contains("$secret"));
+        assertFalse("the spec error code must not leak", message.contains("XPST0003"));
+        assertFalse("the spec error code must not leak", message.contains("FOAR0001"));
+        assertFalse("the location must not leak", message.contains("at line"));
+    }
+
+    private static void chmodAll(final String modeStr) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = server.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            for (final XmldbURI uri : new XmldbURI[]{VALID_QUERY, SYNTAX_ERROR_QUERY, RUNTIME_ERROR_QUERY}) {
+                PermissionFactory.chmod_str(broker, transaction, uri, Optional.of(modeStr), Optional.empty());
+            }
+
+            transaction.commit();
+        }
+    }
+
+    private static DBBroker testUserBroker() throws EXistException, AuthenticationException {
+        final BrokerPool pool = server.getBrokerPool();
+        final Subject testUser = pool.getSecurityManager().authenticate(TEST_USER, TEST_USER);
+        return pool.get(Optional.of(testUser));
+    }
+
+    private static void storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final String module)
+            throws EXistException, PermissionDeniedException, LockException, SAXException, IOException {
+        try (final Collection collection = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK)) {
+            broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(module.getBytes(UTF_8)),
+                    MimeType.XQUERY_TYPE, collection);
+        }
+    }
+
+    private static void createUser(final SecurityManager securityManager, final DBBroker broker, final String username)
+            throws PermissionDeniedException, EXistException {
+        final UserAider user = new UserAider(username);
+        user.setPassword(username);
+
+        Group group = new GroupAider(username);
+        group.setMetadataValue(EXistSchemaType.DESCRIPTION, "Personal group for " + username);
+        group.addManager(user);
+        securityManager.addGroup(broker, group);
+
+        user.addGroup(username);
+        securityManager.addAccount(user);
+
+        group = securityManager.getGroup(username);
+        group.addManager(securityManager.getAccount(username));
+        securityManager.updateGroup(group);
+    }
+}

--- a/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/security/ExecuteWithoutReadTest.java
@@ -253,7 +253,7 @@ public class ExecuteWithoutReadTest {
             throws PermissionDeniedException, XPathException, IOException {
         final BrokerPool pool = broker.getBrokerPool();
 
-        try (final ExecutableResource resource = broker.getResourceForExecution(uri, LockMode.READ_LOCK)) {
+        try (final ExecutableResource resource = broker.getResourceForExecution(uri)) {
             assertNotNull("the caller holds EXECUTE, so the query must resolve", resource);
 
             final XQueryContext context = new XQueryContext(pool);

--- a/exist-core/src/test/java/org/exist/storage/GetResourceForExecutionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/GetResourceForExecutionTest.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * {@link DBBroker#getResourceForExecution(XmldbURI, LockMode)} is the single boundary at which a
+ * {@link DBBroker#getResourceForExecution(XmldbURI)} is the single boundary at which a
  * stored query is authorized for execution: it gates on EXECUTE rather than READ, so that the
  * database can compile a query on behalf of a caller which may run it but not read it — as a Unix
  * kernel reads a {@code --x} binary for a process which cannot read it.
@@ -117,7 +117,7 @@ public class GetResourceForExecutionTest {
     @Test
     public void executeOnlyResourceIsResolvedAndReportsThatTheCallerCannotRead() throws EXistException, AuthenticationException, PermissionDeniedException {
         try (final DBBroker broker = testUserBroker();
-             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY, LockMode.READ_LOCK)) {
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY)) {
 
             assertNotNull("EXECUTE alone must be enough to resolve a query for execution", resource);
             assertNotNull(resource.document().getDocument());
@@ -129,7 +129,7 @@ public class GetResourceForExecutionTest {
     @Test
     public void readableResourceIsResolvedAndReportsThatTheCallerCanRead() throws EXistException, AuthenticationException, PermissionDeniedException {
         try (final DBBroker broker = testUserBroker();
-             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_AND_READ, LockMode.READ_LOCK)) {
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_AND_READ)) {
 
             assertNotNull(resource);
             assertTrue("the caller may read the source, so failures may be disclosed in full",
@@ -140,7 +140,7 @@ public class GetResourceForExecutionTest {
     @Test
     public void readWithoutExecuteIsDenied() throws EXistException, AuthenticationException {
         try (final DBBroker broker = testUserBroker()) {
-            broker.getResourceForExecution(READ_ONLY, LockMode.READ_LOCK);
+            broker.getResourceForExecution(READ_ONLY);
             fail("Execution must require EXECUTE, being able to read the query is not enough");
         } catch (final PermissionDeniedException expected) {
             // expected
@@ -150,7 +150,7 @@ public class GetResourceForExecutionTest {
     @Test
     public void missingResourceIsNotFoundRatherThanDenied() throws EXistException, AuthenticationException, PermissionDeniedException {
         try (final DBBroker broker = testUserBroker()) {
-            assertNull(broker.getResourceForExecution(NOT_STORED, LockMode.READ_LOCK));
+            assertNull(broker.getResourceForExecution(NOT_STORED));
         }
     }
 
@@ -158,7 +158,7 @@ public class GetResourceForExecutionTest {
     public void theDbaCanExecuteAndReadEverything() throws EXistException, PermissionDeniedException {
         final BrokerPool pool = server.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY, LockMode.READ_LOCK)) {
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY)) {
 
             assertNotNull(resource);
             assertTrue("a DBA is never read-blind", resource.callerCanRead());

--- a/exist-core/src/test/java/org/exist/storage/GetResourceForExecutionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/GetResourceForExecutionTest.java
@@ -1,0 +1,233 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.AuthenticationException;
+import org.exist.security.EXistSchemaType;
+import org.exist.security.Group;
+import org.exist.security.Permission;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.PermissionFactory;
+import org.exist.security.SecurityManager;
+import org.exist.security.Subject;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.util.SyntaxException;
+import org.exist.xmldb.XmldbURI;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * {@link DBBroker#getResourceForExecution(XmldbURI, LockMode)} is the single boundary at which a
+ * stored query is authorized for execution: it gates on EXECUTE rather than READ, so that the
+ * database can compile a query on behalf of a caller which may run it but not read it — as a Unix
+ * kernel reads a {@code --x} binary for a process which cannot read it.
+ *
+ * This asserts the gate itself: EXECUTE grants the handle, READ alone does not, and the handle
+ * reports whether the caller may also read the source (which decides how much of a failure may be
+ * disclosed to them). The READ-gated getters must be unaffected.
+ */
+public class GetResourceForExecutionTest {
+
+    private static final String TEST_USER = "executeWithoutReadTestUser";
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/executeWithoutReadTest");
+
+    /** rwx--x--x — the caller may execute it, but not read it */
+    private static final XmldbURI EXECUTE_ONLY = TEST_COLLECTION.append("execute-only.xq");
+
+    /** rwxr-xr-x — the usual mode: the caller may both execute and read it */
+    private static final XmldbURI EXECUTE_AND_READ = TEST_COLLECTION.append("execute-and-read.xq");
+
+    /** rwxr--r-- — the caller may read it, but not execute it */
+    private static final XmldbURI READ_ONLY = TEST_COLLECTION.append("read-only.xq");
+
+    private static final XmldbURI NOT_STORED = TEST_COLLECTION.append("not-stored.xq");
+
+    private static final String QUERY = "<result>{ 1 + 1 }</result>";
+
+    @ClassRule
+    public static final ExistEmbeddedServer server = new ExistEmbeddedServer(true, true);
+
+    @BeforeClass
+    public static void setup() throws EXistException, PermissionDeniedException, SyntaxException, IOException, SAXException, LockException, TriggerException {
+        final BrokerPool pool = server.getBrokerPool();
+        final SecurityManager securityManager = pool.getSecurityManager();
+
+        try (final DBBroker broker = pool.get(Optional.of(securityManager.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            createUser(securityManager, broker, TEST_USER);
+
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
+                collection.getPermissions().setMode("rwxr-xr-x");
+                broker.saveCollection(transaction, collection);
+            }
+
+            storeQuery(broker, transaction, EXECUTE_ONLY, "rwx--x--x");
+            storeQuery(broker, transaction, EXECUTE_AND_READ, "rwxr-xr-x");
+            storeQuery(broker, transaction, READ_ONLY, "rwxr--r--");
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void executeOnlyResourceIsResolvedAndReportsThatTheCallerCannotRead() throws EXistException, AuthenticationException, PermissionDeniedException {
+        try (final DBBroker broker = testUserBroker();
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY, LockMode.READ_LOCK)) {
+
+            assertNotNull("EXECUTE alone must be enough to resolve a query for execution", resource);
+            assertNotNull(resource.document().getDocument());
+            assertFalse("the caller may execute but not read, so failures must not be disclosed to them",
+                    resource.callerCanRead());
+        }
+    }
+
+    @Test
+    public void readableResourceIsResolvedAndReportsThatTheCallerCanRead() throws EXistException, AuthenticationException, PermissionDeniedException {
+        try (final DBBroker broker = testUserBroker();
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_AND_READ, LockMode.READ_LOCK)) {
+
+            assertNotNull(resource);
+            assertTrue("the caller may read the source, so failures may be disclosed in full",
+                    resource.callerCanRead());
+        }
+    }
+
+    @Test
+    public void readWithoutExecuteIsDenied() throws EXistException, AuthenticationException {
+        try (final DBBroker broker = testUserBroker()) {
+            broker.getResourceForExecution(READ_ONLY, LockMode.READ_LOCK);
+            fail("Execution must require EXECUTE, being able to read the query is not enough");
+        } catch (final PermissionDeniedException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void missingResourceIsNotFoundRatherThanDenied() throws EXistException, AuthenticationException, PermissionDeniedException {
+        try (final DBBroker broker = testUserBroker()) {
+            assertNull(broker.getResourceForExecution(NOT_STORED, LockMode.READ_LOCK));
+        }
+    }
+
+    @Test
+    public void theDbaCanExecuteAndReadEverything() throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = server.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final ExecutableResource resource = broker.getResourceForExecution(EXECUTE_ONLY, LockMode.READ_LOCK)) {
+
+            assertNotNull(resource);
+            assertTrue("a DBA is never read-blind", resource.callerCanRead());
+        }
+    }
+
+    /**
+     * The data-read getters keep their READ semantics: relaxing the execution gate must not open a
+     * way to fetch the source of an execute-only query as data.
+     */
+    @Test
+    public void readingAnExecuteOnlyResourceAsDataIsStillDenied() throws EXistException, AuthenticationException {
+        try (final DBBroker broker = testUserBroker()) {
+            broker.getXMLResource(EXECUTE_ONLY, LockMode.READ_LOCK);
+            fail("Reading a query as data must still require READ");
+        } catch (final PermissionDeniedException expected) {
+            // expected
+        }
+    }
+
+    /**
+     * The existing three argument getter must keep validating READ, so that every caller which has
+     * not been migrated to the execution boundary behaves exactly as before.
+     */
+    @Test
+    public void theCollectionGetterDefaultsToRead() throws EXistException, AuthenticationException, PermissionDeniedException, LockException {
+        try (final DBBroker broker = testUserBroker();
+             final Collection collection = broker.openCollection(TEST_COLLECTION, LockMode.READ_LOCK)) {
+
+            try (final LockedDocument lockedDocument = collection.getDocumentWithLock(broker, EXECUTE_ONLY.lastSegment(), LockMode.READ_LOCK)) {
+                fail("the three argument getter must still require READ");
+            } catch (final PermissionDeniedException expected) {
+                // expected
+            }
+
+            try (final LockedDocument lockedDocument = collection.getDocumentWithLock(broker, EXECUTE_ONLY.lastSegment(), LockMode.READ_LOCK, Permission.EXECUTE)) {
+                assertNotNull("the same document is reachable when EXECUTE is the required mode", lockedDocument);
+            }
+        }
+    }
+
+    private static DBBroker testUserBroker() throws EXistException, AuthenticationException {
+        final BrokerPool pool = server.getBrokerPool();
+        final Subject testUser = pool.getSecurityManager().authenticate(TEST_USER, TEST_USER);
+        return pool.get(Optional.of(testUser));
+    }
+
+    private static void storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final String modeStr)
+            throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, SyntaxException {
+        try (final Collection collection = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK)) {
+            broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(QUERY.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
+        }
+        PermissionFactory.chmod_str(broker, transaction, uri, Optional.of(modeStr), Optional.empty());
+    }
+
+    private static void createUser(final SecurityManager securityManager, final DBBroker broker, final String username) throws PermissionDeniedException, EXistException {
+        final UserAider user = new UserAider(username);
+        user.setPassword(username);
+
+        Group group = new GroupAider(username);
+        group.setMetadataValue(EXistSchemaType.DESCRIPTION, "Personal group for " + username);
+        group.addManager(user);
+        securityManager.addGroup(broker, group);
+
+        user.addGroup(username);
+        securityManager.addAccount(user);
+
+        group = securityManager.getGroup(username);
+        group.addManager(securityManager.getAccount(username));
+        securityManager.updateGroup(group);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/ErrorDisclosureTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ErrorDisclosureTest.java
@@ -1,0 +1,187 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A caller which may EXECUTE but not READ a stored query must learn only that the execution
+ * failed. {@link ErrorDisclosure#disclose(XQueryContext, XPathException)} is the filter which
+ * enforces that, so this asserts it strips everything derived from the source and logs the real
+ * error server-side under a correlation id the caller can quote.
+ */
+public class ErrorDisclosureTest {
+
+    private static final String DISCLOSURE_LOGGER = "org.exist.xquery.ErrorDisclosure";
+
+    /** the secrets which must never reach a read-blind caller */
+    private static final String SECRET_MESSAGE = "unknown variable '$secretPassword' in module /db/secret/lib.xqm";
+    private static final int SECRET_LINE = 42;
+    private static final int SECRET_COLUMN = 13;
+
+    private static final Pattern CORRELATION_ID = Pattern.compile("\\(ref ([0-9a-f-]+)\\)");
+
+    private CapturingAppender appender;
+
+    @Before
+    public void attachAppender() {
+        appender = new CapturingAppender();
+        appender.start();
+        // the test log4j2 config sets the root logger to OFF, which would filter these events before
+        // any appender sees them, so install a dedicated LoggerConfig for ErrorDisclosure at level ALL
+        final Logger logger = (Logger) LogManager.getLogger(DISCLOSURE_LOGGER);
+        final LoggerContext ctx = logger.getContext();
+        final Configuration config = ctx.getConfiguration();
+        config.addAppender(appender);
+        final LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+                .withLoggerName(DISCLOSURE_LOGGER)
+                .withLevel(Level.ALL)
+                .withAdditivity(false)
+                .withConfig(config)
+                .build();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        config.addLogger(DISCLOSURE_LOGGER, loggerConfig);
+        ctx.updateLoggers();
+    }
+
+    @After
+    public void detachAppender() {
+        final Logger logger = (Logger) LogManager.getLogger(DISCLOSURE_LOGGER);
+        final LoggerContext ctx = logger.getContext();
+        ctx.getConfiguration().removeLogger(DISCLOSURE_LOGGER);
+        ctx.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    public void fullDisclosureReturnsTheOriginalError() {
+        final XQueryContext context = new XQueryContext();
+        assertEquals("FULL must be the default", ErrorDisclosure.FULL, context.getErrorDisclosure());
+
+        final XPathException original = secretError();
+        final XPathException disclosed = ErrorDisclosure.disclose(context, original);
+
+        assertSame("a read-capable caller must see the error unchanged", original, disclosed);
+        assertTrue("nothing to hide, so nothing to log", appender.events.isEmpty());
+    }
+
+    @Test
+    public void genericDisclosureStripsEverythingDerivedFromTheSource() {
+        final XQueryContext context = new XQueryContext();
+        context.setErrorDisclosure(ErrorDisclosure.GENERIC);
+
+        final XPathException original = secretError();
+        final XPathException disclosed = ErrorDisclosure.disclose(context, original);
+
+        assertNotEquals("a read-blind caller must not see the original error", original, disclosed);
+        assertEquals(ErrorCodes.EXXQDY0010, disclosed.getErrorCode());
+
+        final String message = disclosed.getMessage();
+        assertTrue("the caller learns that the execution failed", message.contains("Query execution failed"));
+        assertFalse("the message must not leak the original message", message.contains(SECRET_MESSAGE));
+        assertFalse("the message must not leak the original error code", message.contains("XPST0003"));
+        // NOTE: assert on the location itself rather than on the digits of SECRET_LINE appearing in the
+        // message, which the hex of a random correlation id can contain by chance
+        assertFalse("the message must not leak the location", message.contains("at line"));
+        assertEquals("the line number must not be carried over", 0, disclosed.getLine());
+        assertEquals("the column number must not be carried over", 0, disclosed.getColumn());
+        assertNull("the cause chain must not be carried over", disclosed.getCause());
+    }
+
+    @Test
+    public void genericDisclosureLogsTheFullErrorUnderTheCorrelationIdGivenToTheCaller() {
+        final XQueryContext context = new XQueryContext();
+        context.setErrorDisclosure(ErrorDisclosure.GENERIC);
+
+        final XPathException original = secretError();
+        final XPathException disclosed = ErrorDisclosure.disclose(context, original);
+
+        final Matcher matcher = CORRELATION_ID.matcher(disclosed.getMessage());
+        assertTrue("the caller must be given a correlation id to quote: " + disclosed.getMessage(), matcher.find());
+        final String correlationId = matcher.group(1);
+
+        assertEquals("the failure must be logged exactly once", 1, appender.events.size());
+        final LogEvent event = appender.events.getFirst();
+        assertEquals(Level.WARN, event.getLevel());
+
+        final String logged = event.getMessage().getFormattedMessage();
+        assertTrue("the log must carry the same correlation id as the caller's error",
+                logged.contains(correlationId));
+        assertTrue("the log must identify the real user", logged.contains("realUser="));
+        assertTrue("the log must identify the effective user", logged.contains("effectiveUser="));
+        assertSame("the full error must be logged for the owner/DBA", original, event.getThrown());
+    }
+
+    @Test
+    public void eachFailureGetsItsOwnCorrelationId() {
+        final XQueryContext context = new XQueryContext();
+        context.setErrorDisclosure(ErrorDisclosure.GENERIC);
+
+        final String first = ErrorDisclosure.disclose(context, secretError()).getMessage();
+        final String second = ErrorDisclosure.disclose(context, secretError()).getMessage();
+
+        assertNotEquals(first, second);
+    }
+
+    private static XPathException secretError() {
+        final XPathException e = new XPathException((Expression) null, ErrorCodes.XPST0003, SECRET_MESSAGE,
+                new IllegalStateException("internal cause"));
+        e.setLocation(SECRET_LINE, SECRET_COLUMN);
+        return e;
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<LogEvent> events = new ArrayList<>();
+
+        CapturingAppender() {
+            super("error-disclosure-capture", null, null, false, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            events.add(event.toImmutable());
+        }
+    }
+}

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
@@ -34,7 +34,6 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.DBSource;
 import org.exist.storage.DBBroker;
 import org.exist.storage.ExecutableResource;
-import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.ErrorDisclosure;
@@ -53,7 +52,7 @@ class XQueryCompiler {
 
         // a resource function module is resolved for execution, so it needs EXECUTE and not READ. This
         // lets an execute-only module register, and matches the gate XQuery.compile now applies
-        try (final ExecutableResource executable = broker.getResourceForExecution(XmldbURI.create(xqueryLocation), LockMode.READ_LOCK)) {
+        try (final ExecutableResource executable = broker.getResourceForExecution(XmldbURI.create(xqueryLocation))) {
             if (executable != null) {
                 return compile(broker, executable.document().getDocument());
             } else {

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
@@ -30,12 +30,14 @@ import java.io.IOException;
 import java.net.URI;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
-import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.DBSource;
 import org.exist.storage.DBBroker;
+import org.exist.storage.ExecutableResource;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.ErrorDisclosure;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 
@@ -48,11 +50,12 @@ class XQueryCompiler {
     public final static String XQUERY_MIME_TYPE = "application/xquery";
     
     public static CompiledXQuery compile(final DBBroker broker, final URI xqueryLocation) throws RestXqServiceCompilationException {
-        
-        try {
-            final DocumentImpl document = broker.getResource(XmldbURI.create(xqueryLocation), Permission.READ);
-            if(document != null) {
-                return compile(broker, document);
+
+        // a resource function module is resolved for execution, so it needs EXECUTE and not READ. This
+        // lets an execute-only module register, and matches the gate XQuery.compile now applies
+        try (final ExecutableResource executable = broker.getResourceForExecution(XmldbURI.create(xqueryLocation), LockMode.READ_LOCK)) {
+            if (executable != null) {
+                return compile(broker, executable.document().getDocument());
             } else {
                 throw new RestXqServiceCompilationException("Invalid document location for XQuery: " + xqueryLocation.toString());
             }
@@ -73,8 +76,16 @@ class XQueryCompiler {
 
                     //set the module load path for any module imports that are relative
                     context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + source.getDocumentPath().removeLastSegment());
-                    
-                    return broker.getBrokerPool().getXQueryService().compile(context, source);
+
+                    // a caller which may execute but not read the module must not learn anything about
+                    // its source from a compile failure
+                    context.setErrorDisclosure(ErrorDisclosure.of(source, broker.getCurrentSubject()));
+
+                    try {
+                        return broker.getBrokerPool().getXQueryService().compile(context, source);
+                    } catch (final XPathException xpe) {
+                        throw ErrorDisclosure.disclose(context, xpe);
+                    }
                 } else {
                     throw new RestXqServiceCompilationException("Invalid mimetype '" +  document.getMimeType() + "' for XQuery: "  + document.getURI().toString());
                 }


### PR DESCRIPTION
### Description:

Makes stored-query permissions match Unix `--x` semantics: a query with `EXECUTE` but not `READ` can now actually be run, without the caller learning anything about its source from a failure.

eXist already has a distinct `EXECUTE` permission bit and `XQuery.execute` already gates on it, not `READ`. But every path that loaded the source to *compile* it hardcoded a `READ` check on the document handle, so `EXECUTE`-without-`READ` never actually worked — setuid queries (whose entire point is running code you can't read) were only reachable by callers who could already read them.

**What changed:**

- `DBBroker.getResourceForExecution(uri, lockMode)` — a new resolution boundary that gates on `EXECUTE`, not `READ`, and reports whether the caller can *also* `READ` the source (`NativeBroker`, `ExecutableResource`).
- `ErrorDisclosure` (new): `FULL`/`GENERIC` error-disclosure levels on `XQueryContext`. A caller who can execute but not read a query gets one generic message + a correlation id — no source text, error message, spec error code, line/column, or module URI. The full error is logged server-side under the correlation id for the owner/DBA. Recomputed on every execution (the compiled query is pooled and shared between users with different permissions), and applied to any failure type a transport can see — not just `XPathException` (serialization `SAXException`/`BadRequestException`, runtime `PermissionDeniedException`, `RuntimeException`) — since a failure surfacing during result serialization is just as informative as one from `execute()`.
- Wired through `RESTServer`, `XQueryServlet`, `SourceFactory`, `XQuery#execute` (compile + execute paths), and RESTXQ's `XQueryCompiler` (resource-function module resolution).
- Fail-closed throughout: an unresolvable/unknown subject is treated as unable to `READ`, not able to.
- Closes a resource-type/mime-type spoofing gap: both the binary resource type *and* the `application/xquery` mime type are now required before something is treated as an execute-without-read target.
- `X-XQuery-Cached` (reveals whether another user recently ran the shared compiled query) is suppressed for read-blind callers.
- Behind no new flag — the `READ` requirement is simply no longer imposed on the execution path; data-read paths (`fn:doc`, serialization, downloads, `?_source`) are untouched.

Collection-traverse (`EXECUTE` on ancestor collections for direct path access) is a separate, orthogonal deviation from Unix semantics and is tracked in #6569, not addressed here.

### Reference:

Closes #6568

### Type of tests:

New JUnit test classes:
- `org.exist.storage.GetResourceForExecutionTest` — the resolution boundary itself
- `org.exist.security.ExecuteWithoutReadTest` — permission semantics
- `org.exist.xquery.ErrorDisclosureTest` — the disclosure filter
- `org.exist.http.RESTExecuteWithoutReadTest` — end-to-end over REST, including the serialization-failure and cache-header-suppression regressions

All pass locally (`mvn -pl exist-core test -Dtest=...`), 28 tests across the four classes.
