### PR TITLE
[refactor] Apply OpenRewrite Java21 recipe

### DIFF
--- a/exist-ant/src/main/java/org/exist/ant/XMLDBExtractTask.java
+++ b/exist-ant/src/main/java/org/exist/ant/XMLDBExtractTask.java
@@ -39,8 +39,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 
 /**
  * an ant task to extract the content of a collection or resource.
@@ -263,10 +261,10 @@ public class XMLDBExtractTask extends AbstractXMLDBTask {
         final Writer writer;
         if (Files.isDirectory(dest)) {
             final Path file = dest.resolve(res.getId());
-            writer = Files.newBufferedWriter(file, UTF_8);
+            writer = Files.newBufferedWriter(file);
 
         } else {
-            writer = Files.newBufferedWriter(destFile, UTF_8);
+            writer = Files.newBufferedWriter(destFile);
         }
         return writer;
     }

--- a/exist-ant/src/main/java/org/exist/ant/XMLDBXPathTask.java
+++ b/exist-ant/src/main/java/org/exist/ant/XMLDBXPathTask.java
@@ -207,10 +207,10 @@ public class XMLDBXPathTask extends AbstractXMLDBTask {
             }
 
             final Path file = dest.toPath().resolve(fname);
-            writer = Files.newBufferedWriter(file, UTF_8);
+            writer = Files.newBufferedWriter(file);
 
         } else {
-            writer = Files.newBufferedWriter(dest.toPath(), UTF_8);
+            writer = Files.newBufferedWriter(dest.toPath());
         }
         return writer;
     }

--- a/exist-ant/src/main/java/org/exist/ant/XMLDBXQueryTask.java
+++ b/exist-ant/src/main/java/org/exist/ant/XMLDBXQueryTask.java
@@ -212,10 +212,10 @@ public class XMLDBXQueryTask extends AbstractXMLDBTask {
             }
 
             final Path file = dest.toPath().resolve(fname);
-            writer = Files.newBufferedWriter(file, UTF_8);
+            writer = Files.newBufferedWriter(file);
 
         } else {
-            writer = Files.newBufferedWriter(dest.toPath(), UTF_8);
+            writer = Files.newBufferedWriter(dest.toPath());
         }
         return writer;
     }

--- a/exist-core/src/main/java/org/exist/backup/Backup.java
+++ b/exist-core/src/main/java/org/exist/backup/Backup.java
@@ -367,20 +367,20 @@ public class Backup {
                     }
 
                     final OutputStream os;
-                    if (resource instanceof ExtendedResource) {
+                    if (resource instanceof ExtendedResource extendedResource) {
                         if (deduplicateBlobs && resource instanceof EXistBinaryResource binaryResource) {
                             // only add distinct blobs to the Blob Store once!
                             final String blobId = binaryResource.getBlobId().toString();
                             if (!seenBlobIds.contains(blobId)) {
                                 os = output.newBlobEntry(blobId);
-                                ((ExtendedResource) resource).getContentIntoAStream(os);
+                                extendedResource.getContentIntoAStream(os);
                                 output.closeEntry();
 
                                 seenBlobIds.add(blobId);
                             }
                         } else {
                             os = output.newEntry(filename);
-                            ((ExtendedResource) resource).getContentIntoAStream(os);
+                            extendedResource.getContentIntoAStream(os);
                             output.closeEntry();
                         }
                     } else {

--- a/exist-core/src/main/java/org/exist/backup/ExportGUI.java
+++ b/exist-core/src/main/java/org/exist/backup/ExportGUI.java
@@ -49,7 +49,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.util.ThreadUtils.newGlobalThread;
 import static org.exist.util.ThreadUtils.newInstanceThread;
 import static se.softhouse.jargo.Arguments.helpArgument;
@@ -600,7 +599,7 @@ public class ExportGUI extends javax.swing.JFrame {
     private void openLog(final String dir) {
         final Path file = SystemExport.getUniqueFile("report", ".log", dir);
         try {
-            logWriter = new PrintWriter(Files.newBufferedWriter(file, UTF_8));
+            logWriter = new PrintWriter(Files.newBufferedWriter(file));
         } catch(final IOException e) {
             System.err.println("ERROR: failed to create log file");
         }

--- a/exist-core/src/main/java/org/exist/backup/FileSystemWriter.java
+++ b/exist-core/src/main/java/org/exist/backup/FileSystemWriter.java
@@ -28,7 +28,6 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -93,7 +92,7 @@ public class FileSystemWriter implements BackupWriter {
     @Override
     public Writer newContents() throws IOException {
         currentContents = currentDir.resolve("__contents__.xml");
-        currentContentsOut = Files.newBufferedWriter(currentContents, StandardCharsets.UTF_8);
+        currentContentsOut = Files.newBufferedWriter(currentContents);
         dataWritten = true;
         return (currentContentsOut);
     }

--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -138,7 +138,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.prefs.Preferences;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.client.InteractiveClient.DATE_TIME_FORMATTER;
 import static org.exist.util.FileUtils.humanSize;
 
@@ -1279,7 +1278,7 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                         }
                     } else {
                         contentSerializer = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-                        try (final Writer writer = Files.newBufferedWriter(file, UTF_8)) {
+                        try (final Writer writer = Files.newBufferedWriter(file)) {
                             // write resource to contentSerializer
                             contentSerializer.setOutput(writer, properties);
                             ((EXistResource) resource).setLexicalHandler(contentSerializer);

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -1170,7 +1170,7 @@ public class InteractiveClient {
 
             //lazy initialization
             if (lazyTraceWriter.isEmpty()) {
-                try (final Writer traceWriter = Files.newBufferedWriter(options.traceQueriesFile.get(), UTF_8)) {
+                try (final Writer traceWriter = Files.newBufferedWriter(options.traceQueriesFile.get())) {
                     traceWriter.write("<?xml version=\"1.0\"?>" + EOL);
                     traceWriter.write("<query-log>" + EOL);
                     this.lazyTraceWriter = Optional.of(traceWriter);
@@ -1265,7 +1265,7 @@ public class InteractiveClient {
             messageln("cannot read file " + file.normalize().toAbsolutePath());
             return;
         }
-        final String commands = Files.readString(file, UTF_8);
+        final String commands = Files.readString(file);
         final XUpdateQueryService service = current.getService(XUpdateQueryService.class);
         final long modifications;
         if (resource == null) {
@@ -2411,7 +2411,7 @@ public class InteractiveClient {
         }
 
         final SAXSerializer serializer = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-        try (final BufferedWriter writer = Files.newBufferedWriter(queryHistoryFile, UTF_8)) {
+        try (final BufferedWriter writer = Files.newBufferedWriter(queryHistoryFile)) {
             serializer.setOutput(writer, null);
             int p = 0;
             if (queryHistory.size() > 20) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
@@ -464,12 +464,12 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
 
     @Override
     public boolean contains(final Item item) {
-        if (item instanceof Node) {
+        if (item instanceof Node node) {
             @Nullable final Document doc;
             if (item instanceof Document document) {
                 doc = document;
             } else {
-                doc = ((Node) item).getOwnerDocument();
+                doc = node.getOwnerDocument();
             }
 
             if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -1100,12 +1100,12 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     @Override
     public boolean containsReference(final Item item) {
         sort();
-        if (item instanceof Node) {
+        if (item instanceof Node node) {
             @Nullable final Document doc;
             if (item instanceof Document document) {
                 doc = document;
             } else {
-                doc = ((Node) item).getOwnerDocument();
+                doc = node.getOwnerDocument();
             }
 
             if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {
@@ -1133,12 +1133,12 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     @Override
     public boolean contains(final Item item) {
         sort();
-        if (item instanceof Node) {
+        if (item instanceof Node node) {
             @Nullable final Document doc;
             if (item instanceof Document document) {
                 doc = document;
             } else {
-                doc = ((Node) item).getOwnerDocument();
+                doc = node.getOwnerDocument();
             }
 
             if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {

--- a/exist-core/src/main/java/org/exist/http/AcceptHeader.java
+++ b/exist-core/src/main/java/org/exist/http/AcceptHeader.java
@@ -169,7 +169,7 @@ public final class AcceptHeader {
         }
         final List<MediaRange> ranges = parse(header);
         if (ranges.isEmpty()) {
-            return Optional.of(available.get(0));  // no (parseable) preference -> first offer
+            return Optional.of(available.getFirst());  // no (parseable) preference -> first offer
         }
 
         String best = null;

--- a/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
+++ b/exist-core/src/main/java/org/exist/http/ws/EvalWebSocketEndpoint.java
@@ -116,7 +116,7 @@ public class EvalWebSocketEndpoint {
 
             Subject subject = null;
             if (authHeaders != null && !authHeaders.isEmpty()) {
-                final String credentials = authHeaders.get(0);
+                final String credentials = authHeaders.getFirst();
                 if (credentials.toLowerCase().startsWith("basic ")) {
                     try {
                         final byte[] decoded = Base64.decodeBase64(

--- a/exist-core/src/main/java/org/exist/jetty/WindowsPathResource.java
+++ b/exist-core/src/main/java/org/exist/jetty/WindowsPathResource.java
@@ -29,7 +29,6 @@ import org.exist.util.OSUtil;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -113,7 +112,7 @@ public final class WindowsPathResource extends Resource {
             return this;
         }
         final URI resolvedUri = URIUtil.addPath(getURI(), subUriPath);
-        final Path path = Paths.get(resolvedUri);
+        final Path path = Path.of(resolvedUri);
         return wrapIfNeeded(resourceFactory.newResource(path), resourceFactory);
     }
 

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -294,10 +294,10 @@ public class JMXClient {
                     values[2] != null ? values[2] : 0));
 
             final Object activeBrokersRaw = connection.getAttribute(name, "ActiveBrokersMap");
-            final CompositeData[] activeBrokers = activeBrokersRaw instanceof CompositeData[]
-                    ? (CompositeData[]) activeBrokersRaw
-                    : activeBrokersRaw instanceof TabularData
-                      ? ((TabularData) activeBrokersRaw).values().toArray(new CompositeData[0])
+            final CompositeData[] activeBrokers = activeBrokersRaw instanceof CompositeData[] cds
+                    ? cds
+                    : activeBrokersRaw instanceof TabularData td
+                      ? td.values().toArray(new CompositeData[0])
                       : new CompositeData[0];
             if (activeBrokers.length > 0) {
                 echo("\nCurrently active threads:");

--- a/exist-core/src/main/java/org/exist/protocolhandler/embedded/EmbeddedInputStream.java
+++ b/exist-core/src/main/java/org/exist/protocolhandler/embedded/EmbeddedInputStream.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 
 import static com.evolvedbinary.j8fu.Either.Left;
 import static com.evolvedbinary.j8fu.Either.Right;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Read document from embedded database as an InputStream.
@@ -132,7 +131,7 @@ public class EmbeddedInputStream extends InputStream {
                                 // serialize the XML to a temporary file
                                 final TemporaryFileManager tempFileManager = TemporaryFileManager.getInstance();
                                 final Path tempFile = tempFileManager.getTemporaryFile();
-                                try (final Writer writer = Files.newBufferedWriter(tempFile, UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                                try (final Writer writer = Files.newBufferedWriter(tempFile, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
                                     serializer.serialize(resource, writer);
                                 }
 

--- a/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
+++ b/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
@@ -149,14 +149,11 @@ public class XercesXmlResolverAdapter implements XMLEntityResolver {
      * @throws SAXNotRecognizedException if the property is not recognised by the XMLReader
      */
     public static void setXmlReaderEntityResolver(final XMLReader xmlReader, @Nullable final org.w3c.dom.ls.LSResourceResolver resolver) throws SAXNotSupportedException, SAXNotRecognizedException {
-        if (resolver instanceof Resolver xmlResolver) {
-            setXmlReaderEntityResolver(xmlReader, xmlResolver);
-        } else if (resolver instanceof XMLEntityResolver xmlEntityResolver) {
-            setXmlReaderEntityResolver(xmlReader, xmlEntityResolver);
-        } else if (resolver == null) {
-            setXmlReaderEntityResolver(xmlReader, (XMLEntityResolver) null);
-        } else {
-            throw new SAXNotSupportedException("Unsupported LSResourceResolver implementation: " + resolver.getClass().getName());
+        switch (resolver) {
+            case null -> setXmlReaderEntityResolver(xmlReader, (XMLEntityResolver) null);
+            case Resolver xmlResolver -> setXmlReaderEntityResolver(xmlReader, xmlResolver);
+            case XMLEntityResolver xmlEntityResolver -> setXmlReaderEntityResolver(xmlReader, xmlEntityResolver);
+            default -> throw new SAXNotSupportedException("Unsupported LSResourceResolver implementation: " + resolver.getClass().getName());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/ConsistencyCheckTask.java
+++ b/exist-core/src/main/java/org/exist/storage/ConsistencyCheckTask.java
@@ -43,8 +43,6 @@ import org.exist.util.Configuration;
 import org.exist.xquery.Expression;
 import org.exist.xquery.TerminatedException;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 public class ConsistencyCheckTask implements SystemTask {
 
     private final static Logger LOG = LogManager.getLogger(ConsistencyCheckTask.class);
@@ -227,7 +225,7 @@ public class ConsistencyCheckTask implements SystemTask {
     private PrintWriter openLog() throws EXistException {
         try {
             final Path file = SystemExport.getUniqueFile("report", ".log", exportDir);
-            return new PrintWriter(Files.newBufferedWriter(file, UTF_8));
+            return new PrintWriter(Files.newBufferedWriter(file));
         } catch (final IOException e) {
             throw new EXistException("ERROR: failed to create report file in " + exportDir, e);
         }

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -729,7 +729,7 @@ public class NativeBroker implements DBBroker {
                     .map(h -> h.resolve("etc").resolve(INIT_COLLECTION_CONFIG))
                     .orElse(Path.of("etc").resolve(INIT_COLLECTION_CONFIG));
             if (Files.exists(fInitCollectionConfig)) {
-                return Files.readString(fInitCollectionConfig, UTF_8);
+                return Files.readString(fInitCollectionConfig);
             }
 
             // 2) fallback to attempting to load from classpath

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
@@ -593,7 +593,7 @@ public class RemoteCollection extends AbstractRemote implements EXistCollection 
             }
 
             final byte[] chunk;
-            if (res instanceof ExtendedResource) {
+            if (res instanceof ExtendedResource extendedResource) {
                 if(res instanceof AbstractRemoteResource resource) {
                     final long contentLen = resource.getContentLength();
                     if (contentLen != -1) {
@@ -603,7 +603,7 @@ public class RemoteCollection extends AbstractRemote implements EXistCollection 
                         chunk = new byte[MAX_UPLOAD_CHUNK];
                     }
                 } else {
-                    final long streamLen = ((ExtendedResource)res).getStreamLength();
+                    final long streamLen = extendedResource.getStreamLength();
                     if (streamLen != -1) {
                         // stream length is known
                         chunk = new byte[(int)Math.min(streamLen, MAX_UPLOAD_CHUNK)];

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -155,8 +155,7 @@ public class ArrowOperator extends AbstractExpression {
             throw new XPathException(this, ErrorCodes.XPTY0004,
                 "Type error: expected function, got " + Type.getTypeName(item0.getType()));
         }
-        final FunctionReference fref = (FunctionReference) item0;
-        try {
+        try (final FunctionReference fref = (FunctionReference) item0) {
             final List<Expression> fparams = new ArrayList<>(parameters.size() + 1);
             fparams.add(new ContextParam(context, leftValue));
             fparams.addAll(parameters);
@@ -167,8 +166,6 @@ public class ArrowOperator extends AbstractExpression {
             fref.analyze(new AnalyzeContextInfo(cachedContextInfo));
             // Evaluate the function
             return fref.eval(null);
-        } finally {
-            fref.close();
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -173,8 +173,7 @@ public class EnclosedExpr extends PathExpr {
                             // in-scope-prefixes() is neutralized for inherited namespace bindings.
                             if (noInherit && ancestorNS != null
                                     && next.getType() == Type.ELEMENT
-                                    && next instanceof NodeImpl) {
-                                final NodeImpl nodeImpl = (NodeImpl) next;
+                                    && next instanceof NodeImpl nodeImpl) {
                                 final boolean isPreExisting = (innerBuilder == null)
                                         || (nodeImpl.getOwnerDocument() != innerBuilder.getDocument());
                                 if (isPreExisting) {

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -148,8 +148,8 @@ public class FunctionFactory {
         if (!isPartial) {
             return fc;
         }
-        if (fc instanceof CastExpression) {
-            fc = ((CastExpression) fc).toFunction();
+        if (fc instanceof CastExpression expression) {
+            fc = expression.toFunction();
         }
         if (!(fc instanceof FunctionCall)) {
             fc = FunctionFactory.wrap(context, (Function) fc);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java
@@ -650,7 +650,7 @@ public class FnFormatDates extends BasicFunction {
         // [ZN] / [Zn] / [ZNn] - timezone name with optional case modifier
         // (W3C XPath Functions 3.1 §9.8.4.7: second-position modifier selects letter case)
         if ("N".equals(timezonePicture) || "n".equals(timezonePicture) || "Nn".equals(timezonePicture)) {
-            final Locale locale = new Locale(language);
+            final Locale locale = Locale.of(language);
             final String tzName = formatNamedTimeZone(absHour, absMinute, isNegative, place, locale);
             if ("n".equals(timezonePicture)) {
                 return tzName.toLowerCase(locale);
@@ -699,7 +699,7 @@ public class FnFormatDates extends BasicFunction {
      */
     private AbstractDateTimeValue adjustForPlaceTimezone(final AbstractDateTimeValue dt,
             final Optional<String> place) throws XPathException {
-        if (!place.isPresent()) {
+        if (place.isEmpty()) {
             return dt;
         }
         try {
@@ -1438,8 +1438,8 @@ public class FnFormatDates extends BasicFunction {
             } else {
                 // Grouping separator
                 np.groupings.add(digitIndex);
-                sepCharsFromRight.add(0, cp);
-                sepPosFromRight.add(0, digitIndex);
+                sepCharsFromRight.addFirst(cp);
+                sepPosFromRight.addFirst(digitIndex);
             }
             i += charLen;
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -175,9 +175,9 @@ public class FnFormatNumbers extends BasicFunction {
 
         final Item optionsItem = args[2].itemAt(0);
 
-        if (optionsItem instanceof MapType) {
+        if (optionsItem instanceof MapType type) {
             // XQ4 map overload
-            return resolveDecimalFormatFromMap((MapType) optionsItem);
+            return resolveDecimalFormatFromMap(type);
         }
 
         // XQ3.1 string overload (decimal format name) — also accepts xs:QName

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
+import java.nio.file.Path;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.FunctionDSL.*;
@@ -388,7 +389,7 @@ public class FunUnparsedText extends BasicFunction {
             // must go through SourceFactory which enforces security checks.
             if (resolvedFromBaseUri && resolvedUri.startsWith("file:")) {
                 final String filePath = resolvedUri.replaceFirst("^file:(?://[^/]*)?", "");
-                final java.nio.file.Path path = java.nio.file.Paths.get(filePath);
+                final Path path = Path.of(filePath);
                 if (java.nio.file.Files.isReadable(path)) {
                     return new FileSource(path, false);
                 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
@@ -285,7 +285,7 @@ public abstract class AbstractMapType extends FunctionReference
 
     public FunctionSignature getSignature() {
         return ACCESSOR;
-    };
+    }
 
     /**
      * Lazy initialization of the accessor function. Creating

--- a/exist-core/src/main/java/org/exist/xquery/util/NumberFormatter.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/NumberFormatter.java
@@ -194,11 +194,11 @@ public abstract class NumberFormatter {
 
     public static NumberFormatter getInstance(final String language) {
         return switch (language) {
-            case "de" -> new NumberFormatter_de(new Locale("de"));
-            case "fr" -> new NumberFormatter_fr(new Locale("fr"));
-            case "nl" -> new NumberFormatter_nl(new Locale("nl"));
-            case "ru" -> new NumberFormatter_ru(new Locale("ru"));
-            case "sv" -> new NumberFormatter_sv(new Locale("sv"));
+            case "de" -> new NumberFormatter_de(Locale.of("de"));
+            case "fr" -> new NumberFormatter_fr(Locale.of("fr"));
+            case "nl" -> new NumberFormatter_nl(Locale.of("nl"));
+            case "ru" -> new NumberFormatter_ru(Locale.of("ru"));
+            case "sv" -> new NumberFormatter_sv(Locale.of("sv"));
             // Unsupported languages fall back to English; using Locale.ENGLISH ensures
             // Month/DayOfWeek display names come back in full English form rather
             // than the JDK ROOT-locale abbreviated form.

--- a/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -404,11 +404,11 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         // primitive-type equality check rejects valid comparisons. The
         // AbstractDateTimeValue instance-check keeps this restricted to the
         // date/time family (no accidental cross-comparison with, say, durations).
-        if (other instanceof AbstractDateTimeValue
+        if (other instanceof AbstractDateTimeValue value
                 && (Type.subTypeOf(getType(), other.getType())
                         || Type.subTypeOf(other.getType(), getType()))) {
             // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
-            final int r = getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            final int r = getImplicitCalendar().compare(value.getImplicitCalendar());
             if (r == DatatypeConstants.INDETERMINATE) {
                 throw new RuntimeException("indeterminate order between " + this + " and " + other);
             }

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -184,8 +184,8 @@ public class SequenceType {
         // takes 1 arg, the key; map(K,V) carries 2 type parameters). Restrict the
         // function-arity/return check to plain function() tests so map and array
         // values continue to satisfy their typed tests.
-        if (primaryType == Type.FUNCTION && item instanceof FunctionReference
-                && !checkFunctionType((FunctionReference) item)) {
+        if (primaryType == Type.FUNCTION && item instanceof FunctionReference reference
+                && !checkFunctionType(reference)) {
             return false;
         }
 

--- a/exist-core/src/test/java/org/exist/TestDataGenerator.java
+++ b/exist-core/src/test/java/org/exist/TestDataGenerator.java
@@ -47,7 +47,6 @@ import org.xmldb.api.modules.XQueryService;
 
 import javax.xml.transform.OutputKeys;
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -103,7 +102,7 @@ public class TestDataGenerator {
                 final Sequence results = service.execute(broker, compiled, Sequence.EMPTY_SEQUENCE);
 
                 final Serializer serializer = broker.borrowSerializer();
-                try(final Writer out = Files.newBufferedWriter(generatedFiles[i], StandardCharsets.UTF_8)) {
+                try(final Writer out = Files.newBufferedWriter(generatedFiles[i])) {
                     final SAXSerializer sax = new SAXSerializer(out, outputProps);
                     serializer.setSAXHandlers(sax, sax);
                     for (final SequenceIterator iter = results.iterate(); iter.hasNext(); ) {
@@ -139,7 +138,7 @@ public class TestDataGenerator {
                 service.declareVariable("count", Integer.valueOf(i));
                 final ResourceSet result = service.execute(compiled);
 
-                try(final Writer out = Files.newBufferedWriter(generatedFiles[i], StandardCharsets.UTF_8)) {
+                try(final Writer out = Files.newBufferedWriter(generatedFiles[i])) {
                     final SAXSerializer sax = new SAXSerializer(out, outputProps);
                     for (ResourceIterator iter = result.getIterator(); iter.hasMoreResources(); ) {
                         try (XMLResource r = (XMLResource) iter.nextResource()) {

--- a/exist-core/src/test/java/org/exist/backup/FileSystemBackupDescriptorTest.java
+++ b/exist-core/src/test/java/org/exist/backup/FileSystemBackupDescriptorTest.java
@@ -53,8 +53,8 @@ class FileSystemBackupDescriptorTest {
         final Path dbDir = backupRoot.resolve("db");
         Files.createDirectories(dbDir);
 
-        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
-        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>", UTF_8);
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML);
+        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>");
         Files.write(dbDir.resolve("test.binary"), "test".getBytes(UTF_8));
 
         final FileSystemBackupDescriptor descriptor = new FileSystemBackupDescriptor(
@@ -71,11 +71,11 @@ class FileSystemBackupDescriptorTest {
         final Path nestedDir = dbDir.resolve("nested");
         Files.createDirectories(nestedDir);
 
-        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
-        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8);
-        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>", UTF_8);
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML);
+        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML);
+        Files.writeString(dbDir.resolve("doc1.xml"), "<test/>");
         Files.write(dbDir.resolve("test.binary"), "test".getBytes(UTF_8));
-        Files.writeString(nestedDir.resolve("nested.xml"), "<nested/>", UTF_8);
+        Files.writeString(nestedDir.resolve("nested.xml"), "<nested/>");
 
         final FileSystemBackupDescriptor descriptor = new FileSystemBackupDescriptor(
                 backupRoot,
@@ -112,8 +112,8 @@ class FileSystemBackupDescriptorTest {
                     <exist:resource name="s4.xml" type="XMLResource" filename="s4.xml"/>
                 </exist:collection>
                 """;
-        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), dbContents, UTF_8);
-        Files.writeString(systemDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), systemContents, UTF_8);
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), dbContents);
+        Files.writeString(systemDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), systemContents);
 
         // root recursively includes /db/system: 3 + 5 = 8
         assertEquals(8,
@@ -130,9 +130,9 @@ class FileSystemBackupDescriptorTest {
         final Path appsDir = Files.createDirectories(dbDir.resolve("apps"));
         final Path fooStuffDir = Files.createDirectories(dbDir.resolve("foo").resolve("stuff"));
 
-        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);         // 2 resources
-        Files.writeString(appsDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8); // 1 resource
-        Files.writeString(fooStuffDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8); // 1 resource
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML);         // 2 resources
+        Files.writeString(appsDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML); // 1 resource
+        Files.writeString(fooStuffDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML); // 1 resource
 
         // 2 (db) + 1 (apps) + 1 (foo/stuff) = 4
         assertEquals(4,
@@ -147,8 +147,8 @@ class FileSystemBackupDescriptorTest {
         final Path nestedDir = dbDir.resolve("nested");
         Files.createDirectories(nestedDir);
 
-        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML, UTF_8);
-        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML, UTF_8);
+        Files.writeString(dbDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), CONTENTS_XML);
+        Files.writeString(nestedDir.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), NESTED_CONTENTS_XML);
 
         final FileSystemBackupDescriptor nestedDescriptor = new FileSystemBackupDescriptor(
                 backupRoot,

--- a/exist-core/src/test/java/org/exist/http/AcceptHeaderTest.java
+++ b/exist-core/src/test/java/org/exist/http/AcceptHeaderTest.java
@@ -40,7 +40,7 @@ public class AcceptHeaderTest {
     public void parseOrdersByQualityThenSpecificity() {
         final List<MediaRange> ranges = AcceptHeader.parse("text/*;q=0.5, text/html, application/json;q=0.9, */*;q=0.1");
         assertEquals(4, ranges.size());
-        assertEquals("text/html", ranges.get(0).mediaType());        // q=1.0
+        assertEquals("text/html", ranges.getFirst().mediaType());        // q=1.0
         assertEquals("application/json", ranges.get(1).mediaType());  // q=0.9
         assertEquals("text/*", ranges.get(2).mediaType());           // q=0.5
         assertEquals("*/*", ranges.get(3).mediaType());              // q=0.1
@@ -50,14 +50,14 @@ public class AcceptHeaderTest {
     public void parseDefaultsQualityToOne() {
         final List<MediaRange> ranges = AcceptHeader.parse("text/html");
         assertEquals(1, ranges.size());
-        assertEquals(1.0, ranges.get(0).quality(), 0.0);
+        assertEquals(1.0, ranges.getFirst().quality(), 0.0);
     }
 
     @Test
     public void parseExtractsParametersExcludingQ() {
         final List<MediaRange> ranges = AcceptHeader.parse("text/html;level=1;q=0.8");
         assertEquals(1, ranges.size());
-        final MediaRange range = ranges.get(0);
+        final MediaRange range = ranges.getFirst();
         assertEquals(0.8, range.quality(), 0.0);
         assertEquals(1, range.parameters().size());
         assertEquals("1", range.parameters().get("level"));
@@ -67,7 +67,7 @@ public class AcceptHeaderTest {
     public void parseRetainsExplicitQZero() {
         final List<MediaRange> ranges = AcceptHeader.parse("text/html;q=0");
         assertEquals(1, ranges.size());
-        assertEquals(0.0, ranges.get(0).quality(), 0.0);
+        assertEquals(0.0, ranges.getFirst().quality(), 0.0);
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -127,13 +127,16 @@ public class RESTExecuteWithoutReadTest {
     private static final String SERIALIZE_FAIL_QUERY = "xquery version \"3.1\";\nlet $secret := 1\nreturn function() { $secret }";
 
     private static final String LIB_MODULE_SRC =
-            "xquery version \"3.1\";\n" +
-            "module namespace lib = \"http://exist-db.org/test/execwithoutread/lib\";\n" +
-            "declare function lib:answer() as xs:integer { 42 };";
+            """
+            xquery version "3.1";
+            module namespace lib = "http://exist-db.org/test/execwithoutread/lib";
+            declare function lib:answer() as xs:integer { 42 };\
+            """;
     private static final String IMPORTS_LIB_SRC =
-            "xquery version \"3.1\";\n" +
-            "import module namespace lib = \"http://exist-db.org/test/execwithoutread/lib\" at \"lib.xqm\";\n" +
-            "<result>{ lib:answer() }</result>";
+            """
+            xquery version "3.1";
+            import module namespace lib = "http://exist-db.org/test/execwithoutread/lib" at "lib.xqm";
+            <result>{ lib:answer() }</result>""";
 
     private static String credentials;
 

--- a/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
+++ b/exist-core/src/test/java/org/exist/http/ws/EvalWebSocketEndpointTest.java
@@ -221,7 +221,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-1\",\"query\":\"1 + 1\"}");
+                    """
+                            {"action":"eval","id":"q-1","query":"1 + 1"}""");
 
             assertTrue("Should receive result within 5s", resultLatch.await(5, TimeUnit.SECONDS));
             assertEquals("2", resultData.get());
@@ -266,9 +267,10 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-2\"," +
-                    "\"query\":\"declare variable $x external; xs:integer($x) * 2\"," +
-                    "\"variables\":{\"x\":\"21\"}}");
+                    """
+                            {"action":"eval","id":"q-2",\
+                            "query":"declare variable $x external; xs:integer($x) * 2",\
+                            "variables":{"x":"21"}}""");
 
             assertTrue("Should receive response within 5s", doneLatch.await(5, TimeUnit.SECONDS));
             assertNull("Should not have error: " + errorData.get(), errorData.get());
@@ -306,7 +308,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-3\",\"query\":\"let $x := retrun\"}");
+                    """
+                            {"action":"eval","id":"q-3","query":"let $x := retrun"}""");
 
             assertTrue("Should receive error within 5s", errorLatch.await(5, TimeUnit.SECONDS));
             final Map<String, Object> error = errorMsg.get();
@@ -346,7 +349,8 @@ public class EvalWebSocketEndpointTest {
         try {
             // Valid query
             session.getBasicRemote().sendText(
-                    "{\"action\":\"compile\",\"id\":\"c-1\",\"query\":\"1 + 1\"}");
+                    """
+                            {"action":"compile","id":"c-1","query":"1 + 1"}""");
 
             assertTrue("Should receive compile result within 5s",
                     compileLatch.await(5, TimeUnit.SECONDS));
@@ -384,7 +388,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"compile\",\"id\":\"c-2\",\"query\":\"let $x := retrun\"}");
+                    """
+                            {"action":"compile","id":"c-2","query":"let $x := retrun"}""");
 
             assertTrue("Should receive compile result within 5s",
                     compileLatch.await(5, TimeUnit.SECONDS));
@@ -426,9 +431,10 @@ public class EvalWebSocketEndpointTest {
         try {
             // Generate 500 items with chunk-size 100 → expect 5 chunks
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-5\"," +
-                    "\"query\":\"1 to 500\"," +
-                    "\"chunk-size\":100,\"streaming\":true}");
+                    """
+                            {"action":"eval","id":"q-5",\
+                            "query":"1 to 500",\
+                            "chunk-size":100,"streaming":true}""");
 
             assertTrue("Should receive all chunks within 10s",
                     finalLatch.await(10, TimeUnit.SECONDS));
@@ -496,7 +502,8 @@ public class EvalWebSocketEndpointTest {
                     progressLatch.await(10, TimeUnit.SECONDS));
 
             session.getBasicRemote().sendText(
-                    "{\"action\":\"cancel\",\"id\":\"q-cancel\"}");
+                    """
+                            {"action":"cancel","id":"q-cancel"}""");
 
             // Await longer than max-execution-time so the watchdog safety net can fire on slow CI.
             assertTrue("Should receive cancelled/error within " + CANCEL_AWAIT_SEC + "s",
@@ -536,7 +543,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-timing\",\"query\":\"1 to 100\"}");
+                    """
+                            {"action":"eval","id":"q-timing","query":"1 to 100"}""");
 
             assertTrue("Should receive result within 5s", resultLatch.await(5, TimeUnit.SECONDS));
             assertNotNull("Should have timing object", resultMsg.get().get("timing"));
@@ -575,7 +583,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-prog\",\"query\":\"1 to 100\"}");
+                    """
+                            {"action":"eval","id":"q-prog","query":"1 to 100"}""");
 
             assertTrue("Should complete within 5s", doneLatch.await(5, TimeUnit.SECONDS));
             assertFalse("Should have at least one progress message",
@@ -618,9 +627,10 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-ser\"," +
-                    "\"query\":\"<root><item>1</item></root>\"," +
-                    "\"serialization\":{\"method\":\"adaptive\"}}");
+                    """
+                            {"action":"eval","id":"q-ser",\
+                            "query":"<root><item>1</item></root>",\
+                            "serialization":{"method":"adaptive"}}""");
 
             assertTrue("Should receive result within 5s", resultLatch.await(5, TimeUnit.SECONDS));
             assertNotNull("Should have result data", resultData.get());
@@ -732,7 +742,8 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-noquery\"}");
+                    """
+                            {"action":"eval","id":"q-noquery"}""");
 
             assertTrue("Should receive error within 5s", errorLatch.await(5, TimeUnit.SECONDS));
         } finally {
@@ -776,9 +787,11 @@ public class EvalWebSocketEndpointTest {
         try {
             // Fire two queries concurrently on the same connection
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"conc-1\",\"query\":\"2 + 3\"}");
+                    """
+                            {"action":"eval","id":"conc-1","query":"2 + 3"}""");
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"conc-2\",\"query\":\"10 * 7\"}");
+                    """
+                            {"action":"eval","id":"conc-2","query":"10 * 7"}""");
 
             assertTrue("Both queries should complete within 5s",
                     doneLatch.await(5, TimeUnit.SECONDS));
@@ -883,8 +896,9 @@ public class EvalWebSocketEndpointTest {
         try {
             // xs:base64Binary('SGVsbG8=') is base64 for "Hello"
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-bin\"," +
-                    "\"query\":\"xs:base64Binary('SGVsbG8=')\"}");
+                    """
+                            {"action":"eval","id":"q-bin",\
+                            "query":"xs:base64Binary('SGVsbG8=')"}""");
 
             assertTrue("Should receive response within 5s", doneLatch.await(5, TimeUnit.SECONDS));
             assertNull("Should not have error: " + errorData.get(), errorData.get());
@@ -932,9 +946,10 @@ public class EvalWebSocketEndpointTest {
 
         try {
             session.getBasicRemote().sendText(
-                    "{\"action\":\"eval\",\"id\":\"q-map\"," +
-                    "\"query\":\"map { 'key': 'value', 'nums': [1, 2, 3] }\"," +
-                    "\"serialization\":{\"method\":\"adaptive\"}}");
+                    """
+                            {"action":"eval","id":"q-map",\
+                            "query":"map { 'key': 'value', 'nums': [1, 2, 3] }",\
+                            "serialization":{"method":"adaptive"}}""");
 
             assertTrue("Should receive response within 5s", doneLatch.await(5, TimeUnit.SECONDS));
             assertNull("Should not have error: " + errorData.get(), errorData.get());
@@ -1032,7 +1047,8 @@ public class EvalWebSocketEndpointTest {
         try {
             // non-DBA user tries admin-cancel
             session.getBasicRemote().sendText(
-                    "{\"action\":\"admin-cancel\",\"id\":\"12345\"}");
+                    """
+                            {"action":"admin-cancel","id":"12345"}""");
 
             assertTrue("Should receive error within 5s", errorLatch.await(5, TimeUnit.SECONDS));
             assertTrue("Should mention permission denied",

--- a/exist-core/src/test/java/org/exist/resolver/CatalogResolutionRegressionTest.java
+++ b/exist-core/src/test/java/org/exist/resolver/CatalogResolutionRegressionTest.java
@@ -29,7 +29,6 @@ import org.xmlresolver.Resolver;
 
 import javax.xml.parsers.SAXParserFactory;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -64,7 +63,7 @@ public class CatalogResolutionRegressionTest {
         final Path tempDir = Files.createTempDirectory("catalog-1975-test");
         try {
             final Path dtd = tempDir.resolve("greeting.dtd");
-            Files.writeString(dtd, "<!ENTITY greeting \"Hello from catalog\">", StandardCharsets.UTF_8);
+            Files.writeString(dtd, "<!ENTITY greeting \"Hello from catalog\">");
 
             final Path catalog = tempDir.resolve("catalog.xml");
             Files.writeString(catalog, """
@@ -72,7 +71,7 @@ public class CatalogResolutionRegressionTest {
                     <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
                         <public publicId="-//EXIST-TEST//GREETING//EN" uri="%s"/>
                     </catalog>
-                    """.formatted(dtd.toUri()), StandardCharsets.UTF_8);
+                    """.formatted(dtd.toUri()));
 
             final String resolved = parseWithCatalog(catalog.toUri().toString(),
                     "<!DOCTYPE root PUBLIC \"-//EXIST-TEST//GREETING//EN\" \"greeting.dtd\">"
@@ -104,7 +103,7 @@ public class CatalogResolutionRegressionTest {
                     <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
                         <public publicId="-//SOME//KNOWN//EN" uri="known.dtd"/>
                     </catalog>
-                    """, StandardCharsets.UTF_8);
+                    """);
 
             final Resolver resolver = ResolverFactory.newResolver(
                     List.of(Tuple(catalog.toUri().toString(), Optional.<InputSource>empty())));

--- a/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
+++ b/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
@@ -48,7 +48,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Random;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 /**
@@ -134,7 +133,7 @@ public class LargeValuesTest {
 
                 final Path tempFile = Files.createTempFile("eXist", ".xml");
                 final Serializer serializer = broker.borrowSerializer();
-                try (final Writer writer = Files.newBufferedWriter(tempFile, UTF_8)) {
+                try (final Writer writer = Files.newBufferedWriter(tempFile)) {
                     serializer.serialize(lockedDoc.getDocument(), writer);
                 } finally {
                     broker.returnSerializer(serializer);
@@ -175,7 +174,7 @@ public class LargeValuesTest {
 
     private Path createDocument() throws IOException {
         final Path file = Files.createTempFile("eXistTest", ".xml");
-        try(final Writer writer = Files.newBufferedWriter(file, UTF_8)) {
+        try(final Writer writer = Files.newBufferedWriter(file)) {
             final Random r = new Random();
             writer.write("<test>");
             for(int i = 0; i < KEY_COUNT; i++) {

--- a/exist-core/src/test/java/org/exist/util/serializer/HtmlSerializerBenchmarkTest.java
+++ b/exist-core/src/test/java/org/exist/util/serializer/HtmlSerializerBenchmarkTest.java
@@ -133,9 +133,11 @@ public class HtmlSerializerBenchmarkTest {
         // both runs should have identical per-char counts (the difference is
         // all in bulk string writes).
         final String script =
-                "function compare(a, b) { return a < b; }\n" +
-                "for (let i = 0; i < items.length; i++) { if (items[i] < threshold) found = true; }\n" +
-                "const html = '<div class=\"x\"><span>foo</span></div>';\n";
+                """
+                function compare(a, b) { return a < b; }
+                for (let i = 0; i < items.length; i++) { if (items[i] < threshold) found = true; }
+                const html = '<div class="x"><span>foo</span></div>';
+                """;
 
         final CountingWriter empty = serializeWithScript("");
         final CountingWriter withScript = serializeWithScript(script);

--- a/exist-core/src/test/java/org/exist/xinclude/W3CXIncludeTestSuite.java
+++ b/exist-core/src/test/java/org/exist/xinclude/W3CXIncludeTestSuite.java
@@ -43,7 +43,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -189,9 +190,10 @@ public class W3CXIncludeTestSuite {
         // Serialize with XInclude expansion
         // Use fn:serialize() to get proper XML output, not just text content
         final String xquery = String.format(
-                "let $doc := doc('%s')\n" +
-                "let $expanded := util:expand($doc, 'expand-xincludes=yes')\n" +
-                "return fn:serialize($expanded, map { 'method': 'xml', 'indent': false(), 'omit-xml-declaration': true() })",
+                """
+                let $doc := doc('%s')
+                let $expanded := util:expand($doc, 'expand-xincludes=yes')
+                return fn:serialize($expanded, map { 'method': 'xml', 'indent': false(), 'omit-xml-declaration': true() })""",
                 inputDocPath);
 
         if ("error".equals(type)) {
@@ -367,11 +369,11 @@ public class W3CXIncludeTestSuite {
         final URL url = W3CXIncludeTestSuite.class.getClassLoader().getResource(TEST_SUITE_DIR);
         if (url != null) {
             try {
-                return Paths.get(url.toURI());
+                return Path.of(url.toURI());
             } catch (final Exception e) {
                 // fall through
             }
         }
-        return Paths.get("src/test/resources", TEST_SUITE_DIR);
+        return Path.of("src/test/resources", TEST_SUITE_DIR);
     }
 }

--- a/exist-core/src/test/java/org/exist/xmldb/concurrent/DBUtils.java
+++ b/exist-core/src/test/java/org/exist/xmldb/concurrent/DBUtils.java
@@ -34,8 +34,6 @@ import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XPathQueryService;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * Static utility methods used by the tests.
  *
@@ -78,7 +76,7 @@ public class DBUtils {
             throw new IllegalArgumentException("Cannot write to output file " + file.toAbsolutePath());
         }
 
-        try (final Writer writer = Files.newBufferedWriter(file, UTF_8)) {
+        try (final Writer writer = Files.newBufferedWriter(file)) {
             final XMLGenerator gen = new XMLGenerator(elementCnt, attrCnt, depth, wordList, namespaces);
             gen.generateXML(writer);
         }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
@@ -54,13 +54,15 @@ public class FunLangTest {
     private static final String TEST_COLLECTION = "fun-lang-test";
 
     private static final String MODULE =
-        "module namespace mod = \"http://exist-db.org/test/fun-lang\";\n" +
-        "\n" +
-        "declare variable $mod:data := <root xml:lang=\"en\"><p>hello</p></root>;\n" +
-        "\n" +
-        "declare function mod:check-lang($lang as xs:string) as xs:boolean {\n" +
-        "    lang($lang, $mod:data/p)\n" +
-        "};\n";
+        """
+        module namespace mod = "http://exist-db.org/test/fun-lang";
+        
+        declare variable $mod:data := <root xml:lang="en"><p>hello</p></root>;
+        
+        declare function mod:check-lang($lang as xs:string) as xs:boolean {
+            lang($lang, $mod:data/p)
+        };
+        """;
 
     @BeforeClass
     public static void setUp() throws XMLDBException {

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/IsMissingElementDeclarationTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/IsMissingElementDeclarationTest.java
@@ -30,7 +30,6 @@ import org.xml.sax.XMLReader;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -79,9 +78,9 @@ public class IsMissingElementDeclarationTest {
     public void realCvcElt1aFailureIsRecognized() throws Exception {
         final Path tempDir = Files.createTempDirectory("is-missing-element-declaration-test");
         try {
-            Files.writeString(tempDir.resolve("schema.xsd"), XSD_1_1_ONLY_SCHEMA, StandardCharsets.UTF_8);
+            Files.writeString(tempDir.resolve("schema.xsd"), XSD_1_1_ONLY_SCHEMA);
             final Path instance = tempDir.resolve("instance.xml");
-            Files.writeString(instance, CONFORMING_INSTANCE, StandardCharsets.UTF_8);
+            Files.writeString(instance, CONFORMING_INSTANCE);
 
             final ValidationReport report = new ValidationReport();
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpSchemaLocationSecurityTest.java
@@ -25,7 +25,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -61,9 +60,9 @@ public class JaxpSchemaLocationSecurityTest {
     public static void setup() throws Exception {
         tempDir = Files.createTempDirectory("jaxp-security-test");
         final Path instance = tempDir.resolve("instance.xml");
-        Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
-        Files.writeString(tempDir.resolve("schema11.xsd"), XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
-        Files.writeString(tempDir.resolve("schema10.xsd"), XSD_1_0_SCHEMA, StandardCharsets.UTF_8);
+        Files.writeString(instance, "<root/>");
+        Files.writeString(tempDir.resolve("schema11.xsd"), XSD_1_1_SCHEMA);
+        Files.writeString(tempDir.resolve("schema10.xsd"), XSD_1_0_SCHEMA);
         fileBaseUri = instance.toUri().toString();
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validation/JaxpXsd11DetectionCacheTest.java
@@ -24,7 +24,6 @@ package org.exist.xquery.functions.validation;
 import org.junit.After;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -58,9 +57,9 @@ public class JaxpXsd11DetectionCacheTest {
         final Path tempDir = Files.createTempDirectory("jaxp-xsd11-cache-test");
         try {
             final Path instance = tempDir.resolve("instance.xml");
-            Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
+            Files.writeString(instance, "<root/>");
             final Path schema = tempDir.resolve("schema.xsd");
-            Files.writeString(schema, XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
+            Files.writeString(schema, XSD_1_1_SCHEMA);
 
             final String baseUri = instance.toUri().toString();
 
@@ -70,7 +69,7 @@ public class JaxpXsd11DetectionCacheTest {
             // Flip the on-disk content to XSD 1.0 without going through the cache -- if the second
             // call is actually served from cache, it must still report the stale (cached) "true",
             // not re-read this new content.
-            Files.writeString(schema, XSD_1_0_SCHEMA, StandardCharsets.UTF_8);
+            Files.writeString(schema, XSD_1_0_SCHEMA);
             assertTrue("second call should be served from cache, not re-read the changed file",
                     Jaxp.isXsd11Schema("subject-a", baseUri, "schema.xsd"));
 
@@ -91,9 +90,9 @@ public class JaxpXsd11DetectionCacheTest {
         final Path tempDir = Files.createTempDirectory("jaxp-xsd11-cache-subject-test");
         try {
             final Path instance = tempDir.resolve("instance.xml");
-            Files.writeString(instance, "<root/>", StandardCharsets.UTF_8);
+            Files.writeString(instance, "<root/>");
             final Path schema = tempDir.resolve("schema.xsd");
-            Files.writeString(schema, XSD_1_1_SCHEMA, StandardCharsets.UTF_8);
+            Files.writeString(schema, XSD_1_1_SCHEMA);
 
             final String baseUri = instance.toUri().toString();
 

--- a/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/Counters.java
+++ b/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/Counters.java
@@ -25,7 +25,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Hashtable;
@@ -69,7 +68,7 @@ public class Counters implements RawBackupSupport {
     private void loadStore() throws EXistException {
         try {
             if(Files.exists(store)) {
-                try(final BufferedReader br = Files.newBufferedReader(store, StandardCharsets.UTF_8)) {
+                try(final BufferedReader br = Files.newBufferedReader(store)) {
                     String line = "";
                     while ((line = br.readLine()) != null) {
                         //Use ; as a DELIMITER, counter names must be tested and rejected when they contain this character!
@@ -217,7 +216,7 @@ public class Counters implements RawBackupSupport {
      * @throws IOException
      */
     private synchronized void serializeTable() throws IOException {
-        try(final PrintWriter pw = new PrintWriter(Files.newBufferedWriter(store, StandardCharsets.UTF_8))) {
+        try(final PrintWriter pw = new PrintWriter(Files.newBufferedWriter(store))) {
             for(final Map.Entry<String, Long> counter : counters.entrySet()) {
                 pw.println(counter.getKey() + DELIMITER + counter.getValue().toString());
             }

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/ResourceAvailable.java
@@ -70,7 +70,7 @@ public class ResourceAvailable extends BasicFunction {
         final String path = args[1].getStringValue();
 
         final Optional<ExistRepository> repo = context.getRepository();
-        if (!repo.isPresent()) {
+        if (repo.isEmpty()) {
             return BooleanValue.FALSE;
         }
 

--- a/extensions/webdav/src/main/java/org/exist/webdav/WebDavLockStore.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/WebDavLockStore.java
@@ -108,7 +108,7 @@ public class WebDavLockStore {
      */
     public LockInfo getLock(final String resourceUri) {
         final List<LockInfo> locks = getLocks(resourceUri);
-        return locks.isEmpty() ? null : locks.get(0);
+        return locks.isEmpty() ? null : locks.getFirst();
     }
 
     /**


### PR DESCRIPTION
Apply OpenRewrite Java21 recipe.

https://docs.openrewrite.org/recipes/java/migrate/upgradetojava21

```sh
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
  --define rewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE \
  --define rewrite.activeRecipes=org.openrewrite.java.migrate.UpgradeToJava21 \
  --define rewrite.exportDatatables=true
```

note: according to javadoc this UTF-8 encoding is default, so it has been removed from code.