### PR TITLE
[ci] Separate real outcome changes from recording noise in the XQTS comparison

### DIFF
--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -1,5 +1,13 @@
 name: XQTS
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Keep a fresh baseline on develop: the xqts-logs artifact expires after
+    # 14 days, so during quiet periods on develop the PR comparison would
+    # otherwise lose its baseline (and drift ever further from the PR base).
+    - cron: '17 2 * * 0,3'
 permissions:
   contents: read
 
@@ -47,6 +55,7 @@ jobs:
           retention-days: 1
           path: /tmp/*.hprof.zst
       - name: Find Latest Successful XQTS Run on Develop
+        id: find-baseline
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -60,22 +69,38 @@ jobs:
             --jq '.[0].databaseId')
 
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-            echo "::error::Could not find a previous successful XQTS run on develop"
-            exit 1
+            echo "::warning::Could not find a previous successful XQTS run on develop — skipping the comparison"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found develop run: ${RUN_ID}"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           fi
-
-          echo "Found develop run: ${RUN_ID}"
-          echo "$RUN_ID" > /tmp/previous_run_id.txt
       - name: Download Previous XQTS Logs
+        id: download-baseline
+        if: steps.find-baseline.outputs.found == 'true'
+        # The baseline's xqts-logs artifact may have expired (14-day
+        # retention). Treat that as "no baseline" rather than failing, so
+        # runs on develop can still publish a fresh baseline artifact —
+        # otherwise an expired baseline would permanently fail every run.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh run download \
             --repo eXist-db/exist \
-            "$(cat /tmp/previous_run_id.txt)" \
+            "${{ steps.find-baseline.outputs.run-id }}" \
             --name xqts-logs \
             --dir /tmp/previous-xqts-output
+      - name: Note Missing Baseline
+        if: steps.download-baseline.outcome != 'success'
+        run: |
+          {
+            echo "> [!WARNING]"
+            echo "> No usable XQTS comparison baseline for \`develop\` was available (no successful run found, or its \`xqts-logs\` artifact expired) — the comparison was skipped. The next successful run on \`develop\` publishes a fresh baseline."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Compare Previous and Current XQTS Results
+        if: steps.download-baseline.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -86,18 +111,20 @@ jobs:
             -Dprevious-label='`develop`' \
             -Dcurrent-label='this run'
       - name: Show Comparison Results
+        if: steps.download-baseline.outcome == 'success'
         run: cat /tmp/xqts-comparison/comparison-results.xml
       - name: Publish Comparison Summary
         # Surface the report on the run's Summary tab (works for fork PRs too)
+        if: steps.download-baseline.outcome == 'success'
         run: cat /tmp/xqts-comparison/comparison-results.md >> "$GITHUB_STEP_SUMMARY"
       - name: Save PR Number
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.download-baseline.outcome == 'success'
         run: echo "${{ github.event.pull_request.number }}" > /tmp/xqts-comparison/pr-number.txt
       - name: Upload XQTS Comparison
         # Consumed by the ci-xqts-comment.yml workflow_run, which posts the
         # comparison as a PR comment with a write-enabled token (needed for
         # PRs from forks, where this workflow's token is read-only).
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.download-baseline.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: xqts-comparison

--- a/exist-xqts/README.md
+++ b/exist-xqts/README.md
@@ -47,9 +47,14 @@ a comparable result folder.
 Two files are written to `comparison-output-dir`:
 
 - `comparison-results.xml` — the comparison data: totals, deltas, the newly
-  passing/failing/erroring/skipped test cases, and warnings when the two runs'
-  `runner-info.xml` metadata indicates environment drift
-  (see [#6326](https://github.com/eXist-db/exist/issues/6326));
+  passing/failing/erroring/skipped test cases (only tests recorded in both
+  runs whose outcome changed, each annotated with its previous status), test
+  cases recorded in only one of the two runs (the runner's JUnit output is
+  not fully deterministic, see
+  [exist-xqts-runner#74](https://github.com/eXist-db/exist-xqts-runner/issues/74)),
+  and warnings when the runs' `runner-info.xml` metadata indicates environment
+  drift (see [#6326](https://github.com/eXist-db/exist/issues/6326)) or the
+  recorded test sets differ;
 - `comparison-results.md` — the same information rendered as GitHub-flavoured
   Markdown, as posted on pull requests by the `ci-xqts-comment.yml` workflow.
 

--- a/exist-xqts/src/main/xslt/compare-results-md.xslt
+++ b/exist-xqts/src/main/xslt/compare-results-md.xslt
@@ -133,18 +133,26 @@
             ' | ', cr:signed-int($chg/@tests),
             ' |', $nl, $nl)"/>
 
-        <!-- Newly changed test cases relative to develop -->
+        <!--
+            Test cases recorded in both runs whose outcome changed. Cases
+            recorded in only one run's JUnit output (recording drift, see
+            https://github.com/eXist-db/exist-xqts-runner/issues/74) are
+            listed separately below and flagged by a warning above.
+        -->
         <xsl:variable name="new-pass" select="cr:change/cr:new/cr:pass/testcase" as="element()*"/>
         <xsl:variable name="new-failures" select="cr:change/cr:new/cr:failures/testcase" as="element()*"/>
         <xsl:variable name="new-errors" select="cr:change/cr:new/cr:errors/testcase" as="element()*"/>
         <xsl:variable name="new-skipped" select="cr:change/cr:new/cr:skipped/testcase" as="element()*"/>
+        <xsl:variable name="only-previous" select="cr:change/cr:recording-drift/cr:only-previous/testcase" as="element()*"/>
+        <xsl:variable name="only-current" select="cr:change/cr:recording-drift/cr:only-current/testcase" as="element()*"/>
 
         <xsl:value-of select="concat(
             'Relative to ', $previous-label, ': ',
             '**', cr:int(count($new-pass)), '** newly passing, ',
             '**', cr:int(count($new-failures)), '** newly failing, ',
             '**', cr:int(count($new-errors)), '** new errors, ',
-            '**', cr:int(count($new-skipped)), '** newly skipped.', $nl, $nl)"/>
+            '**', cr:int(count($new-skipped)), '** newly skipped',
+            ' — counting only tests recorded in both runs whose outcome changed.', $nl, $nl)"/>
 
         <xsl:call-template name="cr:detail-list">
             <xsl:with-param name="heading" select="'🔴 Newly failing tests'"/>
@@ -157,6 +165,14 @@
         <xsl:call-template name="cr:detail-list">
             <xsl:with-param name="heading" select="'🟢 Newly passing tests'"/>
             <xsl:with-param name="cases" select="$new-pass"/>
+        </xsl:call-template>
+        <xsl:call-template name="cr:detail-list">
+            <xsl:with-param name="heading" select="concat('⚪ Recorded only in ', $current-label)"/>
+            <xsl:with-param name="cases" select="$only-current"/>
+        </xsl:call-template>
+        <xsl:call-template name="cr:detail-list">
+            <xsl:with-param name="heading" select="concat('⚪ Recorded only in ', $previous-label)"/>
+            <xsl:with-param name="cases" select="$only-previous"/>
         </xsl:call-template>
 
         <xsl:value-of select="concat($nl, '&lt;sub>Runtime: ',
@@ -172,7 +188,7 @@
             <xsl:value-of select="concat('&lt;details>', $nl,
                 '&lt;summary>', $heading, ' (', cr:int(count($cases)), ')&lt;/summary>', $nl, $nl)"/>
             <xsl:for-each select="$cases[position() le $max-listed]">
-                <xsl:value-of select="concat('- `', @name, '`', $nl)"/>
+                <xsl:value-of select="concat('- `', @name, '`', cr:annotation(.), $nl)"/>
             </xsl:for-each>
             <xsl:if test="count($cases) gt $max-listed">
                 <xsl:value-of select="concat('- … and ', cr:int(count($cases) - $max-listed), ' more', $nl)"/>
@@ -180,5 +196,27 @@
             <xsl:value-of select="concat($nl, '&lt;/details>', $nl, $nl)"/>
         </xsl:if>
     </xsl:template>
+
+    <!--
+        Parenthesised note for a listed test case: its category in the other
+        run (@previous-status, for outcome changes) or in the only run that
+        recorded it (@status, for recording drift).
+    -->
+    <xsl:function name="cr:annotation" as="xs:string">
+        <xsl:param name="case" as="element()"/>
+        <xsl:sequence select="
+            if ($case/@previous-status) then concat(' (was ', cr:status-label($case/@previous-status), ')')
+            else if ($case/@status) then concat(' (', cr:status-label($case/@status), ')')
+            else ''"/>
+    </xsl:function>
+
+    <xsl:function name="cr:status-label" as="xs:string">
+        <xsl:param name="status" as="xs:string"/>
+        <xsl:sequence select="
+            if ($status eq 'pass') then 'passing'
+            else if ($status eq 'failures') then 'failing'
+            else if ($status eq 'errors') then 'in error'
+            else $status"/>
+    </xsl:function>
 
 </xsl:stylesheet>

--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -31,6 +31,8 @@
 
     <xsl:output method="xml" version="1.0" omit-xml-declaration="no" indent="yes" encoding="UTF-8"/>
 
+    <!-- Look up a test case by name across the four category containers of a run summary -->
+    <xsl:key name="cr:testcase-by-name" match="cr:results/*/testcase" use="@name"/>
 
     <xsl:template name="compare-results" as="document-node(element(cr:comparison))">
         <xsl:param name="previous-junit-data-path" as="xs:string" required="yes"/>
