### PR TITLE
[bugfix] cover native collection.xconf.xsd via OASIS catalog + jaxp

### DIFF
--- a/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
+++ b/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
@@ -43,6 +43,7 @@ import org.apache.xerces.xni.grammars.XMLSchemaDescription;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.apache.xerces.xni.parser.XMLInputSource;
 import org.exist.util.XMLReaderObjectFactory;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.*;
 import org.xmlresolver.Resolver;
 
@@ -164,5 +165,29 @@ public class XercesXmlResolverAdapter implements XMLEntityResolver {
      */
     public Resolver getResolver() {
         return resolver;
+    }
+
+    /**
+     * Wraps {@code resolver} as an {@link LSResourceResolver}, falling back to {@code namespaceURI}
+     * as the system id whenever the caller doesn't supply one -- the same fallback {@link
+     * #resolveEntity} already performs for the XNI/SAX pipeline (see its {@code systemId} lookup).
+     *
+     * <p>This fallback matters because {@link Resolver#resolveResource} requires a non-null system
+     * id before it will consult its catalog at all; without it, an OASIS catalog's {@code <uri>}
+     * entry keyed purely by namespace (no {@code schemaLocation} hint on the instance) is invisible
+     * to the XSD 1.1 dynamic-discovery {@link javax.xml.validation.Validator}, which calls {@link
+     * LSResourceResolver#resolveResource} with the root element's namespace but no system id --
+     * even though the same catalog entry already works for the default SAX pipeline via {@link
+     * #resolveEntity}.</p>
+     *
+     * @param resolver the resolver to wrap.
+     *
+     * @return an {@link LSResourceResolver} view of {@code resolver} with the namespace fallback applied.
+     */
+    public static LSResourceResolver asLSResourceResolver(final Resolver resolver) {
+        return (type, namespaceURI, publicId, systemId, baseURI) -> {
+            final String effectiveSystemId = systemId != null ? systemId : namespaceURI;
+            return resolver.resolveResource(type, namespaceURI, publicId, effectiveSystemId, baseURI);
+        };
     }
 }

--- a/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
+++ b/exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java
@@ -190,4 +190,21 @@ public class XercesXmlResolverAdapter implements XMLEntityResolver {
             return resolver.resolveResource(type, namespaceURI, publicId, effectiveSystemId, baseURI);
         };
     }
