### PR TITLE
[test] Poll for shared-pool visibility instead of asserting it synchronously

### DIFF
--- a/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExecuteWithoutReadTest.java
@@ -351,7 +351,7 @@ public class RESTExecuteWithoutReadTest {
         xqPool.clear();
 
         assertEquals(HttpStatus.OK_200, get(EXEC_ONLY_VALID, null).status);
-        final CompiledXQuery pooled = peekPooledQuery(EXEC_ONLY_VALID);
+        final CompiledXQuery pooled = awaitPooledQuery(EXEC_ONLY_VALID);
         assertNotNull("the first run leaves a compiled query in the shared pool", pooled);
 
         for (int i = 0; i < 3; i++) {
@@ -359,7 +359,7 @@ public class RESTExecuteWithoutReadTest {
             assertEquals(HttpStatus.OK_200, response.status);
             assertTrue(response.body.contains("<result>6</result>"));
             assertSame("run " + (i + 1) + " must be a pool hit, not an eviction and recompile",
-                    pooled, peekPooledQuery(EXEC_ONLY_VALID));
+                    pooled, awaitPooledQuery(EXEC_ONLY_VALID));
         }
     }
 
@@ -392,7 +392,7 @@ public class RESTExecuteWithoutReadTest {
         xqPool.clear();
 
         assertTrue(get(EXEC_ONLY_STALENESS, null).body.contains("<result>6</result>"));
-        final CompiledXQuery pooled = peekPooledQuery(EXEC_ONLY_STALENESS);
+        final CompiledXQuery pooled = awaitPooledQuery(EXEC_ONLY_STALENESS);
         assertNotNull(pooled);
 
         overwriteQuery(EXEC_ONLY_STALENESS, CHANGED_QUERY, "rwx--x--x");
@@ -401,7 +401,30 @@ public class RESTExecuteWithoutReadTest {
         assertEquals(HttpStatus.OK_200, afterChange.status);
         assertTrue("the changed query is recompiled, not served from the pool: " + afterChange.body,
                 afterChange.body.contains("<result>10</result>"));
-        assertNotSame("the stale entry is evicted", pooled, peekPooledQuery(EXEC_ONLY_STALENESS));
+        assertNotSame("the stale entry is evicted", pooled, awaitPooledQuery(EXEC_ONLY_STALENESS));
+    }
+
+    /**
+     * Polls the shared pool until it holds an entry for {@code uri}, or {@code timeoutMillis} elapses.
+     * A producing request only returns its compiled query to the pool after the response body is
+     * fully serialized, on the server's request-handling thread — which can still be unwinding the
+     * rest of {@code RESTServer#executeXQuery} after the client here has already read the full HTTP
+     * response on a different thread. A synchronous {@link #peekPooledQuery} right after such a
+     * response is therefore inherently racy under load; this absorbs that gap instead.
+     */
+    private static @Nullable CompiledXQuery awaitPooledQuery(final XmldbURI uri, final long timeoutMillis) throws Exception {
+        final long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (true) {
+            final CompiledXQuery compiled = peekPooledQuery(uri);
+            if (compiled != null || System.currentTimeMillis() >= deadline) {
+                return compiled;
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static @Nullable CompiledXQuery awaitPooledQuery(final XmldbURI uri) throws Exception {
+        return awaitPooledQuery(uri, 1000);
     }
 
     /**


### PR DESCRIPTION
### Description:

`RESTExecuteWithoutReadTest` intermittently fails on CI (observed repeatedly on plain `develop`, e.g. runs on 2026-08-08, 2026-08-10 x2, 2026-08-11 — unrelated to any specific PR), always in `aChangedQueryIsRecompiledForAReadBlindCallerToo` or `aReadBlindCallerReusesThePooledQueryInsteadOfEvictingIt`, with `assertNotNull`/`assertSame` failing on `peekPooledQuery(...)`.

Root cause: `RESTServer#executeXQuery` only returns the compiled query to the shared `XQueryPool` after serializing the response and running `context.runCleanupTasks()`, in the outer `finally` — deliberately, since returning it earlier would let a second concurrent caller borrow the same compiled query while this thread is still mutating shared `XQueryContext` state during serialization/cleanup. But the test asserts pool visibility immediately after its HTTP client finishes reading the response, on a *different* thread — there is no happens-before edge between "client observed the response" and "server thread finished its `finally` block", so the assertion races the server's own cleanup. Under CI's more contended scheduling that race occasionally resolves the other way; on an idle dev machine the server thread almost always wins by a wide margin, which is why it doesn't reproduce locally.

This is a test-timing issue, not a production bug, and not safely fixable by reordering the production code (see above).

### What Changed:

- Added `awaitPooledQuery(uri[, timeoutMillis])`, a short bounded poll (10ms interval, default 1s timeout) around the existing `peekPooledQuery` helper.
- Replaced the synchronous `peekPooledQuery` assertions that immediately follow an HTTP round trip in `aReadBlindCallerReusesThePooledQueryInsteadOfEvictingIt` and `aChangedQueryIsRecompiledForAReadBlindCallerToo` with `awaitPooledQuery`.

### Reference:

Discovered while investigating unrelated CI failures on other PRs; found the same failure recurring directly on `develop` CI with no code changes in between, confirming it's a pre-existing flaky test rather than a regression.

### Type of tests:

- Ran `org.exist.http.RESTExecuteWithoutReadTest` locally 4x in a row after the fix, all green (13/13).