### PR TITLE
[ci] update Moderne build configuration

### DIFF
--- a/.github/workflows/prethink.yml
+++ b/.github/workflows/prethink.yml
@@ -25,7 +25,7 @@ jobs:
           # Pinned to avoid the Maven Central propagation race observed on 2026-05-08, where
           # the parent moderne-cli metadata advertised a release before the platform-specific
           # moderne-cli-linux binary had CDN-synced. Bump intentionally as new releases stabilize.
-          MODERNE_CLI_VERSION: '4.2.3'
+          MODERNE_CLI_VERSION: '4.4.0'
         run: |
           curl -sSL https://app.moderne.io/cli | bash
           echo "$HOME/.moderne/cli/bin" >> $GITHUB_PATH

--- a/.moderne/moderne.yml
+++ b/.moderne/moderne.yml
@@ -1,1 +1,0 @@
-mavenArgs: "-DskipTests -Ddependency-check.skip=true -Ddocker=false"


### PR DESCRIPTION
> **Depends on #6602.** Merge that first — see *Dependencies* below.

### Description:

`.moderne/moderne.yml` held a single line:

```yaml
mavenArgs: "-DskipTests -Ddependency-check.skip=true -Ddocker=false"
```

Every part of it is inert, so the file is removed:

- **`mavenArgs` is a legacy key which the current CLI (4.4.0) ignores.** None of these arguments ever reached Maven. Verified by adding an argument to the key and observing that the reproduce command the CLI logs came back without it. The key it actually reads is `maven.build.arguments`, written by `mod config build maven arguments edit`.
- **`-DskipTests` and `-Ddependency-check.skip=true` duplicate the CLI's own defaults.** It already passes both, plus `-Djacoco.skip=true`, `-Dmaven.javadoc.skip=true`, `-DskipITs` and ~30 other skip flags.
- **`-Ddocker=false` is a no-op.** The `docker` profile activates on `docker=true` (pom.xml#L188-L193), so it is inactive whether the property is `false` or absent.

Removing the file therefore changes no build behaviour — it removes something that looks like configuration but is not. LST production falls back to the CLI defaults, which are sufficient.

`.gitignore` keeps its `!.moderne/moderne.yml` negation, so a real configuration can still be committed here later if one is ever needed. Per-machine tweaks belong in `.moderne/moderne-uncommitted.yml` (git-ignored), which is what `mod config … --local` writes without `--save`.

### Reference:

No issue — build tooling only. No production code, no test code, and `mvn` behaviour is untouched.

**Dependencies**

- **#6602 is required.** Moderne runs `package` over the reactor without `clean`, and until #6602 lands `exist-distribution` fails on every LST build after the first, which means no LST is produced at all. This PR is only correct on top of it.
- **`exist-xqts` needs `exist-xqts-runner` on Maven Central.** Resolving it from GitHub Packages requires credentials — an anonymous GET of the artifact returns 401, since GitHub Packages requires authentication even for public artifacts. Contributors who have a PAT with `read:packages` in their `settings.xml` are unaffected; for anyone else the LST build will fail on that module until the Central publication lands. No exclusion is configured here in anticipation of that.

### Type of tests:

None — this removes a configuration file and changes no code. Verified by building the LST end to end on top of #6602:

- Before, on `develop`: `mod build .` → `MOD FAILED`, "Failed to build an LST", 0 repositories built.
- After, with this PR and #6602 and no config file present: `mod build . --full` → `MOD SUCCEEDED` in 2m 45s, **1 repository built, 153 LST files**.
- The result is queryable: `find_methods` for `org.exist.source.Source isValid()` returns its 3 call sites (`XQueryPool`, `ExternalModuleImpl`, `XQueryURLRewrite`).

Note for reviewers reproducing this: the recipe catalog is machine-global rather than repo configuration, so `mod run` and the MCP search tools additionally need `mod config recipes jar install org.openrewrite:rewrite-java:RELEASE` (or a fuller marketplace) once per machine. That is outside this repository.
