### PR TITLE
[bugfix] Anchor .moderne ignore pattern so it applies at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,9 @@ work/
 # Claude planning files
 plans/
 .codacy/
-.moderne/*
-!.moderne/context/
-!.moderne/moderne.yml
+**/.moderne/*
+!/.moderne/context/
+!/.moderne/moderne.yml
 .github/instructions/
 
 # Debug logs (e.g. from reindex investigation)


### PR DESCRIPTION
## Summary
- `.moderne/*` (slash in the middle) is anchored to the repo root by gitignore's rules, so it only ignored the top-level `.moderne/` directory. Nested `.moderne/` directories created when running Moderne recipes scoped to a submodule (e.g. `exist-core/.moderne/`) were left untracked, showing up as a dirty checkout.
- Switches the pattern to `**/.moderne/*` so it applies at any depth, and anchors the `context/`/`moderne.yml` negations to the repo root (`!/.moderne/context/`, `!/.moderne/moderne.yml`) so nested `.moderne` dirs elsewhere stay fully ignored while the root's committed context files remain tracked.

## What Changed
- `.gitignore`: `.moderne/*` → `**/.moderne/*`, negations anchored with a leading `/`.

Closes https://github.com/eXist-db/exist/issues/6590

## Test Plan
- [x] `git check-ignore -v exist-core/.moderne/apply` → now ignored
- [x] `git check-ignore -v .moderne/context/architecture.md` → still tracked (not ignored)
- [x] `git status` no longer reports nested `.moderne` working directories as dirty