### PR TITLE
[ci] Update exist-xqts-runner to 2.0.0-RC4

### DIFF
--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.exist-db</groupId>
             <artifactId>exist-xqts-runner_2.13</artifactId>
-            <version>2.0.0-RC3</version>
+            <version>2.0.0-RC4</version>
             <exclusions>
                 <!-- use the exist-core version of this project instead -->
                 <exclusion>


### PR DESCRIPTION
### Description:

Bumps the `exist-xqts-runner_2.13` dependency in `exist-xqts/pom.xml` from 2.0.0-RC3 to 2.0.0-RC4.

RC4 includes the fix for the runner's nondeterministic JUnit output: RC3 could serialize a test set's result file while cases were still pending and rewrite it repeatedly mid-run, so each run recorded a slightly different subset of test cases (~40 tests of variance between runs of the same commit). That variance showed up as noise in the XQTS comparison step and triggered its recording-drift warning. With RC4, each test set is serialized exactly once after all of its cases complete — two full local runs against the same commit produced identical recorded test sets (0 presence diffs across 31,752 cases).

RC4 is published to the eXist-db GitHub Packages Maven repository, which CI already resolves via the `maven-github-settings` action and the `github-xqts-runner` repository declared in `exist-parent`.

### Reference:

- eXist-db/exist-xqts-runner#74 (root cause analysis)
- eXist-db/exist-xqts-runner#76 (the fix, released in 2.0.0-RC4)

### Type of tests:

No code changes — dependency version bump only. Verified locally that 2.0.0-RC4 resolves from GitHub Packages; the XQTS CI workflow on this PR exercises the new runner end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqsCRdPehXB5zK1xcNFKEo