### PR TITLE
[feature] restore izpack compression format to xz

### DIFF
--- a/exist-installer/src/main/izpack/install.xml
+++ b/exist-installer/src/main/izpack/install.xml
@@ -41,7 +41,7 @@
         <javaversion>@{maven.compiler.release}</javaversion>
         <requiresjdk>no</requiresjdk>
         <run-privileged condition="izpack.windowsinstall"/>
-        <pack-compression-format>bzip2</pack-compression-format>
+        <pack-compression-format>xz</pack-compression-format>
         <uninstaller name="izpack-uninstaller.jar" path="$INSTALL_PATH/lib"/>
     </info>
 


### PR DESCRIPTION
Restore izpack compression format to xz to improve decompression performance for windows.

Before (bzip2): 9 minutes
After (xz): 1min20sec

thnx Boris for testing. Fixes https://github.com/eXist-db/exist/issues/6517#issuecomment-5026771657 #6517 