### PR TITLE
[feature] Redesign JMH benchmark dashboards: grouping, search, dark mode

### DIFF
--- a/dev/bench/core/index.html
+++ b/dev/bench/core/index.html
@@ -1,281 +1,63 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
-    <style>
-      html {
-        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
-        -webkit-font-smoothing: antialiased;
-        background-color: #fff;
-        font-size: 16px;
-      }
-      body {
-        color: #4a4a4a;
-        margin: 8px;
-        font-size: 1em;
-        font-weight: 400;
-      }
-      header {
-        margin-bottom: 8px;
-        display: flex;
-        flex-direction: column;
-      }
-      main {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      a {
-        color: #3273dc;
-        cursor: pointer;
-        text-decoration: none;
-      }
-      a:hover {
-        color: #000;
-      }
-      button {
-        color: #fff;
-        background-color: #3298dc;
-        border-color: transparent;
-        cursor: pointer;
-        text-align: center;
-      }
-      button:hover {
-        background-color: #2793da;
-        flex: none;
-      }
-      .spacer {
-        flex: auto;
-      }
-      .small {
-        font-size: 0.75rem;
-      }
-      footer {
-        margin-top: 16px;
-        display: flex;
-        align-items: center;
-      }
-      .header-label {
-        margin-right: 4px;
-      }
-      .benchmark-set {
-        margin: 8px 0;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      .benchmark-title {
-        font-size: 3rem;
-        font-weight: 600;
-        word-break: break-word;
-        text-align: center;
-      }
-      .benchmark-graphs {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        align-items: center;
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .benchmark-chart {
-        max-width: 1000px;
-      }
-    </style>
-    <title>Benchmarks</title>
-  </head>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+  <title>exist-core-jmh Benchmarks — eXist-db</title>
+  <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+  <div class="layout" style="flex-direction: column; width: 100%;">
+    <nav class="crumbs">
+      <a href="../../">eXist-db Benchmarks</a>
+      <span class="sep">/</span>
+      <span>exist-core-jmh</span>
+      <span class="sep">·</span>
+      <a href="../indexes/">exist-indexes-jmh</a>
+      <span class="sep">·</span>
+      <a href="https://github.com/eXist-db/exist" rel="noopener">GitHub</a>
+    </nav>
+    <div class="layout" style="flex: 1;">
+      <aside class="sidebar" id="sidebar"></aside>
+      <main class="main">
+        <div class="controlbar">
+          <h1>exist-core-jmh</h1>
+          <span class="meta" id="last-update"></span>
+          <div class="spacer"></div>
+          <input id="search" type="search" placeholder="Filter benchmarks…" aria-label="Filter benchmarks" />
+          <button class="btn" id="theme-toggle" type="button"></button>
+          <button class="btn" id="dl-button" type="button">Download JSON</button>
+        </div>
+        <div id="main"></div>
+        <footer class="page-footer">
+          <span>Data: <a id="repository-link" rel="noopener"></a></span>
+          <span>Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a> · rendered by a custom dashboard, see <a href="https://github.com/eXist-db/exist/blob/develop/.github/workflows/ci-benchmarks.yml">ci-benchmarks.yml</a></span>
+        </footer>
+      </main>
+    </div>
+  </div>
 
-  <body>
-    <header id="header">
-      <div class="header-item">
-        <strong class="header-label">Last Update:</strong>
-        <span id="last-update"></span>
-      </div>
-      <div class="header-item">
-        <strong class="header-label">Repository:</strong>
-        <a id="repository-link" rel="noopener"></a>
-      </div>
-    </header>
-    <main id="main"></main>
-    <footer>
-      <button id="dl-button">Download data as JSON</button>
-      <div class="spacer"></div>
-      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
-    </footer>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+  <script src="../dashboard.js"></script>
+  <script src="data.js"></script>
+  <script>
+    (function () {
+      const data = window.BENCHMARK_DATA;
+      document.getElementById('last-update').textContent = 'Last update: ' + new Date(data.lastUpdate).toLocaleString();
+      const repoLink = document.getElementById('repository-link');
+      repoLink.href = data.repoUrl;
+      repoLink.textContent = data.repoUrl;
+      document.getElementById('dl-button').onclick = () => {
+        const a = document.createElement('a');
+        a.href = 'data:,' + encodeURIComponent(JSON.stringify(data, null, 2));
+        a.download = 'exist-core-jmh_benchmark_data.json';
+        a.click();
+      };
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
-    <script src="data.js"></script>
-    <script id="main-script">
-      'use strict';
-      (function() {
-        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-        const toolColors = {
-          cargo: '#dea584',
-          go: '#00add8',
-          benchmarkjs: '#f1e05a',
-          benchmarkluau: '#000080',
-          pytest: '#3572a5',
-          googlecpp: '#f34b7d',
-          catch2: '#f34b7d',
-          julia: '#a270ba',
-          jmh: '#b07219',
-          benchmarkdotnet: '#178600',
-          customBiggerIsBetter: '#38ff38',
-          customSmallerIsBetter: '#ff3838',
-          _: '#333333'
-        };
-
-        function init() {
-          function collectBenchesPerTestCase(entries) {
-            const map = new Map();
-            for (const entry of entries) {
-              const {commit, date, tool, benches} = entry;
-              for (const bench of benches) {
-                const result = { commit, date, tool, bench };
-                const arr = map.get(bench.name);
-                if (arr === undefined) {
-                  map.set(bench.name, [result]);
-                } else {
-                  arr.push(result);
-                }
-              }
-            }
-            return map;
-          }
-
-          const data = window.BENCHMARK_DATA;
-
-          // Render header
-          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
-          const repoLink = document.getElementById('repository-link');
-          repoLink.href = data.repoUrl;
-          repoLink.textContent = data.repoUrl;
-
-          // Render footer
-          document.getElementById('dl-button').onclick = () => {
-            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
-            const a = document.createElement('a');
-            a.href = dataUrl;
-            a.download = 'benchmark_data.json';
-            a.click();
-          };
-
-          // Prepare data points for charts
-          return Object.keys(data.entries).map(name => ({
-            name,
-            dataSet: collectBenchesPerTestCase(data.entries[name]),
-          }));
-        }
-
-        function renderAllChars(dataSets) {
-
-          function renderGraph(parent, name, dataset) {
-            const canvas = document.createElement('canvas');
-            canvas.className = 'benchmark-chart';
-            parent.appendChild(canvas);
-
-            const color = toolColors[dataset.length > 0 ? dataset[0].tool : '_'];
-            const data = {
-              labels: dataset.map(d => d.commit.id.slice(0, 7)),
-              datasets: [
-                {
-                  label: name,
-                  data: dataset.map(d => d.bench.value),
-                  borderColor: color,
-                  backgroundColor: color + '60', // Add alpha for #rrggbbaa
-                }
-              ],
-            };
-            const options = {
-              scales: {
-                xAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: 'commit',
-                    },
-                  }
-                ],
-                yAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: dataset.length > 0 ? dataset[0].bench.unit : '',
-                    },
-                    ticks: {
-                      beginAtZero: true,
-                    }
-                  }
-                ],
-              },
-              tooltips: {
-                callbacks: {
-                  afterTitle: items => {
-                    const {index} = items[0];
-                    const data = dataset[index];
-                    return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
-                  },
-                  label: item => {
-                    let label = item.value;
-                    const { range, unit } = dataset[item.index].bench;
-                    label += ' ' + unit;
-                    if (range) {
-                      label += ' (' + range + ')';
-                    }
-                    return label;
-                  },
-                  afterLabel: item => {
-                    const { extra } = dataset[item.index].bench;
-                    return extra ? '\n' + extra : '';
-                  }
-                }
-              },
-              onClick: (_mouseEvent, activeElems) => {
-                if (activeElems.length === 0) {
-                  return;
-                }
-                // XXX: Undocumented. How can we know the index?
-                const index = activeElems[0]._index;
-                const url = dataset[index].commit.url;
-                window.open(url, '_blank');
-              },
-            };
-
-            new Chart(canvas, {
-              type: 'line',
-              data,
-              options,
-            });
-          }
-
-          function renderBenchSet(name, benchSet, main) {
-            const setElem = document.createElement('div');
-            setElem.className = 'benchmark-set';
-            main.appendChild(setElem);
-
-            const nameElem = document.createElement('h1');
-            nameElem.className = 'benchmark-title';
-            nameElem.textContent = name;
-            setElem.appendChild(nameElem);
-
-            const graphsElem = document.createElement('div');
-            graphsElem.className = 'benchmark-graphs';
-            setElem.appendChild(graphsElem);
-
-            for (const [benchName, benches] of benchSet.entries()) {
-              renderGraph(graphsElem, benchName, benches)
-            }
-          }
-
-          const main = document.getElementById('main');
-          for (const {name, dataSet} of dataSets) {
-            renderBenchSet(name, dataSet, main);
-          }
-        }
-
-        renderAllChars(init()); // Start
-      })();
-    </script>
-  </body>
+      BenchDashboard.wireTheme(document.getElementById('theme-toggle'));
+      BenchDashboard.render(document.getElementById('main'), document.getElementById('sidebar'), data, 'exist-core-jmh');
+      BenchDashboard.wireSearch(document.getElementById('search'));
+    })();
+  </script>
+</body>
 </html>

