### PR TITLE
[doc] Document recursive xmldb:create-collection() #3869

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCreateCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCreateCollection.java
@@ -48,13 +48,15 @@ public class XMLDBCreateCollection extends XMLDBAbstractCollectionManipulator {
 	public final static FunctionSignature signature = new FunctionSignature(
 			new QName("create-collection", XMLDBModule.NAMESPACE_URI,
 					XMLDBModule.PREFIX),
-            "Create a new collection with name $new-collection as a child of " +
-            "$target-collection-uri. " + XMLDBModule.COLLECTION_URI +
+            "Create a new collection $new-collection as a child of " +
+            "$target-collection-uri. $new-collection may be a path of several " +
+            "segments (for example 'a/b/c/d'); missing intermediate collections " +
+            "are created. " + XMLDBModule.COLLECTION_URI +
             "Returns the path to the new collection if successfully created, " +
             "otherwise the empty sequence.",
 			new SequenceType[]{
 			    new FunctionParameterSequenceType("target-collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The target collection URI"),
-			    new FunctionParameterSequenceType("new-collection", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the new collection to create")},
+			    new FunctionParameterSequenceType("new-collection", Type.STRING, Cardinality.EXACTLY_ONE, "The name or relative path of the new collection to create. Intermediate collections in a path are created as needed")},
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the path to the new collection if successfully created, otherwise the empty sequence"));
 
     public XMLDBCreateCollection(XQueryContext context) {

--- a/exist-core/src/test/xquery/xmldb/create-collection-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/create-collection-tests.xql
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.0";
+
+module namespace t="http://exist-db.org/testsuite/create-collection";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare variable $t:collection-name := "create-collection-test";
+declare variable $t:collection := "/db/" || $t:collection-name;
+
+declare
+    %test:setUp
+function t:setup() {
+    xmldb:create-collection("/db", $t:collection-name)
+};
+
+declare
+    %test:tearDown
+function t:cleanup() {
+    xmldb:remove($t:collection)
+};
+
+declare
+    %test:assertEquals("/db/create-collection-test/child")
+function t:create-single-segment() {
+    xmldb:create-collection($t:collection, "child")
+};
+
+declare
+    %test:assertEquals("/db/create-collection-test/a/b/c/d")
+function t:create-nested-path() {
+    xmldb:create-collection($t:collection, "a/b/c/d")
+};
+
+declare
+    %test:assertTrue
+function t:create-nested-path-creates-intermediates() {
+    let $created := xmldb:create-collection($t:collection, "p/q/r")
+    return
+        xmldb:collection-available($t:collection || "/p")
+        and xmldb:collection-available($t:collection || "/p/q")
+        and xmldb:collection-available($t:collection || "/p/q/r")
+        and $created eq $t:collection || "/p/q/r"
+};
+
+declare
+    %test:assertEquals("/db/create-collection-test/x/y")
+function t:create-nested-path-twice() {
+    let $_ := xmldb:create-collection($t:collection, "x/y")
+    return xmldb:create-collection($t:collection, "x/y")
+};


### PR DESCRIPTION
### Description:

`xmldb:create-collection()` already creates missing path segments. The function docs now say that, and there is an XQSuite for a nested path, intermediates, and creating the same path twice.

### Reference:

https://github.com/eXist-db/exist/issues/3869

### Type of tests:

XQSuite in `exist-core/src/test/xquery/xmldb/create-collection-tests.xql`
