### PR TITLE
Fix ci-benchmarks.yml: activate perf-tests profile

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build exist-core-jmh
         run: >
-          mvn -B install -pl exist-core-jmh -am -DskipTests
+          mvn -B install -Pperf-tests -pl exist-core-jmh -am -DskipTests
           -Ddependency-check.skip=true -Ddocker=false
 
       - name: Run exist-core-jmh benchmarks
@@ -69,12 +69,12 @@ jobs:
 
       - name: Build exist-indexes-jmh
         run: >
-          mvn -B install -pl exist-indexes-jmh -am -DskipTests
+          mvn -B install -Pperf-tests -pl exist-indexes-jmh -am -DskipTests
           -Ddependency-check.skip=true -Ddocker=false
 
       - name: Run exist-indexes-jmh benchmarks
         run: >
-          mvn -B exec:exec -pl exist-indexes-jmh
+          mvn -B exec:exec -Pperf-tests -pl exist-indexes-jmh
           -Dbenchmark.args="-rf json -rff target/jmh-result.json ${{ env.JMH_ARGS }}"
 
       - name: Track exist-indexes-jmh results on gh-pages


### PR DESCRIPTION
## Summary

Every run of the JMH Benchmarks workflow (added in #6608) has failed since merge — all three runs (2 scheduled, 1 manual dispatch) fail identically at the first build step:

```
[ERROR] Could not find the selected project in the reactor: exist-core-jmh
```

`exist-core-jmh` / `exist-indexes-jmh` are gated behind the `perf-tests` Maven profile in the root `pom.xml`, not part of the default reactor — `mvn -pl <module>` can't find them without `-Pperf-tests` active.

## Fix

Add `-Pperf-tests` to all three `mvn -pl` invocations that select these modules: both `install -am` build steps, and the `exec:exec` step for `exist-indexes-jmh`. The `java -jar` step for `exist-core-jmh` needs no change — it runs the already-built jar directly, no reactor lookup involved.

## Test plan

- [x] `mvn install -Pperf-tests -pl exist-core-jmh -am -DskipTests` — builds clean
- [x] `mvn install -Pperf-tests -pl exist-indexes-jmh -am -DskipTests` — builds clean
- [x] `mvn exec:exec -Pperf-tests -pl exist-indexes-jmh -Dbenchmark.args="RangeEqWhereClauseBenchmark -wi 1 -i 1 -f 1 -w 3s -r 3s -p termCount=5"` — runs end to end
- [ ] Live `workflow_dispatch` run pending after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)