--- a/dev/bench/dashboard.js
+++ b/dev/bench/dashboard.js
@@ -1,0 +1,379 @@
+'use strict';
+/* eXist-db JMH benchmark dashboard rendering engine.
+ * Shared by dev/bench/core/index.html and dev/bench/indexes/index.html.
+ * Reads window.BENCHMARK_DATA (written by benchmark-action/github-action-benchmark
+ * into the sibling data.js) and renders a grouped, searchable, dark-mode-aware
+ * dashboard using Chart.js v4.
+ */
+(function () {
+  // Qualitative palette (12 colors), reused per chart by series index.
+  const PALETTE = [
+    '#4493f8', '#f85149', '#3fb950', '#d29922', '#a371f7', '#39c5cf',
+    '#db61a2', '#8b949e', '#58a6ff', '#e3b341', '#ff7b72', '#56d364',
+  ];
+
+  const NOISE_BAND = 3; // percent; changes smaller than this are shown as "stable"
+
+  function el(tag, attrs, children) {
+    const e = document.createElement(tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k === 'class') e.className = v;
+        else if (k === 'text') e.textContent = v;
+        else if (k === 'title') e.title = v;
+        else e.setAttribute(k, v);
+      }
+    }
+    (children || []).forEach((c) => e.appendChild(c));
+    return e;
+  }
+
+  function slugify(s) {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
+  // "pkg.pkg.ClassName.methodName ( {"k":"v"} )" -> {shortClass, pkg, method, paramsObj}
+  function parseBenchName(name) {
+    const m = name.match(/^(.*?)\s*\(\s*(\{[\s\S]*\})\s*\)\s*$/);
+    let qualified = name.trim();
+    let paramsObj = null;
+    if (m) {
+      qualified = m[1].trim();
+      try {
+        paramsObj = JSON.parse(m[2]);
+      } catch (_) {
+        paramsObj = null;
+      }
+    }
+    const lastDot = qualified.lastIndexOf('.');
+    const cls = lastDot === -1 ? '' : qualified.slice(0, lastDot);
+    const method = lastDot === -1 ? qualified : qualified.slice(lastDot + 1);
+    const clsLastDot = cls.lastIndexOf('.');
+    const shortClass = clsLastDot === -1 ? cls : cls.slice(clsLastDot + 1);
+    const pkg = clsLastDot === -1 ? '' : cls.slice(0, clsLastDot);
+    return { shortClass, pkg, fullClass: cls, method, paramsObj };
+  }
+
+  function paramLabel(paramsObj, keys) {
+    if (!paramsObj) return null;
+    const useKeys = keys || Object.keys(paramsObj);
+    if (useKeys.length === 0) return null;
+    return useKeys.map((k) => `${k}=${paramsObj[k]}`).join(', ');
+  }
+
+  // Only the param keys that actually differ across a method's series are worth
+  // showing in the legend — constant keys (e.g. verificationMode=STRICT on every
+  // series) just add noise.
+  function varyingParamKeys(paramsObjList) {
+    const withParams = paramsObjList.filter(Boolean);
+    if (withParams.length === 0) return [];
+    const allKeys = new Set();
+    withParams.forEach((p) => Object.keys(p).forEach((k) => allKeys.add(k)));
+    return [...allKeys].filter((k) => {
+      const values = new Set(withParams.map((p) => p[k]));
+      return values.size > 1;
+    });
+  }
+
+  // Higher value == better performance for this unit?
+  function biggerIsBetter(unit) {
+    if (!unit) return false;
+    const u = unit.toLowerCase();
+    if (u.startsWith('ops')) return true; // ops/s, ops/ms, ...
+    return false; // */op (ms/op, us/op, ns/op, B/op, ...) and anything else: smaller is better
+  }
+
+  // Positive = improvement, negative = regression, regardless of metric direction.
+  function pctChange(prevVal, currVal, unit) {
+    if (prevVal === 0) return null;
+    return biggerIsBetter(unit)
+      ? ((currVal - prevVal) / prevVal) * 100
+      : ((prevVal - currVal) / prevVal) * 100;
+  }
+
+  function badgeFor(pct) {
+    if (pct === null || !Number.isFinite(pct)) {
+      return { cls: 'neutral', text: 'first run' };
+    }
+    if (pct > NOISE_BAND) return { cls: 'good', text: `+${pct.toFixed(1)}%` };
+    if (pct < -NOISE_BAND) return { cls: 'bad', text: `${pct.toFixed(1)}%` };
+    return { cls: 'neutral', text: `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}% (noise)` };
+  }
+
+  // Collapse per-run entries into { className: { method: { series: [{label, unit, points:[{commit,date,value,range,extra}]}] } } }
+  // Series are keyed by the raw JSON params string first; labels are computed afterwards
+  // from only the param keys that actually vary within that method, to avoid repeating
+  // constant params (e.g. verificationMode=STRICT) on every legend entry.
+  function buildGroups(entries) {
+    const classes = new Map();
+    for (const run of entries) {
+      const { commit, date } = run;
+      for (const bench of run.benches) {
+        const { shortClass, pkg, fullClass, method, paramsObj } = parseBenchName(bench.name);
+        const seriesKey = paramsObj ? JSON.stringify(paramsObj) : method;
+
+        if (!classes.has(shortClass)) classes.set(shortClass, { pkg, fullClass, methods: new Map() });
+        const clsEntry = classes.get(shortClass);
+
+        if (!clsEntry.methods.has(method)) clsEntry.methods.set(method, new Map());
+        const seriesMap = clsEntry.methods.get(method);
+
+        if (!seriesMap.has(seriesKey)) seriesMap.set(seriesKey, { paramsObj, unit: bench.unit, points: [] });
+        seriesMap.get(seriesKey).points.push({
+          commit, date,
+          value: bench.value,
+          range: bench.range,
+          extra: bench.extra,
+        });
+      }
+    }
+
+    // Second pass: compute compact labels per method using only varying param keys.
+    for (const clsEntry of classes.values()) {
+      for (const [method, seriesMap] of clsEntry.methods) {
+        const series = [...seriesMap.values()];
+        const varyKeys = varyingParamKeys(series.map((s) => s.paramsObj));
+        series.forEach((s) => {
+          s.label = paramLabel(s.paramsObj, varyKeys) || method;
+        });
+      }
+    }
+
+    return classes;
+  }
+
+  function renderTooltipAfterTitle(point) {
+    if (!point) return '';
+    const c = point.commit;
+    return `\n${c.message}\n\n${c.timestamp} committed by @${c.committer.username}\n`;
+  }
+
+  const allCharts = [];
+
+  function cssVar(name) {
+    return getComputedStyle(document.body).getPropertyValue(name).trim();
+  }
+
+  function makeChart(canvas, seriesList, unit) {
+    let allValues = [];
+    seriesList.forEach((s) => s.points.forEach((p) => allValues.push(p.value)));
+    allValues = allValues.filter((v) => v > 0);
+    const useLog = allValues.length > 1 && Math.max(...allValues) / Math.min(...allValues) > 15;
+
+    const labels = seriesList[0].points.map((p) => p.commit.id.slice(0, 7));
+
+    const datasets = seriesList.map((s, i) => {
+      const color = PALETTE[i % PALETTE.length];
+      return {
+        label: s.label,
+        data: s.points.map((p) => p.value),
+        borderColor: color,
+        backgroundColor: color + '33',
+        pointRadius: s.points.length <= 15 ? 3 : 1.5,
+        borderWidth: 2,
+        tension: 0.15,
+        spanGaps: true,
+      };
+    });
+
+    const chart = new Chart(canvas, {
+      type: 'line',
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        scales: {
+          x: {
+            title: { display: true, text: 'commit', color: cssVar('--fg-muted') },
+            ticks: { color: cssVar('--fg-muted') },
+            grid: { color: cssVar('--chart-grid') },
+          },
+          y: {
+            type: useLog ? 'logarithmic' : 'linear',
+            title: { display: true, text: unit || '', color: cssVar('--fg-muted') },
+            beginAtZero: !useLog,
+            ticks: { color: cssVar('--fg-muted') },
+            grid: { color: cssVar('--chart-grid') },
+          },
+        },
+        plugins: {
+          legend: {
+            display: seriesList.length > 1,
+            position: 'bottom',
+            labels: { boxWidth: 10, boxHeight: 10, font: { size: 10 }, color: cssVar('--fg') },
+          },
+          tooltip: {
+            callbacks: {
+              afterTitle: (items) => {
+                const item = items[0];
+                const s = seriesList[item.datasetIndex];
+                return renderTooltipAfterTitle(s.points[item.dataIndex]);
+              },
+              label: (item) => {
+                const s = seriesList[item.datasetIndex];
+                const p = s.points[item.dataIndex];
+                let label = `${s.label}: ${item.formattedValue} ${s.unit}`;
+                if (p.range) label += ` (${p.range})`;
+                return label;
+              },
+              afterLabel: (item) => {
+                const s = seriesList[item.datasetIndex];
+                const p = s.points[item.dataIndex];
+                return p.extra ? `\n${p.extra}` : '';
+              },
+            },
+          },
+        },
+        onClick: (evt, activeEls, chart) => {
+          if (!activeEls.length) return;
+          const { datasetIndex, index } = activeEls[0];
+          const s = seriesList[datasetIndex];
+          const url = s.points[index].commit.url;
+          window.open(url, '_blank');
+        },
+      },
+    });
+    allCharts.push(chart);
+    return chart;
+  }
+
+  function refreshChartTheme() {
+    const fgMuted = cssVar('--fg-muted');
+    const grid = cssVar('--chart-grid');
+    const fg = cssVar('--fg');
+    allCharts.forEach((chart) => {
+      chart.options.scales.x.title.color = fgMuted;
+      chart.options.scales.x.ticks.color = fgMuted;
+      chart.options.scales.x.grid.color = grid;
+      chart.options.scales.y.title.color = fgMuted;
+      chart.options.scales.y.ticks.color = fgMuted;
+      chart.options.scales.y.grid.color = grid;
+      if (chart.options.plugins.legend.labels) chart.options.plugins.legend.labels.color = fg;
+      chart.update('none');
+    });
+  }
+
+  function chartWorstBadge(seriesList) {
+    let worst = null;
+    let best = null;
+    for (const s of seriesList) {
+      if (s.points.length < 2) continue;
+      const prev = s.points[s.points.length - 2];
+      const curr = s.points[s.points.length - 1];
+      const pct = pctChange(prev.value, curr.value, s.unit);
+      if (pct === null) continue;
+      if (worst === null || pct < worst) worst = pct;
+      if (best === null || pct > best) best = pct;
+    }
+    if (worst === null) return badgeFor(null);
+    if (worst < -NOISE_BAND) return badgeFor(worst);
+    if (best !== null && best > NOISE_BAND) return badgeFor(best);
+    return badgeFor(worst);
+  }
+
+  function render(rootEl, sidebarEl, data, suiteName) {
+    const entries = data.entries[suiteName] || [];
+    if (entries.length === 0) {
+      rootEl.appendChild(el('div', { class: 'empty-state', text: 'No benchmark data recorded for this suite yet.' }));
+      return;
+    }
+
+    const classes = buildGroups(entries);
+    const sortedClassNames = [...classes.keys()].sort((a, b) => a.localeCompare(b));
+
+    const tocList = el('ul', {});
+    sortedClassNames.forEach((clsName) => {
+      const clsEntry = classes.get(clsName);
+      const anchor = 'cls-' + slugify(clsName);
+      const count = clsEntry.methods.size;
+      const link = el('a', { class: 'toc-link', href: '#' + anchor, 'data-search': clsName.toLowerCase() }, [
+        el('span', { text: clsName }),
+        el('span', { class: 'count', text: String(count) }),
+      ]);
+      tocList.appendChild(el('li', {}, [link]));
+    });
+    sidebarEl.appendChild(el('h2', { text: `Benchmarks (${sortedClassNames.length} classes)` }));
+    sidebarEl.appendChild(tocList);
+
+    sortedClassNames.forEach((clsName) => {
+      const clsEntry = classes.get(clsName);
+      const anchor = 'cls-' + slugify(clsName);
+      const details = el('details', { class: 'bench-class', id: anchor, open: 'open', 'data-search': clsName.toLowerCase() });
+      const summary = el('summary', {}, [
+        el('span', { class: 'class-name', text: clsName }),
+        el('span', { class: 'class-pkg', text: clsEntry.pkg }),
+        el('span', { class: 'class-count', text: `${clsEntry.methods.size} chart${clsEntry.methods.size === 1 ? '' : 's'}` }),
+      ]);
+      details.appendChild(summary);
+
+      const grid = el('div', { class: 'chart-grid' });
+      const sortedMethods = [...clsEntry.methods.keys()].sort((a, b) => a.localeCompare(b));
+      sortedMethods.forEach((methodName) => {
+        const seriesMap = clsEntry.methods.get(methodName);
+        const seriesList = [...seriesMap.values()].sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+        const unit = seriesList[0].unit;
+
+        const badge = chartWorstBadge(seriesList);
+        const searchText = (clsName + ' ' + methodName + ' ' + seriesList.map((s) => s.label).join(' ')).toLowerCase();
+
+        const card = el('div', { class: 'chart-card', 'data-search': searchText });
+        card.appendChild(el('div', { class: 'chart-card-header' }, [
+          el('div', { class: 'chart-title', text: methodName }),
+          el('span', { class: `badge ${badge.cls}`, title: 'Change vs. previous run', text: badge.text }),
+        ]));
+        const wrap = el('div', { class: 'chart-canvas-wrap' });
+        const canvas = el('canvas');
+        wrap.appendChild(canvas);
+        card.appendChild(wrap);
+        grid.appendChild(card);
+
+        makeChart(canvas, seriesList, unit);
+      });
+
+      details.appendChild(grid);
+      rootEl.appendChild(details);
+    });
+  }
+
+  function wireSearch(inputEl) {
+    inputEl.addEventListener('input', () => {
+      const q = inputEl.value.trim().toLowerCase();
+      document.querySelectorAll('details.bench-class').forEach((section) => {
+        let sectionHasMatch = false;
+        section.querySelectorAll('.chart-card').forEach((card) => {
+          const match = !q || card.getAttribute('data-search').includes(q);
+          card.classList.toggle('hidden', !match);
+          if (match) sectionHasMatch = true;
+        });
+        section.classList.toggle('hidden', !sectionHasMatch);
+        if (q && sectionHasMatch) section.open = true;
+      });
+      document.querySelectorAll('.toc-link').forEach((link) => {
+        const match = !q || link.getAttribute('data-search').includes(q);
+        link.classList.toggle('hidden', !match);
+      });
+    });
+  }
+
+  function wireTheme(toggleBtn) {
+    const stored = localStorage.getItem('bench-theme');
+    if (stored) document.documentElement.setAttribute('data-theme', stored);
+    const isDark = () => {
+      const attr = document.documentElement.getAttribute('data-theme');
+      if (attr) return attr === 'dark';
+      return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    };
+    const sync = () => { toggleBtn.textContent = isDark() ? '☀️ Light' : '🌙 Dark'; };
+    sync();
+    toggleBtn.addEventListener('click', () => {
+      const next = isDark() ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('bench-theme', next);
+      sync();
+      refreshChartTheme();
+    });
+  }
+
+  window.BenchDashboard = { render, wireSearch, wireTheme, slugify };
+})();

