### PR TITLE
[bugfix] Make mvn package re-runnable

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -481,30 +481,6 @@
                 <version>3.2.0</version>
                 <executions>
                     <execution>
-                        <id>delete-jetty-dest-before-rename</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <delete dir="${assemble.dir}/etc/jetty" failonerror="false" quiet="true"/>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>delete-mac-bundle-jetty-dest-before-rename</id>
-                        <phase>${mac.bundle.phase}</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <delete dir="${mac.bundle.resources.dir}/etc/jetty" failonerror="false" quiet="true"/>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>copy files</id>
                         <phase>package</phase>
                         <goals>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -555,6 +555,36 @@
                             </target>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>rename-jetty-etc-dir-for-appassembler</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <move file="${assemble.dir}/etc/org/exist/jetty/etc"
+                                      tofile="${assemble.dir}/etc/jetty"
+                                      failonerror="false" quiet="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>rename-jetty-etc-dir-for-mac-bundle</id>
+                        <phase>${mac.bundle.phase}</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <move file="${mac.bundle.resources.dir}/etc/org/exist/jetty/etc"
+                                      tofile="${mac.bundle.resources.dir}/etc/jetty"
+                                      failonerror="false" quiet="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -563,32 +593,6 @@
                 <artifactId>copy-rename-maven-plugin</artifactId>
                 <version>1.0</version>
                 <executions>
-                    <execution>
-                        <id>rename-jetty-etc-dir-for-appassembler</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>rename</goal>
-                        </goals>
-                        <configuration>
-                            <sourceFile>${assemble.dir}/etc/org/exist/jetty/etc</sourceFile>
-                            <destinationFile>${assemble.dir}/etc/jetty</destinationFile>
-                            <ignoreFileNotFoundOnIncremental>true</ignoreFileNotFoundOnIncremental>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>rename-jetty-etc-dir-for-mac-bundle</id>
-                        <phase>${mac.bundle.phase}</phase>
-                        <goals>
-                            <goal>rename</goal>
-                        </goals>
-                        <configuration>
-                            <sourceFile>${mac.bundle.resources.dir}/etc/org/exist/jetty/etc</sourceFile>
-                            <destinationFile>${mac.bundle.resources.dir}/etc/jetty</destinationFile>
-                            <ignoreFileNotFoundOnIncremental>true</ignoreFileNotFoundOnIncremental>
-                        </configuration>
-                    </execution>
-
                     <execution>
                         <id>copy-readme-for-appassembler</id>
                         <phase>package</phase>


### PR DESCRIPTION
### Description:

`mvn package` could not be run twice in a row — the second invocation failed in `exist-distribution`:

```
[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.2.1:transform
  (adjust-jetty-deploy-for-appassembler) on project exist-distribution: The directory
  .../exist-distribution-dir/etc/jetty, which is a base directory of a ValidationSet
  or TransformationSet, does not exist.
```

Three `package` steps ran in sequence: `delete-jetty-dest-before-rename` deleted `${assemble.dir}/etc/jetty`, `rename-jetty-etc-dir-for-appassembler` renamed `etc/org/exist/jetty/etc` onto it, and `adjust-jetty-deploy-for-appassembler` transformed the result.

That only works once. On a re-run the rename's source is gone — the first run renamed it away — because `unpack-for-appassembler`, which provides it, is skipped by its `markersDirectory`. The delete had meanwhile removed the perfectly good `etc/jetty` the first run produced, and the rename could not recreate it, so the transform found no directory.

Dropping the two delete executions leaves the previous run's `etc/jetty` in place; the rename then becomes a no-op, which it already tolerates via `ignoreFileNotFoundOnIncremental`. `delete-mac-bundle-jetty-dest-before-rename` is removed for the same reason — the macOS bundle steps have the identical structure.

### Reference:

Closes https://github.com/eXist-db/exist/issues/6601

Also unblocks #6600: Moderne's LST build runs `package` over the reactor without `clean`, so it hit this on every build after the first.

### Type of tests:

None — build configuration only, no production or test code changes. Verified by running the documented build twice in a row (JDK 21, macOS, so the `mac-dmg-on-mac` profile is active and the mac-bundle steps are exercised):

```bash
mvn clean package -DskipTests -Ddependency-check.skip=true -Ddocker=false
mvn package       -DskipTests -Ddependency-check.skip=true -Ddocker=false
```

- Before: run 2 → `eXist-db Distributions ... FAILURE [0.684 s]`
- After: run 2 → `eXist-db Distributions ... SUCCESS [35.046 s]`

and the output is correct, not merely present: `exist-distribution-dir/etc/jetty` holds the full set of jetty config files, with the `jetty-deploy.xslt` adjustment applied to `jetty-deploy.xml`.

Both runs still report `BUILD FAILURE` for `exist-xqts` on my machine — resolving `exist-xqts-runner_2.13` returns 401 from GitHub Packages without credentials. That is unrelated to this change and identical before and after it.
