### PR TITLE
[bugfix] Tolerate ambiguous URI segments in getServletPath()

### DIFF
--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -320,7 +320,7 @@ public class XQueryURLRewrite extends HttpServlet {
 
                     // store the original request URI to org.exist.forward.request-uri
                     modifiedRequest.setAttribute(RQ_ATTR_REQUEST_URI, request.getRequestURI());
-                    modifiedRequest.setAttribute(RQ_ATTR_SERVLET_PATH, request.getServletPath());
+                    modifiedRequest.setAttribute(RQ_ATTR_SERVLET_PATH, getServletPathSafely(request));
 
                 }
                 if (LOG.isTraceEnabled()) {
@@ -369,6 +369,29 @@ public class XQueryURLRewrite extends HttpServlet {
             throw new ServletException("An error occurred while processing request to " + request.getRequestURI() + ": "
                     + e.getMessage(), e);
 
+        }
+    }
+
+    /**
+     * Under Jetty 12's EE10 servlet module, {@link HttpServletRequest#getServletPath()}
+     * throws {@code IllegalArgumentException} (surfaced to the client as a 400 response)
+     * when the request URI contains an ambiguous path segment (e.g. a real '/' next to
+     * an encoded '%2F'), even though {@link HttpServletRequest#getRequestURI()} on the
+     * very same request remains safe to call. This servlet is always mapped with
+     * {@code url-pattern} {@code /*} (see web.xml), a path-prefix mapping with an empty
+     * prefix, so per the Jakarta Servlet spec {@code getServletPath()} is defined to
+     * always return {@code ""} here regardless of the request URI -- Jetty's own
+     * ambiguity check is a blanket refusal to answer, not a sign the answer differs.
+     * Fall back to that known value instead of failing the whole request.
+     *
+     * @see <a href="https://github.com/jetty/jetty.project/issues/12346">jetty/jetty.project#12346</a>
+     */
+    static String getServletPathSafely(final HttpServletRequest request) {
+        try {
+            return request.getServletPath();
+        } catch (final IllegalArgumentException e) {
+            LOG.debug("Falling back to \"\" for servlet path of ambiguous request URI {}: {}", request.getRequestURI(), e.getMessage());
+            return "";
         }
     }
 

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteTest.java
@@ -144,4 +144,43 @@ public class XQueryURLRewriteTest
             assertArrayEquals(newTestParameterMap.get(paramName), wrapper.getParameterMap().get(paramName));
         }
     }
+
+    @Test
+    public void getServletPathSafely_returnsServletPath() {
+        HttpServletRequest mockHttpServletRequest = EasyMock.createMock(HttpServletRequest.class);
+
+        // XQueryURLRewrite is always mapped with url-pattern "/*" (see web.xml), a
+        // path-prefix mapping with an empty prefix, so getServletPath() is "" in practice.
+        expect(mockHttpServletRequest.getServletPath()).andReturn("");
+
+        replay(mockHttpServletRequest);
+        String servletPath = XQueryURLRewrite.getServletPathSafely(mockHttpServletRequest);
+        verify(mockHttpServletRequest);
+
+        assertEquals("", servletPath);
+    }
+
+    /**
+     * Under Jetty 12's EE10 servlet module, {@code getServletPath()} throws
+     * {@link IllegalArgumentException} for a request whose URI carries a
+     * recorded ambiguity violation (e.g. a real '/' next to an encoded
+     * '%2F'). This must not propagate and fail the whole request. Since
+     * XQueryURLRewrite is always mapped with url-pattern "/*", the answer
+     * Jetty refuses to give is always "" anyway (see getServletPathSafely's
+     * javadoc) -- see https://github.com/eXist-db/exist/issues/6618.
+     */
+    @Test
+    public void getServletPathSafely_toleratesAmbiguousUriException() {
+        HttpServletRequest mockHttpServletRequest = EasyMock.createMock(HttpServletRequest.class);
+
+        expect(mockHttpServletRequest.getServletPath())
+                .andThrow(new IllegalArgumentException("400: Ambiguous URI encoding"));
+        expect(mockHttpServletRequest.getRequestURI()).andReturn("/exist/apps/foo/bar%2Fbaz");
+
+        replay(mockHttpServletRequest);
+        String servletPath = XQueryURLRewrite.getServletPathSafely(mockHttpServletRequest);
+        verify(mockHttpServletRequest);
+
+        assertEquals("", servletPath);
+    }
 }

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteTest.java
@@ -146,7 +146,7 @@ public class XQueryURLRewriteTest
     }
 
     @Test
-    public void getServletPathSafely_returnsServletPath() {
+    public void getServletPathSafelyReturnsServletPath() {
         HttpServletRequest mockHttpServletRequest = EasyMock.createMock(HttpServletRequest.class);
 
         // XQueryURLRewrite is always mapped with url-pattern "/*" (see web.xml), a
@@ -170,7 +170,7 @@ public class XQueryURLRewriteTest
      * javadoc) -- see https://github.com/eXist-db/exist/issues/6618.
      */
     @Test
-    public void getServletPathSafely_toleratesAmbiguousUriException() {
+    public void getServletPathSafelyToleratesAmbiguousUriException() {
         HttpServletRequest mockHttpServletRequest = EasyMock.createMock(HttpServletRequest.class);
 
         expect(mockHttpServletRequest.getServletPath())


### PR DESCRIPTION
### Description:

Under Jetty 12's EE10 servlet module, `HttpServletRequest#getServletPath()` throws `IllegalArgumentException` (surfaced to the client as a 400 response) when the request URI contains an ambiguous path segment (e.g. a real `/` next to an encoded `%2F`), even though `getRequestURI()` on the very same request remains safe to call.

`XQueryURLRewrite` is always mapped with `url-pattern` `/*` (see `web.xml`), a path-prefix mapping with an empty prefix, so per the Jakarta Servlet spec `getServletPath()` is defined to always return `""` here regardless of the request URI — Jetty's own ambiguity check is a blanket refusal to answer, not a sign the answer differs. This PR adds a `getServletPathSafely()` helper that falls back to that known value (`""`) instead of failing the whole request when Jetty throws.

See also [jetty/jetty.project#12346](https://github.com/jetty/jetty.project/issues/12346).

### Reference:

Closes #6618

### Type of tests:

Added two JUnit tests to `XQueryURLRewriteTest`:
- `getServletPathSafely_returnsServletPath` — normal path, delegates to `getServletPath()`
- `getServletPathSafely_toleratesAmbiguousUriException` — Jetty throws `IllegalArgumentException`, helper falls back to `""`