--- a/dev/bench/indexes/index.html
+++ b/dev/bench/indexes/index.html
@@ -1,281 +1,63 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
-    <style>
-      html {
-        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
-        -webkit-font-smoothing: antialiased;
-        background-color: #fff;
-        font-size: 16px;
-      }
-      body {
-        color: #4a4a4a;
-        margin: 8px;
-        font-size: 1em;
-        font-weight: 400;
-      }
-      header {
-        margin-bottom: 8px;
-        display: flex;
-        flex-direction: column;
-      }
-      main {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      a {
-        color: #3273dc;
-        cursor: pointer;
-        text-decoration: none;
-      }
-      a:hover {
-        color: #000;
-      }
-      button {
-        color: #fff;
-        background-color: #3298dc;
-        border-color: transparent;
-        cursor: pointer;
-        text-align: center;
-      }
-      button:hover {
-        background-color: #2793da;
-        flex: none;
-      }
-      .spacer {
-        flex: auto;
-      }
-      .small {
-        font-size: 0.75rem;
-      }
-      footer {
-        margin-top: 16px;
-        display: flex;
-        align-items: center;
-      }
-      .header-label {
-        margin-right: 4px;
-      }
-      .benchmark-set {
-        margin: 8px 0;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      .benchmark-title {
-        font-size: 3rem;
-        font-weight: 600;
-        word-break: break-word;
-        text-align: center;
-      }
-      .benchmark-graphs {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        align-items: center;
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .benchmark-chart {
-        max-width: 1000px;
-      }
-    </style>
-    <title>Benchmarks</title>
-  </head>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+  <title>exist-indexes-jmh Benchmarks — eXist-db</title>
+  <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+  <div class="layout" style="flex-direction: column; width: 100%;">
+    <nav class="crumbs">
+      <a href="../../">eXist-db Benchmarks</a>
+      <span class="sep">/</span>
+      <a href="../core/">exist-core-jmh</a>
+      <span class="sep">·</span>
+      <span>exist-indexes-jmh</span>
+      <span class="sep">·</span>
+      <a href="https://github.com/eXist-db/exist" rel="noopener">GitHub</a>
+    </nav>
+    <div class="layout" style="flex: 1;">
+      <aside class="sidebar" id="sidebar"></aside>
+      <main class="main">
+        <div class="controlbar">
+          <h1>exist-indexes-jmh</h1>
+          <span class="meta" id="last-update"></span>
+          <div class="spacer"></div>
+          <input id="search" type="search" placeholder="Filter benchmarks…" aria-label="Filter benchmarks" />
+          <button class="btn" id="theme-toggle" type="button"></button>
+          <button class="btn" id="dl-button" type="button">Download JSON</button>
+        </div>
+        <div id="main"></div>
+        <footer class="page-footer">
+          <span>Data: <a id="repository-link" rel="noopener"></a></span>
+          <span>Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a> · rendered by a custom dashboard, see <a href="https://github.com/eXist-db/exist/blob/develop/.github/workflows/ci-benchmarks.yml">ci-benchmarks.yml</a></span>
+        </footer>
+      </main>
+    </div>
+  </div>
 
-  <body>
-    <header id="header">
-      <div class="header-item">
-        <strong class="header-label">Last Update:</strong>
-        <span id="last-update"></span>
-      </div>
-      <div class="header-item">
-        <strong class="header-label">Repository:</strong>
-        <a id="repository-link" rel="noopener"></a>
-      </div>
-    </header>
-    <main id="main"></main>
-    <footer>
-      <button id="dl-button">Download data as JSON</button>
-      <div class="spacer"></div>
-      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
-    </footer>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+  <script src="../dashboard.js"></script>
+  <script src="data.js"></script>
+  <script>
+    (function () {
+      const data = window.BENCHMARK_DATA;
+      document.getElementById('last-update').textContent = 'Last update: ' + new Date(data.lastUpdate).toLocaleString();
+      const repoLink = document.getElementById('repository-link');
+      repoLink.href = data.repoUrl;
+      repoLink.textContent = data.repoUrl;
+      document.getElementById('dl-button').onclick = () => {
+        const a = document.createElement('a');
+        a.href = 'data:,' + encodeURIComponent(JSON.stringify(data, null, 2));
+        a.download = 'exist-indexes-jmh_benchmark_data.json';
+        a.click();
+      };
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
-    <script src="data.js"></script>
-    <script id="main-script">
-      'use strict';
-      (function() {
-        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-        const toolColors = {
-          cargo: '#dea584',
-          go: '#00add8',
-          benchmarkjs: '#f1e05a',
-          benchmarkluau: '#000080',
-          pytest: '#3572a5',
-          googlecpp: '#f34b7d',
-          catch2: '#f34b7d',
-          julia: '#a270ba',
-          jmh: '#b07219',
-          benchmarkdotnet: '#178600',
-          customBiggerIsBetter: '#38ff38',
-          customSmallerIsBetter: '#ff3838',
-          _: '#333333'
-        };
-
-        function init() {
-          function collectBenchesPerTestCase(entries) {
-            const map = new Map();
-            for (const entry of entries) {
-              const {commit, date, tool, benches} = entry;
-              for (const bench of benches) {
-                const result = { commit, date, tool, bench };
-                const arr = map.get(bench.name);
-                if (arr === undefined) {
-                  map.set(bench.name, [result]);
-                } else {
-                  arr.push(result);
-                }
-              }
-            }
-            return map;
-          }
-
-          const data = window.BENCHMARK_DATA;
-
-          // Render header
-          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
-          const repoLink = document.getElementById('repository-link');
-          repoLink.href = data.repoUrl;
-          repoLink.textContent = data.repoUrl;
-
-          // Render footer
-          document.getElementById('dl-button').onclick = () => {
-            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
-            const a = document.createElement('a');
-            a.href = dataUrl;
-            a.download = 'benchmark_data.json';
-            a.click();
-          };
-
-          // Prepare data points for charts
-          return Object.keys(data.entries).map(name => ({
-            name,
-            dataSet: collectBenchesPerTestCase(data.entries[name]),
-          }));
-        }
-
-        function renderAllChars(dataSets) {
-
-          function renderGraph(parent, name, dataset) {
-            const canvas = document.createElement('canvas');
-            canvas.className = 'benchmark-chart';
-            parent.appendChild(canvas);
-
-            const color = toolColors[dataset.length > 0 ? dataset[0].tool : '_'];
-            const data = {
-              labels: dataset.map(d => d.commit.id.slice(0, 7)),
-              datasets: [
-                {
-                  label: name,
-                  data: dataset.map(d => d.bench.value),
-                  borderColor: color,
-                  backgroundColor: color + '60', // Add alpha for #rrggbbaa
-                }
-              ],
-            };
-            const options = {
-              scales: {
-                xAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: 'commit',
-                    },
-                  }
-                ],
-                yAxes: [
-                  {
-                    scaleLabel: {
-                      display: true,
-                      labelString: dataset.length > 0 ? dataset[0].bench.unit : '',
-                    },
-                    ticks: {
-                      beginAtZero: true,
-                    }
-                  }
-                ],
-              },
-              tooltips: {
-                callbacks: {
-                  afterTitle: items => {
-                    const {index} = items[0];
-                    const data = dataset[index];
-                    return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.committer.username + '\n';
-                  },
-                  label: item => {
-                    let label = item.value;
-                    const { range, unit } = dataset[item.index].bench;
-                    label += ' ' + unit;
-                    if (range) {
-                      label += ' (' + range + ')';
-                    }
-                    return label;
-                  },
-                  afterLabel: item => {
-                    const { extra } = dataset[item.index].bench;
-                    return extra ? '\n' + extra : '';
-                  }
-                }
-              },
-              onClick: (_mouseEvent, activeElems) => {
-                if (activeElems.length === 0) {
-                  return;
-                }
-                // XXX: Undocumented. How can we know the index?
-                const index = activeElems[0]._index;
-                const url = dataset[index].commit.url;
-                window.open(url, '_blank');
-              },
-            };
-
-            new Chart(canvas, {
-              type: 'line',
-              data,
-              options,
-            });
-          }
-
-          function renderBenchSet(name, benchSet, main) {
-            const setElem = document.createElement('div');
-            setElem.className = 'benchmark-set';
-            main.appendChild(setElem);
-
-            const nameElem = document.createElement('h1');
-            nameElem.className = 'benchmark-title';
-            nameElem.textContent = name;
-            setElem.appendChild(nameElem);
-
-            const graphsElem = document.createElement('div');
-            graphsElem.className = 'benchmark-graphs';
-            setElem.appendChild(graphsElem);
-
-            for (const [benchName, benches] of benchSet.entries()) {
-              renderGraph(graphsElem, benchName, benches)
-            }
-          }
-
-          const main = document.getElementById('main');
-          for (const {name, dataSet} of dataSets) {
-            renderBenchSet(name, dataSet, main);
-          }
-        }
-
-        renderAllChars(init()); // Start
-      })();
-    </script>
-  </body>
+      BenchDashboard.wireTheme(document.getElementById('theme-toggle'));
+      BenchDashboard.render(document.getElementById('main'), document.getElementById('sidebar'), data, 'exist-indexes-jmh');
+      BenchDashboard.wireSearch(document.getElementById('search'));
+    })();
+  </script>
+</body>
 </html>