@@ -39,14 +41,18 @@
         <xsl:variable name="current-summary" select="cr:summarise-results($current-junit-data-path)" as="document-node(element(cr:results))"/>
         <xsl:variable name="new-changes" as="element()+">
             <xsl:for-each select="('pass', 'skipped', 'failures', 'errors')">
-                <xsl:sequence select="cr:new-changes($previous-summary/cr:results, $current-summary/cr:results, .)"/>
+                <xsl:sequence select="cr:transition-changes($previous-summary, $current-summary, .)"/>
             </xsl:for-each>
         </xsl:variable>
+        <xsl:variable name="only-previous" as="element()*" select="cr:unrecorded($previous-summary, $current-summary)"/>
+        <xsl:variable name="only-current" as="element()*" select="cr:unrecorded($current-summary, $previous-summary)"/>
         <xsl:variable name="previous-runner-info" as="document-node()?" select="cr:load-runner-info($previous-junit-data-path)"/>
         <xsl:variable name="current-runner-info" as="document-node()?" select="cr:load-runner-info($current-junit-data-path)"/>
         <xsl:document>
             <cr:comparison>
-                <xsl:variable name="warnings" as="element(cr:warning)*" select="cr:drift-warnings($previous-runner-info, $current-runner-info)"/>
+                <xsl:variable name="warnings" as="element(cr:warning)*" select="(
+                    cr:drift-warnings($previous-runner-info, $current-runner-info),
+                    cr:recording-drift-warning($only-previous, $only-current))"/>
                 <xsl:if test="exists($warnings)">
                     <cr:warnings>
                         <xsl:sequence select="$warnings"/>
