### PR TITLE
[bugfix] update ParseHtmlTest to match codelibs nekohtml 3.0.4 behavior

### DIFF
--- a/exist-core/src/test/java/org/exist/xquery/functions/util/ParseHtmlTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/ParseHtmlTest.java
@@ -54,7 +54,7 @@ public class ParseHtmlTest {
             assertEquals(1, result.getItemCount());
             assertTrue(result.itemAt(0) instanceof DocumentImpl);
 
-            final Source expected = Input.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><HTML><head xmlns=\"http://www.w3.org/1999/xhtml\"/><BODY><p>hello <img src=\"1.jpg\"/></p></BODY></HTML>").build();
+            final Source expected = Input.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><HTML><BODY><p>hello <img src=\"1.jpg\"/></p></BODY></HTML>").build();
             final Source actual = Input.fromDocument((DocumentImpl) result.itemAt(0)).build();
 
             final Diff diff = DiffBuilder


### PR DESCRIPTION
codelibs nekohtml 3.0.4 is a full rewrite of the original cyberneko
parser and no longer synthesizes an implicit empty `<head>` element when
none is present in the input HTML.

Old behavior (nekohtml 2.x):
  `<HTML><head xmlns="http://www.w3.org/1999/xhtml"/><BODY>...</BODY></HTML>`

New behavior (nekohtml 3.0.4):
  `<HTML><BODY>...</BODY></HTML>`

The new behavior aligns with the HTML5 tree construction algorithm,
which only inserts `<head>` when there is actual head content.

Update the expected XML in ParseHtmlTest.parseHtml to remove the now-
absent `<head>` element, keeping the test in sync with the upgraded parser.

Closes: bump org.codelibs:nekohtml from 2.1.3 to 3.0.4 (https://github.com/eXist-db/exist/commit/e954c903f58226b56d050ae88a2366db68ea95bc)

Co-authored-by: Junie <junie@jetbrains.com>


