### PR TITLE
[bugfix] Set EXIST_HOME so system:get-exist-home() returns a value.

### DIFF
--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -263,60 +263,62 @@ public class Configuration implements ErrorHandler {
                 configFilename = DatabaseImpl.CONF_XML;
             }
 
-            // firstly, try to read the configuration from a file within the
-            // classpath
-            try {
-                is = Configuration.class.getClassLoader().getResourceAsStream(configFilename);
-
-                if (is != null) {
-                    LOG.info("Reading configuration from classloader");
-                    configFilePath = Optional.of(Path.of(Configuration.class.getClassLoader().getResource(configFilename).toURI()));
-                    existHome = configFilePath.map(p -> p.getParent().getParent());
-                }
-            } catch (final Exception e) {
-                // EB: ignore and go forward, e.g. in case there is an absolute
-                // file name for configFileName
-                LOG.debug("Error reading configuration from classloader: {}", e.getMessage(), e);
-            }
-
             existHomeDirname = existHomeDirname.map(Path::normalize);
 
-            // otherwise, secondly try to read configuration from file. Guess the
+            // firstly, try to read configuration from file. Guess the
             // location if necessary
-            if (is == null) {
-                existHome = existHomeDirname.map(Optional::of)
-                        .orElse(ConfigurationHelper.getExistHome(configFilename));
+            existHome = existHomeDirname.map(Optional::of)
+                    .orElse(ConfigurationHelper.getExistHome(configFilename));
 
-                if (existHome.isEmpty()) {
+            if (existHome.isEmpty()) {
 
-                    // EB: try to create existHome based on location of config file
-                    // when config file points to absolute file location
-                    final Path absoluteConfigFile = Path.of(configFilename);
+                // EB: try to create existHome based on location of config file
+                // when config file points to absolute file location
+                final Path absoluteConfigFile = Path.of(configFilename);
 
-                    if (absoluteConfigFile.isAbsolute() && Files.exists(absoluteConfigFile) && Files.isReadable(absoluteConfigFile)) {
-                        existHome = Optional.of(absoluteConfigFile.getParent());
-                        configFilename = FileUtils.fileName(absoluteConfigFile);
-                    }
+                if (absoluteConfigFile.isAbsolute() && Files.exists(absoluteConfigFile) && Files.isReadable(absoluteConfigFile)) {
+                    existHome = Optional.of(absoluteConfigFile.getParent());
+                    configFilename = FileUtils.fileName(absoluteConfigFile);
                 }
+            }
 
-                Path configFile = Path.of(configFilename);
+            Path configFile = Path.of(configFilename);
 
-                if (!configFile.isAbsolute() && existHome.isPresent()) {
+            if (!configFile.isAbsolute() && existHome.isPresent()) {
 
-                    // try the passed or constructed existHome first
-                    configFile = existHome.get().resolve(configFilename);
+                // try the passed or constructed existHome first
+                configFile = existHome.get().resolve(configFilename);
 
-                    if (!Files.exists(configFile)) {
-                        configFile = existHome.get().resolve(Main.CONFIG_DIR_NAME).resolve(configFilename);
-                    }
+                if (!Files.exists(configFile)) {
+                    configFile = existHome.get().resolve(Main.CONFIG_DIR_NAME).resolve(configFilename);
                 }
+            }
 
-                if (!Files.exists(configFile) || !Files.isReadable(configFile)) {
-                    throw new DatabaseConfigurationException("Unable to read configuration file at " + configFile);
-                }
-
+            if (Files.exists(configFile) && Files.isReadable(configFile)) {
                 configFilePath = Optional.of(configFile.toAbsolutePath());
                 is = Files.newInputStream(configFile);
+            }
+
+            // otherwise, secondly try to read the configuration from a file within the
+            // classpath
+            if (is == null) {
+                try {
+                    is = Configuration.class.getClassLoader().getResourceAsStream(configFilename);
+
+                    if (is != null) {
+                        LOG.info("Reading configuration from classloader");
+                        configFilePath = Optional.of(Path.of(Configuration.class.getClassLoader().getResource(configFilename).toURI()));
+                        existHome = configFilePath.map(p -> p.getParent().getParent());
+                    }
+                } catch (final Exception e) {
+                    // EB: ignore and go forward, e.g. in case there is an absolute
+                    // file name for configFileName
+                    LOG.debug("Error reading configuration from classloader: {}", e.getMessage(), e);
+                }
+            }
+
+            if (is == null) {
+                throw new DatabaseConfigurationException("Unable to read configuration file at " + configFile);
             }
 
             LOG.info("Reading configuration from file {}", configFilePath.map(Path::toString).orElse("Unknown"));

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -271,11 +271,12 @@ public class Configuration implements ErrorHandler {
                 if (is != null) {
                     LOG.info("Reading configuration from classloader");
                     configFilePath = Optional.of(Path.of(Configuration.class.getClassLoader().getResource(configFilename).toURI()));
+                    existHome = configFilePath.map(p -> p.getParent().getParent());
                 }
             } catch (final Exception e) {
                 // EB: ignore and go forward, e.g. in case there is an absolute
                 // file name for configFileName
-                LOG.debug(e);
+                LOG.debug("Error reading configuration from classloader: {}", e.getMessage(), e);
             }
 
             existHomeDirname = existHomeDirname.map(Path::normalize);


### PR DESCRIPTION
Set EXIST_HOME so system:get-exist-home() returns a value when started with ./bin/startup.sh 

There are probably a lot of quality issues on this file, explicitly not addressing these.
The actual change is in commit 1 ; commit 2 re-orders the loading.

fixes #6582


**Summary**
conf.xml was being found on the classpath (from test resources in target/test-classes) because the classpath lookup ran unconditionally before the file-based lookup, allowing it to shadow the real config file.

**Changes**
exist-core/src/main/java/org/exist/util/Configuration.java: Reversed the lookup order in the main constructor — file-based lookup now runs first; classpath is only tried as a fallback when no file is found. The error is thrown only after both strategies are exhausted.

**Verification**
Build: mvn install -pl exist-core -am -DskipTests — success.
Tests: ConfigurationTest — 10/10 passed.