### PR TITLE
Fix xml:id FORG0001 spam in PrecedingAxisBenchmark

### DIFF
--- a/exist-core-jmh/src/main/java/org/exist/xquery/PrecedingAxisBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/xquery/PrecedingAxisBenchmark.java
@@ -36,8 +36,8 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>craigberry's #2129 follow-up reproduced position-dependence for the
  * wildcard preceding axis on a 50,000-element flat document: a query at
- * {@code @xml:id='45000'} took roughly twice as long as the same query at
- * {@code @xml:id='25000'}. The K-bounded sliding window in
+ * {@code @id='45000'} took roughly twice as long as the same query at
+ * {@code @id='25000'}. The K-bounded sliding window in
  * {@code LocationStep.PrecedingFilter} caps the retained match set at K,
  * eliminating the unbounded accumulation that produced the late-position
  * tax.</p>
@@ -87,7 +87,7 @@ public class PrecedingAxisBenchmark {
 
         xqs.query(
                 """
-                let $words := for $i in (1 to 50000) return <w xml:id="{$i}">{$i}</w>
+                let $words := for $i in (1 to 50000) return <w id="{$i}">{$i}</w>
                 return xmldb:store('/db', 'words-large.xml', document {<words>{$words}</words>})
                 """);
     }
@@ -124,7 +124,7 @@ public class PrecedingAxisBenchmark {
         return xqs.query(
                 ("""
                 xquery version "3.1";
-                let $w := doc('%s')//w[@xml:id='%d']
+                let $w := doc('%s')//w[@id='%d']
                 return for $i in (1 to 5) return $w/preceding::*[5 + 1 - $i][self::w]/text()
                 """).formatted(LARGE_DOC, refPosition)
         ).getSize();
@@ -144,7 +144,7 @@ public class PrecedingAxisBenchmark {
         return xqs.query(
                 ("""
                 xquery version "3.1";
-                let $w := doc('%s')//w[@xml:id='%d']
+                let $w := doc('%s')//w[@id='%d']
                 return for $i in (1 to 5) return $w/preceding-sibling::w[$i]/text()
                 """).formatted(LARGE_DOC, refPosition)
         ).getSize();


### PR DESCRIPTION
## Summary

`ci-benchmarks.yml`'s 2026-08-17 `workflow_dispatch` run hit the 90-minute job timeout, and its log turned out to be **4.3 GB**. Root cause: `PrecedingAxisBenchmark.setUp()` builds a 50,000-element corpus with `<w xml:id="{$i}">`. `xml:id` is typed `xs:ID` (NCName-based), so every bare-digit id (`"1"`, `"2"`, ...) fails cast validation, throwing `err:FORG0001` for every element on every trial `setUp()` — results still came out fine, but each exception logs a full stack trace, and across ~6 trials × 50,000 elements that's the bulk of the log bloat.

## What changed

- `PrecedingAxisBenchmark.java` — corpus now uses a plain (non-`xml`-namespaced) `id` attribute instead of `xml:id`; both benchmark queries' `@xml:id=` predicates updated to `@id=`. The benchmark only needs attribute-equality lookup, not real XML-ID semantics, so this doesn't change what's being measured.

## Test plan

- [x] `mvn install -pl exist-core-jmh -am -Pperf-tests -DskipTests` builds clean
- [x] Ran `PrecedingAxisBenchmark.precedingSiblingBaseline` locally (`-f 1 -wi 1 -i 1 -p refPosition=5000`): clean output, no `FORG0001` spam, ~94ms/op — consistent with the pre-fix timing (~94.7ms/op) recorded in the last CI run before it was cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)