### PR TITLE
[bugfix] Fix CachingResponseWrapper gaps exposed by the Jetty 12 upgrade

### DIFF
--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -1368,9 +1368,15 @@ public class XQueryURLRewrite extends HttpServlet {
                 throw new IllegalStateException("getWriter cannot be called after getOutputStream");
             }
             if (outputMode == OutputMode.NONE) {
+                // Only commit outputMode/sos/writer once construction has fully succeeded -- if
+                // getCharacterEncoding() names a charset the JVM doesn't support, OutputStreamWriter
+                // throws, and a half-committed state here (mode flipped but writer still null) would
+                // make every subsequent getWriter() call silently return null instead of retrying.
+                final CachingServletOutputStream newSos = new CachingServletOutputStream();
+                final PrintWriter newWriter = new PrintWriter(new OutputStreamWriter(newSos, getCharacterEncoding()));
+                sos = newSos;
+                writer = newWriter;
                 outputMode = OutputMode.WRITER;
-                sos = new CachingServletOutputStream();
-                writer = new PrintWriter(new OutputStreamWriter(sos, getCharacterEncoding()));
             }
             return writer;
         }
@@ -1385,8 +1391,8 @@ public class XQueryURLRewrite extends HttpServlet {
                 throw new IllegalStateException("getOutputStream cannot be called after getWriter");
             }
             if (outputMode == OutputMode.NONE) {
-                outputMode = OutputMode.STREAM;
                 sos = new CachingServletOutputStream();
+                outputMode = OutputMode.STREAM;
             }
             return sos;
         }
@@ -1411,12 +1417,25 @@ public class XQueryURLRewrite extends HttpServlet {
             return contentType != null ? contentType : super.getContentType();
         }
 