@@ -76,6 +82,16 @@
                     <cr:new>
                         <xsl:sequence select="$new-changes"/>
                     </cr:new>
+                    <xsl:if test="exists($only-previous) or exists($only-current)">
+                        <cr:recording-drift>
+                            <cr:only-previous>
+                                <xsl:sequence select="$only-previous"/>
+                            </cr:only-previous>
+                            <cr:only-current>
+                                <xsl:sequence select="$only-current"/>
+                            </cr:only-current>
+                        </cr:recording-drift>
+                    </xsl:if>
                 </cr:change>
             </cr:comparison>
         </xsl:document>
@@ -128,23 +144,60 @@
         </xsl:choose>
     </xsl:function>
 
-    <xsl:function name="cr:new-changes">
-        <xsl:param name="previous-results" as="element(cr:results)" required="yes"/>
-        <xsl:param name="current-results" as="element(cr:results)" required="yes"/>
-        <xsl:param name="attr-name" as="xs:string" required="yes"/>
-        <xsl:variable name="elem-name" as="xs:QName" select="xs:QName(concat('cr:', $attr-name))"/>
-        <xsl:variable name="previous-results-names" as="xs:string*" select="$previous-results/element()[node-name(.) eq $elem-name]/testcase/@name/string(.)"/>
-        <xsl:element name="cr:{$attr-name}">
-            <xsl:apply-templates mode="simple" select="$current-results/element()[node-name(.) eq $elem-name]/testcase[not(@name = $previous-results-names)]"/>
+    <!--
+        Test cases of the given category in the current run whose outcome
+        genuinely changed: the case was also recorded in the previous run,
+        but under a different category (noted in @previous-status). Cases
+        absent from one run's JUnit output are recording drift, not outcome
+        changes, and are reported separately via cr:unrecorded — see
+        https://github.com/eXist-db/exist-xqts-runner/issues/74.
+    -->
+    <xsl:function name="cr:transition-changes" as="element()">
+        <xsl:param name="previous-summary" as="document-node(element(cr:results))" required="yes"/>
+        <xsl:param name="current-summary" as="document-node(element(cr:results))" required="yes"/>
+        <xsl:param name="category" as="xs:string" required="yes"/>
+        <xsl:variable name="elem-name" as="xs:QName" select="xs:QName(concat('cr:', $category))"/>
+        <xsl:element name="cr:{$category}">
+            <xsl:for-each select="$current-summary/cr:results/element()[node-name(.) eq $elem-name]/testcase">
+                <xsl:variable name="previous-category" as="xs:string" select="local-name(key('cr:testcase-by-name', @name, $previous-summary)[1]/parent::*)"/>
+                <xsl:if test="$previous-category ne '' and $previous-category ne $category">
+                    <xsl:copy>
+                        <xsl:copy-of select="@name"/>
+                        <xsl:attribute name="previous-status" select="$previous-category"/>
+                        <xsl:copy-of select="failure|error"/>
+                    </xsl:copy>
+                </xsl:if>
+            </xsl:for-each>
         </xsl:element>
     </xsl:function>
 