--- a/dev/bench/style.css
+++ b/dev/bench/style.css
@@ -1,0 +1,310 @@
+/* eXist-db JMH benchmark dashboards — shared styling */
+
+:root {
+  --bg: #ffffff;
+  --bg-elevated: #f6f8fa;
+  --fg: #1f2328;
+  --fg-muted: #59636e;
+  --border: #d0d7de;
+  --accent: #0969da;
+  --accent-contrast: #ffffff;
+  --good: #1a7f37;
+  --good-bg: #dafbe1;
+  --bad: #cf222e;
+  --bad-bg: #ffebe9;
+  --neutral-fg: #57606a;
+  --neutral-bg: #eef1f4;
+  --shadow: 0 1px 2px rgba(31, 35, 40, .08);
+  --chart-grid: rgba(31, 35, 40, .08);
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0d1117;
+    --bg-elevated: #161b22;
+    --fg: #e6edf3;
+    --fg-muted: #8d96a0;
+    --border: #30363d;
+    --accent: #4493f8;
+    --accent-contrast: #0d1117;
+    --good: #3fb950;
+    --good-bg: #123321;
+    --bad: #f85149;
+    --bad-bg: #3c1618;
+    --neutral-fg: #8d96a0;
+    --neutral-bg: #1c2128;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .4);
+    --chart-grid: rgba(230, 237, 243, .08);
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #0d1117;
+  --bg-elevated: #161b22;
+  --fg: #e6edf3;
+  --fg-muted: #8d96a0;
+  --border: #30363d;
+  --accent: #4493f8;
+  --accent-contrast: #0d1117;
+  --good: #3fb950;
+  --good-bg: #123321;
+  --bad: #f85149;
+  --bad-bg: #3c1618;
+  --neutral-fg: #8d96a0;
+  --neutral-bg: #1c2128;
+  --shadow: 0 1px 2px rgba(0, 0, 0, .4);
+  --chart-grid: rgba(230, 237, 243, .08);
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  display: flex;
+  min-height: 100vh;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, .mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .92em;
+}
+
+/* --- breadcrumb / top nav shared across all 3 pages --- */
+.crumbs {
+  padding: 10px 20px;
+  font-size: 13px;
+  color: var(--fg-muted);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.crumbs .sep { opacity: .5; }
+
+/* --- layout: sidebar + main --- */
+.layout { display: flex; width: 100%; align-items: flex-start; }
+
+.sidebar {
+  width: 260px;
+  flex: none;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+  padding: 16px;
+  background: var(--bg-elevated);
+}
+
+.sidebar h2 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--fg-muted);
+  margin: 0 0 8px;
+}
+
+.sidebar ul { list-style: none; margin: 0 0 20px; padding: 0; }
+.sidebar li { margin: 0; }
+.sidebar a.toc-link {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 13px;
+}
+.sidebar a.toc-link:hover { background: var(--neutral-bg); text-decoration: none; }
+.sidebar a.toc-link .count {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.sidebar .toc-link.hidden { display: none; }
+
+.main { flex: 1; min-width: 0; padding: 0 24px 48px; }
+
+/* --- sticky control bar --- */
+.controlbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 14px 0;
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.controlbar h1 {
+  font-size: 20px;
+  margin: 0;
+  flex: none;
+}
+
+.controlbar .meta {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+.controlbar .spacer { flex: 1 1 auto; }
+
+#search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 13px;
+  min-width: 220px;
+}
+#search:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+
+button.btn {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+button.btn:hover { background: var(--neutral-bg); }
+
+/* --- benchmark class sections --- */
+details.bench-class {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  background: var(--bg-elevated);
+  scroll-margin-top: 70px;
+}
+details.bench-class.hidden { display: none; }
+
+details.bench-class > summary {
+  cursor: pointer;
+  padding: 12px 16px;
+  list-style: none;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+details.bench-class > summary::-webkit-details-marker { display: none; }
+details.bench-class > summary::before {
+  content: "▸";
+  color: var(--fg-muted);
+  transition: transform .1s;
+}
+details.bench-class[open] > summary::before { transform: rotate(90deg); }
+
+.class-name { font-size: 15px; font-weight: 600; }
+.class-pkg { font-size: 12px; color: var(--fg-muted); }
+.class-count {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-left: auto;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: 14px;
+  padding: 0 16px 16px;
+}
+
+.chart-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  box-shadow: var(--shadow);
+  padding: 10px 12px 6px;
+  min-width: 0;
+}
+.chart-card.hidden { display: none; }
+
+.chart-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.chart-title {
+  font-size: 13px;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.chart-canvas-wrap { height: 240px; position: relative; }
+
+/* --- badges --- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.badge.good { color: var(--good); background: var(--good-bg); }
+.badge.bad { color: var(--bad); background: var(--bad-bg); }
+.badge.neutral { color: var(--neutral-fg); background: var(--neutral-bg); }
+
+/* --- landing page cards (root index.html) --- */
+.landing { max-width: 760px; margin: 0 auto; padding: 48px 24px; }
+.landing h1 { font-size: 28px; margin-bottom: 4px; }
+.landing p.lede { color: var(--fg-muted); margin-top: 0; }
+.dash-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin: 28px 0; }
+.dash-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 18px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow);
+}
+.dash-card h3 { margin: 0 0 6px; font-size: 16px; }
+.dash-card p { margin: 0 0 12px; color: var(--fg-muted); font-size: 13px; }
+.dash-card .stat { font-size: 12px; color: var(--fg-muted); }
+
+footer.page-footer {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--fg-muted);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.empty-state {
+  padding: 40px 16px;
+  text-align: center;
+  color: var(--fg-muted);
+}

