### PR TITLE
[bugfix] Restore XQuery pool integrity for execute-only callers

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -49,6 +49,7 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static org.exist.storage.lock.Lock.LockMode.READ_LOCK;
 import static org.exist.storage.lock.Lock.LockMode.WRITE_LOCK;
@@ -574,6 +575,23 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      */
     @Nullable LockedDocument getDocumentWithLock(DBBroker broker, XmldbURI name, LockMode lockMode, int requiredMode)
             throws LockException, PermissionDeniedException;
+
+    /**
+     * Get the last modified time of a child resource, without checking any permission on it.
+     *
+     * This is a narrow staleness probe: whether a resource has changed is not a permission
+     * question, and no handle on the document escapes — only its timestamp. It is used to decide
+     * whether a cached artefact derived from the resource (e.g. a compiled XQuery in the
+     * {@link org.exist.storage.XQueryPool}) is out of date, which must give the same answer for
+     * every subject.
+     *
+     * @param name The name of the document (without collection path)
+     *
+     * @return the last modified time of the document, or empty if there is no such document
+     *
+     * @throws LockException if the document could not be locked
+     */
+    Optional<Long> getDocumentLastModified(XmldbURI name) throws LockException;
 
     /**
      * Get a child resource as identified by path. This method doesn't put

--- a/exist-core/src/main/java/org/exist/collections/LockedCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/LockedCollection.java
@@ -49,6 +49,7 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Just a Delegate to a {@link Collection} which allows us to also hold a lock
@@ -329,6 +330,11 @@ public class LockedCollection implements Collection {
     @Override
     public LockedDocument getDocumentWithLock(final DBBroker broker, final XmldbURI name, final Lock.LockMode lockMode, final int requiredMode) throws LockException, PermissionDeniedException {
         return collection.getDocumentWithLock(broker, name, lockMode, requiredMode);
+    }
+
+    @Override
+    public Optional<Long> getDocumentLastModified(final XmldbURI name) throws LockException {
+        return collection.getDocumentLastModified(name);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -740,6 +740,21 @@ public class MutableCollection implements Collection {
     }
 
     @Override
+    public Optional<Long> getDocumentLastModified(final XmldbURI name) throws LockException {
+        try(final ManagedCollectionLock collectionLock = lockManager.acquireCollectionReadLock(path);
+                final ManagedDocumentLock docLock = lockManager.acquireDocumentReadLock(getURI().append(name.lastSegment()))) {
+
+            final DocumentImpl doc = documents.get(name.lastSegmentString());
+
+            // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
+            collectionLock.close();
+
+            // NOTE: deliberately no permission check — see Collection#getDocumentLastModified
+            return doc == null ? Optional.empty() : Optional.of(doc.getLastModified());
+        }
+    }
+
+    @Override
     public DocumentImpl getDocumentNoLock(final DBBroker broker, final String rawPath) throws PermissionDeniedException {
         final DocumentImpl doc = documents.get(rawPath);
         if(doc != null) {

--- a/exist-core/src/main/java/org/exist/source/DBSource.java
+++ b/exist-core/src/main/java/org/exist/source/DBSource.java
@@ -26,14 +26,12 @@ import java.io.*;
 import org.exist.EXistException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.QName;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.security.internal.aider.UnixStylePermissionAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock.LockMode;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 
@@ -79,23 +77,32 @@ public class DBSource extends AbstractSource {
         return lastModified;
     }
 
+    /**
+     * Whether this source is unchanged since it was read.
+     *
+     * This asks about staleness only, never about permission: the answer has to be the same for
+     * every subject, or a caller which may execute but not read the resource would judge it INVALID
+     * and evict the compiled query that the {@link org.exist.storage.XQueryPool} shares with all
+     * users. The probe therefore checks no permission on the document and obtains nothing but its
+     * timestamp; permission to execute the query, or to read an imported module, is a separate gate
+     * enforced by the caller.
+     *
+     * @return INVALID if the resource has changed or is gone, VALID otherwise
+     */
     @Override
     public Validity isValid() {
-        Validity result;
-        try (final DBBroker broker = brokerPool.getBroker();
-             final LockedDocument lockedDoc = broker.getXMLResource(doc.getURI(), LockMode.READ_LOCK)) {
-            if (lockedDoc == null) {
-                result = Validity.INVALID;
-            } else if(lockedDoc.getDocument().getLastModified() > lastModified) {
-                result = Validity.INVALID;
-            } else {
-                result = Validity.VALID;
-            }
-        } catch (final EXistException | PermissionDeniedException pde) {
-            result = Validity.INVALID;
+        try (final DBBroker broker = brokerPool.getBroker()) {
+            return broker.getDocumentLastModified(doc.getURI())
+                    .map(docLastModified -> docLastModified > lastModified ? Validity.INVALID : Validity.VALID)
+                    .orElse(Validity.INVALID);
+        } catch (final EXistException e) {
+            return Validity.INVALID;
+        } catch (final PermissionDeniedException e) {
+            // the subject may not traverse to the resource, so it cannot observe a change. Reporting
+            // INVALID here would evict an entry that is shared with subjects which can — and access is
+            // refused by the gates around this call in any case
+            return Validity.VALID;
         }
-
-        return result;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -459,6 +459,31 @@ public interface DBBroker extends AutoCloseable {
         throws PermissionDeniedException;
 
     /**
+     * Get the last modified time of a stored resource, for the purpose of deciding whether an
+     * artefact derived from it — a compiled XQuery in the {@link XQueryPool}, a cached URL rewrite,
+     * … — is out of date.
+     *
+     * Whether a resource has changed is not a permission question: it must be answered identically
+     * for every subject, or a caller which may execute but not read a resource evicts the cache
+     * entries shared with everybody else. So <strong>no permission is checked on the document</strong>
+     * and no handle on it escapes — only its timestamp. Reading the resource itself keeps its usual
+     * gates ({@link #getXMLResource(XmldbURI, LockMode)} for READ,
+     * {@link #getResourceForExecution(XmldbURI)} for EXECUTE).
+     *
+     * Locating the document still opens its Collection, which requires
+     * {@link org.exist.security.Permission#EXECUTE} on every Collection along the path, exactly as
+     * every other resolution does.
+     *
+     * @param docURI absolute path to the resource in the database
+     *
+     * @return the last modified time of the resource, or empty if there is no resource at that path
+     *
+     * @throws PermissionDeniedException if the current subject may not traverse the Collection
+     *     hierarchy to the resource
+     */
+    Optional<Long> getDocumentLastModified(XmldbURI docURI) throws PermissionDeniedException;
+
+    /**
      * Get a new document id that does not yet exist within the collection.
      *
      * @param transaction the transaction

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2573,6 +2573,28 @@ public class NativeBroker implements DBBroker {
     }
 
     @Override
+    public Optional<Long> getDocumentLastModified(XmldbURI docURI) throws PermissionDeniedException {
+        if (docURI == null) {
+            return Optional.empty();
+        }
+        docURI = prepend(docURI.toCollectionPathURI());
+        final XmldbURI collUri = docURI.removeLastSegment();
+        final XmldbURI docUri = docURI.lastSegment();
+        try (final Collection collection = openCollection(collUri, LockMode.READ_LOCK)) {
+            if (collection == null) {
+                return Optional.empty();
+            }
+
+            // no permission check on the document: staleness is not a permission question, and only
+            // the timestamp is handed out — see DBBroker#getDocumentLastModified
+            return collection.getDocumentLastModified(docUri);
+        } catch (final LockException e) {
+            LOG.error("Could not acquire lock on document {}", docURI, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
     public void readBinaryResource(final BinaryDocument blob, final OutputStream os)
             throws IOException {
         try (final Txn transaction = continueOrBeginTransaction()) {

--- a/exist-core/src/main/java/org/exist/storage/XQueryPool.java
+++ b/exist-core/src/main/java/org/exist/storage/XQueryPool.java
@@ -35,6 +35,7 @@ package org.exist.storage;
 import java.text.NumberFormat;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.Objects;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -44,11 +45,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
+import org.exist.security.Subject;
 import org.exist.source.DBSource;
 import org.exist.source.Source;
 import org.exist.util.Configuration;
 import org.exist.util.Holder;
 import org.exist.xquery.*;
+import org.exist.xquery.Module;
 
 /**
  * Global pool for compiled XQuery expressions.
@@ -125,8 +128,9 @@ public class XQueryPool implements BrokerPoolService {
      * @param broker A database broker.
      * @param source The source identifying the XQuery to borrow.
      *
-     * @return The compiled XQuery identified by the source, or null if
-     *     there is no valid compiled representation in the XQuery pool.
+     * @return The compiled XQuery identified by the source, or null if there is no valid compiled
+     *     representation in the XQuery pool, or the caller may not read a module it imports — in
+     *     which case compiling the query itself would be denied at the import gate too.
      *
      * @throws PermissionDeniedException if the caller does not have execute
      *     permission for the compiled XQuery.
@@ -135,6 +139,12 @@ public class XQueryPool implements BrokerPoolService {
             throws PermissionDeniedException {
         if (broker == null || source == null) {
             return null;
+        }
+
+        // check execution permission BEFORE the cache is touched: a caller which may not execute the
+        // query must not be able to perturb the pool which is shared with every other user
+        if (source instanceof DBSource bSource) {
+            bSource.validate(Permission.EXECUTE);
         }
 
         // this will be set to non-null if we can borrow a query... allows us to escape the lamba, see https://github.com/ben-manes/caffeine/issues/192#issuecomment-337365618
@@ -168,19 +178,67 @@ public class XQueryPool implements BrokerPoolService {
             return null;
         }
 
-        //check execution permission
-        if (source instanceof DBSource bSource) {
-            bSource.validate(Permission.EXECUTE);
+        final CompiledXQuery compiledXQuery = borrowedCompiledQuery.value;
+
+        if (!callerMayUseModulesOf(broker, compiledXQuery)) {
+            // a cache hit must never authorize what a cold compile would refuse. The caller cannot read
+            // one of the imported modules, so compiling the query itself would be denied at the import
+            // gate (SourceFactory#getSource). Hand the entry back untouched — it is perfectly good for
+            // the users which may read the module — and let this caller take the cold path, where it
+            // fails exactly as it would with an empty pool
+            returnCompiledXQuery(source, compiledXQuery);
+            return null;
         }
 
-        return borrowedCompiledQuery.value;
+        return compiledXQuery;
+    }
+
+    /**
+     * Determines whether the caller could have resolved every module imported by a pooled compiled
+     * XQuery, had it compiled the query itself.
+     *
+     * A cold compile resolves each imported module through
+     * {@link org.exist.source.SourceFactory#getSource(DBBroker, String, String, boolean)}, which
+     * requires READ on the module. The same gate is applied here, so that borrowing from the pool
+     * grants no access which compiling would not.
+     *
+     * @param broker the database broker
+     * @param compiledXQuery the compiled query to check the imported modules of
+     *
+     * @return true if the caller may read every imported module, false otherwise.
+     */
+    private static boolean callerMayUseModulesOf(final DBBroker broker, final CompiledXQuery compiledXQuery) {
+        final XQueryContext context = compiledXQuery.getContext();
+        if (context == null) {
+            return true;
+        }
+
+        final Subject subject = broker.getCurrentSubject();
+        for (final Iterator<Module> it = context.getAllModules(); it.hasNext(); ) {
+            final Module module = it.next();
+            if (module == null || module.isInternalModule()) {
+                continue;
+            }
+
+            if (((ExternalModule) module).getSource() instanceof DBSource moduleSource) {
+                try {
+                    moduleSource.validate(subject, Permission.READ);
+                } catch (final PermissionDeniedException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Not serving the pooled query, the caller may not read the imported module {}",
+                                moduleSource.pathOrShortIdentifier());
+                    }
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
      * Determines if a compiled XQuery is still valid.
      *
-     * @param broker the database broker
-     * @param source the source of the query
      * @param compiledXQuery the compiled query
      *
      * @return true if the compiled query is still valid, false otherwise.

--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -26,6 +26,8 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.EXistSchemaType;
 import org.exist.security.Group;
 import org.exist.security.PermissionDeniedException;
@@ -33,10 +35,16 @@ import org.exist.security.PermissionFactory;
 import org.exist.security.SecurityManager;
 import org.exist.security.internal.aider.GroupAider;
 import org.exist.security.internal.aider.UserAider;
+import org.exist.source.DBSource;
+import org.exist.source.Source;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.ExistWebServer;
 import org.exist.util.LockException;
@@ -98,11 +106,25 @@ public class RESTExecuteWithoutReadTest {
     private static final XmldbURI EXEC_ONLY_SERIALIZE_FAIL = TEST_COLLECTION.append("exec-only-serialize-fail.xq");
     private static final XmldbURI READABLE_SERIALIZE_FAIL = TEST_COLLECTION.append("readable-serialize-fail.xq");
 
+    /** an XQuery library module, execute-only for "other" (rwx--x--x) — NOT readable by the test user */
+    private static final XmldbURI LIB_MODULE = TEST_COLLECTION.append("lib.xqm");
+    /** a main query that imports {@link #LIB_MODULE}, likewise execute-only for the test user */
+    private static final XmldbURI IMPORTS_LIB = TEST_COLLECTION.append("imports-lib.xq");
+
     private static final String VALID_QUERY = "xquery version \"3.1\";\n<result>{ sum(1 to 3) }</result>";
     private static final String BROKEN_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn $secret +";
     // returns a function item; execute() succeeds but serialization of the result fails with SENR0001,
     // which is the path that escaped ErrorDisclosure before the fix
     private static final String SERIALIZE_FAIL_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn function() { $secret }";
+
+    private static final String LIB_MODULE_SRC =
+            "xquery version \"3.1\";\n" +
+            "module namespace lib = \"http://exist-db.org/test/execwithoutread/lib\";\n" +
+            "declare function lib:answer() as xs:integer { 42 };";
+    private static final String IMPORTS_LIB_SRC =
+            "xquery version \"3.1\";\n" +
+            "import module namespace lib = \"http://exist-db.org/test/execwithoutread/lib\" at \"lib.xqm\";\n" +
+            "<result>{ lib:answer() }</result>";
 
     private static String credentials;
 
@@ -130,6 +152,9 @@ public class RESTExecuteWithoutReadTest {
             storeQuery(broker, transaction, NOT_EXECUTABLE, VALID_QUERY, "rw-r--r--");
             storeQuery(broker, transaction, EXEC_ONLY_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwx--x--x");
             storeQuery(broker, transaction, READABLE_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwxr-xr-x");
+
+            storeQuery(broker, transaction, LIB_MODULE, LIB_MODULE_SRC, "rwx--x--x");
+            storeQuery(broker, transaction, IMPORTS_LIB, IMPORTS_LIB_SRC, "rwx--x--x");
 
             transaction.commit();
         }
@@ -256,6 +281,65 @@ public class RESTExecuteWithoutReadTest {
         final Response response = get(NOT_EXECUTABLE, null);
 
         assertEquals(HttpStatus.FORBIDDEN_403, response.status);
+    }
+
+    /**
+     * A read-blind caller cannot run a query that {@code import module ... at}'s a module it cannot
+     * READ — and this holds whether or not the shared compiled-query pool is already warm.
+     *
+     * One might expect a warm pool to help: another user compiles the query, the module is linked into
+     * the pooled {@link org.exist.xquery.CompiledXQuery}, and the read-blind caller borrows it under
+     * EXECUTE without re-reading the module. It does not. {@link XQueryPool#borrowCompiledXQuery}
+     * revalidates the pooled query through {@link DBSource#isValid()}, which re-opens EACH imported
+     * module with a {@code getXMLResource(READ_LOCK)} under the CALLING subject. The read-blind caller
+     * is denied there, the entry is judged invalid and evicted, and the query is recompiled — which
+     * resolves the module on READ ({@link org.exist.source.SourceFactory#getSource}) and is denied
+     * again. So the outcome is deterministic, not cache-warmth-dependent.
+     */
+    @Test
+    public void aReadBlindCallerCannotRunAQueryImportingAnUnreadableModule() throws Exception {
+        final XQueryPool xqPool = existEmbeddedServer.getBrokerPool().getXQueryPool();
+
+        // COLD: nothing pooled -> recompile -> module resolved on READ -> denied -> generic failure.
+        xqPool.clear();
+        final Response cold = get(IMPORTS_LIB, null);
+        assertEquals("cold: recompile resolves the module on READ, denied: " + cold.body,
+                HttpStatus.INTERNAL_SERVER_ERROR_500, cold.status);
+        assertTrue("cold failure is generic for a read-blind caller: " + cold.body,
+                cold.body.contains("Query execution failed"));
+        assertFalse("no result when the import failed: " + cold.body, cold.body.contains("42"));
+
+        // WARM: the system subject has already compiled and pooled the query (module linked in), yet
+        // the read-blind caller STILL fails identically — the pool's validity check re-reads the module
+        // under the caller's READ. This is the asymmetry hypothesis being empirically refuted.
+        xqPool.clear();
+        primeQueryPool(IMPORTS_LIB);
+        final Response warm = get(IMPORTS_LIB, null);
+        assertEquals("warm: pool validity re-reads the module under the caller's READ, still denied: " + warm.body,
+                HttpStatus.INTERNAL_SERVER_ERROR_500, warm.status);
+        assertTrue("warm failure is generic, exactly as cold: " + warm.body,
+                warm.body.contains("Query execution failed"));
+        assertFalse("a pooled module-importing query is not reusable by a read-blind caller: " + warm.body,
+                warm.body.contains("42"));
+    }
+
+    /**
+     * Compiles a stored query as the system subject and returns it to the shared pool, standing in for
+     * any read-capable principal having run it first. Keyed by {@link DBSource} (document URI), so the
+     * REST execution path finds this entry for the same resource.
+     */
+    private static void primeQueryPool(final XmldbURI uri) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final LockedDocument locked = broker.getXMLResource(uri, LockMode.READ_LOCK)) {
+            final BinaryDocument bin = (BinaryDocument) locked.getDocument();
+            final Source source = new DBSource(pool, bin, true);
+            final XQuery xquery = pool.getXQueryService();
+            final XQueryContext context = new XQueryContext(pool);
+            context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI.append(bin.getCollection().getURI()).toString());
+            final CompiledXQuery compiled = xquery.compile(context, source);
+            pool.getXQueryPool().returnCompiledXQuery(source, compiled);
+        }
     }
 
     private static void assertNoLeak(final String body) {

--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -57,6 +57,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -68,6 +70,9 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -106,12 +111,16 @@ public class RESTExecuteWithoutReadTest {
     private static final XmldbURI EXEC_ONLY_SERIALIZE_FAIL = TEST_COLLECTION.append("exec-only-serialize-fail.xq");
     private static final XmldbURI READABLE_SERIALIZE_FAIL = TEST_COLLECTION.append("readable-serialize-fail.xq");
 
+    /** execute-only, and overwritten by {@link #aChangedQueryIsRecompiledForAReadBlindCallerToo()} */
+    private static final XmldbURI EXEC_ONLY_STALENESS = TEST_COLLECTION.append("exec-only-staleness.xq");
+
     /** an XQuery library module, execute-only for "other" (rwx--x--x) — NOT readable by the test user */
     private static final XmldbURI LIB_MODULE = TEST_COLLECTION.append("lib.xqm");
     /** a main query that imports {@link #LIB_MODULE}, likewise execute-only for the test user */
     private static final XmldbURI IMPORTS_LIB = TEST_COLLECTION.append("imports-lib.xq");
 
     private static final String VALID_QUERY = "xquery version \"3.1\";\n<result>{ sum(1 to 3) }</result>";
+    private static final String CHANGED_QUERY = "xquery version \"3.1\";\n<result>{ sum(1 to 4) }</result>";
     private static final String BROKEN_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn $secret +";
     // returns a function item; execute() succeeds but serialization of the result fails with SENR0001,
     // which is the path that escaped ErrorDisclosure before the fix
@@ -150,6 +159,7 @@ public class RESTExecuteWithoutReadTest {
             storeQuery(broker, transaction, READABLE_VALID, VALID_QUERY, "rwxr-xr-x");
             storeQuery(broker, transaction, READABLE_BROKEN, BROKEN_QUERY, "rwxr-xr-x");
             storeQuery(broker, transaction, NOT_EXECUTABLE, VALID_QUERY, "rw-r--r--");
+            storeQuery(broker, transaction, EXEC_ONLY_STALENESS, VALID_QUERY, "rwx--x--x");
             storeQuery(broker, transaction, EXEC_ONLY_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwx--x--x");
             storeQuery(broker, transaction, READABLE_SERIALIZE_FAIL, SERIALIZE_FAIL_QUERY, "rwxr-xr-x");
 
@@ -287,14 +297,15 @@ public class RESTExecuteWithoutReadTest {
      * A read-blind caller cannot run a query that {@code import module ... at}'s a module it cannot
      * READ — and this holds whether or not the shared compiled-query pool is already warm.
      *
-     * One might expect a warm pool to help: another user compiles the query, the module is linked into
-     * the pooled {@link org.exist.xquery.CompiledXQuery}, and the read-blind caller borrows it under
-     * EXECUTE without re-reading the module. It does not. {@link XQueryPool#borrowCompiledXQuery}
-     * revalidates the pooled query through {@link DBSource#isValid()}, which re-opens EACH imported
-     * module with a {@code getXMLResource(READ_LOCK)} under the CALLING subject. The read-blind caller
-     * is denied there, the entry is judged invalid and evicted, and the query is recompiled — which
-     * resolves the module on READ ({@link org.exist.source.SourceFactory#getSource}) and is denied
-     * again. So the outcome is deterministic, not cache-warmth-dependent.
+     * Running a module-importing query without READ on the module is a separate feature (see #6594,
+     * "Not in this issue"); what this test pins down is that it fails the SAME way cold and warm, and
+     * that the warm attempt leaves the pool as it found it.
+     *
+     * Cold, the compile is denied at the import gate ({@link org.exist.source.SourceFactory#getSource},
+     * READ). Warm, {@link XQueryPool#borrowCompiledXQuery} applies that very gate to the imported
+     * module sources of the pooled query, declines to serve it, puts it back, and lets the caller take
+     * the cold path — so a cache hit can never authorize what a cold compile would refuse, and the
+     * entry survives for the users which may read the module.
      */
     @Test
     public void aReadBlindCallerCannotRunAQueryImportingAnUnreadableModule() throws Exception {
@@ -307,20 +318,117 @@ public class RESTExecuteWithoutReadTest {
                 HttpStatus.INTERNAL_SERVER_ERROR_500, cold.status);
         assertTrue("cold failure is generic for a read-blind caller: " + cold.body,
                 cold.body.contains("Query execution failed"));
-        assertFalse("no result when the import failed: " + cold.body, cold.body.contains("42"));
+        assertFalse("no result when the import failed: " + cold.body, cold.body.contains("<result>42</result>"));
 
-        // WARM: the system subject has already compiled and pooled the query (module linked in), yet
-        // the read-blind caller STILL fails identically — the pool's validity check re-reads the module
-        // under the caller's READ. This is the asymmetry hypothesis being empirically refuted.
+        // WARM: a read-capable principal has compiled and pooled the query (module linked in). The
+        // read-blind caller still fails identically — and the pooled entry is untouched.
         xqPool.clear();
         primeQueryPool(IMPORTS_LIB);
+        final CompiledXQuery pooled = peekPooledQuery(IMPORTS_LIB);
+        assertNotNull("the read-capable principal left an entry in the shared pool", pooled);
+
         final Response warm = get(IMPORTS_LIB, null);
-        assertEquals("warm: pool validity re-reads the module under the caller's READ, still denied: " + warm.body,
+        assertEquals("warm: the module gate refuses what a cold compile would refuse: " + warm.body,
                 HttpStatus.INTERNAL_SERVER_ERROR_500, warm.status);
         assertTrue("warm failure is generic, exactly as cold: " + warm.body,
                 warm.body.contains("Query execution failed"));
         assertFalse("a pooled module-importing query is not reusable by a read-blind caller: " + warm.body,
-                warm.body.contains("42"));
+                warm.body.contains("<result>42</result>"));
+
+        assertSame("the refused caller must not evict the entry others can use",
+                pooled, peekPooledQuery(IMPORTS_LIB));
+    }
+
+    /**
+     * The pool is shared with every other user, so a read-blind caller must get real cache hits out of
+     * it and leave it as it found it. Before the fix each such request judged the entry INVALID — the
+     * validity probe resolved the document through the READ-gated getter under the calling subject —
+     * evicting it and forcing a recompile for everybody.
+     */
+    @Test
+    public void aReadBlindCallerReusesThePooledQueryInsteadOfEvictingIt() throws Exception {
+        final XQueryPool xqPool = existEmbeddedServer.getBrokerPool().getXQueryPool();
+        xqPool.clear();
+
+        assertEquals(HttpStatus.OK_200, get(EXEC_ONLY_VALID, null).status);
+        final CompiledXQuery pooled = peekPooledQuery(EXEC_ONLY_VALID);
+        assertNotNull("the first run leaves a compiled query in the shared pool", pooled);
+
+        for (int i = 0; i < 3; i++) {
+            final Response response = get(EXEC_ONLY_VALID, null);
+            assertEquals(HttpStatus.OK_200, response.status);
+            assertTrue(response.body.contains("<result>6</result>"));
+            assertSame("run " + (i + 1) + " must be a pool hit, not an eviction and recompile",
+                    pooled, peekPooledQuery(EXEC_ONLY_VALID));
+        }
+    }
+
+    /**
+     * A caller which may not execute the query at all is refused before the cache is touched, so the
+     * pooled entry survives its attempt untouched.
+     */
+    @Test
+    public void aCallerWithoutExecuteLeavesThePooledEntryIntact() throws Exception {
+        final XQueryPool xqPool = existEmbeddedServer.getBrokerPool().getXQueryPool();
+        xqPool.clear();
+        primeQueryPool(NOT_EXECUTABLE);
+
+        final CompiledXQuery pooled = peekPooledQuery(NOT_EXECUTABLE);
+        assertNotNull(pooled);
+
+        assertEquals(HttpStatus.FORBIDDEN_403, get(NOT_EXECUTABLE, null).status);
+
+        assertSame("a caller with no EXECUTE must not perturb shared pool state",
+                pooled, peekPooledQuery(NOT_EXECUTABLE));
+    }
+
+    /**
+     * Permission-free validity must not cost us staleness: overwriting a stored query still evicts the
+     * pooled compilation, for a read-blind caller as for any other.
+     */
+    @Test
+    public void aChangedQueryIsRecompiledForAReadBlindCallerToo() throws Exception {
+        final XQueryPool xqPool = existEmbeddedServer.getBrokerPool().getXQueryPool();
+        xqPool.clear();
+
+        assertTrue(get(EXEC_ONLY_STALENESS, null).body.contains("<result>6</result>"));
+        final CompiledXQuery pooled = peekPooledQuery(EXEC_ONLY_STALENESS);
+        assertNotNull(pooled);
+
+        overwriteQuery(EXEC_ONLY_STALENESS, CHANGED_QUERY, "rwx--x--x");
+
+        final Response afterChange = get(EXEC_ONLY_STALENESS, null);
+        assertEquals(HttpStatus.OK_200, afterChange.status);
+        assertTrue("the changed query is recompiled, not served from the pool: " + afterChange.body,
+                afterChange.body.contains("<result>10</result>"));
+        assertNotSame("the stale entry is evicted", pooled, peekPooledQuery(EXEC_ONLY_STALENESS));
+    }
+
+    /**
+     * Borrows the pooled compilation of a stored query as the system subject and immediately returns
+     * it, so that a test can identify the entry without changing what the pool holds.
+     */
+    private static @Nullable CompiledXQuery peekPooledQuery(final XmldbURI uri) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final LockedDocument locked = broker.getXMLResource(uri, LockMode.READ_LOCK)) {
+            final Source source = new DBSource(pool, (BinaryDocument) locked.getDocument(), true);
+            final XQueryPool xqPool = pool.getXQueryPool();
+            final CompiledXQuery compiled = xqPool.borrowCompiledXQuery(broker, source);
+            if (compiled != null) {
+                xqPool.returnCompiledXQuery(source, compiled);
+            }
+            return compiled;
+        }
+    }
+
+    private static void overwriteQuery(final XmldbURI uri, final String query, final String modeStr) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            storeQuery(broker, transaction, uri, query, modeStr);
+            transaction.commit();
+        }
     }
 
     /**


### PR DESCRIPTION
### Description:

Since #6586 (execute-without-read) an **execute-only caller** — one with `EXECUTE` but not `READ` on a stored query — actually reaches `XQueryPool#borrowCompiledXQuery`. That path was not safe for such a caller, and this PR restores pool integrity.

`DBSource#isValid()` resolved the document through the **READ-gated** `getXMLResource(uri, READ_LOCK)` as the calling subject and mapped `PermissionDeniedException` to `Validity.INVALID`. Three consequences:

1. A legitimate execute-only caller invalidated the compiled query, **evicted it from the pool shared with all users**, and forced a recompile on every request.
2. The same READ check was applied to every imported module's `DBSource` (`XQueryContext#checkModulesValid`), so a warm pool never helped a module-importing query either.
3. `computeIfPresent` polled and evicted **before** `EXECUTE` was validated, so even a caller with no permission at all perturbed shared pool state.

The root cause is that `isValid()` conflated two unrelated questions: **staleness** (has the source changed?) and **permission** (may this subject read it?). Validity is a staleness question and has nothing to do with who is asking.

**What changed**

- **Permission-free staleness.** New `DBBroker#getDocumentLastModified(XmldbURI)` (backed by a new `Collection#getDocumentLastModified`): brief read lock, **no permission check on the document**, returns only the timestamp — no document handle escapes, and it needs no subject, so it is not run under an elevated one. `DBSource#isValid()` uses it, and `INVALID` again means exactly "changed or deleted", for every caller. No change to the `Validity` enum or to any `!= VALID` comparison. This single change heals the pool, the imported-module validity walk, and `XQueryURLRewrite`'s `urlCache` eviction together. Locating the document still opens its Collection, which keeps its usual `EXECUTE` gate; if that denies, validity answers `VALID` rather than evicting an entry the subject cannot even observe.
- **Gate before cache.** `borrowCompiledXQuery` validates `EXECUTE` on the `DBSource` **before** it touches the cache, so a caller without permission gets `PermissionDeniedException` with zero cache interaction.
- **Cache-hit gates ≡ cold-path gates.** Borrow now validates the caller against every external module source of the compiled query with the gate the cold path enforces (`READ`, as in `SourceFactory#getSource`). When it fails, the entry is handed back to the pool untouched and borrow returns `null`, so the caller takes the cold path and fails exactly as it would with an empty pool. A cache hit can never authorize what a cold compile would refuse — and, unlike throwing here, cold and warm stay indistinguishable to the caller.

**Unchanged:** the `Source.Validity` enum; every other `Source` implementation (`FileSource`, `ClassLoaderSource`, `StringSource`, `URLSource`); `returnCompiledXQuery`; the RESTXQ cache; all data-read getters. Reading a query as data still requires `READ`.

**Not in this PR:** letting a read-blind caller actually *run* a module-importing query — that needs modules resolved on `EXECUTE` and is deferred by the issue. After this PR such a query fails cleanly and consistently rather than by cache-dependent eviction.

While verifying, a related but distinct pre-existing defect turned up and is filed separately as #6598: `setUid`/`setGid` is applied in `XQuery#execute`, after compilation, so it does not cover module imports. It reproduces identically before and after this PR.

### Reference:

Closes https://github.com/eXist-db/exist/issues/6594
Follows #6568 / #6586 (execute-without-read). Companion: #6593 (stored-query lock lifetime). Spun off: #6598.

### Type of tests:

Java, in `org.exist.http.RESTExecuteWithoutReadTest` (13 tests) — this is broker-pool, permission and HTTP-pipeline behaviour, which XQSuite cannot express (no live request context, and the assertions are about shared `XQueryPool` state).

The first commit is the failing reproduction; the second is the fix. Three new tests, each verified to fail with the fix reverted and pass with it:

- `aReadBlindCallerReusesThePooledQueryInsteadOfEvictingIt` — prime the pool, then run repeatedly as an execute-only user; every run is a pool hit and the pooled instance is identical throughout.
- `aCallerWithoutExecuteLeavesThePooledEntryIntact` — a caller with no `EXECUTE` gets 403 and the pooled entry survives untouched.
- `aChangedQueryIsRecompiledForAReadBlindCallerToo` — genuine staleness still evicts: overwrite the stored query and the next borrow recompiles.
- `aReadBlindCallerCannotRunAQueryImportingAnUnreadableModule` (rewritten from the reproduction commit) — cold and warm now fail identically, and the warm attempt leaves the pool as it found it. Also fixes a latent flake in it: `body.contains("42")` matched the correlation UUID (`f242fd23-…`), now `<result>42</result>`.

Local runs (JDK 21):

- `RESTExecuteWithoutReadTest` — 13 tests
- `org.exist.collections.**`, `org.exist.storage.**` — 525 tests
- `org.exist.http.**`, `org.exist.source.**`, `org.exist.xquery.functions.util.**` — 134 tests

All green. `ConcurrencyTest` and `org.exist.xmldb.concurrent.*` were excluded — they are surefire-excluded in `exist-core/pom.xml` and deadlock independently of this change.
