### PR TITLE
[hotfix]: align BouncyCastle modules to override Tika 1.84

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -169,7 +169,6 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.85</version>
         </dependency>
 
         <dependency>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -124,6 +124,7 @@
         <methanol.version>1.9.0</methanol.version>
         <appassembler.version>2.1.0</appassembler.version>
         <aspectj.version>1.9.25.1</aspectj.version>
+        <bouncycastle.version>1.85</bouncycastle.version>
         <exquery.distribution.version>0.2.1</exquery.distribution.version>
         <icu.version>76.1</icu.version>
         <izpack.version>5.2.6</izpack.version>
@@ -677,6 +678,29 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>2.22.1</version>
+            </dependency>
+            <!-- Align Bouncy Castle with exist-core; overrides Tika 3.3.1's bouncycastle.version=1.84
+                 (bcutil/bcpkix/bcjmail). Mixed 1.84+1.85 on CLASSPATH=/exist/lib/* causes
+                 NoSuchFieldError on IANAObjectIdentifiers (see #6589). -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcjmail-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Force `bcprov/bcutil/bcpkix/bcjmail` to `${bouncycastle.version}` so exploded lib/ does not mix BC 1.85 with Tika's 1.84

close #6589
