### PR TITLE
[ci] Enable OCI media types for container image attestations

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -142,7 +142,7 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile
           platforms: linux/amd64,linux/arm64
-          outputs: type=image,oci-mediatypes=true,push=true
+          outputs: type=image,oci-mediatypes=true,oci-artifact=true,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha
@@ -156,7 +156,7 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile-DEBUG
           platforms: linux/amd64,linux/arm64
-          outputs: type=image,oci-mediatypes=true,push=true
+          outputs: type=image,oci-mediatypes=true,oci-artifact=true,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -142,7 +142,7 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          outputs: type=image,oci-mediatypes=true,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha
@@ -156,7 +156,7 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile-DEBUG
           platforms: linux/amd64,linux/arm64
-          push: true
+          outputs: type=image,oci-mediatypes=true,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha


### PR DESCRIPTION
### Description:

The published `existdb/existdb` image on Docker Hub carries valid SBOM (SPDX) and provenance (SLSA) attestations in its OCI index, but Docker Hub / Docker Scout report them as missing. Root cause: Scout discovers attestations via the OCI 1.1 Referrers API, which requires the attestation manifest to carry a `subject` descriptor pointing back to the image manifest it describes. BuildKit only emits that `subject` field (as an "OCI artifact" attestation) when the image itself is pushed with OCI media types — our `docker/build-push-action` steps didn't request that.

This PR adds `oci-mediatypes=true` to the `outputs` of both staging build/push steps (main + DEBUG), alongside the existing `push=true`.

### What Changed:

- `.github/workflows/ci-container.yml`: replaced `push: true` with `outputs: type=image,oci-mediatypes=true,push=true` on the "Build & push staging image (main)" and "Build & push staging image (DEBUG)" steps.

### Reference:

- [moby/buildkit#6171](https://github.com/moby/buildkit/issues/6171) — "Enable OCI artifact for attestation manifest by default", fixed in BuildKit v0.32.0+, conditional on OCI media types being enabled for the image output.
- [BuildKit attestation storage docs](https://github.com/moby/buildkit/blob/master/docs/attestations/attestation-storage.md) — confirms the index-level `vnd.docker.reference.type: attestation-manifest` annotation (which this workflow's own "Verify published manifest" step checks) is unchanged by this switch, so no other workflow changes are needed.

### Type of tests:

No new tests added — this is CI publish-pipeline configuration. Verification: this workflow's own "Verify published manifest (arch + attestations)" step already asserts attestation manifests are present; once merged, confirm on the next `develop` publish run that Docker Hub / `docker scout policy existdb/existdb:latest` shows the SBOM and provenance requirements as satisfied rather than "Missing".