### PR TITLE
[bugfix] Candidate B for #6690 — keep axis duplicate-suppression state per call

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -594,9 +594,49 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
         }
     }
 
+    /**
+     * Whether this call has already stamped {@code nodes[idx]} with a context bearing the same
+     * context id as {@code reference}'s.
+     *
+     * <p>This replaces reading the stamp back off the {@code NodeProxy}. The proxies in this set
+     * are shared with {@code LocationStep}'s cached structural-index result, which is held for a
+     * whole query execution, so a stamp read from the proxy could have been left by a *previous*
+     * evaluation of the same step — in which case every node was suppressed and the step returned
+     * empty. Keeping the duplicate-suppression state per call confines it to the evaluation that
+     * created it. See issue #6690.</p>
+     *
+     * @param stamped the per-call record of stamps applied so far
+     * @param idx the index into {@link #nodes} of the candidate node
+     * @param reference the context node being matched against
+     * @param contextId the context id of the current evaluation
+     * @return true if the candidate should be skipped as a duplicate
+     */
+    private boolean alreadyStampedInThisCall(final Map<Integer, Integer> stamped, final int idx,
+            final NodeProxy reference, final int contextId) {
+        if (contextId == Expression.IGNORE_CONTEXT || reference.getContext() == null) {
+            return false;
+        }
+        final Integer previous = stamped.get(idx);
+        return previous != null && previous == reference.getContext().getContextId();
+    }
+
+    /**
+     * Records that this call has stamped {@code nodes[idx]}, so a later reference in the same call
+     * sees it as a duplicate exactly as reading the proxy's own context used to.
+     *
+     * @param stamped the per-call record of stamps applied so far
+     * @param idx the index into {@link #nodes} of the node just stamped
+     */
+    private void recordStamp(final Map<Integer, Integer> stamped, final int idx) {
+        if (nodes[idx].getContext() != null) {
+            stamped.put(idx, nodes[idx].getContext().getContextId());
+        }
+    }
+
     @Override
     public NodeSet selectPrecedingSiblings(final NodeSet contextSet, final int contextId) {
         sort();
+        final Map<Integer, Integer> stamped = new HashMap<>();
         final NodeSet result = new NewArrayNodeSet();
         for(final NodeProxy reference : contextSet) {
             final NodeId parentId = reference.getNodeId().getParentId();
@@ -647,10 +687,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                     break;
                 }
                 if(currentId.getTreeLevel() == refId.getTreeLevel() && currentId.compareTo(refId) < 0) {
-                    if (contextId != Expression.IGNORE_CONTEXT
-                            && nodes[i].getContext() != null
-                            && reference.getContext() != null
-                            && nodes[i].getContext().getContextId() == reference.getContext().getContextId()) {
+                    if (alreadyStampedInThisCall(stamped, i, reference, contextId)) {
                         continue;
                     }
 
@@ -661,6 +698,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                             nodes[i].addContextNode(contextId, reference);
                         }
                     }
+                    recordStamp(stamped, i);
                     result.add(nodes[i]);
                 }
             }
@@ -678,6 +716,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     @Override
     public NodeSet selectFollowingSiblings(final NodeSet contextSet, final int contextId) {
         sort();
+        final Map<Integer, Integer> stamped = new HashMap<>();
         final NodeSet result = new NewArrayNodeSet();
         for(final NodeProxy reference : contextSet) {
             final NodeId parentId = reference.getNodeId().getParentId();
@@ -731,10 +770,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 }
                 enteredSubtree = true;
                 if(currentId.getTreeLevel() == refId.getTreeLevel() && currentId.compareTo(refId) > 0) {
-                    if (contextId != Expression.IGNORE_CONTEXT
-                            && nodes[i].getContext() != null
-                            && reference.getContext() != null
-                            && nodes[i].getContext().getContextId() == reference.getContext().getContextId()) {
+                    if (alreadyStampedInThisCall(stamped, i, reference, contextId)) {
                         continue;
                     }
 
@@ -745,6 +781,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                             nodes[i].addContextNode(contextId, reference);
                         }
                     }
+                    recordStamp(stamped, i);
                     result.add(nodes[i]);
                 }
             }
