### PR TITLE
[bugfix] XQSuite: don't re-serialize already-serialized failure values

### DIFF
--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
@@ -29,6 +29,7 @@ import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 import org.junit.ComparisonFailure;
@@ -158,7 +159,7 @@ public class ExtTestFailureFunction extends JUnitIntegrationFunction {
         return 0;
     }
 
-    private String expectedToString(final MapType expected) throws XPathException, SAXException, IOException {
+    private String expectedToString(final MapType expected) throws XPathException {
         final Sequence seqExpectedValue = expected.get(new StringValue(this, "value"));
         if(!seqExpectedValue.isEmpty()) {
             return seqToString(seqExpectedValue);
@@ -191,12 +192,25 @@ public class ExtTestFailureFunction extends JUnitIntegrationFunction {
         }
     }
 
-    private String seqToString(final Sequence seq) throws IOException, XPathException, SAXException {
-        try(final StringWriter writer = new StringWriter()) {
-            final XQuerySerializer xquerySerializer = new XQuerySerializer(context.getBroker(), new Properties(), writer);
-            xquerySerializer.serialize(seq);
-            return writer.toString();
+    /**
+     * The values reaching here have already been serialized to strings by the XQSuite layer
+     * (xqsuite.xql's test:expected-strings / test:actual-strings, and the adaptive serialize()
+     * calls beside them), so they are taken verbatim. Running them through a serializer a second
+     * time would escape the markup they contain, and a result of {@code <doc/>} would reach the
+     * failure message as {@code &lt;doc/&gt;}.
+     *
+     * @param seq the already-serialized value(s) to render into the failure message
+     *
+     * @return the concatenated string values
+     *
+     * @throws XPathException if a string value cannot be obtained
+     */
+    private String seqToString(final Sequence seq) throws XPathException {
+        final StringBuilder builder = new StringBuilder();
+        for (final SequenceIterator it = seq.iterate(); it.hasNext(); ) {
+            builder.append(it.nextItem().getStringValue());
         }
+        return builder.toString();
     }
 
     private String errorMapToString(final Sequence seqErrorMap) throws IOException, XPathException, SAXException {

--- a/exist-core/src/test/java/org/exist/test/runner/SerializationFailureMessageSuite.java
+++ b/exist-core/src/test/java/org/exist/test/runner/SerializationFailureMessageSuite.java
@@ -1,0 +1,36 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.test.runner;
+
+import org.junit.runner.RunWith;
+
+/**
+ * XSuite that runs {@code failing-serialization.xqm} (a single assertion failure whose result is a
+ * node) so we can assert on how the actual value is rendered into the failure message.
+ */
+@RunWith(XSuite.class)
+@XSuite.XSuiteFiles({
+    "src/test/resources/org/exist/test/runner/failing-serialization.xqm"
+})
+public class SerializationFailureMessageSuite {
+}

--- a/exist-core/src/test/java/org/exist/test/runner/XSuiteFailureMessageTest.java
+++ b/exist-core/src/test/java/org/exist/test/runner/XSuiteFailureMessageTest.java
@@ -1,0 +1,79 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.test.runner;
+
+import org.junit.ComparisonFailure;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The XQSuite layer hands {@link ExtTestFailureFunction} values it has already serialized to
+ * strings. Serializing them a second time on the Java side escaped their markup, so a test whose
+ * result was {@code <doc a="1">text</doc>} reported it as {@code &lt;doc a="1"&gt;text&lt;/doc&gt;}
+ * and a string result containing markup was escaped twice over.
+ */
+class XSuiteFailureMessageTest {
+
+    @Test
+    void nodeResultIsNotEscapedIntoTheFailureMessage() {
+        final ComparisonFailure failure = runSuiteAndGetComparisonFailure();
+
+        assertEquals("<doc a=\"1\">text</doc>", failure.getActual(),
+            "a node-valued result should reach the failure message as markup, not XML-escaped");
+    }
+
+    private static ComparisonFailure runSuiteAndGetComparisonFailure() {
+        final List<Failure> collected = new ArrayList<>();
+        final JUnitCore core = new JUnitCore();
+        core.addListener(new RunListener() {
+            @Override
+            public void testFailure(final Failure failure) {
+                collected.add(failure);
+            }
+        });
+
+        final Result result = core.run(SerializationFailureMessageSuite.class);
+        assertFalse(result.wasSuccessful(), "suite is expected to fail (failing-serialization.xqm)");
+
+        final ComparisonFailure comparisonFailure = collected.stream()
+            .map(Failure::getException)
+            .filter(ComparisonFailure.class::isInstance)
+            .map(ComparisonFailure.class::cast)
+            .findFirst()
+            .orElse(null);
+        assertNotNull(comparisonFailure,
+            "expected a ComparisonFailure from failing-serialization.xqm; collected: " + collected.size());
+
+        return comparisonFailure;
+    }
+}

--- a/exist-core/src/test/resources/org/exist/test/runner/failing-serialization.xqm
+++ b/exist-core/src/test/resources/org/exist/test/runner/failing-serialization.xqm
@@ -1,0 +1,36 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+(:
+ : Intentionally failing xqsuite test whose result is a node, so the reported "but was:" value
+ : can be checked for over-escaping. See XSuiteFailureMessageTest.
+ :)
+xquery version "3.1";
+
+module namespace fs = "http://exist-db.org/xquery/failing-serialization-module";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertEquals("DELIBERATELY-NOT-THE-RESULT")
+function fs:nodeResult() {
+    <doc a="1">text</doc>
+};


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

Closes #6698

## Summary

XQSuite failure messages XML-escaped the actual and expected values — once for a node-valued result, twice for a string-valued one — so a test returning `<doc a="1">text</doc>` reported it as `&lt;doc a="1"&gt;text&lt;/doc&gt;`. The assertion outcome was always correct; only the diagnostic was unreadable.

## What Changed

**`exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java`**

`seqToString` now takes the string value verbatim instead of re-serializing it.

Everything reaching this class has already been serialized by the XQuery layer — `xqsuite.xql`'s `test:actual-strings` / `test:expected-strings` call `fn:serialize(..., adaptive)`, and the paths beside them pass `serialize()` output too, so every entry in the expected and actual maps is an `xs:string`. `seqToString` was running that string through `XQuerySerializer` a second time with no output method set, which defaults to the XML method and escapes the markup the string contains.

`expectedToString`'s `throws` clause narrows to `XPathException`; `SAXException` and `IOException` were only needed by the serializer call that is now gone. `errorMapToString` is untouched — it serializes a genuine map and sets `method=adaptive` deliberately.

**`exist-core/src/test/java/org/exist/test/runner/XSuiteFailureMessageTest.java`** and its fixture — a regression test for the node case, following the existing `XSuiteDebuggabilityTest` / `DebuggabilityNavigabilitySuite` pattern.

## A fix that looks right and is not

Setting `method=adaptive` here, to match the neighboring `errorMapToString`, is the obvious-looking one-liner. It is wrong: adaptive renders an `xs:string` as a quoted literal with doubled internal quotes, so the node case comes out as `"<doc a=""1"">text</doc>"` and the `expected:` side picks up stray quotation marks too. Recording it here because it is the first thing a reader of this code will reach for.

## Open question — the residual escape on string results

**This PR fixes node-valued results outright. String-valued results improve from two escapes to one, and the remaining one is deliberately not addressed here.**

That escape comes from `xqsuite.xql` building `<output>{ $result }</output>` and then serializing `output/node()`. Putting a string inside an element turns it into a text node, which is escaped on the way back out.

I did not attempt it because it is a design question rather than a local fix: once the value is inside that element, "a string that happens to contain markup" and "a text node" are indistinguishable, so fixing it requires deciding what the report element should actually hold. Answering that in this PR would bundle a design decision into a change that is otherwise a self-contained correctness fix.

Happy to take direction on whether that belongs here, in a follow-up, or in a broader look at the report structure.

## Test Plan

- [x] `XSuiteFailureMessageTest` fails on unfixed `develop` with exactly the escaped value, passes with the fix
- [x] Full `mvn test` on `exist-core` — 7,250 tests, 0 failures, 0 errors, 101 skipped; confirmed `XSuiteFailureMessageTest` and the existing `XSuiteDebuggabilityTest` both ran within it
- [x] Codacy PMD clean on the changed Java files
- [x] `license:check` clean

## Scope

Confined to failure message rendering — no assertion outcome changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
