### PR TITLE
[bugfix] Candidate A for #6690 — reset predicate contexts when a cached index result is reused

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -584,6 +584,23 @@ public class LocationStep extends Step {
         }
     }
 
+    /**
+     * Clears predicate contexts left on the cached structural-index result by a previous
+     * evaluation of this step.
+     *
+     * <p>{@link #currentSet} is held for the whole query execution, and the sibling and
+     * preceding/following select methods stamp its {@code NodeProxy} objects in place. Their
+     * duplicate-suppression guard reads those stamps, so without this reset it sees state left
+     * over from the previous evaluation and skips every node. Only reuse of a cached set needs
+     * this; a freshly built one carries no contexts.</p>
+     */
+    private void clearCachedSetPredicateContexts() {
+        for (final NodeProxy p : currentSet) {
+            p.clearContext(Expression.IGNORE_CONTEXT);
+        }
+    }
+
+
     protected Sequence getAttributes(final XQueryContext context, final Sequence contextSequence)
             throws XPathException {
         if (!contextSequence.isPersistentSet()) {
@@ -884,6 +901,8 @@ public class LocationStep extends Step {
                     currentSet = index.findElementsByTagName(ElementValue.ELEMENT, docs, test.getName(), null, this);
                     currentDocs = docs;
                     registerUpdateListener();
+                } else {
+                    clearCachedSetPredicateContexts();
                 }
                 return switch (axis) {
                     case Constants.PRECEDING_SIBLING_AXIS -> currentSet.selectPrecedingSiblings(contextSet, contextId);
@@ -971,6 +990,8 @@ public class LocationStep extends Step {
                     currentSet = index.findElementsByTagName(ElementValue.ELEMENT, docs, test.getName(), null, this);
                     currentDocs = docs;
                     registerUpdateListener();
+                } else {
+                    clearCachedSetPredicateContexts();
                 }
 
                 if (position > -1) {

--- a/exist-core/src/test/java/org/exist/xquery/SiblingAxisRepeatedEvaluationRegressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/SiblingAxisRepeatedEvaluationRegressionTest.java
@@ -1,0 +1,142 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for issue #6690. An axis step with a name test returned the correct result on
+ * its first evaluation and an empty sequence on every evaluation after that, within a single
+ * query, whenever the context node carried a predicate context item.
+ *
+ * <p>{@code LocationStep} caches its structural-index lookup for the whole query execution, and
+ * the sibling and preceding/following select methods stamped those cached {@link
+ * org.exist.dom.persistent.NodeProxy} objects in place with the matching reference node's
+ * context. On the next evaluation a duplicate-suppression guard saw the leftover stamp and
+ * skipped every node.</p>
+ *
+ * <p>Each expression is evaluated four times over the same bound node. The first value in each
+ * result is what the unfixed code got right; positions two onwards are what it dropped.</p>
+ */
+public class SiblingAxisRepeatedEvaluationRegressionTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static final String TEST_DOC = "/db/i6690.xml";
+
+    private static final String PROLOG = "xquery version \"3.1\"; declare namespace t=\"urn:example\"; ";
+
+    /** Bound via a predicate, so the node carries a context item — the condition that triggers the bug. */
+    private static final String VIA_PREDICATE =
+            "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:target)[1] ";
+
+    /** Bound via a plain path, so the node carries no context item. */
+    private static final String VIA_PATH =
+            "let $n := (doc('" + TEST_DOC + "')/t:root//t:target)[1] ";
+
+    @BeforeClass
+    public static void storeTestDocument() throws XMLDBException {
+        query("""
+                xmldb:store('/db', 'i6690.xml',
+                    <t:root xmlns:t="urn:example">
+                        <t:key>K1</t:key>
+                        <t:wrap><t:a/><t:target/></t:wrap>
+                    </t:root>)
+                """);
+    }
+
+    @AfterClass
+    public static void removeTestDocument() throws XMLDBException {
+        query("xmldb:remove('/db', 'i6690.xml')");
+    }
+
+    private static String query(final String xquery) throws XMLDBException {
+        final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query(xquery);
+        return result.getSize() == 0 ? "" : result.getResource(0).getContent().toString();
+    }
+
+    /** Evaluates {@code $n/<step>} four times over the same node, returning e.g. "1,1,1,1". */
+    private static String fourTimes(final String binding, final String step) throws XMLDBException {
+        return query(PROLOG + binding
+                + "return string-join(for $i in 1 to 4 return string(count($n" + step + ")), ',')");
+    }
+
+    @Test
+    public void precedingSiblingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding-sibling::t:a"));
+    }
+
+    @Test
+    public void followingSiblingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", query(PROLOG
+                + "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:a)[1] "
+                + "return string-join(for $i in 1 to 4 return string(count($n/following-sibling::t:target)), ',')"));
+    }
+
+    @Test
+    public void precedingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding::t:a"));
+    }
+
+    @Test
+    public void followingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", query(PROLOG
+                + "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:a)[1] "
+                + "return string-join(for $i in 1 to 4 return string(count($n/following::t:target)), ',')"));
+    }
+
+    /** A node reached without a predicate was never affected; pin it. */
+    @Test
+    public void precedingSiblingNameTestViaPlainPathIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PATH, "/preceding-sibling::t:a"));
+    }
+
+    /** The wildcard form takes a different branch and was never affected; pin it. */
+    @Test
+    public void precedingSiblingWildcardIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding-sibling::*"));
+    }
+
+    /** Other axes were never affected; pin one. */
+    @Test
+    public void ancestorNameTestIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/ancestor::t:wrap"));
+    }
+
+    /** A name that matches no sibling must stay empty, not become non-empty. */
+    @Test
+    public void nonMatchingSiblingNameTestStaysEmpty() throws XMLDBException {
+        assertEquals("0,0,0,0", fourTimes(VIA_PREDICATE, "/preceding-sibling::t:absent"));
+    }
+}


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