@@ -760,6 +797,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     @Override
     public NodeSet selectFollowing(final NodeSet pl, final int position, final int contextId) throws XPathException, UnsupportedOperationException {
         sort();
+        final Map<Integer, Integer> stamped = new HashMap<>();
         final NodeSet result = new NewArrayNodeSet();
         for(final NodeProxy reference : pl) {
             final int idx = findDoc(reference.getOwnerDocument());
@@ -781,11 +819,8 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 }
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
-                        if (contextId != Expression.IGNORE_CONTEXT
-                                && contextId != Expression.NO_CONTEXT_ID
-                                && nodes[j].getContext() != null
-                                && reference.getContext() != null
-                                && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {
+                        if (contextId != Expression.NO_CONTEXT_ID
+                                && alreadyStampedInThisCall(stamped, j, reference, contextId)) {
                             continue;
                         }
 
@@ -796,6 +831,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                                 nodes[j].addContextNode(contextId, reference);
                             }
                         }
+                        recordStamp(stamped, j);
                         result.add(nodes[j]);
                     }
                     if(n == position) {
@@ -818,6 +854,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
             final int contextId) throws XPathException,
             UnsupportedOperationException {
         sort();
+        final Map<Integer, Integer> stamped = new HashMap<>();
         final NodeSet result = new NewArrayNodeSet();
         for(final NodeProxy reference : pl) {
             final int idx = findDoc(reference.getOwnerDocument());
@@ -836,11 +873,8 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
             for(int j = i; j >= documentNodesOffset[idx]; j--) {
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
-                        if (contextId != Expression.IGNORE_CONTEXT
-                                && contextId != Expression.NO_CONTEXT_ID
-                                && nodes[j].getContext() != null
-                                && reference.getContext() != null
-                                && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {
+                        if (contextId != Expression.NO_CONTEXT_ID
+                                && alreadyStampedInThisCall(stamped, j, reference, contextId)) {
                             continue;
                         }
 
@@ -851,6 +885,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                                 nodes[j].addContextNode(contextId, reference);
                             }
                         }
+                        recordStamp(stamped, j);
                         result.add(nodes[j]);
                     }
                     if(n == position) {

--- a/exist-core/src/test/java/org/exist/xquery/SiblingAxisRepeatedEvaluationRegressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/SiblingAxisRepeatedEvaluationRegressionTest.java
@@ -1,0 +1,142 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for issue #6690. An axis step with a name test returned the correct result on
+ * its first evaluation and an empty sequence on every evaluation after that, within a single
+ * query, whenever the context node carried a predicate context item.
+ *
+ * <p>{@code LocationStep} caches its structural-index lookup for the whole query execution, and
+ * the sibling and preceding/following select methods stamped those cached {@link
+ * org.exist.dom.persistent.NodeProxy} objects in place with the matching reference node's
+ * context. On the next evaluation a duplicate-suppression guard saw the leftover stamp and
+ * skipped every node.</p>
+ *
+ * <p>Each expression is evaluated four times over the same bound node. The first value in each
+ * result is what the unfixed code got right; positions two onwards are what it dropped.</p>
+ */
+public class SiblingAxisRepeatedEvaluationRegressionTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer =
+            new ExistXmldbEmbeddedServer(false, true, true);
+
+    private static final String TEST_DOC = "/db/i6690.xml";
+
+    private static final String PROLOG = "xquery version \"3.1\"; declare namespace t=\"urn:example\"; ";
+
+    /** Bound via a predicate, so the node carries a context item — the condition that triggers the bug. */
+    private static final String VIA_PREDICATE =
+            "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:target)[1] ";
+
+    /** Bound via a plain path, so the node carries no context item. */
+    private static final String VIA_PATH =
+            "let $n := (doc('" + TEST_DOC + "')/t:root//t:target)[1] ";
+
+    @BeforeClass
+    public static void storeTestDocument() throws XMLDBException {
+        query("""
+                xmldb:store('/db', 'i6690.xml',
+                    <t:root xmlns:t="urn:example">
+                        <t:key>K1</t:key>
+                        <t:wrap><t:a/><t:target/></t:wrap>
+                    </t:root>)
+                """);
+    }
+
+    @AfterClass
+    public static void removeTestDocument() throws XMLDBException {
+        query("xmldb:remove('/db', 'i6690.xml')");
+    }
+
+    private static String query(final String xquery) throws XMLDBException {
+        final XQueryService xqs = existEmbeddedServer.getRoot().getService(XQueryService.class);
+        final ResourceSet result = xqs.query(xquery);
+        return result.getSize() == 0 ? "" : result.getResource(0).getContent().toString();
+    }
+
+    /** Evaluates {@code $n/<step>} four times over the same node, returning e.g. "1,1,1,1". */
+    private static String fourTimes(final String binding, final String step) throws XMLDBException {
+        return query(PROLOG + binding
+                + "return string-join(for $i in 1 to 4 return string(count($n" + step + ")), ',')");
+    }
+
+    @Test
+    public void precedingSiblingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding-sibling::t:a"));
+    }
+
+    @Test
+    public void followingSiblingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", query(PROLOG
+                + "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:a)[1] "
+                + "return string-join(for $i in 1 to 4 return string(count($n/following-sibling::t:target)), ',')"));
+    }
+
+    @Test
+    public void precedingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding::t:a"));
+    }
+
+    @Test
+    public void followingNameTestIsStableAcrossEvaluations() throws XMLDBException {
+        assertEquals("1,1,1,1", query(PROLOG
+                + "let $n := (doc('" + TEST_DOC + "')//t:key[. = 'K1']/ancestor::t:root//t:a)[1] "
+                + "return string-join(for $i in 1 to 4 return string(count($n/following::t:target)), ',')"));
+    }
+
+    /** A node reached without a predicate was never affected; pin it. */
+    @Test
+    public void precedingSiblingNameTestViaPlainPathIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PATH, "/preceding-sibling::t:a"));
+    }
+
+    /** The wildcard form takes a different branch and was never affected; pin it. */
+    @Test
+    public void precedingSiblingWildcardIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/preceding-sibling::*"));
+    }
+
+    /** Other axes were never affected; pin one. */
+    @Test
+    public void ancestorNameTestIsStable() throws XMLDBException {
+        assertEquals("1,1,1,1", fourTimes(VIA_PREDICATE, "/ancestor::t:wrap"));
+    }
+
+    /** A name that matches no sibling must stay empty, not become non-empty. */
+    @Test
+    public void nonMatchingSiblingNameTestStaysEmpty() throws XMLDBException {
+        assertEquals("0,0,0,0", fourTimes(VIA_PREDICATE, "/preceding-sibling::t:absent"));
+    }
+}


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

