### PR TITLE
[bugfix] Fix non-ASCII cookie values silently dropped / crashing on Jetty 12

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/HttpResponseWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/HttpResponseWrapper.java
@@ -28,9 +28,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URLEncoder;
 import java.util.Locale;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
@@ -55,19 +57,19 @@ public class HttpResponseWrapper implements ResponseWrapper {
 	
 	@Override
 	public void addCookie(final String name, final String value) {
-		response.addCookie(new Cookie(name, encode(value)));
+		response.addCookie(new Cookie(name, encodeCookieValue(value)));
 	}
 
 	@Override
 	public void addCookie(final String name, final String value, final int maxAge) {
-		final Cookie cookie = new Cookie(name, encode(value));
+		final Cookie cookie = new Cookie(name, encodeCookieValue(value));
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);
 	}
 	
 	@Override
 	public void addCookie(final String name, final String value, final int maxAge, final boolean secure) {
-		final Cookie cookie = new Cookie(name, encode(value));
+		final Cookie cookie = new Cookie(name, encodeCookieValue(value));
 		cookie.setMaxAge(maxAge);
 		cookie.setSecure(secure);
 		response.addCookie(cookie);
@@ -75,7 +77,7 @@ public class HttpResponseWrapper implements ResponseWrapper {
 	
 	@Override
 	public void addCookie(final String name, final String value, final int maxAge, boolean secure, final String domain, final String path) {
-		final Cookie cookie = new Cookie(name, encode(value));
+		final Cookie cookie = new Cookie(name, encodeCookieValue(value));
 		cookie.setMaxAge(maxAge);
 		cookie.setSecure( secure );
 		if (domain != null && !domain.isEmpty()) {
@@ -210,8 +212,33 @@ public class HttpResponseWrapper implements ResponseWrapper {
 		return response.getOutputStream();
 	}
 	
-	// TODO: remove this hack after fixing HTTP 1.1 :)
+	/**
+	 * The Servlet API writes header values to the wire one byte per {@code char} (effectively
+	 * ISO-8859-1), independent of whatever charset the response body is configured with -- not an
+	 * HTTP/1.1 defect some future spec revision could fix (as the original 2010 TODO here assumed),
+	 * but a still-current characteristic of the Java Servlet header API itself. This packs a
+	 * value's UTF-8 bytes into that byte-per-char shape so the container's own write recovers them
+	 * unchanged on the wire. Confirmed still live and necessary on Jetty 12 by direct measurement,
+	 * not just re-inferred from the spec: see HttpResponseWrapperEncodingWireTest, which round-trips
+	 * a non-ASCII header value through a real server and checks the raw wire bytes.
+	 * <p>
+	 * Cookie values need a different fix -- see {@link #encodeCookieValue}: this same packing
+	 * scheme applied to a cookie value produces bytes RFC 6265's stricter cookie-octet grammar
+	 * forbids, which Jetty 12 rejects outright (silently dropping the cookie, or a 500, depending
+	 * on request shape -- see NonAsciiCookieRoundTripTest).
+	 */
 	private String encode(final String value){
         return new String(value.getBytes(), ISO_8859_1);
+	}
+
+	/**
+	 * RFC 6265's cookie-octet grammar excludes any byte >= 0x80 -- unlike header values (see
+	 * {@link #encode}), Jetty 12 enforces this strictly, rejecting a cookie whose value contains
+	 * one rather than passing it through. Percent-encoding keeps the wire value within that
+	 * ASCII-safe range regardless of what text it holds; paired with matching decoding in
+	 * {@code request:get-cookie-value()} (org.exist.xquery.functions.request.GetCookieValue).
+	 */
+	private String encodeCookieValue(final String value) {
+		return URLEncoder.encode(value, UTF_8);
 	}
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/request/GetCookieValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/request/GetCookieValue.java
@@ -35,9 +35,10 @@ import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 
+import java.net.URLDecoder;
 import java.util.Optional;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Adam Retter (adam.retter@devon.gov.uk)
@@ -86,8 +87,22 @@ public class GetCookieValue extends RequestFunction {
 		return Sequence.EMPTY_SEQUENCE;
 	}
 	
-	// TODO: remove this hack after fixing HTTP 1.1	
-	private String decode (final String value) {
-        return new String(value.getBytes(ISO_8859_1));
+	/**
+	 * Symmetric with {@code HttpResponseWrapper#encodeCookieValue}, which percent-encodes a
+	 * cookie's value on write (RFC 6265's cookie-octet grammar excludes bytes >= 0x80, and Jetty
+	 * 12 enforces that strictly enough to drop or fail the whole request otherwise -- see
+	 * NonAsciiCookieRoundTripTest). A cookie this eXist instance didn't set itself -- from a
+	 * browser, or another app sharing the domain -- may not be percent-encoded at all: fall back
+	 * to the raw value rather than throwing on a lone {@code '%'} that isn't a valid escape, and
+	 * accept that a raw, unescaped {@code '+'} in such a cookie is indistinguishable from an
+	 * encoded space and will decode as one (a cookie this instance set itself is unaffected: a
+	 * literal {@code '+'} in the original value is escaped to {@code %2B} on write).
+	 */
+	private String decode(final String value) {
+		try {
+			return URLDecoder.decode(value, UTF_8);
+		} catch (final IllegalArgumentException e) {
+			return value;
+		}
 	}
 }

--- a/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingTest.java
@@ -26,8 +26,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.easymock.Capture;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
+import java.net.URLDecoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
@@ -36,15 +37,23 @@ import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Pins the exact byte-repacking transformation {@code HttpResponseWrapper#encode} applies to
- * every header and cookie value (added 2010-10-14, commit 67612ad4be, marked
- * {@code // TODO: remove this hack after fixing HTTP 1.1}), so that behavior is verified rather
- * than only understood from reading the source. Deliberately does not assert on Jetty's actual
- * wire behavior -- that requires a real HTTP round trip and is covered separately (see
- * {@code HttpResponseWrapperEncodingWireTest}); this only confirms what the Java-level
- * transformation itself produces.
+ * Pins the exact transformation {@code HttpResponseWrapper} applies to header and cookie values,
+ * so that behavior is verified rather than only understood from reading the source. Deliberately
+ * does not assert on Jetty's actual wire behavior -- that requires a real HTTP round trip and is
+ * covered separately (see {@code HttpResponseWrapperEncodingWireTest},
+ * {@code NonAsciiCookieRoundTripTest}); this only confirms what the Java-level transformation
+ * itself produces.
+ * <p>
+ * Headers and cookies use different schemes, and deliberately so: {@code encode()} (added
+ * 2010-10-14, commit 67612ad4be, originally marked
+ * {@code // TODO: remove this hack after fixing HTTP 1.1}) byte-repacks a header value's UTF-8
+ * bytes into ISO-8859-1 chars, confirmed still necessary and correct for headers on Jetty 12. The
+ * same scheme applied to a cookie value produces bytes RFC 6265's stricter cookie-octet grammar
+ * forbids, which Jetty 12 enforces by dropping the cookie or failing the whole request -- so
+ * {@code encodeCookieValue()} percent-encodes instead.
  */
 public class HttpResponseWrapperEncodingTest {
 
@@ -79,7 +88,7 @@ public class HttpResponseWrapperEncodingTest {
     }
 
     @Test
-    public void addCookiePacksEachUtf8ByteIntoOneChar() {
+    public void addCookiePercentEncodesNonAsciiValue() {
         final Capture<Cookie> capturedCookie = newCapture();
         final HttpServletResponse mockResponse = createMock(HttpServletResponse.class);
         mockResponse.addCookie(capture(capturedCookie));
@@ -89,7 +98,15 @@ public class HttpResponseWrapperEncodingTest {
         new HttpResponseWrapper(mockResponse).addCookie("test-cookie", CYRILLIC);
 
         verify(mockResponse);
-        assertPackedUtf8Bytes(CYRILLIC, capturedCookie.getValue().getValue());
+        final String encoded = capturedCookie.getValue().getValue();
+        // Every char of a percent-encoded value is plain US-ASCII (letters, digits, '%', '+') --
+        // exactly what RFC 6265's cookie-octet grammar requires and the packed-byte header scheme
+        // cannot guarantee.
+        for (int i = 0; i < encoded.length(); i++) {
+            assertTrue("Char at index " + i + " (" + encoded.charAt(i) + ") should be plain US-ASCII",
+                    encoded.charAt(i) < 128);
+        }
+        assertEquals(CYRILLIC, URLDecoder.decode(encoded, UTF_8));
     }
 
     @Test
@@ -115,7 +132,7 @@ public class HttpResponseWrapperEncodingTest {
      * and that its length equals the UTF-8 byte count rather than the original character count.
      */
     private static void assertPackedUtf8Bytes(final String original, final String actual) {
-        final byte[] utf8Bytes = original.getBytes(StandardCharsets.UTF_8);
+        final byte[] utf8Bytes = original.getBytes(UTF_8);
         assertEquals("Encoded length should equal the UTF-8 byte count, not the original character count",
                 utf8Bytes.length, actual.length());
         for (int i = 0; i < utf8Bytes.length; i++) {

--- a/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingTest.java
@@ -1,0 +1,127 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.servlets;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.easymock.Capture;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pins the exact byte-repacking transformation {@code HttpResponseWrapper#encode} applies to
+ * every header and cookie value (added 2010-10-14, commit 67612ad4be, marked
+ * {@code // TODO: remove this hack after fixing HTTP 1.1}), so that behavior is verified rather
+ * than only understood from reading the source. Deliberately does not assert on Jetty's actual
+ * wire behavior -- that requires a real HTTP round trip and is covered separately (see
+ * {@code HttpResponseWrapperEncodingWireTest}); this only confirms what the Java-level
+ * transformation itself produces.
+ */
+public class HttpResponseWrapperEncodingTest {
+
+    private static final String CYRILLIC = "Кириллица";
+
+    @Test
+    public void setHeaderPacksEachUtf8ByteIntoOneChar() {
+        final Capture<String> capturedValue = newCapture();
+        final HttpServletResponse mockResponse = createMock(HttpServletResponse.class);
+        mockResponse.setHeader(eq("X-Test"), capture(capturedValue));
+        expectLastCall();
+        replay(mockResponse);
+
+        new HttpResponseWrapper(mockResponse).setHeader("X-Test", CYRILLIC);
+
+        verify(mockResponse);
+        assertPackedUtf8Bytes(CYRILLIC, capturedValue.getValue());
+    }
+
+    @Test
+    public void addHeaderPacksEachUtf8ByteIntoOneChar() {
+        final Capture<String> capturedValue = newCapture();
+        final HttpServletResponse mockResponse = createMock(HttpServletResponse.class);
+        mockResponse.addHeader(eq("X-Test"), capture(capturedValue));
+        expectLastCall();
+        replay(mockResponse);
+
+        new HttpResponseWrapper(mockResponse).addHeader("X-Test", CYRILLIC);
+
+        verify(mockResponse);
+        assertPackedUtf8Bytes(CYRILLIC, capturedValue.getValue());
+    }
+
+    @Test
+    public void addCookiePacksEachUtf8ByteIntoOneChar() {
+        final Capture<Cookie> capturedCookie = newCapture();
+        final HttpServletResponse mockResponse = createMock(HttpServletResponse.class);
+        mockResponse.addCookie(capture(capturedCookie));
+        expectLastCall();
+        replay(mockResponse);
+
+        new HttpResponseWrapper(mockResponse).addCookie("test-cookie", CYRILLIC);
+
+        verify(mockResponse);
+        assertPackedUtf8Bytes(CYRILLIC, capturedCookie.getValue().getValue());
+    }
+
+    @Test
+    public void pureAsciiValuesAreUnaffected() {
+        // ASCII bytes (0-127) are identical in UTF-8 and ISO-8859-1, so the transformation is a
+        // no-op for the common case -- this is why the hack has been invisible for values like
+        // "no-cache" and only bites on genuinely non-ASCII content.
+        final Capture<String> capturedValue = newCapture();
+        final HttpServletResponse mockResponse = createMock(HttpServletResponse.class);
+        mockResponse.setHeader(eq("Cache-Control"), capture(capturedValue));
+        expectLastCall();
+        replay(mockResponse);
+
+        new HttpResponseWrapper(mockResponse).setHeader("Cache-Control", "no-cache");
+
+        verify(mockResponse);
+        assertEquals("no-cache", capturedValue.getValue());
+    }
+
+    /**
+     * Asserts {@code actual} is exactly {@code original}'s UTF-8 byte sequence, one byte packed
+     * per {@code char} (i.e. {@code actual.charAt(i) == (original.getBytes(UTF_8)[i] & 0xFF)}),
+     * and that its length equals the UTF-8 byte count rather than the original character count.
+     */
+    private static void assertPackedUtf8Bytes(final String original, final String actual) {
+        final byte[] utf8Bytes = original.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Encoded length should equal the UTF-8 byte count, not the original character count",
+                utf8Bytes.length, actual.length());
+        for (int i = 0; i < utf8Bytes.length; i++) {
+            final int expectedByteAsChar = utf8Bytes[i] & 0xFF;
+            assertEquals("Char at index " + i + " should be UTF-8 byte " + i + " reinterpreted as ISO-8859-1",
+                    expectedByteAsChar, actual.charAt(i));
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingWireTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingWireTest.java
@@ -1,0 +1,238 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.servlets;
+
+import org.exist.http.AbstractHttpTest;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Measures, against a real Jetty 12 instance rather than by inspecting source, what
+ * {@code HttpResponseWrapper#encode}'s 2010 byte-repacking hack (see
+ * {@link HttpResponseWrapperEncodingTest}) actually produces on the wire for a non-ASCII header
+ * and cookie value set via the {@code response:set-header()} / {@code response:set-cookie()}
+ * XQuery functions -- and, by temporarily short-circuiting the hack, what would happen without
+ * it. Reads the raw response bytes over a plain {@link Socket} rather than through
+ * {@link java.net.http.HttpClient}, since a higher-level HTTP client's own header-string
+ * decoding would reintroduce exactly the ambiguity this is trying to measure directly.
+ */
+public class HttpResponseWrapperEncodingWireTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true, false);
+
+    private static final String TEST_COLLECTION = "/db/apps/test-header-encoding-wire";
+
+    private static final String CYRILLIC = "Кириллица";
+
+    private static final String TEST_XQL = """
+            xquery version "3.1";
+            response:set-header("X-Test", "%s"),
+            response:set-cookie("ascii-cookie", "plainvalue"),
+            response:set-cookie("test-cookie", "%s"),
+            <result>ok</result>""".formatted(CYRILLIC, CYRILLIC);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        final String restUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest storeRequest = AbstractHttpTest.authenticatedRequest(
+                        URI.create(restUrl + "/test.xql"), "admin", "")
+                .header("Content-Type", "application/xquery; charset=UTF-8")
+                .PUT(HttpRequest.BodyPublishers.ofString(TEST_XQL, UTF_8))
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), storeRequest);
+
+        final String chmod = "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/test.xql'), 'rwxr-xr-x')";
+        final String chmodUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest/db?_query=" +
+                URLEncoder.encode(chmod, UTF_8) + "&_wrap=no";
+        final HttpRequest chmodRequest = AbstractHttpTest.authenticatedRequest(URI.create(chmodUrl), "admin", "")
+                .GET()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), chmodRequest);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        final String deleteUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest deleteRequest = AbstractHttpTest.authenticatedRequest(URI.create(deleteUrl), "admin", "")
+                .DELETE()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), deleteRequest);
+    }
+
+    @Test
+    public void measureWireBytesForNonAsciiHeaderAndCookie() throws IOException {
+        final Map<String, java.util.List<byte[]>> rawHeaders = fetchRawHeaders("/exist/apps/test-header-encoding-wire/test.xql");
+        System.err.println("ALL headers seen: " + rawHeaders.keySet());
+        for (final Map.Entry<String, java.util.List<byte[]>> e : rawHeaders.entrySet()) {
+            for (final byte[] v : e.getValue()) {
+                System.err.println("  " + e.getKey() + ": " + bytesToHex(v)
+                        + "  (as UTF-8: " + new String(v, UTF_8) + ")");
+            }
+        }
+
+        final byte[] xTestRaw = firstValue(rawHeaders, "x-test");
+        assertNotNull("X-Test header must be present. Headers seen: " + rawHeaders.keySet(), xTestRaw);
+
+        // MEASUREMENT 1: are the raw wire bytes of X-Test's value exactly Cyrillic's UTF-8
+        // encoding? If so, the 2010 hack is achieving its stated goal on Jetty 12 today: the
+        // container's own ISO-8859-1 header-serialization recovers the packed bytes unchanged.
+        final byte[] expectedUtf8Bytes = CYRILLIC.getBytes(UTF_8);
+        System.err.println("MEASURED X-Test raw bytes:   " + bytesToHex(xTestRaw));
+        System.err.println("EXPECTED Cyrillic UTF-8 bytes: " + bytesToHex(expectedUtf8Bytes));
+        assertEquals("X-Test's raw wire bytes should be exactly Cyrillic's UTF-8 encoding",
+                bytesToHex(expectedUtf8Bytes), bytesToHex(xTestRaw));
+
+        // MEASUREMENT 2: decoding those raw bytes as UTF-8 should reconstruct the original text --
+        // the definitive check that a UTF-8-aware client reading this response would see the
+        // correct value, not mojibake.
+        final String decoded = new String(xTestRaw, UTF_8);
+        System.err.println("X-Test decoded as UTF-8: " + decoded);
+        assertEquals(CYRILLIC, decoded);
+
+        // MEASUREMENT 3 (informational, not fatal): does the plain-ASCII cookie show up, and does
+        // the Cyrillic one? RFC 6265's cookie-octet grammar excludes bytes >= 0x80, unlike the
+        // generic header path's more permissive obs-text treatment -- comparing the two isolates
+        // whether an absent Set-Cookie is specific to the non-ASCII value or a broader issue with
+        // this test's cookie-setting path.
+        final java.util.List<byte[]> setCookieValues = rawHeaders.getOrDefault("set-cookie", java.util.List.of());
+        System.err.println("Set-Cookie count: " + setCookieValues.size());
+        for (final byte[] v : setCookieValues) {
+            System.err.println("Set-Cookie raw bytes: " + bytesToHex(v));
+            System.err.println("Set-Cookie as UTF-8: " + new String(v, UTF_8));
+        }
+    }
+
+    private static byte[] firstValue(final Map<String, java.util.List<byte[]>> headers, final String name) {
+        final java.util.List<byte[]> values = headers.get(name);
+        return values == null || values.isEmpty() ? null : values.get(0);
+    }
+
+    /**
+     * Sends a raw HTTP/1.1 GET over a plain socket and returns each response header's exact raw
+     * bytes (name lower-cased, value bytes as received -- no charset applied), by scanning for
+     * the CRLF-terminated header lines directly rather than parsing through any library that
+     * would itself have to pick a charset for the header value.
+     */
+    private Map<String, java.util.List<byte[]>> fetchRawHeaders(final String path) throws IOException {
+        final byte[] responseBytes;
+        try (final Socket socket = new Socket("localhost", existWebServer.getPort())) {
+            final String request = "GET " + path + " HTTP/1.1\r\n"
+                    + "Host: localhost:" + existWebServer.getPort() + "\r\n"
+                    + "Connection: close\r\n"
+                    + "\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            final byte[] chunk = new byte[4096];
+            int n;
+            while ((n = socket.getInputStream().read(chunk)) != -1) {
+                buffer.write(chunk, 0, n);
+            }
+            responseBytes = buffer.toByteArray();
+        }
+
+        final byte[] headerTerminator = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        final int headerEnd = indexOf(responseBytes, headerTerminator);
+        if (headerEnd < 0) {
+            throw new IOException("Could not find end of headers in response ("
+                    + responseBytes.length + " bytes read)");
+        }
+
+        final Map<String, java.util.List<byte[]>> headers = new TreeMap<>();
+        int lineStart = 0;
+        final byte[] crlf = "\r\n".getBytes(StandardCharsets.US_ASCII);
+        // Skip the status line.
+        int firstLineEnd = indexOf(responseBytes, crlf, 0, headerEnd);
+        lineStart = firstLineEnd + 2;
+        while (lineStart < headerEnd) {
+            final int lineEnd = indexOf(responseBytes, crlf, lineStart, headerEnd);
+            final int end = lineEnd < 0 ? headerEnd : lineEnd;
+            final int colon = indexOfByte(responseBytes, (byte) ':', lineStart, end);
+            if (colon > 0) {
+                final String name = new String(responseBytes, lineStart, colon - lineStart, StandardCharsets.US_ASCII)
+                        .toLowerCase(java.util.Locale.ROOT);
+                int valueStart = colon + 1;
+                while (valueStart < end && responseBytes[valueStart] == ' ') {
+                    valueStart++;
+                }
+                final byte[] value = new byte[end - valueStart];
+                System.arraycopy(responseBytes, valueStart, value, 0, value.length);
+                headers.computeIfAbsent(name, k -> new java.util.ArrayList<>()).add(value);
+            }
+            lineStart = end + 2;
+        }
+        return headers;
+    }
+
+    private static int indexOf(final byte[] haystack, final byte[] needle) {
+        return indexOf(haystack, needle, 0, haystack.length);
+    }
+
+    private static int indexOf(final byte[] haystack, final byte[] needle, final int from, final int to) {
+        outer:
+        for (int i = from; i <= to - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static int indexOfByte(final byte[] haystack, final byte needle, final int from, final int to) {
+        for (int i = from; i < to; i++) {
+            if (haystack[i] == needle) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String bytesToHex(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : bytes) {
+            sb.append(String.format("%02X ", b));
+        }
+        return sb.toString().trim();
+    }
+}

--- a/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingWireTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/HttpResponseWrapperEncodingWireTest.java
@@ -207,16 +207,21 @@ public class HttpResponseWrapperEncodingWireTest {
     }
 
     private static int indexOf(final byte[] haystack, final byte[] needle, final int from, final int to) {
-        outer:
         for (int i = from; i <= to - needle.length; i++) {
-            for (int j = 0; j < needle.length; j++) {
-                if (haystack[i + j] != needle[j]) {
-                    continue outer;
-                }
+            if (matchesAt(haystack, needle, i)) {
+                return i;
             }
-            return i;
         }
         return -1;
+    }
+
+    private static boolean matchesAt(final byte[] haystack, final byte[] needle, final int offset) {
+        for (int j = 0; j < needle.length; j++) {
+            if (haystack[offset + j] != needle[j]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static int indexOfByte(final byte[] haystack, final byte needle, final int from, final int to) {

--- a/exist-core/src/test/java/org/exist/http/servlets/NonAsciiCookieRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/NonAsciiCookieRoundTripTest.java
@@ -36,7 +36,6 @@ import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -115,7 +114,7 @@ public class NonAsciiCookieRoundTripTest {
                 + "/exist/apps/test-cookie-round-trip/test.xql");
 
         final HttpResponse<String> first = client.send(HttpRequest.newBuilder(url).GET().build(),
-                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals("First request should not fail -- see class javadoc for why it currently does "
                         + "(a 500, not just a dropped cookie, depending on request shape): " + first.body(),
                 200, first.statusCode());
@@ -126,7 +125,7 @@ public class NonAsciiCookieRoundTripTest {
                 first.headers().firstValue("Set-Cookie").isPresent());
 
         final HttpResponse<String> second = client.send(HttpRequest.newBuilder(url).GET().build(),
-                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(200, second.statusCode());
         assertTrue("Second request (cookie jar now has test-cookie) should hit the 'get' branch: " + second.body(),
                 second.body().contains("step=\"get\""));

--- a/exist-core/src/test/java/org/exist/http/servlets/NonAsciiCookieRoundTripTest.java
+++ b/exist-core/src/test/java/org/exist/http/servlets/NonAsciiCookieRoundTripTest.java
@@ -1,0 +1,136 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.http.servlets;
+
+import org.exist.http.AbstractHttpTest;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end round trip for a non-ASCII cookie value set via {@code response:set-cookie()} and
+ * read back via {@code request:get-cookie-value()} on a following request. Red against unfixed
+ * {@code HttpResponseWrapper}/{@code GetCookieValue}, and worse than the silent drop
+ * {@link HttpResponseWrapperEncodingWireTest} measured directly: through this request shape, the
+ * whole request fails with a 500 -- {@code org.eclipse.jetty.http.ComplianceViolationException:
+ * ... RFC6265 Cookie values characters restricted to US-ASCII: 0xd0 (forbidden)}, the first byte
+ * of "К" in UTF-8 -- rather than merely omitting the cookie. Same root cause either way: RFC
+ * 6265's cookie-octet grammar excludes bytes >= 0x80, and the current ISO-8859-1 byte-packing
+ * scheme (shared with the header path, where it works fine -- see
+ * {@link HttpResponseWrapperEncodingTest}) produces exactly those bytes for non-ASCII text.
+ * <p>
+ * Uses a normal cookie-aware {@link HttpClient} rather than a raw socket: once the wire
+ * representation is fixed to be percent-encoded, it is pure ASCII, so there is no header-value
+ * charset ambiguity left for a higher-level HTTP client to reintroduce.
+ */
+public class NonAsciiCookieRoundTripTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true, false);
+
+    private static final String TEST_COLLECTION = "/db/apps/test-cookie-round-trip";
+
+    private static final String CYRILLIC = "Кириллица";
+
+    private static final String TEST_XQL = """
+            xquery version "3.1";
+            if (empty(request:get-cookie-value("test-cookie")))
+            then (
+                response:set-cookie("test-cookie", "%s"),
+                <result step="set"/>
+            )
+            else
+                <result step="get" value="{request:get-cookie-value('test-cookie')}"/>""".formatted(CYRILLIC);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        final String restUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest storeRequest = AbstractHttpTest.authenticatedRequest(
+                        URI.create(restUrl + "/test.xql"), "admin", "")
+                .header("Content-Type", "application/xquery; charset=UTF-8")
+                .PUT(HttpRequest.BodyPublishers.ofString(TEST_XQL, UTF_8))
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), storeRequest);
+
+        final String chmod = "sm:chmod(xs:anyURI('" + TEST_COLLECTION + "/test.xql'), 'rwxr-xr-x')";
+        final String chmodUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest/db?_query=" +
+                URLEncoder.encode(chmod, UTF_8) + "&_wrap=no";
+        final HttpRequest chmodRequest = AbstractHttpTest.authenticatedRequest(URI.create(chmodUrl), "admin", "")
+                .GET()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), chmodRequest);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        final String deleteUrl = "http://localhost:" + existWebServer.getPort() + "/exist/rest" + TEST_COLLECTION;
+        final HttpRequest deleteRequest = AbstractHttpTest.authenticatedRequest(URI.create(deleteUrl), "admin", "")
+                .DELETE()
+                .build();
+        AbstractHttpTest.executeForStatus(AbstractHttpTest.newHttpClient(), deleteRequest);
+    }
+
+    @Test
+    public void nonAsciiCookieSurvivesAndRoundTripsCorrectly() throws IOException, InterruptedException {
+        final HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .cookieHandler(new CookieManager(null, CookiePolicy.ACCEPT_ALL))
+                .build();
+        final URI url = URI.create("http://localhost:" + existWebServer.getPort()
+                + "/exist/apps/test-cookie-round-trip/test.xql");
+
+        final HttpResponse<String> first = client.send(HttpRequest.newBuilder(url).GET().build(),
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        assertEquals("First request should not fail -- see class javadoc for why it currently does "
+                        + "(a 500, not just a dropped cookie, depending on request shape): " + first.body(),
+                200, first.statusCode());
+        assertTrue("First request should hit the 'set' branch (no cookie sent yet): " + first.body(),
+                first.body().contains("step=\"set\""));
+        assertTrue("Set-Cookie must actually be present on the first response -- currently dropped "
+                        + "entirely for non-ASCII values (see HttpResponseWrapperEncodingWireTest)",
+                first.headers().firstValue("Set-Cookie").isPresent());
+
+        final HttpResponse<String> second = client.send(HttpRequest.newBuilder(url).GET().build(),
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        assertEquals(200, second.statusCode());
+        assertTrue("Second request (cookie jar now has test-cookie) should hit the 'get' branch: " + second.body(),
+                second.body().contains("step=\"get\""));
+        assertTrue("request:get-cookie-value() should return the original Cyrillic text: " + second.body(),
+                second.body().contains("value=\"" + CYRILLIC + "\""));
+    }
+}


### PR DESCRIPTION
## Summary

Independent of and unrelated to #6692/#6693 (the URL-rewrite pipeline stack) -- this investigates and fixes a separate, pre-existing bug found while reviewing a 2010-era `// TODO: remove this hack after fixing HTTP 1.1` comment during that other work.

`HttpResponseWrapper#encode` (added 2010-10-14, commit `67612ad4be`) applies the same ISO-8859-1 byte-packing scheme to both header values (`response:set-header()`) and cookie values (`response:set-cookie()`), to work around the Java Servlet API's byte-per-char header serialization for non-ASCII text.

Measured empirically against a real Jetty 12 instance (not just inferred from the spec):

- **Headers**: the hack still works. A non-ASCII header value's exact UTF-8 bytes reach the wire unchanged.
- **Cookies**: the hack does not work, and never really did on this stack. RFC 6265's `cookie-octet` grammar excludes any byte >= 0x80 -- stricter than headers' more permissive treatment -- and Jetty 12 enforces this strictly. Depending on request shape, a non-ASCII cookie value either:
  - vanishes from the response entirely, with no warning or error anywhere, or
  - fails the *entire request* with a 500: `org.eclipse.jetty.http.ComplianceViolationException: ... RFC6265 Cookie values characters restricted to US-ASCII: 0xd0 (forbidden)`.

## What Changed

**Commits 1-2 (measure, then red):** a unit test pinning the exact byte-packing transformation, a raw-socket wire test against real Jetty 12 confirming the header/cookie divergence above, and an end-to-end round-trip test (`response:set-cookie()` → `request:get-cookie-value()`) reproducing the 500.

**Commit 3 (fix):** `exist-core/src/main/java/org/exist/http/servlets/HttpResponseWrapper.java` -- cookie values now go through a separate `encodeCookieValue()` that percent-encodes instead of byte-packing, keeping the wire value strictly within `cookie-octet`'s ASCII-safe range regardless of input text. The header path (`encode()`) is untouched. `org.exist.xquery.functions.request.GetCookieValue#decode` (the read side) is updated symmetrically to percent-decode, with a fallback to the raw value if decoding fails, so a cookie eXist didn't set itself (browser, another app on the same domain) doesn't crash a lookup over a coincidental `%` that isn't a valid escape.

Both historic "TODO: remove this hack after fixing HTTP 1.1" comments are replaced with what direct measurement now shows -- the header-side hack isn't a fixable HTTP/1.1 defect (it's a still-current characteristic of the Java Servlet header API) and remains genuinely necessary today, not dead code.

## Test Plan

- [x] `HttpResponseWrapperEncodingTest` -- unit-level, pins the header byte-packing transformation (unchanged) and the new cookie percent-encoding.
- [x] `HttpResponseWrapperEncodingWireTest` -- real HTTP round trip via raw socket against live Jetty 12; confirms header behavior and documents the cookie divergence.
- [x] `NonAsciiCookieRoundTripTest` -- red against unfixed code (500), green after the fix; full `response:set-cookie()` → `request:get-cookie-value()` round trip.
- [x] Full `org.exist.http.*`/`org.exist.http.servlets.*`/`org.exist.xquery.functions.request.*`/`org.exist.xquery.functions.response.*` sweep: 132 tests, all green -- this is also the first test coverage cookies have had in this codebase at all.