### PR TITLE
[ci] Pin oci-artifact=false so Docker Hub/Scout can ingest published images

### DIFF
--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -142,7 +142,12 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile
           platforms: linux/amd64,linux/arm64
-          outputs: type=image,oci-mediatypes=true,oci-artifact=true,push=true
+          # oci-artifact must stay false: Docker Hub/Scout ingestion drops
+          # subject-bearing artifact-style attestation manifests (empty config,
+          # vnd.oci.empty.v1+json), so images pushed with oci-artifact=true get
+          # no Scout analysis at all. BuildKit >=0.32 defaults it to true when
+          # oci-mediatypes=true, hence the explicit pin.
+          outputs: type=image,oci-mediatypes=true,oci-artifact=false,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha
@@ -156,7 +161,8 @@ jobs:
           context: exist-docker/target/exist-docker-${{ steps.ver.outputs.version }}-docker-dir
           file: exist-docker/target/classes/Dockerfile-DEBUG
           platforms: linux/amd64,linux/arm64
-          outputs: type=image,oci-mediatypes=true,oci-artifact=true,push=true
+          # oci-artifact=false: see comment on the main image push above.
+          outputs: type=image,oci-mediatypes=true,oci-artifact=false,push=true
           provenance: mode=max
           sbom: true
           cache-from: type=gha


### PR DESCRIPTION
### Description:

Docker Scout's web platform reports **"No data" on every policy for every image published since 2026-08-11**. Root cause: 3d2d990b1d + 1dab6f9fe0 switched the staging pushes to `oci-artifact=true`, which makes BuildKit publish SBOM/provenance as OCI 1.1 *artifact-style* attestation manifests (`artifactType`, `subject` descriptor, empty `application/vnd.oci.empty.v1+json` config). Docker Hub's ingestion cannot handle that format: the tag's image list on Hub silently loses its attestation-manifest rows, and Scout's platform-side analysis never runs for the index.

This PR keeps `oci-mediatypes=true` but pins `oci-artifact=false` explicitly (BuildKit ≥ 0.32 defaults it to true whenever OCI media types are requested — which is exactly how this slipped in), restoring the legacy attestation-manifest format that Hub/Scout demonstrably ingest. `provenance: mode=max` and `sbom: true` are unchanged.

Evidence:

- **Hub metadata drop**: `existdb/existdb:7.0.0-beta3` (legacy format, June 2026) keeps all 4 manifest rows on Hub incl. the two `unknown/unknown` attestation rows; all tags pushed since the switch (`latest`, `latest-staging`, `7.0.0-SNAPSHOT`, …) list only the 2 arch rows — attestations silently dropped.
- **Control case**: `library/nginx:latest` (pushed 2026-08-05) still publishes legacy-format attestations, and Hub registers all 16 manifest rows. Docker's own official images do not use `oci-artifact`.
- **The images themselves are fine**: `docker scout quickview registry://existdb/existdb:latest` evaluates all 7 policies locally (SBOM/provenance obtained from attestation), and `docker scout push --dry-run` processes the index without error — the gap is purely in the platform's automatic Hub ingestion. The registry side is also correct (valid OCI index, working Referrers API), which disproves the Referrers-discovery rationale of 3d2d990b1d: nginx is discovered fine without a subject descriptor.
- The `-staging` and promoted tags share one index digest, so the `imagetools` promote step is not a factor.

Verification plan: after this merges and the next develop publish runs, the new `latest` digest should regain its attestation rows on Hub and appear with policy results in the Scout dashboard. (Note: the Scout dashboard *Policies* page is deprecated and retires 2026-09-01 — worth adding a CLI-side `docker scout policy` gate to CI regardless, but that is out of scope here.)

### Reference:

Follow-up to #6543; amends 3d2d990b1d and 1dab6f9fe0.

### Type of tests:

CI workflow change only — verified against the live registry/Hub/Scout state as described above; no code or unit tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3ijgq42qx821xy4JiAZUE
