### PR TITLE
[bugfix] Guard against null Path.of(getRealPath()/getPathTranslated()) across servlet/urlrewrite code

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/RedirectorServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/RedirectorServlet.java
@@ -160,6 +160,11 @@ public class RedirectorServlet extends AbstractExistHttpServlet {
             }
         // Try to find the XQuery
         final String qpath = getServletContext().getRealPath(query);
+        // the Servlet API permits getRealPath() to return null when the webapp is not exploded
+        // on disk (e.g. served from a packed/embedded context).
+        if (qpath == null) {
+            throw new ServletException("Cannot read XQuery source from " + query);
+        }
         final Path p = Path.of(qpath);
         if (!(Files.isReadable(p) && Files.isRegularFile(p))) {
             throw new ServletException("Cannot read XQuery source from " + p.toAbsolutePath());

--- a/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XQueryServlet.java
@@ -240,12 +240,17 @@ public class XQueryServlet extends AbstractExistHttpServlet {
     protected void process(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         //first, adjust the path
         String path = request.getPathTranslated();
-        if(path == null) {
-            path = request.getRequestURI().substring(request.getContextPath().length());
-            final int p = path.lastIndexOf(';');
+        // the request path relative to the context, e.g. "/db/apps/optimize.xql" -- kept around
+        // (regardless of whether pathTranslated already gave us a disk path) so that a request
+        // which cannot be resolved to a file on disk can still be tried against the database.
+        String contextRelativePath = request.getRequestURI().substring(request.getContextPath().length());
+        {
+            final int p = contextRelativePath.lastIndexOf(';');
             if(p != Constants.STRING_NOT_FOUND)
-                {path = path.substring(0, p);}
-            path = getServletContext().getRealPath(path);
+                {contextRelativePath = contextRelativePath.substring(0, p);}
+        }
+        if(path == null) {
+            path = getServletContext().getRealPath(contextRelativePath);
         }
         
         //second, perform descriptor actions
@@ -358,18 +363,32 @@ public class XQueryServlet extends AbstractExistHttpServlet {
                 sendError(output, "Error", e.getMessage());
             }
         } else {
-            final Path f = Path.of(path);
-            if(!Files.isReadable(f)) {
-                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                sendError(output, "Cannot read source file", path);
-                return;
+            final Path f = path == null ? null : Path.of(path);
+            if (f != null && Files.isReadable(f)) {
+                source = new FileSource(f, Charset.forName(encoding), true);
+            } else {
+                // No readable file on disk (or no disk path at all -- the Servlet API allows both
+                // HttpServletRequest#getPathTranslated() and ServletContext#getRealPath(String) to
+                // return null, which happens e.g. for a request forwarded to a resource that only
+                // exists in the database). Fall back to resolving it there before giving up.
+                // See https://github.com/eXist-db/exist/issues/6615
+                try (final DBBroker broker = getPool().get(Optional.ofNullable(user))) {
+                    source = SourceFactory.getSourceForExecution(broker, null, contextRelativePath, true);
+                } catch (final EXistException | IOException | PermissionDeniedException e) {
+                    getLog().error(e.getMessage(), e);
+                }
+                if (source == null) {
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    sendError(output, "Cannot read source file", path != null ? path : contextRelativePath);
+                    return;
+                }
             }
-            source = new FileSource(f, Charset.forName(encoding), true);
         }
-        
+
         if (source == null) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             sendError(output, "Source not found", path);
+            return;
         }
         
         boolean reportErrors = false;

--- a/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
@@ -48,6 +48,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
+import javax.annotation.Nullable;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -229,7 +230,8 @@ public class XSLTServlet extends HttpServlet {
                 } else if (uri.startsWith("xmldb:exist://")) {
                     baseUri = XmldbURI.xmldbUriFor(uri).getCollectionPath();
                 } else {
-                    baseUri = getCurrentDir(request).toAbsolutePath().toString();
+                    final Path currentDir = getCurrentDir(request);
+                    baseUri = currentDir == null ? null : currentDir.toAbsolutePath().toString();
                 }
                 xinclude.setModuleLoadPath(baseUri);
 
@@ -321,7 +323,13 @@ public class XSLTServlet extends HttpServlet {
 
                 } else {
                     // relative path is relative to the current working directory
-                    f = getCurrentDir(request).resolve(stylesheet);
+                    final Path currentDir = getCurrentDir(request);
+                    if (currentDir == null) {
+                        response.sendError(HttpServletResponse.SC_NOT_FOUND,
+                                "Stylesheet not found (URL: " + stylesheet + ")");
+                        return null;
+                    }
+                    f = currentDir.resolve(stylesheet);
                     stylesheet = f.toUri().toASCIIString();
                 }
 
@@ -339,7 +347,7 @@ public class XSLTServlet extends HttpServlet {
     /*
      * Please explain what this method is about. Write about assumptions / input.
      */
-    private Path getCurrentDir(HttpServletRequest request) {
+    private @Nullable Path getCurrentDir(HttpServletRequest request) {
         String path = request.getPathTranslated();
         if (path == null) {
             path = request.getRequestURI().substring(request.getContextPath().length());
@@ -348,6 +356,12 @@ public class XSLTServlet extends HttpServlet {
                 path = path.substring(0, p);
             }
             path = getServletContext().getRealPath(path);
+            // the Servlet API permits both getPathTranslated() and getRealPath() to return null
+            // when the container cannot map the request to a location on disk (e.g. a request
+            // forwarded to a database-only resource); there is no directory to report.
+            if (path == null) {
+                return null;
+            }
         }
 
         final Path file = Path.of(path).normalize();

--- a/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
@@ -347,7 +347,8 @@ public class XSLTServlet extends HttpServlet {
     /*
      * Please explain what this method is about. Write about assumptions / input.
      */
-    private @Nullable Path getCurrentDir(HttpServletRequest request) {
+    // package-private rather than private so it is directly testable without reflection
+    @Nullable Path getCurrentDir(HttpServletRequest request) {
         String path = request.getPathTranslated();
         if (path == null) {
             path = request.getRequestURI().substring(request.getContextPath().length());

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/RewriteConfig.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/RewriteConfig.java
@@ -185,11 +185,17 @@ public class RewriteConfig {
             }
         } else {
             try {
-                final Path d = Path.of(urlRewrite.getConfig().getServletContext().getRealPath("/")).normalize();
-                final Path configFile = d.resolve(controllerConfig);
-                if (Files.isReadable(configFile)) {
-                    final Document doc = parseConfig(configFile);
-                    parse(doc);
+                final String rootRealPath = urlRewrite.getConfig().getServletContext().getRealPath("/");
+                // the Servlet API permits getRealPath() to return null when the webapp is not
+                // exploded on disk (e.g. served from a packed/embedded context); in that case
+                // there is no filesystem controller-config.xml to load.
+                if (rootRealPath != null) {
+                    final Path d = Path.of(rootRealPath).normalize();
+                    final Path configFile = d.resolve(controllerConfig);
+                    if (Files.isReadable(configFile)) {
+                        final Document doc = parseConfig(configFile);
+                        parse(doc);
+                    }
                 }
             } catch (final ParserConfigurationException | IOException | SAXException e) {
                 throw new ServletException("Failed to parse controller.xml: " + e.getMessage(), e);

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -863,6 +863,12 @@ public class XQueryURLRewrite extends HttpServlet {
 
     private SourceInfo findSourceFromFs(final String basePath, final String[] components) {
         final String realPath = config.getServletContext().getRealPath(basePath);
+        // the Servlet API permits getRealPath() to return null when the container cannot map
+        // basePath to a location on disk; there is no filesystem controller to find.
+        if (realPath == null) {
+            LOG.warn("Base path for XQueryURLRewrite does not point to a directory");
+            return null;
+        }
         final Path baseDir = Path.of(realPath);
         if (!Files.isDirectory(baseDir)) {
             LOG.warn("Base path for XQueryURLRewrite does not point to a directory");

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -1200,10 +1200,7 @@ public class XQueryURLRewrite extends HttpServlet {
         public String getPathTranslated() {
             final String pathInfo = getPathInfo();
             if (pathInfo == null) {
-                super.getPathTranslated();
-            }
-            if (pathInfo == null) {
-                return (null);
+                return super.getPathTranslated();
             }
             return super.getSession().getServletContext().getRealPath(pathInfo);
         }

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -861,7 +861,8 @@ public class XQueryURLRewrite extends HttpServlet {
         return findDbControllerXql(broker, collectionUri, subResourceUri);
     }
 
-    private SourceInfo findSourceFromFs(final String basePath, final String[] components) {
+    // package-private rather than private so it is directly testable without reflection
+    SourceInfo findSourceFromFs(final String basePath, final String[] components) {
         final String realPath = config.getServletContext().getRealPath(basePath);
         // the Servlet API permits getRealPath() to return null when the container cannot map
         // basePath to a location on disk; there is no filesystem controller to find.

--- a/exist-core/src/test/java/org/exist/http/servlets/XQueryServletNullPathTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/XQueryServletNullPathTest.java
@@ -1,0 +1,206 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.servlets;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.collections.Collection;
+import org.exist.security.PermissionFactory;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for <a href="https://github.com/eXist-db/exist/issues/6615">eXist-db/exist#6615</a>.
+ * <p>
+ * The Servlet API explicitly allows {@link HttpServletRequest#getPathTranslated()} and
+ * {@link ServletContext#getRealPath(String)} to return {@code null} when the container cannot map
+ * the request to a location on disk -- which is exactly what happens for a request that is forwarded
+ * (e.g. via {@code <exist:forward>}) to a resource that only exists in the database. Before the fix,
+ * {@link XQueryServlet#process(HttpServletRequest, HttpServletResponse)} passed that {@code null}
+ * straight into {@link java.nio.file.Path#of(String, String...)}, which throws an unhandled
+ * {@link NullPointerException} that surfaces to the client as a raw HTTP 500.
+ */
+public class XQueryServletNullPathTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private static final XmldbURI TEST_COLLECTION = XmldbURI.create("/db/apps/xqueryservlet-null-path-test");
+    private static final XmldbURI TEST_RESOURCE = TEST_COLLECTION.append("optimize.xql");
+    private static final String TEST_QUERY = "xquery version \"3.1\"; <ok/>";
+
+    /** Stores a resource ONLY in the database -- there is deliberately no file on disk for it. */
+    @BeforeClass
+    public static void storeDatabaseOnlyResource() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION)) {
+                collection.getPermissions().setMode("rwxr-xr-x");
+                broker.saveCollection(transaction, collection);
+                broker.storeDocument(transaction, TEST_RESOURCE.lastSegment(),
+                        new StringInputSource(TEST_QUERY.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
+            }
+            PermissionFactory.chmod_str(broker, transaction, TEST_RESOURCE, Optional.of("rwxr-xr-x"), Optional.empty());
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void nullPathTranslatedFallsBackToDatabaseResourceAndExecutesIt() throws Exception {
+        final XQueryServlet servlet = newInitializedServlet();
+
+        // Simulates a request forwarded to the database-only resource stored above: as in the
+        // previous test, neither getPathTranslated() nor getRealPath() can resolve a disk path.
+        final HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        expect(request.getPathTranslated()).andReturn(null).anyTimes();
+        expect(request.getRequestURI()).andReturn("/exist" + TEST_RESOURCE).anyTimes();
+        expect(request.getContextPath()).andReturn("/exist").anyTimes();
+        expect(request.getMethod()).andReturn("GET").anyTimes();
+        expect(request.getParameterMap()).andReturn(java.util.Collections.emptyMap()).anyTimes();
+        replay(request);
+
+        final RecordingResponse response = new RecordingResponse();
+
+        servlet.process(request, response);
+
+        assertEquals("body: " + response.getBodyAsString(), HttpServletResponse.SC_OK, response.getStatus());
+        assertTrue("expected the database-resident query to have executed: " + response.getBodyAsString(),
+                response.getBodyAsString().contains("<ok/>"));
+    }
+
+    @Test
+    public void nullPathTranslatedReturnsCleanNotFoundInsteadOfNPE() throws Exception {
+        final XQueryServlet servlet = newInitializedServlet();
+
+        // Simulates a request forwarded to a virtual/database-only path: neither
+        // getPathTranslated() nor (later) ServletContext#getRealPath(String) can resolve to a real
+        // file on disk, so both return null -- as the Servlet API permits.
+        final HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        expect(request.getPathTranslated()).andReturn(null).anyTimes();
+        expect(request.getRequestURI()).andReturn("/exist/apps/does-not-exist.xql").anyTimes();
+        expect(request.getContextPath()).andReturn("/exist").anyTimes();
+        replay(request);
+
+        final RecordingResponse response = new RecordingResponse();
+
+        // Before the fix: throws NullPointerException from Path.of(null) at XQueryServlet.process().
+        servlet.process(request, response);
+
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+    }
+
+    private static XQueryServlet newInitializedServlet() throws ServletException {
+        final ServletContext mockServletContext = createNiceMock(ServletContext.class);
+        // Mirrors a deployment where the webapp is not exploded on disk (e.g. served from a
+        // packed/embedded context): getRealPath() legitimately returns null for any input.
+        expect(mockServletContext.getRealPath(org.easymock.EasyMock.anyString())).andReturn(null).anyTimes();
+        replay(mockServletContext);
+
+        final ServletConfig mockServletConfig = createNiceMock(ServletConfig.class);
+        expect(mockServletConfig.getServletContext()).andReturn(mockServletContext).anyTimes();
+        replay(mockServletConfig);
+
+        final XQueryServlet servlet = new XQueryServlet();
+        servlet.init(mockServletConfig);
+        return servlet;
+    }
+
+    /**
+     * A minimal {@link HttpServletResponse} that records the status code and captures the body,
+     * delegating everything else to a nice mock.
+     */
+    private static class RecordingResponse extends HttpServletResponseWrapper {
+        private final UnsynchronizedByteArrayOutputStream body = new UnsynchronizedByteArrayOutputStream();
+        private int status = HttpServletResponse.SC_OK;
+
+        RecordingResponse() {
+            super(createNiceReplayedResponse());
+        }
+
+        private static HttpServletResponse createNiceReplayedResponse() {
+            final HttpServletResponse mock = createNiceMock(HttpServletResponse.class);
+            replay(mock);
+            return mock;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() {
+            return new ServletOutputStream() {
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setWriteListener(final WriteListener writeListener) {
+                }
+
+                @Override
+                public void write(final int b) {
+                    body.write(b);
+                }
+            };
+        }
+
+        @Override
+        public void setStatus(final int sc) {
+            this.status = sc;
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        String getBodyAsString() {
+            return body.toString(StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/servlets/XQueryServletNullPathTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/XQueryServletNullPathTest.java
@@ -43,7 +43,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -180,6 +179,7 @@ public class XQueryServletNullPathTest {
 
                 @Override
                 public void setWriteListener(final WriteListener writeListener) {
+                    // non-blocking I/O is not exercised by this test; nothing to wire up here
                 }
 
                 @Override
@@ -200,7 +200,7 @@ public class XQueryServletNullPathTest {
         }
 
         String getBodyAsString() {
-            return body.toString(StandardCharsets.UTF_8);
+            return body.toString(UTF_8);
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/http/servlets/XSLTServletGetCurrentDirTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/XSLTServletGetCurrentDirTest.java
@@ -1,0 +1,79 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.servlets;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertNull;
+
+/**
+ * {@code XSLTServlet#getCurrentDir(HttpServletRequest)} had the same defect shape as
+ * eXist-db/exist#6615: when {@code HttpServletRequest#getPathTranslated()} is {@code null}, it falls
+ * back to {@code ServletContext#getRealPath(String)} and passes the result straight into
+ * {@code Path.of()} -- but the Servlet API permits {@code getRealPath()} to return {@code null} too
+ * (e.g. a webapp not exploded on disk), which threw an unhandled {@link NullPointerException} instead
+ * of letting the caller report a clean "not found".
+ */
+public class XSLTServletGetCurrentDirTest {
+
+    @Test
+    public void nullPathTranslatedAndNullRealPathReturnsNullInsteadOfNPE() throws Exception {
+        final ServletContext mockContext = createNiceMock(ServletContext.class);
+        expect(mockContext.getRealPath(anyString())).andReturn(null).anyTimes();
+        replay(mockContext);
+
+        final ServletConfig mockConfig = createNiceMock(ServletConfig.class);
+        expect(mockConfig.getServletContext()).andReturn(mockContext).anyTimes();
+        replay(mockConfig);
+
+        final XSLTServlet servlet = new XSLTServlet();
+        servlet.init(mockConfig);
+
+        final HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        expect(request.getPathTranslated()).andReturn(null).anyTimes();
+        expect(request.getRequestURI()).andReturn("/exist/db/apps/style.xsl").anyTimes();
+        expect(request.getContextPath()).andReturn("/exist").anyTimes();
+        replay(request);
+
+        final Method getCurrentDir = XSLTServlet.class.getDeclaredMethod("getCurrentDir", HttpServletRequest.class);
+        getCurrentDir.setAccessible(true);
+
+        try {
+            // Before the fix: Path.of(null) throws NullPointerException, wrapped by reflection in
+            // InvocationTargetException.
+            final Object currentDir = getCurrentDir.invoke(servlet, request);
+            assertNull("no directory can be resolved when the container has no real path", currentDir);
+        } catch (final InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/servlets/XSLTServletGetCurrentDirTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/XSLTServletGetCurrentDirTest.java
@@ -23,11 +23,9 @@ package org.exist.http.servlets;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
@@ -46,7 +44,7 @@ import static org.junit.Assert.assertNull;
 public class XSLTServletGetCurrentDirTest {
 
     @Test
-    public void nullPathTranslatedAndNullRealPathReturnsNullInsteadOfNPE() throws Exception {
+    public void nullPathTranslatedAndNullRealPathReturnsNullInsteadOfNPE() throws ServletException {
         final ServletContext mockContext = createNiceMock(ServletContext.class);
         expect(mockContext.getRealPath(anyString())).andReturn(null).anyTimes();
         replay(mockContext);
@@ -64,16 +62,8 @@ public class XSLTServletGetCurrentDirTest {
         expect(request.getContextPath()).andReturn("/exist").anyTimes();
         replay(request);
 
-        final Method getCurrentDir = XSLTServlet.class.getDeclaredMethod("getCurrentDir", HttpServletRequest.class);
-        getCurrentDir.setAccessible(true);
-
-        try {
-            // Before the fix: Path.of(null) throws NullPointerException, wrapped by reflection in
-            // InvocationTargetException.
-            final Object currentDir = getCurrentDir.invoke(servlet, request);
-            assertNull("no directory can be resolved when the container has no real path", currentDir);
-        } catch (final InvocationTargetException e) {
-            throw (Exception) e.getCause();
-        }
+        // Before the fix: Path.of(null) throws NullPointerException.
+        final Object currentDir = servlet.getCurrentDir(request);
+        assertNull("no directory can be resolved when the container has no real path", currentDir);
     }
 }

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteFindSourceFromFsTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteFindSourceFromFsTest.java
@@ -1,0 +1,74 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.urlrewrite;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertNull;
+
+/**
+ * {@code XQueryURLRewrite#findSourceFromFs(String, String[])} passed
+ * {@code ServletContext#getRealPath(String)}'s result straight into {@code Path.of()} without a null
+ * check. The Servlet API explicitly permits {@code getRealPath()} to return {@code null} when the
+ * container cannot map a path to disk (e.g. a webapp not exploded on disk), which -- since this
+ * method sits on the controller.xql lookup path exercised by every filesystem-routed request through
+ * {@code XQueryURLRewrite} -- would throw an unhandled {@link NullPointerException} on effectively
+ * every request. Same defect shape as eXist-db/exist#6615.
+ */
+public class XQueryURLRewriteFindSourceFromFsTest {
+
+    @Test
+    public void nullRealPathReturnsNullInsteadOfNPE() throws Exception {
+        final ServletContext mockContext = createNiceMock(ServletContext.class);
+        expect(mockContext.getRealPath(anyString())).andReturn(null).anyTimes();
+        replay(mockContext);
+
+        final ServletConfig mockConfig = createNiceMock(ServletConfig.class);
+        expect(mockConfig.getServletContext()).andReturn(mockContext).anyTimes();
+        replay(mockConfig);
+
+        final XQueryURLRewrite rewrite = new XQueryURLRewrite();
+        rewrite.init(mockConfig);
+
+        final Method findSourceFromFs = XQueryURLRewrite.class.getDeclaredMethod(
+                "findSourceFromFs", String.class, String[].class);
+        findSourceFromFs.setAccessible(true);
+
+        try {
+            // Before the fix: Path.of(null) throws NullPointerException, wrapped by reflection in
+            // InvocationTargetException.
+            final Object sourceInfo = findSourceFromFs.invoke(rewrite, "/", new String[]{"apps", "optimize.xql"});
+            assertNull("no filesystem controller can be found when the container has no real path", sourceInfo);
+        } catch (final InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteFindSourceFromFsTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteFindSourceFromFsTest.java
@@ -25,9 +25,6 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
@@ -46,7 +43,7 @@ import static org.junit.Assert.assertNull;
 public class XQueryURLRewriteFindSourceFromFsTest {
 
     @Test
-    public void nullRealPathReturnsNullInsteadOfNPE() throws Exception {
+    public void nullRealPathReturnsNullInsteadOfNPE() {
         final ServletContext mockContext = createNiceMock(ServletContext.class);
         expect(mockContext.getRealPath(anyString())).andReturn(null).anyTimes();
         replay(mockContext);
@@ -58,17 +55,8 @@ public class XQueryURLRewriteFindSourceFromFsTest {
         final XQueryURLRewrite rewrite = new XQueryURLRewrite();
         rewrite.init(mockConfig);
 
-        final Method findSourceFromFs = XQueryURLRewrite.class.getDeclaredMethod(
-                "findSourceFromFs", String.class, String[].class);
-        findSourceFromFs.setAccessible(true);
-
-        try {
-            // Before the fix: Path.of(null) throws NullPointerException, wrapped by reflection in
-            // InvocationTargetException.
-            final Object sourceInfo = findSourceFromFs.invoke(rewrite, "/", new String[]{"apps", "optimize.xql"});
-            assertNull("no filesystem controller can be found when the container has no real path", sourceInfo);
-        } catch (final InvocationTargetException e) {
-            throw (Exception) e.getCause();
-        }
+        // Before the fix: Path.of(null) throws NullPointerException.
+        final Object sourceInfo = rewrite.findSourceFromFs("/", new String[]{"apps", "optimize.xql"});
+        assertNull("no filesystem controller can be found when the container has no real path", sourceInfo);
     }
 }

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteRequestWrapperTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/XQueryURLRewriteRequestWrapperTest.java
@@ -1,0 +1,84 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.urlrewrite;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.exist.http.urlrewrite.XQueryURLRewrite.RequestWrapper;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * {@link RequestWrapper#getPathTranslated()} had dead code: when its own {@code getPathInfo()}
+ * override returned {@code null} (the whole in-context path is consumed by the servlet path, i.e.
+ * a full-match forward), it called {@code super.getPathTranslated()} but discarded the result, then
+ * unconditionally returned {@code null} regardless of what the underlying request would have
+ * reported. That silently threw away information the underlying container may have had, forcing
+ * every full-match forward through this wrapper down the null-path branch downstream (see
+ * {@code XQueryServlet}, fixed for eXist-db/exist#6615) even when the container could have resolved
+ * a real path.
+ */
+public class XQueryURLRewriteRequestWrapperTest {
+
+    @Test
+    public void nullPathInfoFallsBackToUnderlyingRequestPathTranslated() {
+        final HttpServletRequest underlying = createNiceMock(HttpServletRequest.class);
+        expect(underlying.getParameterMap()).andReturn(Collections.emptyMap()).anyTimes();
+        expect(underlying.getPathTranslated()).andReturn("/underlying/real/path").anyTimes();
+        replay(underlying);
+
+        final RequestWrapper wrapper = new RequestWrapper(underlying);
+        // Same length in-context path and servlet path -- getPathInfo() computes to null.
+        wrapper.setPaths("/apps/foo", "/apps/foo");
+
+        assertEquals("/underlying/real/path", wrapper.getPathTranslated());
+    }
+
+    @Test
+    public void nonNullPathInfoResolvesViaServletContextRealPath() {
+        final ServletContext servletContext = createNiceMock(ServletContext.class);
+        expect(servletContext.getRealPath("/bar.xql")).andReturn("/resolved/real/path").anyTimes();
+        replay(servletContext);
+
+        final HttpSession session = createNiceMock(HttpSession.class);
+        expect(session.getServletContext()).andReturn(servletContext).anyTimes();
+        replay(session);
+
+        final HttpServletRequest underlying = createNiceMock(HttpServletRequest.class);
+        expect(underlying.getParameterMap()).andReturn(Collections.emptyMap()).anyTimes();
+        expect(underlying.getSession()).andReturn(session).anyTimes();
+        replay(underlying);
+
+        final RequestWrapper wrapper = new RequestWrapper(underlying);
+        // Longer in-context path than servlet path -- getPathInfo() computes to "/bar.xql".
+        wrapper.setPaths("/apps/foo/bar.xql", "/apps/foo");
+
+        assertEquals("/resolved/real/path", wrapper.getPathTranslated());
+    }
+}

--- a/extensions/images/src/main/java/org/exist/http/servlets/ScaleImageJAI.java
+++ b/extensions/images/src/main/java/org/exist/http/servlets/ScaleImageJAI.java
@@ -117,11 +117,11 @@ public class ScaleImageJAI extends HttpServlet {
 			Path baseDir = getAbsolutePath(baseDirStr);
 			store = new FileSystemStorage(baseDir);
 		}
-		
+
 		String outputDirStr = config.getInitParameter("output-dir");
 		if (outputDirStr == null)
 			outputDirStr = "scaled";
-		
+
 		outputDir = getAbsolutePath(outputDirStr);
 		if (!Files.exists(outputDir)) {
 			try {
@@ -142,10 +142,16 @@ public class ScaleImageJAI extends HttpServlet {
 			caching = cacheStr.equalsIgnoreCase("yes") || cacheStr.equalsIgnoreCase("true");
 	}
 
-	private Path getAbsolutePath(String dirStr) {
+	private Path getAbsolutePath(String dirStr) throws ServletException {
 		Path dir = Paths.get(dirStr);
 		if (!dir.isAbsolute()) {
 			String path = getServletConfig().getServletContext().getRealPath(".");
+			// the Servlet API permits getRealPath() to return null when the webapp is not
+			// exploded on disk (e.g. served from a packed/embedded context).
+			if (path == null) {
+				throw new ServletException("Cannot resolve relative path '" + dirStr
+						+ "' to an absolute path: the servlet container has no real path for \".\"");
+			}
 			return Paths.get(path, dirStr);
 		}
 		return dir;


### PR DESCRIPTION
## Summary

- Fixes an unhandled `NullPointerException` in `XQueryServlet.process()`: the Servlet API permits `HttpServletRequest#getPathTranslated()` and `ServletContext#getRealPath(String)` to return `null` when the container can't map a request to a disk path (e.g. `<exist:forward servlet="XQueryServlet">` to a database-only path like `/db/apps/optimize.xql`). That `null` was passed straight into `Path.of()`, crashing with a raw HTTP 500 instead of resolving the resource or returning a clean 404.
- Fixes the dead code in `XQueryURLRewrite.RequestWrapper#getPathTranslated()` that was silently discarding a real path and always returning `null` — the actual mechanism that hands `XQueryServlet` a null path in the first place.
- Applies the same null-guard to five more call sites found to share the identical defect shape (`Path.of()`/`Paths.get()` fed directly from `getRealPath()`/`getPathTranslated()` with no null check): `XQueryURLRewrite#findSourceFromFs()`, `XSLTServlet#getCurrentDir()`, `RewriteConfig#configure()`, `RedirectorServlet#service()`, and `ScaleImageJAI#getAbsolutePath()`.

## What Changed

- `XQueryServlet.java` — when no readable file is found on disk (null or nonexistent path), falls back to resolving the resource in the database via `SourceFactory` before returning a clean 404.
- `XQueryURLRewrite.java` — fixed `RequestWrapper#getPathTranslated()`'s discarded return value; added a null guard in `findSourceFromFs()`.
- `XSLTServlet.java` — `getCurrentDir()` now returns `null` instead of crashing; both callers treat that the same as their existing "not found" case.
- `RewriteConfig.java` — a null real path for the webapp root is now treated like a missing/unreadable `controller-config.xml` (skip, don't crash).
- `RedirectorServlet.java` — fails fast with the same `ServletException` message the neighboring readability check already uses.
- `extensions/images/ScaleImageJAI.java` — fails fast at `init()` with a clear `ServletException`. Note: this module is commented out of `extensions/pom.xml` (`Not used`) and doesn't currently compile against `develop` for unrelated reasons (a missing `NativeBroker` method), so this change is verified by inspection only, not a green build.

## Test Plan

- [x] `XQueryServletNullPathTest` — reproduces the exact reported NPE (confirmed RED against unfixed code), and a second test proving the database fallback resolves and executes a database-only resource end-to-end.
- [x] `XQueryURLRewriteRequestWrapperTest` — covers both branches of the fixed `getPathTranslated()`.
- [x] `XQueryURLRewriteFindSourceFromFsTest`, `XSLTServletGetCurrentDirTest` — reflection-based tests for the two most reachable of the five additional sites, confirmed RED against unfixed code with the identical NPE stack trace shape before fixing.
- [x] Full `exist-core` `http`/`urlrewrite`/security regression suite passes with no failures.

Closes https://github.com/eXist-db/exist/issues/6615