+
+    /**
+     * As {@link #asLSResourceResolver(Resolver)}, but accepting whichever concrete resolver type
+     * {@code Shared#resolveCatalogArgument} returns -- the namespace fallback is only applied when
+     * {@code resolver} is an {@link Resolver} (the implementation that needs it); any other {@link
+     * LSResourceResolver} (e.g. {@link org.exist.validation.resolver.SearchResourceResolver}, which
+     * already resolves purely by namespace on its own) is returned unchanged, as is {@code null}.
+     *
+     * @param resolver the resolver to adapt, or null.
+     *
+     * @return an {@link LSResourceResolver} with the namespace fallback applied where needed, or
+     * {@code null} if {@code resolver} was {@code null}.
+     */
+    @Nullable
+    public static LSResourceResolver asLSResourceResolver(@Nullable final LSResourceResolver resolver) {
+        return resolver instanceof Resolver xmlResolver ? asLSResourceResolver(xmlResolver) : resolver;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -50,6 +50,7 @@ import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.resolver.XercesXmlResolverAdapter;
+import org.xmlresolver.Resolver;
 import org.exist.storage.BrokerPool;
 import org.exist.util.Configuration;
 import org.exist.util.ExistSAXParserFactory;
@@ -565,8 +566,10 @@ public class Jaxp extends BasicFunction {
      * @return a {@link Validator} for the only XSD 1.1-capable pipeline this
      * Xerces fork supports: {@link SchemaFactory}/{@link Schema} with no
      * pre-supplied schema documents, so it dynamically discovers the schema
-     * from the instance's own schemaLocation hint, mirroring how the default
-     * SAXParser pipeline behaves for XSD 1.0.
+     * from the instance's own schemaLocation hint or, when {@code resolver} is
+     * an OASIS/system catalog, purely from the root element's namespace via
+     * {@link XercesXmlResolverAdapter#asLSResourceResolver}, mirroring how the
+     * default SAXParser pipeline behaves for XSD 1.0.
      */
     private Validator newXsd11Validator(@Nullable final LSResourceResolver resolver, final boolean useCache) throws SAXException {
         final SchemaFactory schemaFactory = SchemaFactory.newInstance(XSD_1_1_NS);
@@ -581,7 +584,14 @@ public class Jaxp extends BasicFunction {
         final Schema schema = schemaFactory.newSchema();
         final Validator validator = schema.newValidator();
         if (resolver != null) {
-            validator.setResourceResolver(resolver);
+            // org.xmlresolver.Resolver#resolveResource requires a non-null systemId before it will
+            // consult its catalog at all (unlike SearchResourceResolver, which resolves purely by
+            // namespace), so an OASIS catalog's <uri> entry keyed by namespace alone is otherwise
+            // invisible to this dynamic-discovery validator when the instance carries no
+            // schemaLocation hint. See XercesXmlResolverAdapter#asLSResourceResolver.
+            validator.setResourceResolver(resolver instanceof Resolver xmlResolver
+                    ? XercesXmlResolverAdapter.asLSResourceResolver(xmlResolver)
+                    : resolver);
         }
         return validator;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -50,7 +50,6 @@ import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.resolver.XercesXmlResolverAdapter;
-import org.xmlresolver.Resolver;
 import org.exist.storage.BrokerPool;
 import org.exist.util.Configuration;
 import org.exist.util.ExistSAXParserFactory;
@@ -588,10 +587,8 @@ public class Jaxp extends BasicFunction {
             // consult its catalog at all (unlike SearchResourceResolver, which resolves purely by
             // namespace), so an OASIS catalog's <uri> entry keyed by namespace alone is otherwise
             // invisible to this dynamic-discovery validator when the instance carries no
-            // schemaLocation hint. See XercesXmlResolverAdapter#asLSResourceResolver.
-            validator.setResourceResolver(resolver instanceof Resolver xmlResolver
-                    ? XercesXmlResolverAdapter.asLSResourceResolver(xmlResolver)
-                    : resolver);
+            // schemaLocation hint.
+            validator.setResourceResolver(XercesXmlResolverAdapter.asLSResourceResolver(resolver));
         }
         return validator;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -32,6 +32,7 @@ import javax.xml.validation.Validator;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
+import org.exist.resolver.XercesXmlResolverAdapter;
 import org.exist.storage.BrokerPool;
 import org.exist.validation.ValidationReport;
 import org.exist.xquery.BasicFunction;
@@ -237,10 +238,13 @@ public class Jaxv extends BasicFunction  {
             // directly, and SearchResourceResolver also implements it (in addition to the
             // Xerces-specific XMLEntityResolver/XNI interface it uses for validation:jaxp()'s
             // SAX pipeline), so the directory-search/collection case (a catalog URL ending
-            // in '/') works here too.
+            // in '/') works here too. Wrapped via XercesXmlResolverAdapter#asLSResourceResolver
+            // so an xs:import with no schemaLocation (resolved purely by namespace) also works
+            // through an org.xmlresolver.Resolver-backed (OASIS/system) catalog -- see that
+            // method's Javadoc for why the raw Resolver alone can't do this.
             if (args.length == 4) {
                 final LSResourceResolver resolver = Shared.resolveCatalogArgument(this, brokerPool, context.getBroker(), context.getSubject(), args[3]);
-                factory.setResourceResolver(resolver);
+                factory.setResourceResolver(XercesXmlResolverAdapter.asLSResourceResolver(resolver));
             }
 
             // Create grammar -- xs:import/xs:include resolution (via the resolver se

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
@@ -1,0 +1,192 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.validate;
+
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Closes the integration gap left by <a href="https://github.com/eXist-db/exist/pull/6528">#6528</a>:
+ * native XSDs ship at {@code $EXIST_HOME/schema/} and {@code WEB-INF/catalog.xml} maps
+ * {@code http://exist-db.org/collection-config/1.0} to {@code collection.xconf.xsd}, but nothing
+ * asserts that {@code validation:jaxp*} can apply that grammar via an OASIS catalog the way
+ * tools (e.g. eXide) are expected to.
+ *
+ * <p>{@link #jaxvXsd11AgainstNativeCollectionSchemaValid} /
+ * {@link #jaxvXsd11AgainstNativeCollectionSchemaEmptyFailsAssert} are the control: the schema
+ * file itself is fine when handed to {@code validation:jaxv-report} with the XSD 1.1 language URI.
+ * {@link #jaxpViaOasisCatalogAgainstNativeCollectionSchemaValid} is the missing path — currently
+ * fails with {@code cvc-elt.1.a} (declaration not found) even when the catalog {@code <uri>} entry
+ * points at an absolute {@code file:} URI of the same XSD.</p>
+ *
+ * <p>Existing XSD 1.1 coverage in {@link JaxpXsdCatalogTest} only exercises
+ * <em>directory-search</em> catalogs over {@code /db/.../}; {@link
+ * org.exist.validation.CollectionConfigSchema6000Test} validates the native XSD via raw
+ * {@code SchemaFactory}, not {@code validation:jaxp}.</p>
+ *
+ * @see <a href="https://github.com/eXist-db/exist/issues/6686">#6686</a>
+ * @see <a href="https://github.com/eXist-db/eXide/issues/842">eXide#842</a>
+ */
+public class NativeSchemaJaxpCatalogGapTest {
+
+    private static final String COLLECTION_CONFIG_NS = "http://exist-db.org/collection-config/1.0";
+    private static final String XSD_1_1 = "http://www.w3.org/XML/XMLSchema/v1.1";
+
+    private static final String VALID_COLLECTION_XCONF = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+                <index/>
+            </collection>
+            """;
+
+    private static final String EMPTY_COLLECTION_XCONF = """
+            <collection xmlns="http://exist-db.org/collection-config/1.0"/>
+            """;
+
+    private static final String NO_VALIDATION = """
+            <?xml version='1.0'?>
+            <collection xmlns='http://exist-db.org/collection-config/1.0'>
+                <validation mode='no'/>
+            </collection>
+            """;
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static Path nativeSchemaPath;
+    private static String nativeSchemaFileUri;
+
+    @BeforeClass
+    public static void prepareResources() throws XMLDBException, IOException {
+        nativeSchemaPath = resolveSchemaPath();
+        assertTrue("""
+                Native schema not found at %s \
+                (run from repo root: mvn test -pl exist-core -Dtest=NativeSchemaJaxpCatalogGapTest)
+                """.formatted(nativeSchemaPath).strip(),
+                Files.exists(nativeSchemaPath));
+        nativeSchemaFileUri = nativeSchemaPath.toAbsolutePath().toUri().toString();
+
+        try (Collection conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(),
+                "system/config/db/native-schema-gap")) {
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE,
+                    NO_VALIDATION.getBytes());
+        }
+
+        try (Collection col = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(),
+                "native-schema-gap")) {
+            // Mirrors WEB-INF/catalog.xml's collection-config mapping, but with an absolute
+            // file: URI so the embedded harness does not depend on $EXIST_HOME layout.
+            final String catalog = """
+                    <?xml version="1.0"?>
+                    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+                        <uri name="%s" uri="%s"/>
+                    </catalog>
+                    """.formatted(COLLECTION_CONFIG_NS, nativeSchemaFileUri);
+            ExistXmldbEmbeddedServer.storeResource(col, "catalog.xml", catalog.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(col, "valid.xml", VALID_COLLECTION_XCONF.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(col, "empty.xml", EMPTY_COLLECTION_XCONF.getBytes());
+        }
+    }
+
+    @Before
+    public void clearGrammarCache() throws XMLDBException {
+        final ResourceSet results = existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        results.getResource(0).getContent();
+    }
+
+    @Test
+    public void jaxvXsd11AgainstNativeCollectionSchemaValid() throws Exception {
+        final String query = """
+                validation:jaxv-report(
+                    doc('/db/native-schema-gap/valid.xml'),
+                    xs:anyURI('%s'),
+                    '%s')
+                """.formatted(nativeSchemaFileUri, XSD_1_1);
+        assertReportStatus(query, "valid");
+    }
+
+    @Test
+    public void jaxvXsd11AgainstNativeCollectionSchemaEmptyFailsAssert() throws Exception {
+        final String query = """
+                validation:jaxv-report(
+                    doc('/db/native-schema-gap/empty.xml'),
+                    xs:anyURI('%s'),
+                    '%s')
+                """.formatted(nativeSchemaFileUri, XSD_1_1);
+        final String report = executeOne(query);
+        assertXpathEvaluatesTo("invalid", "//status/text()", report);
+        assertTrue("expected xs:assert failure, got: " + report,
+                report.contains("cvc-assertion") || report.contains("count(*)"));
+    }
+
+    /**
+     * Expected RED on current develop: OASIS catalog → native {@code collection.xconf.xsd}
+     * does not supply the grammar to {@code validation:jaxp-report} (cvc-elt.1.a).
+     */
+    @Test
+    public void jaxpViaOasisCatalogAgainstNativeCollectionSchemaValid() throws Exception {
+        final String query = """
+                validation:jaxp-report(
+                    doc('/db/native-schema-gap/valid.xml'),
+                    false(),
+                    xs:anyURI('/db/native-schema-gap/catalog.xml'))
+                """;
+        assertReportStatus(query, "valid");
+    }
+
+    private static void assertReportStatus(final String query, final String expected)
+            throws XMLDBException, SAXException, IOException, XpathException {
+        assertXpathEvaluatesTo(expected, "//status/text()", executeOne(query));
+    }
+
+    private static String executeOne(final String query) throws XMLDBException {
+        final ResourceSet results = existEmbeddedServer.executeQuery(query);
+        assertEquals(1, results.getSize());
+        return (String) results.getResource(0).getContent();
+    }
+
+    private static Path resolveSchemaPath() {
+        final Path base = Path.of(System.getProperty("user.dir"));
+        Path p = base.resolve("schema").resolve("collection.xconf.xsd");
+        if (!Files.exists(p)) {
+            p = base.getParent().resolve("schema").resolve("collection.xconf.xsd");
+        }
+        return p;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
@@ -121,7 +121,7 @@ public class NativeSchemaJaxpCatalogGapTest {
                     <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
                         <uri name="%s" uri="%s"/>
                     </catalog>
-                    """.formatted(COLLECTION_CONFIG_NS, nativeSchemaFileUri);
+                    """.formatted(COLLECTION_CONFIG_NS, escapeXmlAttribute(nativeSchemaFileUri));
             ExistXmldbEmbeddedServer.storeResource(col, "catalog.xml", catalog.getBytes());
             ExistXmldbEmbeddedServer.storeResource(col, "valid.xml", VALID_COLLECTION_XCONF.getBytes());
             ExistXmldbEmbeddedServer.storeResource(col, "empty.xml", EMPTY_COLLECTION_XCONF.getBytes());
@@ -192,5 +192,16 @@ public class NativeSchemaJaxpCatalogGapTest {
             p = base.getParent().resolve("schema").resolve("collection.xconf.xsd");
         }
         return p;
+    }
+
+    /**
+     * Escapes {@code value} for use inside a double-quoted XML attribute. Needed because {@link
+     * #nativeSchemaFileUri} is derived from the checkout's own filesystem path via {@link
+     * Path#toUri()}, which does not escape XML-attribute-special characters (e.g. {@code &}) that
+     * a directory name could legally contain -- without this, such a path would produce a
+     * malformed {@code catalog.xml}.
+     */
+    private static String escapeXmlAttribute(final String value) {
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace("\"", "&quot;");
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java
@@ -51,9 +51,13 @@ import static org.junit.Assert.assertTrue;
  * <p>{@link #jaxvXsd11AgainstNativeCollectionSchemaValid} /
  * {@link #jaxvXsd11AgainstNativeCollectionSchemaEmptyFailsAssert} are the control: the schema
  * file itself is fine when handed to {@code validation:jaxv-report} with the XSD 1.1 language URI.
- * {@link #jaxpViaOasisCatalogAgainstNativeCollectionSchemaValid} is the missing path — currently
- * fails with {@code cvc-elt.1.a} (declaration not found) even when the catalog {@code <uri>} entry
- * points at an absolute {@code file:} URI of the same XSD.</p>
+ * {@link #jaxpViaOasisCatalogAgainstNativeCollectionSchemaValid} was the missing path — it used to
+ * fail with {@code cvc-elt.1.a} (declaration not found) even when the catalog {@code <uri>} entry
+ * pointed at an absolute {@code file:} URI of the same XSD, because {@code
+ * org.xmlresolver.Resolver#resolveResource} requires a non-null system id before consulting its
+ * catalog, and the XSD 1.1 dynamic-discovery validator calls it with the root namespace but no
+ * system id when the instance carries no {@code schemaLocation} hint. Fixed by {@link
+ * org.exist.resolver.XercesXmlResolverAdapter#asLSResourceResolver}.</p>
  *
  * <p>Existing XSD 1.1 coverage in {@link JaxpXsdCatalogTest} only exercises
  * <em>directory-search</em> catalogs over {@code /db/.../}; {@link
@@ -156,8 +160,8 @@ public class NativeSchemaJaxpCatalogGapTest {
     }
 
     /**
-     * Expected RED on current develop: OASIS catalog → native {@code collection.xconf.xsd}
-     * does not supply the grammar to {@code validation:jaxp-report} (cvc-elt.1.a).
+     * OASIS catalog → native {@code collection.xconf.xsd}, resolved purely by namespace (no
+     * {@code schemaLocation} hint on the instance).
      */
     @Test
     public void jaxpViaOasisCatalogAgainstNativeCollectionSchemaValid() throws Exception {


### PR DESCRIPTION
### Description:

Adds `NativeSchemaJaxpCatalogGapTest` to close the integration gap left by #6528, and fixes the gap it found:

- **Green control:** `validation:jaxv-report` + XSD 1.1 language URI against `schema/collection.xconf.xsd` (valid minimal `collection.xconf`; empty one fails `xs:assert`).
- **Previously missing path (now fixed):** `validation:jaxp-report` via an OASIS catalog whose `<uri>` maps `http://exist-db.org/collection-config/1.0` to an absolute `file:` URI of that same native XSD — mirrors the `WEB-INF/catalog.xml` → `$EXIST_HOME/schema/` wiring tools are meant to use.

**Root cause:** `Jaxp#newXsd11Validator` wired an OASIS/system catalog's `org.xmlresolver.Resolver` in directly as the XSD 1.1 validator's `LSResourceResolver`. That resolver's `resolveResource()` requires a non-null `systemId` before it will consult the catalog at all, so a `<uri>` entry keyed purely by namespace was invisible whenever the instance carried no `schemaLocation` hint — even though the same catalog entry already worked for the default SAX pipeline, which falls back to the namespace as the systemId (see `XercesXmlResolverAdapter#resolveEntity`).

**Fix:** `XercesXmlResolverAdapter#asLSResourceResolver` applies that same namespace-as-systemId fallback. Code review of the first fix found `validation:jaxv()`'s SchemaFactory catalog wiring had the identical unfixed gap (same raw-`Resolver` pass-through, for `xs:import`/`xs:include` resolution during schema compilation), so it's fixed the same way and both call sites now share a single `asLSResourceResolver(LSResourceResolver)` dispatch instead of duplicating the `instanceof` check.

Existing coverage did not catch this: `JaxpXsdCatalogTest` XSD 1.1 cases use directory-search over `/db/.../`, which `SearchResourceResolver` already resolves purely by namespace; `CollectionConfigSchema6000Test` / Maven validate use raw `SchemaFactory`, not `validation:jaxp`.

### What Changed

- `exist-core/src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java` — new `asLSResourceResolver(Resolver)` wrapping an `org.xmlresolver.Resolver` as an `LSResourceResolver` with a namespace→systemId fallback, plus an `asLSResourceResolver(LSResourceResolver)` overload that dispatches on the concrete resolver type (only wrapping when it's a `Resolver`) so both call sites below share one implementation.
- `exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java` — `newXsd11Validator` now routes its catalog resolver through the new adapter before handing it to the XSD 1.1 `Validator`.
- `exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java` — same fix for the `SchemaFactory#setResourceResolver` catalog wiring.
- `exist-core/src/test/java/org/exist/xquery/functions/validate/NativeSchemaJaxpCatalogGapTest.java` — the regression test; updated comments now that the gap is closed, and escapes the generated catalog's `file:` URI attribute (`Path#toUri()` doesn't XML-escape characters like `&` a checkout path could contain).

### Reference:

- Closes https://github.com/eXist-db/exist/issues/6686
- Related: #6528 / #6189, eXist-db/eXide#842

### Type of tests:

JUnit (`ExistXmldbEmbeddedServer`) in `exist-core`.

```
mvn -pl exist-core -Dtest=NativeSchemaJaxpCatalogGapTest test
```

### Test Plan

- [x] `NativeSchemaJaxpCatalogGapTest` — 3/3 green (was 2/3, 1 expected-red)
- [x] `JaxpXsdCatalogTest` — 12/12 green (no regression)
- [x] Full `validate`/`validation` package (`JaxpParseTest`, `JaxvTest`, `JaxpDtdCatalogTest`, `JaxpSchemaLocationSecurityTest`, `JaxpXsd11DetectionCacheTest`, `IsMissingElementDeclarationTest`, Jing*/Parse* suites, etc.) — 77/77 green
- [x] CI: all checks green except a pre-existing network flake (`unparsed-text-from-url`, unrelated fn:unparsed-text() GitHub-raw fetch)

Made with [Cursor](https://cursor.com)