--- a/index.html
+++ b/index.html
@@ -2,20 +2,49 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>eXist-db JMH Benchmarks</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>eXist-db JMH Benchmarks</title>
+  <link rel="stylesheet" href="dev/bench/style.css">
 </head>
 <body>
-  <h1>eXist-db JMH Benchmarks</h1>
-  <p>
-    This branch hosts data for the JMH benchmark dashboards published by
-    <a href="https://github.com/eXist-db/exist/blob/develop/.github/workflows/ci-benchmarks.yml">.github/workflows/ci-benchmarks.yml</a>,
-    via <a href="https://github.com/benchmark-action/github-action-benchmark">benchmark-action/github-action-benchmark</a>.
-  </p>
-  <p>No benchmark data has been published yet. Once the workflow has run at least once, dashboards will appear at:</p>
-  <ul>
-    <li><a href="dev/bench/core/">dev/bench/core/</a> &mdash; exist-core-jmh</li>
-    <li><a href="dev/bench/indexes/">dev/bench/indexes/</a> &mdash; exist-indexes-jmh</li>
-  </ul>
+  <div class="layout" style="flex-direction: column; width: 100%;">
+    <nav class="crumbs">
+      <span>eXist-db Benchmarks</span>
+      <span class="sep">·</span>
+      <a href="https://github.com/eXist-db/exist" rel="noopener">GitHub</a>
+    </nav>
+    <div class="landing">
+      <h1>eXist-db JMH Benchmarks</h1>
+      <p class="lede">
+        Performance trend dashboards generated weekly (and on manual dispatch) by
+        <a href="https://github.com/eXist-db/exist/blob/develop/.github/workflows/ci-benchmarks.yml">ci-benchmarks.yml</a>,
+        via <a href="https://github.com/benchmark-action/github-action-benchmark">benchmark-action/github-action-benchmark</a>.
+      </p>
+
+      <div class="dash-cards">
+        <div class="dash-card">
+          <h3>exist-core-jmh</h3>
+          <p>Core XQuery engine, DOM, storage and lock benchmarks.</p>
+          <a href="dev/bench/core/">Open dashboard →</a>
+        </div>
+        <div class="dash-card">
+          <h3>exist-indexes-jmh</h3>
+          <p>Lucene, Range, Ngram and general-comparison indexing benchmarks.</p>
+          <a href="dev/bench/indexes/">Open dashboard →</a>
+        </div>
+      </div>
+
+      <p class="lede">
+        Each dashboard groups benchmarks by class, supports search/filtering, and shows the
+        percent change against the previous run. Raw historical data backing each chart is
+        available as JSON from the download button on each dashboard.
+      </p>
+
+      <footer class="page-footer">
+        <span>Source: <a href="https://github.com/eXist-db/exist">eXist-db/exist</a></span>
+        <span>gh-pages branch</span>
+      </footer>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
The default `github-action-benchmark` template renders one flat, unsorted
chart per benchmark+parameter-set with no navigation and no dark mode.
As more benchmarks were added this became unusable (168 charts on
`exist-core-jmh` alone). This replaces it with a grouped, searchable
dashboard.