-    <xsl:template match="testcase" mode="simple">
-        <xsl:copy>
-            <xsl:copy-of select="@name"/>
-            <xsl:copy-of select="failure|error"/>
-        </xsl:copy>
-    </xsl:template>
+    <!--
+        Test cases recorded in one run's JUnit output but entirely absent
+        from the other's — not passed, failed, errored, or skipped there.
+    -->
+    <xsl:function name="cr:unrecorded" as="element()*">
+        <xsl:param name="summary" as="document-node(element(cr:results))" required="yes"/>
+        <xsl:param name="other-summary" as="document-node(element(cr:results))" required="yes"/>
+        <xsl:for-each select="$summary/cr:results/*/testcase[empty(key('cr:testcase-by-name', @name, $other-summary))]">
+            <testcase name="{@name}" status="{local-name(parent::*)}"/>
+        </xsl:for-each>
+    </xsl:function>
+
+    <xsl:function name="cr:recording-drift-warning" as="element(cr:warning)?">
+        <xsl:param name="only-previous" as="element()*"/>
+        <xsl:param name="only-current" as="element()*"/>
+        <xsl:if test="exists($only-previous) or exists($only-current)">
+            <cr:warning kind="recording-drift">
+                <cr:summary>
+                    <xsl:value-of select="concat(
+                        count($only-previous) + count($only-current),
+                        ' test cases were recorded in only one of the two runs (',
+                        count($only-previous), ' only in the previous run, ',
+                        count($only-current), ' only in the current run). The runner''s JUnit output is not fully deterministic (see https://github.com/eXist-db/exist-xqts-runner/issues/74), so totals and per-category deltas include recording noise; the newly passing/failing lists count only tests recorded in both runs.')"/>
+                </cr:summary>
+            </cr:warning>
+        </xsl:if>
+    </xsl:function>
 
     <!--
         Locate `runner-info.xml` next to the run's output dir. The junit data


