### PR TITLE
Add system:get-jmx-token() to expose JMXServlet's access token

### DIFF
--- a/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXServlet.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.BrokerPool;
-import org.exist.util.UUIDGenerator;
 import org.exist.util.serializer.DOMSerializer;
 import org.w3c.dom.Element;
 
@@ -42,15 +41,12 @@ import javax.management.ReflectionException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Properties;
@@ -85,7 +81,6 @@ public class JMXServlet extends HttpServlet {
     protected final static Logger LOG = LogManager.getLogger(JMXServlet.class);
 
     private static final String TOKEN_KEY = "token";
-    private static final String TOKEN_FILE = "jmxservlet.token";
     private static final String WEBINF_DATA_DIR = "WEB-INF/data";
 
     private final static Properties defaultProperties = new Properties();
@@ -97,8 +92,7 @@ public class JMXServlet extends HttpServlet {
 
     private final Set<String> localhostAddresses = new HashSet<>();
     private JMXtoXML client;
-    private Path dataDir;
-    private Path tokenFile;
+    private JMXTokenProvider tokenProvider;
 
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
@@ -108,7 +102,7 @@ public class JMXServlet extends HttpServlet {
             // Localhost is always authorized to access
             LOG.debug("Local access granted");
 
-        } else if (hasSecretToken(request, getToken())) {
+        } else if (hasSecretToken(request, tokenProvider.getToken().orElse(null))) {
             // Correct token is provided
             LOG.debug("Correct token provided by {}", request.getRemoteHost());
 
@@ -199,21 +193,14 @@ public class JMXServlet extends HttpServlet {
         // Register all known localhost addresses
         registerLocalHostAddresses();
 
-        // Get directory for token file
-        final String jmxDataDir = client.getDataDir();
-        if (jmxDataDir == null) {
-            dataDir = Path.of(config.getServletContext().getRealPath(WEBINF_DATA_DIR)).normalize();
-        } else {
-            dataDir = Path.of(jmxDataDir).normalize();
-        }
-        if (!Files.isDirectory(dataDir) || !Files.isWritable(dataDir)) {
-            LOG.error("Cannot access directory {}", WEBINF_DATA_DIR);
-        }
+        // Resolve the token, backed by the DiskUsage MBean's DataDirectory, falling back to
+        // WEB-INF/data if that MBean attribute is unavailable. getRealPath() can return null
+        // (e.g. when the webapp isn't unpacked to disk), in which case there is no fallback.
+        final String realPath = config.getServletContext().getRealPath(WEBINF_DATA_DIR);
+        final Path fallbackDataDir = realPath != null ? Path.of(realPath).normalize() : null;
+        tokenProvider = new JMXTokenProvider(client, fallbackDataDir);
 
-        // Setup token and tokenfile
-        obtainTokenFileReference();
-
-        LOG.info("JMXservlet token: {}", getToken());
+        LOG.info("JMXservlet token: {}", tokenProvider.getToken().orElse(null));
 
     }
 
@@ -276,62 +263,6 @@ public class JMXServlet extends HttpServlet {
         }
         final String[] tokenValue = request.getParameterValues(TOKEN_KEY);
         return ArrayUtils.contains(tokenValue, token);
-    }
-
-    /**
-     * Obtain reference to token file
-     */
-    private void obtainTokenFileReference() {
-
-        if (tokenFile == null) {
-            tokenFile = dataDir.resolve(TOKEN_FILE);
-            LOG.info("Token file:  {}", tokenFile.toAbsolutePath().toAbsolutePath());
-        }
-    }
-
-    /**
-     * Get token from file, create if not existent. Data is read for each call so the file can be updated run-time.
-     *
-     * @return Toke for servlet
-     */
-    private String getToken() {
-
-        final Properties props = new Properties();
-        String token = null;
-
-        // Read if possible
-        if (Files.exists(tokenFile)) {
-
-            try (final InputStream is = Files.newInputStream(tokenFile)) {
-                props.load(is);
-                token = props.getProperty(TOKEN_KEY);
-            } catch (final IOException ex) {
-                LOG.error(ex.getMessage());
-            }
-
-        }
-
-        // Create and write when needed
-        if (!Files.exists(tokenFile) || token == null) {
-
-            // Create random token
-            token = UUIDGenerator.getUUIDversion4();
-
-            // Set value to properties
-            props.setProperty(TOKEN_KEY, token);
-
-            // Write data to file
-            try (final OutputStream os = Files.newOutputStream(tokenFile)) {
-                props.store(os, "JMXservlet token: http://localhost:8080/exist/status?token=......");
-            } catch (final IOException ex) {
-                LOG.error(ex.getMessage());
-            }
-
-            LOG.debug("Token written to file {}", tokenFile.toAbsolutePath().toString());
-
-        }
-
-        return token;
     }
 
 }

--- a/exist-core/src/main/java/org/exist/management/client/JMXTokenProvider.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXTokenProvider.java
@@ -1,0 +1,162 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.client;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.util.UUIDGenerator;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Canonical resolution of {@link JMXServlet}'s shared secret token, i.e. the value the servlet
+ * accepts via its {@code token} request parameter as an alternative to a request originating
+ * from localhost (see {@code JMXServlet#hasSecretToken}).
+ * <p>
+ * The token is persisted in a {@code jmxservlet.token} properties file inside the data
+ * directory reported by the {@code org.exist.management.exist:type=DiskUsage} MBean's
+ * {@code DataDirectory} attribute, falling back to a caller-supplied directory (e.g.
+ * {@code JMXServlet}'s {@code WEB-INF/data}) if that attribute is unavailable.
+ * <p>
+ * Both {@code JMXServlet} and the {@code system:get-jmx-token()} XQuery function delegate to
+ * this class rather than each re-deriving the token/data-dir resolution independently.
+ *
+ * @author eXist-db authors
+ */
+public class JMXTokenProvider {
+
+    private static final Logger LOG = LogManager.getLogger(JMXTokenProvider.class);
+
+    private static final String TOKEN_KEY = "token";
+    private static final String TOKEN_FILE = "jmxservlet.token";
+    private static final String TOKEN_FILE_COMMENT = """
+            JMXservlet token
+            Use: /exist/status?token=<token>
+            Obtain: system:get-jmx-token()""";
+
+    private final JMXtoXML client;
+
+    @Nullable
+    private final Path fallbackDataDir;
+
+    /**
+     * @param client a connected {@link JMXtoXML} client used to resolve the data directory
+     */
+    public JMXTokenProvider(final JMXtoXML client) {
+        this(client, null);
+    }
+
+    /**
+     * @param client          a connected {@link JMXtoXML} client used to resolve the data directory
+     * @param fallbackDataDir the data directory to use if the client cannot report one, or null
+     *                        if there is no fallback available
+     */
+    public JMXTokenProvider(final JMXtoXML client, @Nullable final Path fallbackDataDir) {
+        this.client = client;
+        this.fallbackDataDir = fallbackDataDir;
+    }
+
+    /**
+     * Resolve the directory the token file lives in, the same way {@code JMXServlet} does: the
+     * {@code DiskUsage} MBean's {@code DataDirectory} attribute, or the caller-supplied fallback
+     * if that attribute is unavailable.
+     *
+     * @return the resolved data directory, or empty if neither source yielded one
+     */
+    public Optional<Path> getDataDir() {
+        final String jmxDataDir;
+        try {
+            jmxDataDir = client.getDataDir();
+        } catch (final RuntimeException e) {
+            LOG.error("Unable to determine data directory from JMX: {}", e.getMessage(), e);
+            return Optional.ofNullable(fallbackDataDir).map(Path::normalize);
+        }
+
+        final Path dataDir;
+        if (jmxDataDir != null) {
+            dataDir = Path.of(jmxDataDir).normalize();
+        } else if (fallbackDataDir != null) {
+            dataDir = fallbackDataDir.normalize();
+        } else {
+            return Optional.empty();
+        }
+
+        if (!Files.isDirectory(dataDir) || !Files.isWritable(dataDir)) {
+            LOG.error("Cannot access data directory {}", dataDir);
+        }
+
+        return Optional.of(dataDir);
+    }
+
+    /**
+     * Get the token, reading it from (or creating and persisting it in, if not yet present) the
+     * {@code jmxservlet.token} file in the resolved data directory. Data is read for each call so
+     * the file can be updated at run-time.
+     *
+     * @return the token, or empty if the data directory could not be resolved
+     */
+    public Optional<String> getToken() {
+        return getDataDir().map(this::readOrCreateToken);
+    }
+
+    private String readOrCreateToken(final Path dataDir) {
+        final Path tokenFile = dataDir.resolve(TOKEN_FILE);
+
+        final Properties props = new Properties();
+        String token = null;
+
+        if (Files.exists(tokenFile)) {
+            try (final InputStream is = Files.newInputStream(tokenFile)) {
+                props.load(is);
+                token = props.getProperty(TOKEN_KEY);
+            } catch (final IOException e) {
+                LOG.error(e.getMessage());
+            }
+        }
+
+        if (token == null) {
+            // Create random token
+            token = UUIDGenerator.getUUIDversion4();
+
+            // Set value to properties
+            props.setProperty(TOKEN_KEY, token);
+
+            // Write data to file
+            try (final OutputStream os = Files.newOutputStream(tokenFile)) {
+                props.store(os, TOKEN_FILE_COMMENT);
+            } catch (final IOException e) {
+                LOG.error(e.getMessage());
+            }
+
+            LOG.debug("Token written to file {}", tokenFile.toAbsolutePath());
+        }
+
+        return token;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetJmxToken.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetJmxToken.java
@@ -1,0 +1,74 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.system;
+
+import org.exist.dom.QName;
+import org.exist.management.client.JMXTokenProvider;
+import org.exist.management.client.JMXtoXML;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.FunctionReturnSequenceType;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.StringValue;
+import org.exist.xquery.value.Type;
+
+/**
+ * Return the JMXServlet access token, i.e. the same secret {@code JMXServlet} accepts via its
+ * {@code token} request parameter for requests that do not originate from localhost.
+ *
+ * @author eXist-db authors
+ */
+public class GetJmxToken extends BasicFunction {
+
+    public final static FunctionSignature signature = new FunctionSignature(
+            new QName("get-jmx-token", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
+            "Returns the JMXServlet access token, i.e. the secret accepted via the 'token' request " +
+            "parameter of /exist/status (JMXServlet) as an alternative to a request originating " +
+            "from localhost. Resolved via the same DiskUsage MBean-based data directory lookup " +
+            "JMXServlet itself uses, so the two never diverge. Returns the empty sequence if JMX, " +
+            "or the token, could not be resolved. This function is only available to the DBA role.",
+            FunctionSignature.NO_ARGS,
+            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE,
+                    "the JMXServlet access token, or the empty sequence if it could not be resolved"));
+
+    public GetJmxToken(final XQueryContext context) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        if (!context.getSubject().hasDbaRole()) {
+            throw new XPathException(this, "Only a DBA can call system:get-jmx-token()");
+        }
+
+        final JMXtoXML client = new JMXtoXML();
+        client.connect();
+
+        final JMXTokenProvider tokenProvider = new JMXTokenProvider(client);
+        return tokenProvider.getToken()
+                .<Sequence>map(token -> new StringValue(this, token))
+                .orElse(Sequence.EMPTY_SEQUENCE);
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/SystemModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/SystemModule.java
@@ -86,7 +86,8 @@ public class SystemModule extends AbstractInternalModule {
             new FunctionDef(GetUptime.signature, GetUptime.class),
             new FunctionDef(FunctionAvailable.signature, FunctionAvailable.class),
             
-            new FunctionDef(ClearXQueryCache.signature, ClearXQueryCache.class)
+            new FunctionDef(ClearXQueryCache.signature, ClearXQueryCache.class),
+            new FunctionDef(GetJmxToken.signature, GetJmxToken.class)
     };
 	
 	public SystemModule(Map<String, List<?>> parameters) {

--- a/exist-core/src/test/java/org/exist/management/client/JMXTokenProviderTest.java
+++ b/exist-core/src/test/java/org/exist/management/client/JMXTokenProviderTest.java
@@ -1,0 +1,179 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.management.client;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the resolution paths that {@code system:get-jmx-token()} relies on but can't itself
+ * exercise via XQSuite: a live test instance always has the {@code DiskUsage} MBean registered
+ * (see {@code AgentFactory#initDBInstance}), so "JMX unavailable" can only be simulated by
+ * substituting a {@link JMXtoXML} client directly, at this unit level.
+ */
+public class JMXTokenProviderTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static JMXtoXML clientReturning(final String dataDir) {
+        return new JMXtoXML() {
+            @Override
+            public String getDataDir() {
+                return dataDir;
+            }
+        };
+    }
+
+    private static JMXtoXML clientThrowing(final RuntimeException e) {
+        return new JMXtoXML() {
+            @Override
+            public String getDataDir() {
+                throw e;
+            }
+        };
+    }
+
+    @Test
+    public void getDataDirUsesMBeanValueWhenAvailable() throws IOException {
+        final Path dataDir = temporaryFolder.newFolder("mbean-data-dir").toPath();
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(dataDir.toString()));
+
+        assertEquals(Optional.of(dataDir), provider.getDataDir());
+    }
+
+    @Test
+    public void getDataDirFallsBackWhenMBeanReturnsNull() throws IOException {
+        final Path fallback = temporaryFolder.newFolder("fallback-data-dir").toPath();
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(null), fallback);
+
+        assertEquals(Optional.of(fallback), provider.getDataDir());
+    }
+
+    @Test
+    public void getDataDirIsEmptyWhenMBeanReturnsNullAndNoFallback() {
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(null));
+
+        assertEquals(Optional.empty(), provider.getDataDir());
+    }
+
+    @Test
+    public void getDataDirFallsBackWhenMBeanLookupThrows() throws IOException {
+        final Path fallback = temporaryFolder.newFolder("fallback-data-dir").toPath();
+        final JMXtoXML client = clientThrowing(new NullPointerException("no MBean connection"));
+        final JMXTokenProvider provider = new JMXTokenProvider(client, fallback);
+
+        assertEquals(Optional.of(fallback), provider.getDataDir());
+    }
+
+    @Test
+    public void getDataDirIsEmptyWhenMBeanLookupThrowsAndNoFallback() {
+        final JMXtoXML client = clientThrowing(new NullPointerException("no MBean connection"));
+        final JMXTokenProvider provider = new JMXTokenProvider(client);
+
+        assertEquals(Optional.empty(), provider.getDataDir());
+    }
+
+    @Test
+    public void getTokenIsEmptyWhenDataDirCannotBeResolved() {
+        // Mirrors system:get-jmx-token()'s construction: no fallback, MBean unavailable.
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(null));
+
+        assertEquals(Optional.empty(), provider.getToken());
+    }
+
+    @Test
+    public void getTokenCreatesAndPersistsNewTokenWhenFileAbsent() throws IOException {
+        final Path dataDir = temporaryFolder.newFolder("new-token-dir").toPath();
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(dataDir.toString()));
+
+        final Optional<String> token = provider.getToken();
+
+        assertTrue(token.isPresent());
+        assertFalse(token.get().isBlank());
+
+        final Path tokenFile = dataDir.resolve("jmxservlet.token");
+        assertTrue(Files.exists(tokenFile));
+
+        final Properties persisted = new Properties();
+        try (final var is = Files.newInputStream(tokenFile)) {
+            persisted.load(is);
+        }
+        assertEquals(token.get(), persisted.getProperty("token"));
+
+        final String raw = Files.readString(tokenFile);
+        assertThat(raw, containsString("/exist/status?token=<token>"));
+        assertThat(raw, containsString("system:get-jmx-token()"));
+    }
+
+    @Test
+    public void getTokenReadsExistingTokenRatherThanCreatingNew() throws IOException {
+        final Path dataDir = temporaryFolder.newFolder("existing-token-dir").toPath();
+        final Path tokenFile = dataDir.resolve("jmxservlet.token");
+        final Properties existing = new Properties();
+        existing.setProperty("token", "existing-token-value");
+        try (final var os = Files.newOutputStream(tokenFile)) {
+            existing.store(os, null);
+        }
+
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(dataDir.toString()));
+
+        assertThat(provider.getToken(), equalTo(Optional.of("existing-token-value")));
+    }
+
+    @Test
+    public void getTokenRegeneratesTokenWhenExistingFileHasNoTokenProperty() throws IOException {
+        final Path dataDir = temporaryFolder.newFolder("corrupt-token-dir").toPath();
+        final Path tokenFile = dataDir.resolve("jmxservlet.token");
+        final Properties withoutTokenKey = new Properties();
+        withoutTokenKey.setProperty("not-the-token-key", "irrelevant");
+        try (final var os = Files.newOutputStream(tokenFile)) {
+            withoutTokenKey.store(os, null);
+        }
+
+        final JMXTokenProvider provider = new JMXTokenProvider(clientReturning(dataDir.toString()));
+        final Optional<String> token = provider.getToken();
+
+        assertTrue(token.isPresent());
+        assertFalse(token.get().isBlank());
+
+        final Properties persisted = new Properties();
+        try (final var is = Files.newInputStream(tokenFile)) {
+            persisted.load(is);
+        }
+        assertEquals(token.get(), persisted.getProperty("token"));
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/system/GetJmxTokenTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/system/GetJmxTokenTest.java
@@ -1,0 +1,118 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.system;
+
+import org.exist.TestUtils;
+import org.exist.management.client.JMXtoXML;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xmldb.EXistXQueryService;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.exist.xmldb.XmldbURI.LOCAL_DB;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GetJmxTokenTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer dba = new ExistXmldbEmbeddedServer(false, true, true);
+
+    @Test
+    public void dbaCanGetToken() throws XMLDBException {
+        final ResourceSet result = dba.executeQuery("system:get-jmx-token()");
+        assertEquals(1, result.getSize());
+
+        final String token = (String) result.getResource(0).getContent();
+        assertFalse(token.isBlank());
+    }
+
+    @Test
+    public void tokenIsStableAcrossCalls() throws XMLDBException {
+        final ResourceSet first = dba.executeQuery("system:get-jmx-token()");
+        final ResourceSet second = dba.executeQuery("system:get-jmx-token()");
+
+        assertThat((String) second.getResource(0).getContent(), equalTo((String) first.getResource(0).getContent()));
+    }
+
+    @Test
+    public void tokenFileChangesAreReflectedOnNextCall() throws XMLDBException, IOException {
+        final ResourceSet before = dba.executeQuery("system:get-jmx-token()");
+        final String originalToken = (String) before.getResource(0).getContent();
+
+        // Locate the actual on-disk token file the running instance is using, via the same
+        // DiskUsage MBean lookup JMXTokenProvider itself relies on.
+        final JMXtoXML client = new JMXtoXML();
+        client.connect();
+        final Path tokenFile = Path.of(client.getDataDir()).resolve("jmxservlet.token");
+        assertTrue(Files.exists(tokenFile));
+
+        // Overwrite it with a new token while the instance is still running.
+        final String replacementToken = "replacement-" + originalToken;
+        try {
+            writeToken(tokenFile, replacementToken);
+
+            final ResourceSet after = dba.executeQuery("system:get-jmx-token()");
+            final String tokenAfterEdit = (String) after.getResource(0).getContent();
+
+            assertThat(tokenAfterEdit, equalTo(replacementToken));
+            assertThat(tokenAfterEdit, not(equalTo(originalToken)));
+        } finally {
+            // Leave the file as it was so other tests in this class see a consistent token.
+            writeToken(tokenFile, originalToken);
+        }
+    }
+
+    private static void writeToken(final Path tokenFile, final String token) throws IOException {
+        final Properties props = new Properties();
+        props.setProperty("token", token);
+        try (final var os = Files.newOutputStream(tokenFile)) {
+            props.store(os, null);
+        }
+    }
+
+    @Test
+    public void guestIsDenied() throws XMLDBException {
+        final Collection guestRoot = DatabaseManager.getCollection(LOCAL_DB, TestUtils.GUEST_DB_USER, TestUtils.GUEST_DB_PWD);
+        final EXistXQueryService guestQueryService = guestRoot.getService(EXistXQueryService.class);
+
+        final XMLDBException e = assertThrows(XMLDBException.class,
+                () -> guestQueryService.query("system:get-jmx-token()"));
+
+        assertThat(e.getMessage(), containsString("DBA"));
+    }
+}

--- a/exist-core/src/test/xquery/system/get-jmx-token.xqm
+++ b/exist-core/src/test/xquery/system/get-jmx-token.xqm
@@ -1,0 +1,54 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace test-system-get-jmx-token="http://exist-db.org/xquery/test/system/get-jmx-token";
+
+import module namespace system="http://exist-db.org/xquery/system";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(: Happy path: a DBA gets back exactly one non-blank token, in the shape produced by
+ : org.exist.util.UUIDGenerator#getUUIDversion4 (a standard UUID.toString()). :)
+declare
+    %test:assertXPath("matches($result, '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')")
+function test-system-get-jmx-token:dba-gets-token() {
+    system:get-jmx-token()
+};
+
+(: The token is read from (or created once and then persisted in) the jmxservlet.token
+ : file, so repeated calls within the same run must agree. :)
+declare
+    %test:assertTrue
+function test-system-get-jmx-token:token-is-stable-across-calls() {
+    system:get-jmx-token() eq system:get-jmx-token()
+};
+
+(: Only error state: a caller without the DBA role is refused outright. There is no
+ : dedicated error code for this - GetJmxToken raises a plain XPathException, which
+ : surfaces as the generic eXist "exerr:ERROR". :)
+declare
+    %test:user("guest", "guest")
+    %test:assertError("exerr:ERROR")
+function test-system-get-jmx-token:guest-is-denied() {
+    system:get-jmx-token()
+};


### PR DESCRIPTION
### Description:

`JMXServlet` waives its `token` requirement only for requests whose literal peer address is a registered loopback address. Any other client — behind a reverse proxy, container port-publishing, or on the LAN — must supply the correct `token` query parameter. There was previously no supported way for an XQuery application to obtain that token (or the data directory it's derived from) without re-implementing the servlet's private resolution logic, which tends to silently diverge from the real value (the `WEB-INF/data` fallback, or the `DiskUsage` MBean-based data directory lookup).

This PR:

1. Extracts `JMXServlet`'s token/data-dir resolution (`init()`'s `dataDir` lookup, `obtainTokenFileReference()`, `getToken()`) into a new shared class, `JMXTokenProvider`, in `org.exist.management.client`. `JMXServlet` now delegates to it instead of keeping the logic private.
2. Adds `system:get-jmx-token()` as its own function class, `GetJmxToken`, under `org.exist.xquery.functions.system` (matching the existing one-class-per-function convention, e.g. `GetExistHome.java`), registered in `SystemModule`, DBA-gated the same way `Shutdown`/`ClearXQueryCache` already check `hasDbaRole()`. It returns the empty sequence if JMX/the token can't be resolved, rather than raising an error.

Both callers now resolve the token via the exact same code path, so they can't drift apart.

### Reference:

Closes #6620

### Type of tests:

- **Java unit tests** (`JMXTokenProviderTest`): MBean-value vs. fallback-dir vs. empty resolution (including when the MBean lookup throws), token creation/persistence, reading an existing token file, regenerating a token file that's missing the `token` property. These exercise the JMX-unavailable paths that can't be reached from a live test instance, since `AgentFactory#initDBInstance` registers the `DiskUsage` MBean unconditionally at startup.
- **Java integration test** (`GetJmxTokenTest`, via `ExistXmldbEmbeddedServer`): a DBA gets a stable, non-blank token; a non-DBA (`guest`) is denied; editing the on-disk `jmxservlet.token` file while the instance is running is picked up on the next call (no caching).
- **XQSuite** (`get-jmx-token.xqm`): happy path (DBA gets a UUID-shaped token), token stability across calls, and the one XQuery-level error case (`%test:user("guest", "guest")` + `%test:assertError("exerr:ERROR")`).
- Full `exist-core` test suite run locally: 7203 tests, 0 failures, 0 errors.