### PR TITLE
[bugfix] Release the stored query's READ_LOCK at end-of-compile over REST and XML-RPC

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -652,8 +652,8 @@ public class RESTServer {
                 serveSource(broker, resource, descriptor, request, response, path, options,
                         outputProperties);
             } else {
-                executeResource(broker, transaction, resource, request, response, path, options,
-                        outputProperties, servletPath);
+                executeResource(broker, transaction, resource, lockedDocument, request, response, path,
+                        options, outputProperties, servletPath);
             }
         } finally {
             if (lockedDocument != null) {
@@ -825,6 +825,8 @@ public class RESTServer {
      * @param broker the database broker
      * @param transaction the database transaction
      * @param resource the resource to execute
+     * @param lockedDocument the read lock held on {@code resource}, released at end-of-compile (#6593);
+     *                       the caller's own close of it afterwards is a no-op
      * @param request the request
      * @param response the response
      * @param path the path of the request
@@ -837,19 +839,19 @@ public class RESTServer {
      * @throws IOException if an I/O error occurs
      */
     private void executeResource(final DBBroker broker, final Txn transaction, final DocumentImpl resource,
-            final HttpServletRequest request, final HttpServletResponse response, final String path,
-            final QueryRequestOptions options, final Properties outputProperties,
+            final LockedDocument lockedDocument, final HttpServletRequest request, final HttpServletResponse response,
+            final String path, final QueryRequestOptions options, final Properties outputProperties,
             final XmldbURI servletPath)
             throws BadRequestException, PermissionDeniedException, IOException {
         final String pathInfo = XmldbURI.create(path).trimFromBeginning(servletPath).toString();
         try {
             if (MimeType.XQUERY_TYPE.getName().equals(resource.getMimeType())) {
                 // Execute the XQuery
-                executeXQuery(broker, transaction, resource, request, response,
+                executeXQuery(broker, transaction, resource, lockedDocument, request, response,
                         outputProperties, servletPath.toString(), pathInfo);
             } else if (MimeType.XPROC_TYPE.getName().equals(resource.getMimeType())) {
                 // Execute the XProc
-                executeXProc(broker, transaction, resource, request, response,
+                executeXProc(broker, transaction, resource, lockedDocument, request, response,
                         outputProperties, servletPath.toString(), pathInfo);
             }
         } catch (final XPathException e) {
@@ -1110,11 +1112,11 @@ public class RESTServer {
                 try {
                     if (MimeType.XQUERY_TYPE.getName().equals(resource.getMimeType())) {
                         // Execute the XQuery
-                        executeXQuery(broker, transaction, resource, request, response,
+                        executeXQuery(broker, transaction, resource, resolved.lockedDocument(), request, response,
                                 outputProperties, resolved.servletPath().toString(), pathInfo);
                     } else {
                         // Execute the XProc
-                        executeXProc(broker, transaction, resource, request, response,
+                        executeXProc(broker, transaction, resource, resolved.lockedDocument(), request, response,
                                 outputProperties, resolved.servletPath().toString(), pathInfo);
                     }
 
@@ -1673,7 +1675,7 @@ public class RESTServer {
         final Properties outputProperties = new Properties(defaultOutputKeysProperties);
         try {
             // Execute the XQuery
-            executeXQuery(broker, transaction, resolved.resource(), request, response,
+            executeXQuery(broker, transaction, resolved.resource(), resolved.lockedDocument(), request, response,
                     outputProperties, resolved.servletPath().toString(), pathInfo);
         } catch (final XPathException e) {
             writeXPathExceptionHtml(response, HttpServletResponse.SC_BAD_REQUEST, DEFAULT_ENCODING, null, path.toString(), e);
@@ -2123,10 +2125,18 @@ public class RESTServer {
     /**
      * Directly execute an XQuery stored as a binary document in the database.
      *
+     * The document READ_LOCK held on the query by {@code lockedDocument} is only needed for a
+     * consistent snapshot across resolution, permission evaluation and compilation: it is
+     * released here as soon as a compiled query is obtained — never held through execution or
+     * result serialization, where the executor may block on further collection/document locks
+     * while a concurrent store of the query blocks on this one (#6593). Closing it again in a
+     * caller's {@code finally} is a harmless no-op, and covers the paths that fail before or
+     * during compilation.
+     *
      * @throws PermissionDeniedException
      */
     private void executeXQuery(final DBBroker broker, final Txn transaction, final DocumentImpl resource,
-            final HttpServletRequest request, final HttpServletResponse response,
+            final LockedDocument lockedDocument, final HttpServletRequest request, final HttpServletResponse response,
             final Properties outputProperties, final String servletPath, final String pathInfo)
             throws XPathException, BadRequestException, PermissionDeniedException {
 
@@ -2172,16 +2182,21 @@ public class RESTServer {
 
             try {
                 final long compilationTime;
-                if (compiled == null) {
-                    try {
-                        final long compilationStart = System.currentTimeMillis();
-                        compiled = xquery.compile(context, source);
-                        compilationTime = System.currentTimeMillis() - compilationStart;
-                    } catch (final IOException e) {
-                        throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
+                try {
+                    if (compiled == null) {
+                        try {
+                            final long compilationStart = System.currentTimeMillis();
+                            compiled = xquery.compile(context, source);
+                            compilationTime = System.currentTimeMillis() - compilationStart;
+                        } catch (final IOException e) {
+                            throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
+                        }
+                    } else {
+                        compilationTime = 0;
                     }
-                } else {
-                    compilationTime = 0;
+                } finally {
+                    // compiled (or failed to): the query document's lock has done its job (#6593)
+                    lockedDocument.close();
                 }
 
                 DebuggeeFactory.checkForDebugRequest(request, context);
@@ -2221,10 +2236,15 @@ public class RESTServer {
     /**
      * Directly execute an XProc stored as a XML document in the database.
      *
+     * As in {@link #executeXQuery(DBBroker, Txn, DocumentImpl, LockedDocument, HttpServletRequest,
+     * HttpServletResponse, Properties, String, String)}, the READ_LOCK held on the pipeline
+     * document by {@code lockedDocument} is released once the driver query is compiled, before
+     * execution begins (#6593).
+     *
      * @throws PermissionDeniedException
      */
     private void executeXProc(final DBBroker broker, final Txn transaction, final DocumentImpl resource,
-            final HttpServletRequest request, final HttpServletResponse response,
+            final LockedDocument lockedDocument, final HttpServletRequest request, final HttpServletResponse response,
             final Properties outputProperties, final String servletPath, final String pathInfo)
             throws XPathException, BadRequestException, PermissionDeniedException {
 
@@ -2259,17 +2279,22 @@ public class RESTServer {
             reqw.setPathInfo(pathInfo);
 
             final long compilationTime;
-            if (compiled == null) {
-                try {
-                    final long compilationStart = System.currentTimeMillis();
-                    compiled = xquery.compile(context, source);
-                    compilationTime = System.currentTimeMillis() - compilationStart;
-                } catch (final IOException e) {
-                    throw new BadRequestException("Failed to read query from "
-                            + source.getURL(), e);
+            try {
+                if (compiled == null) {
+                    try {
+                        final long compilationStart = System.currentTimeMillis();
+                        compiled = xquery.compile(context, source);
+                        compilationTime = System.currentTimeMillis() - compilationStart;
+                    } catch (final IOException e) {
+                        throw new BadRequestException("Failed to read query from "
+                                + source.getURL(), e);
+                    }
+                } else {
+                    compilationTime = 0;
                 }
-            } else {
-                compilationTime = 0;
+            } finally {
+                // compiled (or failed to): the pipeline document's lock has done its job (#6593)
+                lockedDocument.close();
             }
 
             try {

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -1997,17 +1997,8 @@ public class RpcConnection implements RpcAPI {
 
         final Optional<String> sortBy = Optional.ofNullable(parameters.get(RpcAPI.SORT_EXPR)).map(Object::toString);
 
-        return this.<Map<String, Object>>readDocument(XmldbURI.createInternal(pathToQuery)).apply((document, broker, transaction) -> {
-            final BinaryDocument xquery = (BinaryDocument) document;
-            if (xquery.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new EXistException("Document " + pathToQuery + " is not a binary resource");
-            }
-
-            if (!xquery.getPermissions().validate(user, Permission.READ | Permission.EXECUTE)) {
-                throw new PermissionDeniedException("Insufficient privileges to access resource");
-            }
-
-            final Source source = new DBSource(broker.getBrokerPool(), xquery, true);
+        return withDb((broker, transaction) -> {
+            final Source source = resolveStoredXQuery(broker, transaction, pathToQuery);
 
             try {
                 final Map<String, Object> rpcResponse = this.<Map<String, Object>>compileQuery(broker, transaction, source, parameters)
@@ -2025,17 +2016,8 @@ public class RpcConnection implements RpcAPI {
 
         final Optional<String> sortBy = Optional.ofNullable(parameters.get(RpcAPI.SORT_EXPR)).map(Object::toString);
 
-        return this.<Map<String, Object>>readDocument(XmldbURI.createInternal(pathToQuery)).apply((document, broker, transaction) -> {
-            final BinaryDocument xquery = (BinaryDocument) document;
-            if (xquery.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new EXistException("Document " + pathToQuery + " is not a binary resource");
-            }
-
-            if (!xquery.getPermissions().validate(user, Permission.READ | Permission.EXECUTE)) {
-                throw new PermissionDeniedException("Insufficient privileges to access resource");
-            }
-
-            final Source source = new DBSource(broker.getBrokerPool(), xquery, true);
+        return withDb((broker, transaction) -> {
+            final Source source = resolveStoredXQuery(broker, transaction, pathToQuery);
 
             try {
                 final Map<String, Object> rpcResponse = this.<Map<String, Object>>compileQuery(broker, transaction, source, parameters)
@@ -2044,6 +2026,36 @@ public class RpcConnection implements RpcAPI {
             } catch (final XPathException e) {
                 throw new EXistException(e);
             }
+        });
+    }
+
+    /**
+     * Resolves a stored XQuery to a {@link Source}, holding the document READ_LOCK only while
+     * the document is resolved and its permissions are checked. The lock is released on return,
+     * before the query is compiled and executed: holding the query document's lock while the
+     * executor goes on to acquire further collection/document locks is one edge of the
+     * save-while-running deadlock (#6593).
+     *
+     * @param broker the broker to use for the operation
+     * @param transaction the transaction to use for the operation
+     * @param pathToQuery the database path of the stored query
+     *
+     * @return the source of the stored query
+     *
+     * @throws EXistException if the document is missing or is not a binary resource
+     * @throws PermissionDeniedException if the current user may not execute the stored query
+     */
+    private Source resolveStoredXQuery(final DBBroker broker, final Txn transaction, final String pathToQuery) throws EXistException, PermissionDeniedException {
+        return this.<Source>readDocument(broker, transaction, XmldbURI.createInternal(pathToQuery)).apply((document, broker1, transaction1) -> {
+            if (document.getResourceType() != DocumentImpl.BINARY_FILE) {
+                throw new EXistException("Document " + pathToQuery + " is not a binary resource");
+            }
+
+            if (!document.getPermissions().validate(user, Permission.READ | Permission.EXECUTE)) {
+                throw new PermissionDeniedException("Insufficient privileges to access resource");
+            }
+
+            return new DBSource(broker1.getBrokerPool(), (BinaryDocument) document, true);
         });
     }
 

--- a/exist-core/src/test/java/org/exist/http/StoredQueryLockReleaseTest.java
+++ b/exist-core/src/test/java/org/exist/http/StoredQueryLockReleaseTest.java
@@ -1,0 +1,292 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.xmlrpc.client.XmlRpcClient;
+import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+import org.exist.collections.Collection;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.lock.LockTable;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.test.ExistWebServer;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The document READ_LOCK taken on a stored XQuery to resolve and compile it must be released at
+ * end-of-compile — never held through execution and result serialization. An executor which parks
+ * on further collection/document locks while holding the query document's shared lock is one
+ * required edge of the save-while-running deadlock family, and it also means a concurrent store of
+ * that query blocks until the execution finishes.
+ *
+ * Each test runs a stored query which signals that its execution phase has begun (by storing a
+ * marker document) and then polls for a release document; while it is parked, the test asserts
+ * that no lock is still held on the query document, stores a new version of the very query being
+ * executed — which must complete immediately — and only then releases the executor, which finishes
+ * on the old source.
+ *
+ * See https://github.com/eXist-db/exist/issues/6593
+ */
+public class StoredQueryLockReleaseTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("storedQueryLockRelease");
+
+    private static final XmldbURI REST_QUERY = TEST_COLLECTION.append("slow-rest.xq");
+    private static final XmldbURI REST_STARTED = TEST_COLLECTION.append("started-rest.xml");
+    private static final XmldbURI REST_RELEASE = TEST_COLLECTION.append("release-rest.xml");
+
+    private static final XmldbURI RPC_QUERY = TEST_COLLECTION.append("slow-rpc.xq");
+    private static final XmldbURI RPC_STARTED = TEST_COLLECTION.append("started-rpc.xml");
+    private static final XmldbURI RPC_RELEASE = TEST_COLLECTION.append("release-rpc.xml");
+
+    private static final String NEW_QUERY = "xquery version \"3.1\";\n\"new\"";
+
+    private static ExecutorService executor;
+    private static String credentials;
+
+    /**
+     * Stores a marker document to signal that its execution phase (and therefore its compilation)
+     * has finished, then parks polling for a release document, so the test fully controls how long
+     * the execution phase lasts. The poll is bounded so that a deadlocked run under a regressed
+     * server fails instead of hanging forever.
+     */
+    private static String awaitQuery(final XmldbURI startedUri, final XmldbURI releaseUri) {
+        return "xquery version \"3.1\";\n" +
+                "declare function local:await($tries as xs:integer) as xs:string {\n" +
+                "    if (doc-available('" + releaseUri + "')) then 'old'\n" +
+                "    else if ($tries le 0) then 'timeout'\n" +
+                "    else (util:wait(25), local:await($tries - 1))\n" +
+                "};\n" +
+                "let $started := xmldb:store('" + startedUri.removeLastSegment() + "', '" + startedUri.lastSegment() + "', <started/>)\n" +
+                "return local:await(600)";
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        executor = Executors.newCachedThreadPool();
+        credentials = Base64.encodeBase64String("admin:".getBytes(UTF_8));
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
+                broker.saveCollection(transaction, collection);
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test(timeout = 60_000)
+    public void restSaveDuringExecutionCompletes() throws Exception {
+        store(REST_QUERY, awaitQuery(REST_STARTED, REST_RELEASE), MimeType.XQUERY_TYPE);
+
+        final Future<Response> running = executor.submit(() -> get(REST_QUERY));
+        try {
+            awaitDocumentExists(REST_STARTED);
+
+            // compilation is over, execution has begun: the executor must no longer hold the
+            // query document's READ_LOCK
+            assertNoLockHeldOn(REST_QUERY);
+
+            // the #5916 hang edge: storing a new version of the query being executed must
+            // complete immediately, not block until the execution finishes
+            final Future<?> save = executor.submit(() -> {
+                store(REST_QUERY, NEW_QUERY, MimeType.XQUERY_TYPE);
+                return null;
+            });
+            save.get(10, TimeUnit.SECONDS);
+            assertFalse("the save must not have waited for the execution to finish", running.isDone());
+        } finally {
+            // whatever happened above, un-park the executing query
+            store(REST_RELEASE, "<release/>", MimeType.XML_TYPE);
+        }
+
+        final Response response = running.get(30, TimeUnit.SECONDS);
+        assertEquals(200, response.status);
+        assertTrue("the in-flight execution finishes on the old source: " + response.body,
+                response.body.contains("old"));
+
+        final Response after = get(REST_QUERY);
+        assertEquals(200, after.status);
+        assertTrue("the next execution runs the newly stored version: " + after.body,
+                after.body.contains("new"));
+    }
+
+    @Test(timeout = 60_000)
+    public void xmlRpcSaveDuringExecutionCompletes() throws Exception {
+        store(RPC_QUERY, awaitQuery(RPC_STARTED, RPC_RELEASE), MimeType.XQUERY_TYPE);
+
+        final Future<Map<String, Object>> running = executor.submit(() -> executeStoredQuery(RPC_QUERY));
+        try {
+            awaitDocumentExists(RPC_STARTED);
+
+            assertNoLockHeldOn(RPC_QUERY);
+
+            final Future<?> save = executor.submit(() -> {
+                store(RPC_QUERY, NEW_QUERY, MimeType.XQUERY_TYPE);
+                return null;
+            });
+            save.get(10, TimeUnit.SECONDS);
+            assertFalse("the save must not have waited for the execution to finish", running.isDone());
+        } finally {
+            store(RPC_RELEASE, "<release/>", MimeType.XML_TYPE);
+        }
+
+        final Map<String, Object> response = running.get(30, TimeUnit.SECONDS);
+        assertNull("the in-flight execution succeeds: " + response, response.get("error"));
+        assertEquals("the in-flight execution finishes on the old source: " + response,
+                "old", singleTypedResult(response));
+
+        final Map<String, Object> after = executeStoredQuery(RPC_QUERY);
+        assertEquals("the next execution runs the newly stored version: " + after,
+                "new", singleTypedResult(after));
+    }
+
+    /**
+     * Asserts that no thread holds a lock on {@code uri} right now. While the stored query is in
+     * its execution phase the only candidate holder is the request thread executing it, so this
+     * pins down the #6593 invariant: the query document's READ_LOCK is released at end-of-compile.
+     */
+    private static void assertNoLockHeldOn(final XmldbURI uri) {
+        final LockTable lockTable = existEmbeddedServer.getBrokerPool().getLockManager().getLockTable();
+        assertFalse("no lock on " + uri + " may outlive the compilation of the query",
+                lockTable.getAcquired().containsKey(uri.toString()));
+    }
+
+    private static void awaitDocumentExists(final XmldbURI uri) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final long deadline = System.currentTimeMillis() + 30_000;
+        while (true) {
+            try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                 final LockedDocument locked = broker.getXMLResource(uri, LockMode.READ_LOCK)) {
+                if (locked != null) {
+                    return;
+                }
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Timed out waiting for " + uri + " — the stored query never reached its execution phase");
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static void store(final XmldbURI uri, final String content, final MimeType mimeType) throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            try (final Collection collection = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK)) {
+                broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(content.getBytes(UTF_8)),
+                        mimeType, collection);
+            }
+            transaction.commit();
+        }
+    }
+
+    /**
+     * Unpacks the value of the single item of an {@code executeT} response.
+     */
+    private static String singleTypedResult(final Map<String, Object> response) {
+        final Object[] results = (Object[]) response.get("results");
+        assertEquals("expected a single result item: " + response, 1, results.length);
+        @SuppressWarnings("unchecked")
+        final Map<String, String> item = (Map<String, String>) results[0];
+        return item.get("value");
+    }
+
+    private static Map<String, Object> executeStoredQuery(final XmldbURI uri) throws Exception {
+        final XmlRpcClient client = new XmlRpcClient();
+        final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+        config.setEnabledForExtensions(true);
+        config.setServerURL(new URL("http://localhost:" + existWebServer.getPort() + "/xmlrpc"));
+        config.setBasicUserName("admin");
+        config.setBasicPassword("");
+        client.setConfig(config);
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> result = (Map<String, Object>) client.execute("executeT",
+                Arrays.asList(uri.toString(), new HashMap<String, Object>()));
+        return result;
+    }
+
+    private static Response get(final XmldbURI uri) throws Exception {
+        final String path = "http://localhost:" + existWebServer.getPort() + "/rest" + uri;
+
+        final HttpURLConnection connection = (HttpURLConnection) new URL(path).openConnection();
+        try {
+            connection.setRequestProperty("Authorization", "Basic " + credentials);
+            connection.setRequestMethod("GET");
+            connection.connect();
+
+            final int status = connection.getResponseCode();
+            final InputStream is = status < 400 ? connection.getInputStream() : connection.getErrorStream();
+            final String body = is == null ? "" : new String(is.readAllBytes(), UTF_8);
+
+            return new Response(status, body);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private record Response(int status, String body) {
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/StoredQueryLockReleaseTest.java
+++ b/exist-core/src/test/java/org/exist/http/StoredQueryLockReleaseTest.java
@@ -104,14 +104,16 @@ public class StoredQueryLockReleaseTest {
      * server fails instead of hanging forever.
      */
     private static String awaitQuery(final XmldbURI startedUri, final XmldbURI releaseUri) {
-        return "xquery version \"3.1\";\n" +
-                "declare function local:await($tries as xs:integer) as xs:string {\n" +
-                "    if (doc-available('" + releaseUri + "')) then 'old'\n" +
-                "    else if ($tries le 0) then 'timeout'\n" +
-                "    else (util:wait(25), local:await($tries - 1))\n" +
-                "};\n" +
-                "let $started := xmldb:store('" + startedUri.removeLastSegment() + "', '" + startedUri.lastSegment() + "', <started/>)\n" +
-                "return local:await(600)";
+        return """
+                xquery version "3.1";
+                declare function local:await($tries as xs:integer) as xs:string {
+                    if (doc-available('%s')) then 'old'
+                    else if ($tries le 0) then 'timeout'
+                    else (util:wait(25), local:await($tries - 1))
+                };
+                let $started := xmldb:store('%s', '%s', <started/>)
+                return local:await(600)"""
+                .formatted(releaseUri, startedUri.removeLastSegment(), startedUri.lastSegment());
     }
 
     @BeforeClass


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #6635** — the first commit here is that PR's test-timing fix (`RESTExecuteWithoutReadTest` touches the same `RESTServer#executeXQuery` area). Please merge #6635 first; this PR then reduces to its own single commit. Review only the last commit: b332fbf60a.

### Description:

When a stored XQuery is executed over **REST** or **XML-RPC**, the document READ_LOCK acquired to resolve and compile the query was held for the **entire request** — through execution *and* result serialization — instead of being released once compilation is done. An executor that parks on further collection/document locks while holding the query document's shared lock is one required edge of the save-while-running deadlock family (#5916, #4022, #4233), and it also meant that storing a new version of a query blocked until every in-flight execution of it had finished. All other stored-query paths (`XQueryServlet`, RESTXQ, `import module` from db) already release the lock at or before end-of-compile.

**Invariant established:** the document READ_LOCK on a stored XQuery is held at most for *resolution + compilation* and is released immediately after compilation returns (or after a pool hit makes compilation unnecessary). It is never held during execution or result serialization.

### What Changed:

- **REST** (`RESTServer`): `executeXQuery` / `executeXProc` now receive the `LockedDocument` from their callers (`serveResource`/`executeResource`, `executePostExecutable`, `checkForXQueryTarget`) and close it in a `finally` around the compile block — after `pool.borrowCompiledXQuery` hits, or right after `xquery.compile` returns or throws — **before** `xquery.execute` and `writeResults`. The caller-side `finally` blocks are kept unchanged as a backstop for paths that fail before execution; `ManagedLock#close` is idempotent, so the second close is a no-op.
- **XML-RPC** (`RpcConnection`): `execute` / `executeT` no longer wrap compile + execute in `readDocument(...)`. A new `resolveStoredXQuery` helper resolves the document, checks `READ | EXECUTE`, and builds the `DBSource` under the READ_LOCK, which is released on return; the query is compiled and run outside the locked scope. Side fix: the old code cast to `BinaryDocument` *before* the binary-type check, so pointing `execute` at an XML document threw a raw `ClassCastException` — it now throws the intended "is not a binary resource" `EXistException`.

### Behaviour change (release note):

Storing a query that is currently executing via REST or XML-RPC no longer blocks until the execution finishes: the store completes immediately and the in-flight execution continues on the old source (blob refcounting keeps the old bytes alive). This matches the long-standing behaviour of app requests via `XQueryServlet`.

### Reference:

Closes https://github.com/eXist-db/exist/issues/6593
Deadlock family: #5916, #4022, #4233. Related: #6586, #6594.

### Type of tests:

New JUnit integration test `org.exist.http.StoredQueryLockReleaseTest` covering both interfaces. A stored query signals the start of its execution phase by storing a marker document, then parks polling for a release document; the test asserts via `LockTable` that no lock on the query document outlives compilation, stores a new version of the very query being executed (must complete immediately — the #5916 hang edge), then releases the executor and checks it finishes on the old source while the next run picks up the new one. Verified **red on unpatched code** (both tests fail at the lock assertion, which is deliberately placed before the concurrent save so a regressed server fails cleanly instead of deadlocking CI) and **green with the fix**.

Regression suites run locally, all green: `StoredQueryLockReleaseTest` (2), `RESTExecuteWithoutReadTest` (13), `RESTServiceTest` (47), `XmlRpcTest` (46), `XMLDBSecurityTest` (174), `ExecuteWithoutReadTest` (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pfpnr2M2v9c6XNvC9bssh