### PR DESCRIPTION
### Description:

Hardens the XQTS PR-comment comparison introduced in #6564, prompted by the confusing report on #6643 ([comment](https://github.com/eXist-db/exist/pull/6643#issuecomment-5337007404)): a dependabot no-op PR was shown with "**40** newly passing, **3** newly failing" while the failures delta read 0 and total tests moved by +20.

Investigation showed the numbers were technically reconcilable but dominated by noise: the runner's JUnit output is not deterministic. Two CI runs of the **same commit** (runs [32210739156](https://github.com/eXist-db/exist/actions/runs/32210739156) and [32210738133](https://github.com/eXist-db/exist/actions/runs/32210738133), seconds apart, identical runner JAR, no qt3tests changes since May) recorded 31,213 vs 31,253 tests — 96 test cases present in only one of the two outputs, but only **one** genuine outcome flip. The old name-set diff counted every unrecorded test as "newly" passing/failing. Root cause filed as eXist-db/exist-xqts-runner#74.

**Commit 1 — comparison semantics** (`compare-results.xslt`, `compare-results-md.xslt`):
- The newly passing/failing/erroring/skipped lists now contain only tests recorded in **both** runs whose category changed, each annotated with its previous status (e.g. `` `Axes112` (was passing)``), so the summary-table deltas can be reconciled against the lists.
- Tests recorded in only one run are reported separately ("⚪ Recorded only in …" sections, annotated with their status) and flagged by a `> [!WARNING]` recording-drift notice alongside the existing runner-drift warnings.
- Name lookup switched from an O(n·m) sequence comparison to an `xsl:key`.

Rendered against the two same-commit runs above, the comment now reads: *"**1** newly passing, **0** newly failing, **0** new errors, **0** newly skipped — counting only tests recorded in both runs whose outcome changed"*, with a warning about the 96 unrecorded cases — instead of reporting dozens of phantom changes.

**Commit 2 — baseline freshness and resilience** (`ci-xqts.yml`):
- The baseline (latest successful develop run's `xqts-logs` artifact, 14-day retention) both drifts from the PRs' actual base and eventually expires during quiet periods on develop. Once expired, **every** XQTS run fails at the download step — including develop runs — so no fresh baseline can ever be published. That state was reached on 2026-08-19 (newest baseline: 2026-08-04, artifact expired).
- Adds a twice-weekly `schedule` trigger so develop keeps publishing a fresh baseline, and treats a missing/expired baseline as "skip the comparison" with a step-summary warning instead of failing the run, so the next successful develop run always self-heals the pipeline.

### Reference:

- https://github.com/eXist-db/exist/pull/6643#issuecomment-5337007404 (the confusing report)
- https://github.com/eXist-db/exist-xqts-runner/issues/74 (root cause: nondeterministic JUnit output)
- #6564 (the feature being hardened), #6326 (environment-drift warnings)

### Type of tests:

Ran the `xqts-compare` goal's stylesheets via Saxon over the JUnit data of the two same-commit CI runs above: reports 1 outcome change + 28/68 recording drift with the warning. A self-comparison of one run reports all zeros with no warning and no drift sections. Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146yb2sFYkgDbwJ5ci7sZ1C