**This is one of two candidate fixes for #6690. See #6700 for the design question, the trade-offs, and a link to the alternative candidate. Please do not merge this without reading that issue — the two PRs are deliberately competing, not stacked.**

Addresses #6690

## Summary

An axis step with a name test returned the correct result on its first evaluation and an empty sequence on every evaluation after that, within a single query, whenever the context node carried a predicate context item. Silent — no error, no warning, data loss proportional to loop length.

## What Changed

**`exist-core/src/main/java/org/exist/xquery/LocationStep.java`**

`LocationStep` caches its structural-index lookup in `currentSet` for the whole query execution, and `NewArrayNodeSet`'s sibling and preceding/following select methods stamp those cached `NodeProxy` objects in place with the matching reference node's context. A duplicate-suppression guard then reads those stamps back — and on the second evaluation it is reading stamps left by the first, so it suppresses every node.

This change clears predicate contexts on `currentSet` when the cached set is *reused* rather than freshly built, so the guard only ever sees stamps from the current evaluation. A freshly built set carries no contexts, so only the reuse path needs it.

Applied at the two call sites that feed the guarded select methods: `getSiblings` and `getPrecedingOrFollowing`.

## Why not simply remove the guard

The guard is still needed. With it disabled the new regression test passes, but **ten existing tests fail** across `axes.xql`, `npt.xqm` and `positional-nested.xql` — including the file the guard's original 2019 commit added its tests to. It suppresses genuine duplicates between different reference nodes *within* one evaluation. The bug is the stale state it reads, not the guard.

## Known limitation

The previous evaluation's result set holds the same `NodeProxy` instances as the cached set, so clearing at the start of evaluation *n* retroactively mutates the result of evaluation *n-1*. I could not construct a case where that is observable — it is harmless under `count()` and in every test we have — but it is a real property of this approach and the main reason candidate B exists. This is discussed in #6700.

## Test Plan

- [x] New `SiblingAxisRepeatedEvaluationRegressionTest` fails on unfixed `develop`, passes with the fix
- [x] Evaluates each affected axis four times over the same node; pins the wildcard form, a node reached without a predicate, an unaffected axis, and a non-matching name alongside
- [x] `xquery.CoreTests` — the whole `src/test/xquery` corpus, including the ten tests naive guard removal breaks — green
- [x] Full `mvn test` on `exist-core` green
- [x] Codacy PMD clean on the changed file
- [x] `license:check` clean

## Scope

Two call sites in one class. No change to the node-set algorithms or to any hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