The action only writes `index.html` when it's missing (`addIndexHtmlIfNeeded`
in `github-action-benchmark`'s `write.ts`) — every run after that only
appends to `data.js` — so these files are safe to hand-maintain going
forward; no workflow change needed.

Before/after screenshots are in the comment below.

## What changed
- `dev/bench/style.css`, `dev/bench/dashboard.js` (new) — shared theme
  (light/dark, system-aware + manual toggle) and rendering engine: groups
  charts by class → method (one series per JMH param set instead of one
  chart per combination — `exist-core-jmh` 168→29 charts,
  `exist-indexes-jmh` 60→20), sidebar TOC + search/filter, log-scale
  y-axis for wide-spread series, and a per-chart %-change badge
  (direction-aware by unit — see the companion upstream issue below).
  Chart.js 2.9.2 → 4.4.4.
- `dev/bench/core/index.html`, `dev/bench/indexes/index.html` — slimmed
  to shells loading the shared CSS/JS.
- `index.html` — restyled root landing page.

## CI
The failing **Codacy** check found **0 issues and analyzed 0 files** for
this diff (confirmed via the Codacy API directly) — it's reporting
`action_required`, which on this repo's Codacy integration means "needs a
maintainer to view the dashboard," not "found a defect." `gh-pages` has no
branch protection, so this can't block merge either way.

## Test plan
- [x] Verified in a local static server against real `data.js` from the
      live `gh-pages` branch — no console errors.
- [x] Confirmed chart-count reduction (168→29, 60→20) against the actual
      data.
- [x] Manually exercised search/filter, dark/light toggle (incl. live
      re-theming of already-rendered charts), and log-scale detection.
- [x] Maintainer review of visual design/density, especially
      `ReindexDeleteStrategyBenchmark` (up to 20 series per chart).
- [ ] Confirm GitHub Pages redeploys cleanly from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)