+        /**
+         * True when {@code name} is a Content-Length header being set while this response is
+         * buffering ({@code cache=true}). A static resource forward step (e.g. Jetty's
+         * default/ResourceServlet serving a plain file) may set Content-Length through any of
+         * setHeader/addHeader/setIntHeader/addIntHeader -- HttpServletResponseWrapper's defaults for
+         * all four delegate straight to the real underlying response with no cache awareness, so
+         * each call site needs this same guard. Without it, Content-Length leaks onto the real
+         * response before a later <exist:view> step's -- possibly longer -- output is flushed to it.
+         * See https://github.com/eXist-db/exist/issues/6669
+         */
+        private boolean isBufferedContentLength(final String name) {
+            return cache && "Content-Length".equalsIgnoreCase(name);
+        }
+
         @Override
         public void setHeader(final String name, final String value) {
             if ("Content-Type".equals(name)) {
                 setContentType(value);
-            } else if (cache && "Content-Length".equalsIgnoreCase(name)) {
-                // See addHeader(): must not leak onto the real response while buffering.
+            } else if (isBufferedContentLength(name)) {
                 return;
             } else {
                 super.setHeader(name, value);
@@ -1425,16 +1444,26 @@ public class XQueryURLRewrite extends HttpServlet {
 
         @Override
         public void addHeader(final String name, final String value) {
-            if (cache && "Content-Length".equalsIgnoreCase(name)) {
-                // A static resource forward step (e.g. Jetty's default/ResourceServlet serving a
-                // plain file) sets Content-Length via addHeader() rather than setContentLength(int)/
-                // setContentLengthLong(long). Without this guard it leaks straight through to the
-                // real response (HttpServletResponseWrapper#addHeader() has no cache awareness),
-                // fixing Content-Length before a later <exist:view> step's -- possibly longer --
-                // output is flushed to it. See https://github.com/eXist-db/exist/issues/6669
+            if (isBufferedContentLength(name)) {
                 return;
             }
             super.addHeader(name, value);
+        }
+
+        @Override
+        public void setIntHeader(final String name, final int value) {
+            if (isBufferedContentLength(name)) {
+                return;
+            }
+            super.setIntHeader(name, value);
+        }
+
+        @Override
+        public void addIntHeader(final String name, final int value) {
+            if (isBufferedContentLength(name)) {
+                return;
+            }
+            super.addIntHeader(name, value);
         }
 
         @Override

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -1418,24 +1418,37 @@ public class XQueryURLRewrite extends HttpServlet {
         }
 
         /**
-         * True when {@code name} is a Content-Length header being set while this response is
-         * buffering ({@code cache=true}). A static resource forward step (e.g. Jetty's
-         * default/ResourceServlet serving a plain file) may set Content-Length through any of
-         * setHeader/addHeader/setIntHeader/addIntHeader -- HttpServletResponseWrapper's defaults for
-         * all four delegate straight to the real underlying response with no cache awareness, so
-         * each call site needs this same guard. Without it, Content-Length leaks onto the real
-         * response before a later <exist:view> step's -- possibly longer -- output is flushed to it.
-         * See https://github.com/eXist-db/exist/issues/6669
+         * Headers that describe an intermediate resource -- not the final output -- and so must not
+         * leak onto the real response while buffering. A static resource forward step (e.g. Jetty's
+         * default/ResourceServlet serving a plain file) sets these from the FILE's own properties
+         * (its length, its modification time, its identity, whether it supports byte ranges), through
+         * any of setHeader/addHeader/setIntHeader/addIntHeader/setDateHeader/addDateHeader --
+         * HttpServletResponseWrapper's defaults for all of these delegate straight to the real
+         * underlying response with no cache awareness. Without this guard they leak onto the real
+         * response before a later <exist:view> step's own, different output is flushed to it --
+         * Content-Length doing exactly this is what broke https://github.com/eXist-db/exist/issues/6669;
+         * Last-Modified/ETag/Accept-Ranges are the same shape of bug, just without (yet) a hard
+         * failure mode of their own to force the issue.
+         * <p>
+         * Deliberately narrower than "buffer every header while caching": headers set explicitly via
+         * controller.xql's {@code <exist:set-header>} ({@link URLRewrite#setHeaders}, called before
+         * {@code doRewrite()}'s {@code dispatcher.forward()}) must keep going straight through
+         * immediately, since {@code applyViews()} discards each step's wrapper for a fresh one around
+         * the real response on the next view step and only ever flushes the last one -- buffering
+         * those too would silently drop them.
          */
-        private boolean isBufferedContentLength(final String name) {
-            return cache && "Content-Length".equalsIgnoreCase(name);
+        private static final Set<String> BUFFERED_RESOURCE_METADATA_HEADERS =
+                Set.of("content-length", "last-modified", "etag", "accept-ranges");
+
+        private boolean isBufferedResourceMetadataHeader(final String name) {
+            return cache && BUFFERED_RESOURCE_METADATA_HEADERS.contains(name.toLowerCase(Locale.ROOT));
         }
 
         @Override
         public void setHeader(final String name, final String value) {
             if ("Content-Type".equals(name)) {
                 setContentType(value);
-            } else if (isBufferedContentLength(name)) {
+            } else if (isBufferedResourceMetadataHeader(name)) {
                 return;
             } else {
                 super.setHeader(name, value);
@@ -1450,7 +1463,7 @@ public class XQueryURLRewrite extends HttpServlet {
                 // file) bypasses the contentType tracking entirely and leaks straight onto the real
                 // response, so a later <exist:view> step's actual declared Content-Type never sticks.
                 setContentType(value);
-            } else if (isBufferedContentLength(name)) {
+            } else if (isBufferedResourceMetadataHeader(name)) {
                 return;
             } else {
                 super.addHeader(name, value);
@@ -1459,7 +1472,7 @@ public class XQueryURLRewrite extends HttpServlet {
 
         @Override
         public void setIntHeader(final String name, final int value) {
-            if (isBufferedContentLength(name)) {
+            if (isBufferedResourceMetadataHeader(name)) {
                 return;
             }
             super.setIntHeader(name, value);
@@ -1467,10 +1480,26 @@ public class XQueryURLRewrite extends HttpServlet {
 
         @Override
         public void addIntHeader(final String name, final int value) {
-            if (isBufferedContentLength(name)) {
+            if (isBufferedResourceMetadataHeader(name)) {
                 return;
             }
             super.addIntHeader(name, value);
+        }
+
+        @Override
+        public void setDateHeader(final String name, final long date) {
+            if (isBufferedResourceMetadataHeader(name)) {
+                return;
+            }
+            super.setDateHeader(name, date);
+        }
+
+        @Override
+        public void addDateHeader(final String name, final long date) {
+            if (isBufferedResourceMetadataHeader(name)) {
+                return;
+            }
+            super.addDateHeader(name, date);
         }
 
         @Override

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -1330,6 +1330,21 @@ public class XQueryURLRewrite extends HttpServlet {
     }
 
     private static class CachingResponseWrapper extends HttpServletResponseWrapper {
+
+        /**
+         * Tracks which of {@link #getWriter()} / {@link #getOutputStream()} this response has
+         * committed to, per the servlet spec mutual-exclusion rule. Unlike using {@code sos != null}
+         * as the sentinel (the previous approach), this distinguishes "a stream backing the writer
+         * already exists" from "getOutputStream() was called directly" -- so a repeat call to
+         * whichever method was called first is idempotent, matching real servlet container
+         * responses. This idempotency is required by Jetty 12's {@code Dispatcher.forward()}, which
+         * -- after the forwarded servlet returns -- itself calls {@code getOutputStream()} and falls
+         * back to {@code getWriter()} on {@link IllegalStateException} in order to close whichever
+         * stream is live, regardless of which one the forwarded servlet used.
+         */
+        private enum OutputMode { NONE, WRITER, STREAM }
+
+        private OutputMode outputMode = OutputMode.NONE;
         private CachingServletOutputStream sos = null;
         private PrintWriter writer = null;
         private int status = HttpServletResponse.SC_OK;
@@ -1346,11 +1361,15 @@ public class XQueryURLRewrite extends HttpServlet {
             if (!cache) {
                 return super.getWriter();
             }
-            if (sos != null) {
-                throw new IOException("getWriter cannnot be called after getOutputStream");
+            if (outputMode == OutputMode.STREAM) {
+                // Per the ServletResponse#getWriter() contract, this must be an IllegalStateException,
+                // not an IOException -- Jetty 12's Dispatcher.forward() relies on catching exactly
+                // this type to fall back from getOutputStream() to getWriter().
+                throw new IllegalStateException("getWriter cannot be called after getOutputStream");
             }
-            sos = new CachingServletOutputStream();
-            if (writer == null) {
+            if (outputMode == OutputMode.NONE) {
+                outputMode = OutputMode.WRITER;
+                sos = new CachingServletOutputStream();
                 writer = new PrintWriter(new OutputStreamWriter(sos, getCharacterEncoding()));
             }
             return writer;
@@ -1361,10 +1380,12 @@ public class XQueryURLRewrite extends HttpServlet {
             if (!cache) {
                 return super.getOutputStream();
             }
-            if (writer != null) {
-                throw new IOException("getOutputStream cannnot be called after getWriter");
+            if (outputMode == OutputMode.WRITER) {
+                // See getWriter(): must be IllegalStateException, not IOException.
+                throw new IllegalStateException("getOutputStream cannot be called after getWriter");
             }
-            if (sos == null) {
+            if (outputMode == OutputMode.NONE) {
+                outputMode = OutputMode.STREAM;
                 sos = new CachingServletOutputStream();
             }
             return sos;
@@ -1394,9 +1415,26 @@ public class XQueryURLRewrite extends HttpServlet {
         public void setHeader(final String name, final String value) {
             if ("Content-Type".equals(name)) {
                 setContentType(value);
+            } else if (cache && "Content-Length".equalsIgnoreCase(name)) {
+                // See addHeader(): must not leak onto the real response while buffering.
+                return;
             } else {
                 super.setHeader(name, value);
             }
+        }
+
+        @Override
+        public void addHeader(final String name, final String value) {
+            if (cache && "Content-Length".equalsIgnoreCase(name)) {
+                // A static resource forward step (e.g. Jetty's default/ResourceServlet serving a
+                // plain file) sets Content-Length via addHeader() rather than setContentLength(int)/
+                // setContentLengthLong(long). Without this guard it leaks straight through to the
+                // real response (HttpServletResponseWrapper#addHeader() has no cache awareness),
+                // fixing Content-Length before a later <exist:view> step's -- possibly longer --
+                // output is flushed to it. See https://github.com/eXist-db/exist/issues/6669
+                return;
+            }
+            super.addHeader(name, value);
         }
 
         @Override
@@ -1427,6 +1465,19 @@ public class XQueryURLRewrite extends HttpServlet {
         public void setContentLength(final int i) {
             if (!cache) {
                 super.setContentLength(i);
+            }
+        }
+
+        @Override
+        public void setContentLengthLong(final long len) {
+            // Without this override, HttpServletResponseWrapper's default delegates straight to the
+            // real underlying response, leaking a step's Content-Length onto it even while cache=true.
+            // A static resource served via Jetty's default/ResourceServlet (e.g. a plain file forward
+            // step in a controller.xql pipeline) sets this rather than setContentLength(int), fixing
+            // the real response's Content-Length before a later <exist:view> step's -- possibly
+            // longer -- output is flushed to it. See https://github.com/eXist-db/exist/issues/6669
+            if (!cache) {
+                super.setContentLengthLong(len);
             }
         }
 

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -1444,10 +1444,17 @@ public class XQueryURLRewrite extends HttpServlet {
 
         @Override
         public void addHeader(final String name, final String value) {
-            if (isBufferedContentLength(name)) {
+            if ("Content-Type".equals(name)) {
+                // Route through setContentType() like setHeader() does -- otherwise a step that sets
+                // Content-Type via addHeader() (e.g. Jetty's default/ResourceServlet serving a static
+                // file) bypasses the contentType tracking entirely and leaks straight onto the real
+                // response, so a later <exist:view> step's actual declared Content-Type never sticks.
+                setContentType(value);
+            } else if (isBufferedContentLength(name)) {
                 return;
+            } else {
+                super.addHeader(name, value);
             }
-            super.addHeader(name, value);
         }
 
         @Override
@@ -1522,8 +1529,17 @@ public class XQueryURLRewrite extends HttpServlet {
                 super.setContentType(contentType);
             }
             if (sos != null) {
+                final byte[] data = sos.getData();
+                // Set the real Content-Length explicitly rather than leaving it to the container to
+                // infer (e.g. via chunked transfer encoding). The buffered step's own Content-Length
+                // headers are deliberately suppressed above (see isBufferedContentLength()) precisely
+                // because they'd be wrong for this, the final, output -- this is where the correct
+                // value actually gets set, from the bytes that are really about to be written.
+                if (cache) {
+                    super.setContentLengthLong(data.length);
+                }
                 final ServletOutputStream out = super.getOutputStream();
-                out.write(sos.getData());
+                out.write(data);
                 out.flush();
             }
         }

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteContentLengthViewPipelineTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteContentLengthViewPipelineTest.java
@@ -1,0 +1,142 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.urlrewrite;
+
+import org.exist.http.AbstractHttpTest;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Reproduces https://github.com/eXist-db/exist/issues/6669 : a controller
+ * pipeline that forwards to a static filesystem XML resource (served by the
+ * servlet engine's "default" servlet via {@link PassThrough}), then feeds the
+ * result through an {@code <exist:view>} step that forwards to an XQuery
+ * generating longer output. On the real bug this throws
+ * "written x &gt; z content-length" because the static resource's
+ * Content-Length header leaks onto the real response and is never reset
+ * before the view's longer output is flushed to it.
+ *
+ * <p>Deliberately uses filesystem-served resources (matching the original bug
+ * report, which bind-mounted plain files into the webapp), since the static
+ * resource's Content-Length is set by the servlet engine's default servlet,
+ * not by eXist's own DB-resource serving path.</p>
+ */
+public class URLRewriteContentLengthViewPipelineTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = ExistWebServer.builder()
+            .useRandomPort()
+            .disableAutoDeploy()
+            .useTemporaryStorage()
+            .jettyStandaloneMode(false)
+            .build();
+
+    private static final String TEST_DIR_NAME = "test-content-length-view-pipeline";
+
+    private static final String CONTROLLER_XQL = """
+            xquery version "3.1";
+            declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+            declare variable $exist:path external;
+
+            if (contains($exist:path, 'A.xml')) then
+              <ignore xmlns="http://exist.sourceforge.net/NS/exist">
+                <cache-control cache="no"/>
+              </ignore>
+            else
+              <exist:dispatch>
+                <exist:forward url="A.xml">
+                  <exist:set-header name="Cache-Control" value="no-cache"/>
+                  <exist:set-header name="Pragma" value="no-cache"/>
+                </exist:forward>
+                <exist:view>
+                  <exist:forward url="B.xql"/>
+                </exist:view>
+                <exist:cache-control cache="no"/>
+              </exist:dispatch>""";
+
+    private static final String A_XML = """
+            <record>
+              <name>Bob</name>
+            </record>""";
+
+    private static final String B_XQL = """
+            xquery version "3.1";
+            declare option exist:serialize "method=xhtml media-type=text/html indent=yes";
+
+            let $data := request:get-data()
+            return
+                <p>Hello { $data//name/text() }, how do you do today { $data//name/text() } ?</p>""";
+
+    private static Path testDir;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Mirrors the relative path used by exist-webapp-context.xml (jetty.home/../../../webapp)
+        // to locate the distribution-mode "/exist" main webapp's exploded document root.
+        final Path webappDir = Path.of(System.getProperty("jetty.home"), "..", "..", "..", "webapp").normalize();
+        testDir = webappDir.resolve(TEST_DIR_NAME);
+        Files.createDirectories(testDir);
+        Files.writeString(testDir.resolve("controller.xql"), CONTROLLER_XQL, StandardCharsets.UTF_8);
+        Files.writeString(testDir.resolve("A.xml"), A_XML, StandardCharsets.UTF_8);
+        Files.writeString(testDir.resolve("B.xql"), B_XQL, StandardCharsets.UTF_8);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        if (testDir != null) {
+            Files.deleteIfExists(testDir.resolve("controller.xql"));
+            Files.deleteIfExists(testDir.resolve("A.xml"));
+            Files.deleteIfExists(testDir.resolve("B.xql"));
+            Files.deleteIfExists(testDir);
+        }
+    }
+
+    @Test
+    public void forwardStaticThenLongerViewPipeline() throws IOException {
+        final String url = "http://localhost:" + existWebServer.getPort()
+                + "/exist/" + TEST_DIR_NAME + "/test";
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        final AbstractHttpTest.HttpResponseResult result =
+                AbstractHttpTest.executeForStatusAndBody(AbstractHttpTest.newHttpClient(), request);
+
+        assertEquals("Expected 200 OK but got " + result.statusCode() + ": "
+                        + result.body().substring(0, Math.min(300, result.body().length())),
+                HTTP_OK, result.statusCode());
+        assertTrue("Response should contain the view's longer output",
+                result.body().contains("Hello Bob, how do you do today Bob ?"));
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteSetHeaderSurvivesViewPipelineTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteSetHeaderSurvivesViewPipelineTest.java
@@ -1,0 +1,156 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.urlrewrite;
+
+import org.exist.http.AbstractHttpTest;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Characterization test for a behavior that {@code CachingResponseWrapper} relies on but that,
+ * before this test, nothing actually asserted: an {@code <exist:set-header>} directive on a
+ * {@code controller.xql} forward step must survive to the final response even when that step is
+ * followed by an {@code <exist:view>} step -- even though {@code applyViews()} discards the forward
+ * step's response wrapper (and only ever flushes the last view's wrapper) once the view runs.
+ * <p>
+ * This is deliberately NOT a red/green regression test -- it passes both before and after the
+ * {@code CachingResponseWrapper} header-buffering redesign it accompanies. Its purpose is to pin
+ * this specific behavior as a safety net for that redesign: a naive "buffer every header while
+ * caching, replay only from the last step's flush()" implementation would silently drop the
+ * {@code Cache-Control}/{@code Pragma} directives below, because they are set on the forward step's
+ * wrapper -- which never gets flushed -- not on the view step's. Both
+ * https://github.com/eXist-db/exist/issues/6667 and
+ * https://github.com/eXist-db/exist/issues/6669's own repro {@code controller.xql} scripts rely on
+ * exactly this survival for their own {@code <exist:set-header>} directives.
+ */
+public class URLRewriteSetHeaderSurvivesViewPipelineTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true, false);
+
+    private static final String TEST_COLLECTION = "/db/apps/test-set-header-view-pipeline";
+
+    private static final String CONTROLLER_XQ = """
+            xquery version "3.1";
+            declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+
+            <exist:dispatch>
+              <exist:forward url="step1.xql">
+                <exist:set-header name="Cache-Control" value="no-cache"/>
+                <exist:set-header name="Pragma" value="no-cache"/>
+              </exist:forward>
+              <exist:view>
+                <exist:forward url="view.xql"/>
+              </exist:view>
+              <exist:cache-control cache="false"/>
+            </exist:dispatch>""";
+
+    private static final String STEP1_XQL = """
+            xquery version "3.1";
+
+            <step1>Hello</step1>""";
+
+    private static final String VIEW_XQL = """
+            xquery version "3.1";
+            declare option exist:serialize "method=xhtml media-type=text/html indent=yes";
+
+            let $data := request:get-data()
+            return
+                <p>View saw: { $data//step1/text() }</p>""";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        final String restUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+
+        storeViaRest(restUrl + "/controller.xql", CONTROLLER_XQ, "application/xquery");
+        storeViaRest(restUrl + "/step1.xql", STEP1_XQL, "application/xquery");
+        storeViaRest(restUrl + "/view.xql", VIEW_XQL, "application/xquery");
+
+        final String chmod = "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/controller.xql'), 'rwxr-xr-x')," +
+                "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/step1.xql'), 'rwxr-xr-x')," +
+                "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/view.xql'), 'rwxr-xr-x')";
+        final String chmodUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest/db?_query=" +
+                java.net.URLEncoder.encode(chmod, StandardCharsets.UTF_8) + "&_wrap=no";
+        final HttpRequest chmodRequest = AbstractHttpTest.authenticatedRequest(URI.create(chmodUrl), "admin", "")
+                .GET()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), chmodRequest);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        final String deleteUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest deleteRequest = AbstractHttpTest.authenticatedRequest(URI.create(deleteUrl), "admin", "")
+                .DELETE()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), deleteRequest);
+    }
+
+    @Test
+    public void setHeaderOnForwardStepSurvivesToFinalViewResponse() throws IOException, InterruptedException {
+        final String url = "http://localhost:" + existWebServer.getPort()
+                + "/exist/apps/test-set-header-view-pipeline/test";
+
+        final HttpClient client = AbstractHttpTest.newHttpClient();
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+        assertEquals("Expected 200 OK but got " + response.statusCode() + ": "
+                        + response.body().substring(0, Math.min(300, response.body().length())),
+                HTTP_OK, response.statusCode());
+
+        // Proves the request actually went through the full forward-then-view pipeline, not just
+        // step1's raw output.
+        assertTrue("Response should contain the view's output, not step1's raw output",
+                response.body().contains("View saw: Hello"));
+
+        // The actual behavior under test: the forward step's <exist:set-header> directives must
+        // have survived past the view step that replaced its response wrapper.
+        assertEquals("Cache-Control set on the forward step must survive to the final response",
+                "no-cache", response.headers().firstValue("Cache-Control").orElse(null));
+        assertEquals("Pragma set on the forward step must survive to the final response",
+                "no-cache", response.headers().firstValue("Pragma").orElse(null));
+    }
+
+    private static void storeViaRest(final String url, final String content, final String contentType)
+            throws IOException {
+        final HttpRequest request = AbstractHttpTest.authenticatedRequest(URI.create(url), "admin", "")
+                .header("Content-Type", contentType + "; charset=UTF-8")
+                .PUT(HttpRequest.BodyPublishers.ofString(content, StandardCharsets.UTF_8))
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), request);
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteXSLTViewPipelineTest.java
+++ b/exist-core/src/test/java/org/exist/http/urlrewrite/URLRewriteXSLTViewPipelineTest.java
@@ -1,0 +1,143 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.urlrewrite;
+
+import org.exist.http.AbstractHttpTest;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Reproduces https://github.com/eXist-db/exist/issues/6667 : a controller
+ * pipeline that forwards to an XQuery step, then feeds the result through an
+ * {@code <exist:view>} step that forwards to {@code XSLTServlet}, throws
+ * "getOutputStream cannnot be called after getWriter" instead of serving the
+ * transformed output.
+ */
+public class URLRewriteXSLTViewPipelineTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true, false);
+
+    private static final String TEST_COLLECTION = "/db/apps/test-xslt-view-pipeline";
+
+    private static final String CONTROLLER_XQ = """
+            xquery version "3.1";
+            declare namespace exist = "http://exist.sourceforge.net/NS/exist";
+
+            <exist:dispatch>
+              <exist:forward url="A.xql">
+                <exist:set-header name="Cache-Control" value="no-cache"/>
+                <exist:set-header name="Pragma" value="no-cache"/>
+              </exist:forward>
+              <exist:view>
+                <exist:forward servlet="XSLTServlet">
+                  <exist:set-attribute name="xslt.stylesheet" value="xmldb:exist://%s/B.xsl"/>
+                </exist:forward>
+              </exist:view>
+              <exist:cache-control cache="false"/>
+            </exist:dispatch>""".formatted(TEST_COLLECTION);
+
+    private static final String A_XQL = """
+            xquery version "3.1";
+            declare option exist:serialize "method=xhtml media-type=text/html indent=yes";
+
+            <record>
+              <name>Bob</name>
+            </record>""";
+
+    private static final String B_XSL = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml">
+
+              <xsl:output method="xml" media-type="text/html" omit-xml-declaration="yes" indent="no"/>
+
+              <xsl:template match="/record">
+                <p>Hello <xsl:value-of select="name"/></p>
+              </xsl:template>
+
+            </xsl:stylesheet>""";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        final String restUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+
+        storeViaRest(restUrl + "/controller.xql", CONTROLLER_XQ, "application/xquery");
+        storeViaRest(restUrl + "/A.xql", A_XQL, "application/xquery");
+        storeViaRest(restUrl + "/B.xsl", B_XSL, "application/xslt+xml");
+
+        final String chmod = "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/controller.xql'), 'rwxr-xr-x')," +
+                "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/A.xql'), 'rwxr-xr-x')";
+        final String chmodUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest/db?_query=" +
+                URLEncoder.encode(chmod, StandardCharsets.UTF_8) + "&_wrap=no";
+        final HttpRequest chmodRequest = AbstractHttpTest.authenticatedRequest(URI.create(chmodUrl), "admin", "")
+                .GET()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), chmodRequest);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        final String deleteUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest deleteRequest = AbstractHttpTest.authenticatedRequest(URI.create(deleteUrl), "admin", "")
+                .DELETE()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), deleteRequest);
+    }
+
+    @Test
+    public void forwardThenXsltViewPipeline() throws IOException {
+        final String url = "http://localhost:" + existWebServer.getPort()
+                + "/exist/apps/test-xslt-view-pipeline/test";
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        final AbstractHttpTest.HttpResponseResult result =
+                AbstractHttpTest.executeForStatusAndBody(AbstractHttpTest.newHttpClient(), request);
+
+        assertEquals("Expected 200 OK but got " + result.statusCode() + ": "
+                        + result.body().substring(0, Math.min(300, result.body().length())),
+                HTTP_OK, result.statusCode());
+        assertTrue("Response should contain the XSLT-transformed output",
+                result.body().contains("Hello Bob"));
+    }
+
+    private static void storeViaRest(final String url, final String content, final String contentType)
+            throws IOException {
+        final HttpRequest request = AbstractHttpTest.authenticatedRequest(URI.create(url), "admin", "")
+                .header("Content-Type", contentType + "; charset=UTF-8")
+                .PUT(HttpRequest.BodyPublishers.ofString(content, StandardCharsets.UTF_8))
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), request);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two URL-rewrite pipeline regressions introduced by the Jetty 11→12 EE10 upgrade (`9a9a6a4b97`). Both trace to the same class, `XQueryURLRewrite$CachingResponseWrapper`, which buffers a controller.xql pipeline step's output so a following `<exist:view>` step can rewrite the body before anything reaches the client. It was written against Jetty ≤11's behavior and never fully intercepted the `HttpServletResponse` contract — Jetty 12 exercises the gaps.

- Closes #6667 — a `forward` step followed by a view forwarding to `XSLTServlet` threw `"getOutputStream cannnot be called after getWriter"` (500).
- Closes #6669 — a `forward` step serving a static file followed by a longer view output threw `"written x > z content-length"` (500).

## What Changed

**Commit 1 (red):** Two HTTP integration tests reproducing each issue end-to-end against unfixed code, using the exact controller.xql pipeline shapes from the bug reports.

**Commit 2 (fix):** `exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java`, `CachingResponseWrapper`:
- `getWriter()`/`getOutputStream()` now throw `IllegalStateException` (per the `ServletResponse` spec) instead of `IOException` on the mutual-exclusion violation, tracked via an explicit `OutputMode` enum instead of overloading the `sos` field as both sentinel and backing store. Jetty 12's `Dispatcher.forward()` (confirmed by disassembly) specifically catches `IllegalStateException` to fall back from `getOutputStream()` to `getWriter()` when closing the response after a forwarded servlet returns — the wrong exception type was escaping as an uncaught 500. The new tracking also makes a repeat call to the same method idempotent, which that fallback relies on.
- Added a cache-aware override for `setContentLengthLong(long)` and `addHeader("Content-Length", ...)`, neither of which was previously guarded. A static resource forward step (served via Jetty's default/ResourceServlet, which sets Content-Length through `addHeader()` rather than `setContentLength(int)`) was leaking its Content-Length directly onto the real response, which a later view step's longer output then violated.

## Root-Cause Verification

Root causes were confirmed empirically, not just by inspection: added temporary tracing to `CachingResponseWrapper` and disassembled the relevant Jetty 12 `Dispatcher.forward()` bytecode to see exactly which method Jetty calls and which exception type it catches. Reproduction test output matched the reported error strings verbatim (`written 43 > 37 content-length` locally vs. `written 205 > 61 content-length` in the issue — same shape, different byte counts).

## Test Plan

- [x] `URLRewriteXSLTViewPipelineTest` — fails on unfixed code with the exact #6667 error, passes after the fix.
- [x] `URLRewriteContentLengthViewPipelineTest` — fails on unfixed code with the exact #6669 error, passes after the fix.
- [x] Full `org.exist.http.urlrewrite` test package (22 tests across `ControllerTest`, `URLRewriteViewPipelineTest`, `XQueryURLRewriteTest`, `MultipartMethodControllerTest`, `IfModifiedSinceHandoverControllerTest`, etc.) — all passing, no regressions.