**This is one of two candidate fixes for #6690. See #6700 for the design question, the trade-offs, and a link to the alternative candidate. Please do not merge this without reading that issue — the two PRs are deliberately competing, not stacked.**

Addresses #6690

## Summary

An axis step with a name test returned the correct result on its first evaluation and an empty sequence on every evaluation after that, within a single query, whenever the context node carried a predicate context item. Silent — no error, no warning, data loss proportional to loop length.

## What Changed

**`exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java`**

The duplicate-suppression guard in `selectPrecedingSiblings`, `selectFollowingSiblings`, `selectPreceding` and `selectFollowing` decided whether it had already handled a node by reading a context stamp back off the `NodeProxy`. Those proxies are shared with `LocationStep`'s cached structural-index result, which is held for a whole query execution — so on the second evaluation the guard was reading stamps left by the first, and suppressed every node.

This change stops the guard reading the proxy. Each call now records which nodes it has stamped and with which context id, in a map local to that call, and the guard consults that instead. Within one call the behavior is identical to before; across calls there is nothing to leak, whatever the caller does with the cache.

Two small private helpers, `alreadyStampedInThisCall` and `recordStamp`, keep the four methods readable and the transformation obviously faithful — the recorded value is exactly what the guard used to read off the proxy.

Note the preceding/following guards carry an extra `contextId != NO_CONTEXT_ID` condition that the sibling ones do not; that asymmetry is preserved at the call sites rather than folded into the helper.

## Why not simply remove the guard

Removing it is not an option. With it disabled the new regression test passes, but **ten existing tests fail** across `axes.xql`, `npt.xqm` and `positional-nested.xql` — including the file the guard's original 2019 commit added its tests to. It suppresses genuine duplicates between different reference nodes *within* one evaluation. The bug is where that state was stored, not the guard.

## Cost

A small map allocated per call when a context id is in play. It is bounded by the number of nodes actually stamped, not by the size of the cached set, so it scales with the result rather than the index — but it is an allocation in a hot path where there was none, and that is a fair thing to weigh against candidate A's smaller footprint. Discussed in #6700.

## Test Plan

- [x] New `SiblingAxisRepeatedEvaluationRegressionTest` fails on unfixed `develop`, passes with the fix
- [x] Evaluates each affected axis four times over the same node; pins the wildcard form, a node reached without a predicate, an unaffected axis, and a non-matching name alongside
- [x] `xquery.CoreTests` — the whole `src/test/xquery` corpus, including the ten tests naive guard removal breaks — green
- [x] Full `mvn test` on `exist-core` green
- [x] Codacy PMD clean on the changed file
- [x] `license:check` clean

## Scope

One class, four methods, no behavior change within a single evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
